### PR TITLE
Check for type recursion without boxing

### DIFF
--- a/testsuite/tests/letrec-check/unboxed.ml
+++ b/testsuite/tests/letrec-check/unboxed.ml
@@ -23,14 +23,17 @@ Line 2, characters 12-19:
 Error: This kind of expression is not allowed as right-hand side of "let rec"
 |}];;
 
+(* This test was made to error by disallowing singleton recursive unboxed types.
+   We keep it in case these are re-allowed, in which case it should error with:
+   [This kind of expression is not allowed as right-hand side of "let rec"] *)
 type r = A of r [@@unboxed]
 let rec y = A y;;
 [%%expect{|
-type r = A of r [@@unboxed]
-Line 2, characters 12-15:
-2 | let rec y = A y;;
-                ^^^
-Error: This kind of expression is not allowed as right-hand side of "let rec"
+Line 1, characters 0-27:
+1 | type r = A of r [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "r" is recursive without boxing:
+         "r" contains "r"
 |}];;
 
 (* This test is not allowed if 'a' is unboxed, but should be accepted

--- a/testsuite/tests/typing-layouts-products/letrec.ml
+++ b/testsuite/tests/typing-layouts-products/letrec.ml
@@ -6,14 +6,17 @@
  }
 *)
 
+(* This test was made to error by disallowing singleton recursive unboxed types.
+   We keep it in case these are re-allowed, in which case it should error with:
+   [This kind of expression is not allowed as right-hand side of "let rec"] *)
 type t : value = #{ t : t }
 let rec t = #{ t = t }
 [%%expect{|
-type t = #{ t : t; }
-Line 2, characters 12-22:
-2 | let rec t = #{ t = t }
-                ^^^^^^^^^^
-Error: This kind of expression is not allowed as right-hand side of "let rec"
+Line 1, characters 0-27:
+1 | type t : value = #{ t : t }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t" is recursive without boxing:
+         "t" contains "t"
 |}]
 
 type bx = { bx : ubx }

--- a/testsuite/tests/typing-layouts-products/recursive.ml
+++ b/testsuite/tests/typing-layouts-products/recursive.ml
@@ -6,59 +6,119 @@
  }
 *)
 
-(* CR layouts v7.2: figure out the story for recursive unboxed products.
-   Consider that the following is allowed upstream:
-      type t = { t : t } [@@unboxed]
-   We should also give good errors for infinite-size unboxed records (see the
-   test at the bottom of this file with a depth-100 kind).
-*)
+(* We only allow recursion of unboxed product types through boxing, otherwise
+   the type is uninhabitable and usually also infinite-size. *)
 
-(************************************)
-(* Basic recursive unboxed products *)
+(***********************************************)
+(* Allowed (guarded) recursive unboxed records *)
 
-type t : value = #{ t : t }
+(* Guarded by `list` *)
+type t = #{ tl: t list }
 [%%expect{|
-type t = #{ t : t; }
+type t = #{ tl : t list; }
 |}]
 
-type t : float64 = #{ t : t }
+module AbstractList : sig
+  type 'a t
+end = struct
+  type 'a t = Cons of 'a * 'a list | Nil
+end
 [%%expect{|
-type t = #{ t : t; }
+module AbstractList : sig type 'a t end
 |}]
 
-
-type t : value = #{ t : t }
+type t = #{ tl: t AbstractList.t }
 [%%expect{|
-type t = #{ t : t; }
+type t = #{ tl : t AbstractList.t; }
 |}]
 
-(* CR layouts v7.2: Once we support unboxed records with elements of kind [any],
-   and detect bad recursive unboxed records with an occurs check, this error
-   should improve.
-*)
+type 'a mylist = Cons of 'a * 'a list | Nil
+and t = { t : t mylist } [@@unboxed]
+[%%expect{|
+type 'a mylist = Cons of 'a * 'a list | Nil
+and t = { t : t mylist; } [@@unboxed]
+|}]
+
+(* This passes the unboxed recursion check (as [pair] always has jkind
+   [value & value], [(int, bad) pair] is indeed finite-size, but it fails the
+   jkind check *)
+type ('a, 'b) pair = #{ a : 'a ; b : 'b }
+type bad = #{ bad : (int, bad) pair }
+[%%expect{|
+type ('a, 'b) pair = #{ a : 'a; b : 'b; }
+Line 2, characters 0-37:
+2 | type bad = #{ bad : (int, bad) pair }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error:
+       The layout of bad is value & value
+         because of the definition of pair at line 1, characters 0-41.
+       But the layout of bad must be a sublayout of value
+         because of the definition of pair at line 1, characters 0-41.
+|}]
+
+(* This fails the unboxed recursion check; we must look into [pair] since it's
+   part of the same mutually recursive type decl. *)
+type ('a, 'b) pair = #{ a : 'a ; b : 'b }
+and bad = #{ bad : (int, bad) pair }
+[%%expect{|
+Line 2, characters 0-36:
+2 | and bad = #{ bad : (int, bad) pair }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "bad" is recursive without boxing:
+         "bad" contains "(int, bad) pair",
+         "(int, bad) pair" contains "bad"
+|}]
+
+(* Guarded by a function *)
+type t = #{ f1 : t -> t ; f2 : t -> t }
+[%%expect{|
+type t = #{ f1 : t -> t; f2 : t -> t; }
+|}]
+
+(* Guarded by a tuple *)
+type a = #{ b : b }
+and b = a * a
+[%%expect{|
+type a = #{ b : b; }
+and b = a * a
+|}]
+
+(* Guarded by a function *)
+type a = #{ b : b }
+and b = #{ c1 : c ; c2 : c }
+and c = unit -> a
+[%%expect{|
+type a = #{ b : b; }
+and b = #{ c1 : c; c2 : c; }
+and c = unit -> a
+|}]
+
+(* Recursion through modules guarded by a function *)
+module rec A : sig
+  type t = #{ b1 : B.t ; b2 : B.t }
+end = struct
+  type t = #{ b1 : B.t ; b2 : B.t }
+end
+and B : sig
+  type t = unit -> A.t
+end = struct
+  type t = unit -> A.t
+end
+[%%expect{|
+module rec A : sig type t = #{ b1 : B.t; b2 : B.t; } end
+and B : sig type t = unit -> A.t end
+|}]
+
+(**********************************)
+(* Infinite-sized unboxed records *)
+
 type bad = #{ bad : bad ; i : int}
 [%%expect{|
 Line 1, characters 0-34:
 1 | type bad = #{ bad : bad ; i : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
-       The layout of bad is any & any
-         because it is an unboxed record.
-       But the layout of bad must be representable
-         because it is the type of record field bad.
-|}]
-
-type bad = #{ bad : bad }
-[%%expect{|
-Line 1, characters 0-25:
-1 | type bad = #{ bad : bad }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
-       The layout of bad is any
-         because a dummy kind of any is used to check mutually recursive datatypes.
-                 Please notify the Jane Street compilers group if you see this output.
-       But the layout of bad must be representable
-         because it is the type of record field bad.
+Error: The definition of "bad" is recursive without boxing:
+         "bad" contains "bad"
 |}]
 
 type a_bad = #{ b_bad : b_bad }
@@ -67,12 +127,9 @@ and b_bad = #{ a_bad : a_bad }
 Line 1, characters 0-31:
 1 | type a_bad = #{ b_bad : b_bad }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
-       The layout of a_bad is any
-         because a dummy kind of any is used to check mutually recursive datatypes.
-                 Please notify the Jane Street compilers group if you see this output.
-       But the layout of a_bad must be representable
-         because it is the type of record field a_bad.
+Error: The definition of "a_bad" is recursive without boxing:
+         "a_bad" contains "b_bad",
+         "b_bad" contains "a_bad"
 |}]
 
 type bad : any = #{ bad : bad }
@@ -80,23 +137,46 @@ type bad : any = #{ bad : bad }
 Line 1, characters 0-31:
 1 | type bad : any = #{ bad : bad }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
-       The layout of bad is any
-         because of the annotation on the declaration of the type bad.
-       But the layout of bad must be representable
-         because it is the type of record field bad.
+Error: The definition of "bad" is recursive without boxing:
+         "bad" contains "bad"
 |}]
 
-type 'a id = #{ a : 'a }
-type bad = bad id
+type bad = #{ x : #(int * u) }
+and u = T of bad [@@unboxed]
 [%%expect{|
-type 'a id = #{ a : 'a; }
-Line 2, characters 0-17:
-2 | type bad = bad id
-    ^^^^^^^^^^^^^^^^^
+Line 1, characters 0-30:
+1 | type bad = #{ x : #(int * u) }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "bad" is recursive without boxing:
+         "bad" contains "u",
+         "u" contains "bad"
+|}]
+
+type 'a record_id = #{ a : 'a }
+type 'a alias_id = 'a
+[%%expect{|
+type 'a record_id = #{ a : 'a; }
+type 'a alias_id = 'a
+|}]
+
+type bad = bad record_id
+[%%expect{|
+Line 1, characters 0-24:
+1 | type bad = bad record_id
+    ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The type abbreviation "bad" is cyclic:
-         "bad" = "bad id",
-         "bad id" contains "bad"
+         "bad" = "bad record_id",
+         "bad record_id" contains "bad"
+|}]
+
+type bad = bad alias_id
+[%%expect{|
+Line 1, characters 0-23:
+1 | type bad = bad alias_id
+    ^^^^^^^^^^^^^^^^^^^^^^^
+Error: The type abbreviation "bad" is cyclic:
+         "bad" = "bad alias_id",
+         "bad alias_id" = "bad"
 |}]
 
 
@@ -105,11 +185,8 @@ type 'a bad = #{ bad : 'a bad ; u : 'a}
 Line 1, characters 0-39:
 1 | type 'a bad = #{ bad : 'a bad ; u : 'a}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
-       The layout of 'a bad is any & any
-         because it is an unboxed record.
-       But the layout of 'a bad must be representable
-         because it is the type of record field bad.
+Error: The definition of "bad" is recursive without boxing:
+         "'a bad" contains "'a bad"
 |}]
 
 type 'a bad = { bad : 'a bad ; u : 'a}
@@ -117,80 +194,282 @@ type 'a bad = { bad : 'a bad ; u : 'a}
 type 'a bad = { bad : 'a bad; u : 'a; }
 |}]
 
-(****************************)
-(* A particularly bad error *)
-
 type bad : float64 = #{ bad : bad ; i : int}
 [%%expect{|
 Line 1, characters 0-44:
 1 | type bad : float64 = #{ bad : bad ; i : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "bad" is ((((((((((((((((((((((((((((((((((((
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (
-                                                                    (float64 & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value) & value
-         because it is an unboxed record.
-       But the layout of type "bad" must be a sublayout of float64
-         because of the annotation on the declaration of the type bad.
+Error: The definition of "bad" is recursive without boxing:
+         "bad" contains "bad"
+|}]
+
+type bad = #{ a : t ; b : t }
+[%%expect{|
+type bad = #{ a : t; b : t; }
+|}]
+
+type 'a bad = #{ a : 'a bad }
+[%%expect{|
+Line 1, characters 0-29:
+1 | type 'a bad = #{ a : 'a bad }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "bad" is recursive without boxing:
+         "'a bad" contains "'a bad"
+|}]
+
+type bad = #( s * s )
+and ('a : any) record_id2 = #{ a : 'a }
+and s = #{ u : u }
+and u = #(int * bad record_id2)
+[%%expect{|
+Line 1, characters 0-21:
+1 | type bad = #( s * s )
+    ^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "bad" is recursive without boxing:
+         "bad" = "#(s * s)",
+         "#(s * s)" contains "s",
+         "s" contains "u",
+         "u" = "#(int * bad record_id2)",
+         "#(int * bad record_id2)" contains "bad record_id2",
+         "bad record_id2" contains "bad"
+|}]
+
+type bad = #( s * s )
+and ('a : any) record_id2 = #{ a : 'a }
+and s = #{ u : u }
+and u = #(int * bad record_id2)
+[%%expect{|
+Line 1, characters 0-21:
+1 | type bad = #( s * s )
+    ^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "bad" is recursive without boxing:
+         "bad" = "#(s * s)",
+         "#(s * s)" contains "s",
+         "s" contains "u",
+         "u" = "#(int * bad record_id2)",
+         "#(int * bad record_id2)" contains "bad record_id2",
+         "bad record_id2" contains "bad"
+|}]
+
+(* We also check recursive types via modules *)
+module rec Bad_rec1 : sig
+  type t = #( s * s )
+  and s = #{ u : Bad_rec2.u }
+end = struct
+  type t = #( s * s )
+  and s = #{ u : Bad_rec2.u }
+end
+and Bad_rec2 : sig
+  type u = Bad_rec1.t id
+  and 'a id = 'a
+end = struct
+  type u = Bad_rec1.t id
+  and 'a id = 'a
+end
+[%%expect{|
+Lines 1-7, characters 0-3:
+1 | module rec Bad_rec1 : sig
+2 |   type t = #( s * s )
+3 |   and s = #{ u : Bad_rec2.u }
+4 | end = struct
+5 |   type t = #( s * s )
+6 |   and s = #{ u : Bad_rec2.u }
+7 | end
+Error: The definition of "Bad_rec1.t" is recursive without boxing:
+         "Bad_rec1.t" = "#(Bad_rec1.s * Bad_rec1.s)",
+         "#(Bad_rec1.s * Bad_rec1.s)" contains "Bad_rec1.s",
+         "Bad_rec1.s" contains "Bad_rec2.u",
+         "Bad_rec2.u" = "Bad_rec1.t Bad_rec2.id",
+         "Bad_rec1.t Bad_rec2.id" = "Bad_rec1.t"
+|}]
+
+(* When we allow records with elements of unrepresentable layout, this should
+   still be disallowed. *)
+module M : sig
+  type ('a : any) opaque_id : any
+end = struct
+  type ('a : any) opaque_id = 'a
+end
+[%%expect{|
+module M : sig type ('a : any) opaque_id : any end
+|}]
+type a = #{ b : b M.opaque_id }
+and b = #{ a : a M.opaque_id }
+[%%expect{|
+Line 1, characters 12-29:
+1 | type a = #{ b : b M.opaque_id }
+                ^^^^^^^^^^^^^^^^^
+Error: Unboxed record element types must have a representable layout.
+       The layout of b M.opaque_id is any
+         because of the definition of opaque_id at line 2, characters 2-33.
+       But the layout of b M.opaque_id must be representable
+         because it is the type of record field b.
+|}]
+
+(* Make sure we look through [as] types *)
+
+type 'a t = #{ x: ('a s as 'm) list ; m : 'm }
+and 'b s = #{ x : 'b t }
+[%%expect{|
+Line 1, characters 0-46:
+1 | type 'a t = #{ x: ('a s as 'm) list ; m : 'm }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t" is recursive without boxing:
+         "'a t" contains "'a s",
+         "'a s" contains "'a t"
+|}]
+
+type 'a t = #{ x: ('a s as 'm) }
+and 'b s = #{ x : 'b t }
+[%%expect{|
+Line 1, characters 0-32:
+1 | type 'a t = #{ x: ('a s as 'm) }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t" is recursive without boxing:
+         "'a t" contains "'a s",
+         "'a s" contains "'a t"
+|}]
+
+(***************************************)
+(* Singleton recursive unboxed records *)
+
+type 'a safe = #{ a : 'a }
+type x = int safe safe
+[%%expect{|
+type 'a safe = #{ a : 'a; }
+type x = int safe safe
+|}]
+
+type 'a id = 'a
+type x = #{ x : x id }
+[%%expect{|
+type 'a id = 'a
+type x = #{ x : x id; }
+|}]
+
+(* CR layouts v7.2: allow bounded repetition of the same type constructor of
+   unboxed records. *)
+type 'a safe = #{ a : 'a }
+and x = int safe safe
+[%%expect{|
+Line 2, characters 0-21:
+2 | and x = int safe safe
+    ^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "x" is recursive without boxing:
+         "x" = "int safe safe",
+         "int safe safe" contains "int safe"
+|}]
+
+(* We could allow these, as although they have unguarded recursion,
+   they are finite size (thanks to the fact that we represent single-field
+   records as the layout of the field rather than as a singleton product).
+   However, allowing them makes checking for recursive types more difficult,
+   and they are uninhabitable anyway. *)
+
+type bad : value = #{ bad : bad }
+[%%expect{|
+Line 1, characters 0-33:
+1 | type bad : value = #{ bad : bad }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "bad" is recursive without boxing:
+         "bad" contains "bad"
+|}]
+
+type bad : float64 = #{ bad : bad }
+[%%expect{|
+Line 1, characters 0-35:
+1 | type bad : float64 = #{ bad : bad }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "bad" is recursive without boxing:
+         "bad" contains "bad"
+|}]
+
+
+type bad : value = #{ bad : bad }
+[%%expect{|
+Line 1, characters 0-33:
+1 | type bad : value = #{ bad : bad }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "bad" is recursive without boxing:
+         "bad" contains "bad"
+|}]
+
+type bad = #{ bad : bad }
+[%%expect{|
+Line 1, characters 0-25:
+1 | type bad = #{ bad : bad }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "bad" is recursive without boxing:
+         "bad" contains "bad"
+|}]
+
+(* We actually can create singleton recursive unboxed record types,
+   through recursive modules *)
+
+module F (X : sig type t end) = struct
+  type u = #{ u : X.t }
+end
+
+module rec M : sig
+  type u
+  type t = u
+end = struct
+  include F(M)
+  type t = u
+end
+[%%expect{|
+module F : functor (X : sig type t end) -> sig type u = #{ u : X.t; } end
+module rec M : sig type u type t = u end
+|}]
+
+module F (X : sig
+    type u
+    type t = #{ u : u }
+  end) = struct
+  type u = X.t = #{ u : X.u }
+end
+
+module rec M : sig
+  type u
+  type t = #{ u : u }
+end = struct
+  include F(M)
+  type t = #{ u : u }
+  let rec u = #{ u }
+end
+[%%expect{|
+module F :
+  functor (X : sig type u type t = #{ u : u; } end) ->
+    sig type u = X.t = #{ u : X.u; } end
+Line 14, characters 14-20:
+14 |   let rec u = #{ u }
+                   ^^^^^^
+Error: This kind of expression is not allowed as right-hand side of "let rec"
+|}]
+
+
+(* This should still error once unboxed records elements need not have a
+   representable layout *)
+module type S = sig
+  type u : any
+  type t = #{ a : u ; b : u }
+end
+module F (X : S) = struct
+  type u = X.t = #{ a : X.u ; b : X.u}
+end
+
+module rec M : S = struct
+  include F(M)
+  type t = #{ a : u ; b : u }
+  let rec u = #{ u ; u }
+end
+[%%expect{|
+Line 3, characters 14-21:
+3 |   type t = #{ a : u ; b : u }
+                  ^^^^^^^
+Error: Unboxed record element types must have a representable layout.
+       The layout of u is any
+         because of the definition of u at line 2, characters 2-14.
+       But the layout of u must be representable
+         because it is the type of record field a.
 |}]

--- a/testsuite/tests/typing-layouts-products/unboxed_records_alpha.ml
+++ b/testsuite/tests/typing-layouts-products/unboxed_records_alpha.ml
@@ -25,7 +25,11 @@ type t = { x : t_void; } [@@unboxed]
 
 type bad : void = #{ bad : bad }
 [%%expect{|
-type bad = #{ bad : bad; }
+Line 1, characters 0-32:
+1 | type bad : void = #{ bad : bad }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "bad" is recursive without boxing:
+         "bad" contains "bad"
 |}]
 
 type ('a : void) bad  = #{ bad : 'a bad ; u : 'a}
@@ -33,11 +37,8 @@ type ('a : void) bad  = #{ bad : 'a bad ; u : 'a}
 Line 1, characters 0-49:
 1 | type ('a : void) bad  = #{ bad : 'a bad ; u : 'a}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error:
-       The layout of 'a bad is any & any
-         because it is an unboxed record.
-       But the layout of 'a bad must be representable
-         because it is the type of record field bad.
+Error: The definition of "bad" is recursive without boxing:
+         "'a bad" contains "'a bad"
 |}]
 
 (******************************************************************************)

--- a/testsuite/tests/typing-unboxed-types/test.ml
+++ b/testsuite/tests/typing-unboxed-types/test.ml
@@ -108,17 +108,24 @@ Error: This type cannot be unboxed because
        its constructor has more than one field.
 |}];;
 
-(* let rec must be rejected *)
+(* This test was made to error by disallowing singleton recursive unboxed types.
+   We keep it in case these are re-allowed, in which case it should error with:
+   [This kind of expression is not allowed as right-hand side of "let rec"] *)
 type t10 : value = A of t10 [@@ocaml.unboxed];;
 [%%expect{|
-type t10 = A of t10 [@@unboxed]
+Line 1, characters 0-45:
+1 | type t10 : value = A of t10 [@@ocaml.unboxed];;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t10" is recursive without boxing:
+         "t10" contains "t10"
 |}];;
 let rec x = A x;;
 [%%expect{|
-Line 1, characters 12-15:
+Line 1, characters 14-15:
 1 | let rec x = A x;;
-                ^^^
-Error: This kind of expression is not allowed as right-hand side of "let rec"
+                  ^
+Error: This expression has type "t1" but an expression was expected of type
+         "string"
 |}];;
 
 (* Representation mismatch between module and signature must be rejected *)
@@ -352,29 +359,51 @@ in assert (f x = #{ f = 3.14});;
 - : unit = ()
 |}];;
 
-(* Check for a potential infinite loop in the typing algorithm. *)
+(* Check for a potential infinite loop in the typing algorithm.
+   (This test was made to error upon disallowing singleton recursive [@@unboxed]
+   types. We keep it around in case these are re-allowed.) *)
 type 'a t12 = M of 'a t12 [@@ocaml.unboxed];;
 [%%expect{|
-type 'a t12 = M of 'a t12 [@@unboxed]
+Line 1, characters 0-43:
+1 | type 'a t12 = M of 'a t12 [@@ocaml.unboxed];;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t12" is recursive without boxing:
+         "'a t12" contains "'a t12"
 |}];;
 let f (a : int t12 array) = a.(0);;
 [%%expect{|
-val f : int t12 array -> int t12 = <fun>
+Line 1, characters 15-18:
+1 | let f (a : int t12 array) = a.(0);;
+                   ^^^
+Error: Unbound type constructor "t12"
+Hint: Did you mean "t1", "t11" or "t2"?
 |}];;
 
 type 'a t12 : value = #{ a : 'a t12 };;
 [%%expect{|
-type 'a t12 = #{ a : 'a t12; }
+Line 1, characters 0-37:
+1 | type 'a t12 : value = #{ a : 'a t12 };;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "t12" is recursive without boxing:
+         "'a t12" contains "'a t12"
 |}];;
 let f (a : int t12 array) = a.(0);;
 [%%expect{|
-val f : int t12 array -> int t12 = <fun>
+Line 1, characters 15-18:
+1 | let f (a : int t12 array) = a.(0);;
+                   ^^^
+Error: Unbound type constructor "t12"
+Hint: Did you mean "t1", "t11" or "t2"?
 |}];;
 
 (* Check for another possible loop *)
 type t13 = A : _ t12 -> t13 [@@ocaml.unboxed];;
 [%%expect{|
-type t13 = A : 'a t12 -> t13 [@@unboxed]
+Line 1, characters 17-20:
+1 | type t13 = A : _ t12 -> t13 [@@ocaml.unboxed];;
+                     ^^^
+Error: Unbound type constructor "t12"
+Hint: Did you mean "t1", "t11", "t13" or "t2"?
 |}];;
 
 

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -756,7 +756,11 @@ Error: The native code version of the primitive is mandatory
 (* PR#7424 *)
 type 'a b = B of 'a b b [@@unboxed];;
 [%%expect{|
-type 'a b = B of 'a b b [@@unboxed]
+Line 1, characters 0-35:
+1 | type 'a b = B of 'a b b [@@unboxed];;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The definition of "b" is recursive without boxing:
+         "'a b" contains "'a b b"
 |}]
 
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2116,6 +2116,20 @@ let unbox_once env ty =
   | Tpoly (ty, _) -> Stepped ty
   | _ -> Final_result
 
+let contained_without_boxing env ty =
+  match get_desc ty with
+  | Tconstr _ ->
+    begin match unbox_once env ty with
+    | Stepped ty -> [ty]
+    | Stepped_record_unboxed_product tys -> tys
+    | Final_result | Missing _ -> []
+    end
+  | Tunboxed_tuple labeled_tys ->
+    List.map snd labeled_tys
+  | Tpoly (ty, _) -> [ty]
+  | Tvar _ | Tarrow _ | Ttuple _ | Tobject _ | Tfield _ | Tnil | Tlink _
+  | Tsubst _ | Tvariant _ | Tunivar _ | Tpackage _ -> []
+
 (* We use ty_prev to track the last type for which we found a definition,
    allowing us to return a type for which a definition was found even if
    we eventually bottom out at a missing cmi file, or otherwise. *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -581,6 +581,10 @@ val get_unboxed_type_approximation : Env.t -> type_expr -> type_expr
        [get_unboxed_type_representation], but doesn't indicate whether the type
        was fully expanded or not. *)
 
+val contained_without_boxing : Env.t -> type_expr -> type_expr list
+    (* Return all types that are directly contained without boxing
+      (or "without indirection" or "flatly") *)
+
 (* Given the row from a variant type, determine if it is immediate.  Currently
    just checks that all constructors have no arguments, doesn't consider
    void. *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -89,6 +89,7 @@ type error =
   | Unboxed_mutable_label
   | Recursive_abbrev of string * Env.t * reaching_type_path
   | Cycle_in_def of string * Env.t * reaching_type_path
+  | Unboxed_recursion of string * Env.t * reaching_type_path
   | Definition_mismatch of type_expr * Env.t * Includecore.type_mismatch option
   | Constraint_failed of Env.t * Errortrace.unification_error
   | Inconsistent_constraint of Env.t * Errortrace.unification_error
@@ -2065,6 +2066,105 @@ let check_well_founded_decl  ~abs_env env loc path decl to_check =
        end)} in
   it.it_type_declaration it (Ctype.generic_instance_declaration decl)
 
+(* We only allow recursion in unboxed product types to occur through boxes,
+   otherwise the type is uninhabitable and usually also infinite-size.
+   See [typing-layouts-unboxed-records/recursive.ml].
+
+   Because [check_well_founded] already ruled out recursion through structural
+   types, we just look for a cycle in nominal unboxed types ([@@unboxed] types
+   and unboxed records), tracking the set of seen paths.
+
+   For each group of mutually recursive type declarations, we define the
+   following "type contains" transitive relation on type expressions:
+
+   1. Unboxed records and variants defined in the group contain their fields.
+
+      If [type 'a t = #{ ...; lbl : u;  ... }],
+      or [type 'a t = { lbl : u } [@@unboxed]],
+      or [type 'a t = U of u [@@unboxed]]
+      is in the recursive group, then ['a t] contains [u].
+
+   2. Abbreviations defined in the group contain their expansions.
+
+      If [type 'a t = u] is in the recursive group then ['a t] contains [u].
+
+   3. Unboxed tuples contain their components.
+
+      [#(u_1 * ...)] contains all [u_i].
+
+   4. Types not in the group contain the parameters indicated by their layout.
+
+      ['a t] contains ['a] if [layout_of 'a] or [any] occurs in ['a t]'s layout.
+      Note: We don't yet have [layout_of], so currently only consider [any].
+
+   If a path starting from the type expression on the LHS of a declaration
+   contains two types with the same head type constructor, and that repeated
+   type is an unboxed record or variant, then the check raises a type error.
+
+   CR layouts v7.2: accept safe types that expand the same path multiple times,
+   e.g. [type 'a t = #{ a : 'a } and x = int t t], either by using layouts
+   variables or the algorithm from "Unboxed data constructors - or, how cpp
+   decides a halting problem."
+   See https://github.com/ocaml-flambda/flambda-backend/pull/3407.
+*)
+type step_result =
+  | Contained of type_expr list
+  | Expanded_to of type_expr
+  | Is_cyclic
+let check_unboxed_recursion ~abs_env env loc path0 ty0 to_check =
+  let contained_parameters tyl layout =
+    (* A type whose layout has [any] could contain all its parameters.
+       CR layouts v11: update this function for [layout_of] layouts. *)
+    let rec has_any : Jkind_types.Layout.Const.t -> bool = function
+      | Any -> true
+      | Base _ -> false
+      | Product l -> List.exists has_any l
+    in
+    if has_any layout then tyl else []
+  in
+  let step_once parents ty =
+    match get_desc ty with
+    | Tconstr (path, tyl, _) ->
+      if to_check path then
+        if Path.Set.mem path parents then
+          Is_cyclic, parents
+        else
+          let parents = Path.Set.add path parents in
+          match Ctype.try_expand_safe_opt env ty with
+          | ty' ->
+            Expanded_to ty', parents
+          | exception Ctype.Cannot_expand ->
+            Contained (Ctype.contained_without_boxing env ty), parents
+      else
+        begin try
+          (* Determine contained types by layout for decls outside of the
+             recursive group *)
+          let jkind = (Env.find_type path env).type_jkind in
+          let layout = Option.get (Jkind.get_layout jkind) in
+          Contained (contained_parameters tyl layout), parents
+        with Not_found | Invalid_argument _ ->
+          (* Because [to_check path] is false, this decl has already been
+            typechecked, so it's already in [env] with a constant layout. *)
+          Misc.fatal_error "Typedecl.check_unboxed_recursion"
+        end
+    | _ -> Contained (Ctype.contained_without_boxing env ty), parents
+  in
+  let rec visit parents trace ty =
+    match step_once parents ty with
+    | Contained tys, parents ->
+      List.iter (fun ty' -> visit parents (Contains (ty, ty') :: trace) ty') tys
+    | Expanded_to ty', parents ->
+      visit parents (Expands_to(ty,ty') :: trace) ty'
+    | Is_cyclic, _ ->
+      raise (Error (loc, Unboxed_recursion (path0, abs_env, List.rev trace)))
+  in
+  Ctype.wrap_trace_gadt_instances env (visit Path.Set.empty []) ty0
+
+let check_unboxed_recursion_decl ~abs_env env loc path decl to_check =
+  let decl = Ctype.generic_instance_declaration decl in
+  let ty = Btype.newgenty (Tconstr (path, decl.type_params, ref Mnil)) in
+  check_unboxed_recursion ~abs_env env loc (Path.name path) ty to_check
+
 (* Check for non-regular abbreviations; an abbreviation
    [type 'a t = ...] is non-regular if the expansion of [...]
    contains instances [ty t] where [ty] is not equal to ['a].
@@ -2353,6 +2453,11 @@ let transl_type_decl env rec_flag sdecl_list =
     decls;
   List.iter (fun (tdecl, _shape) ->
     check_abbrev_regularity ~abs_env new_env id_loc_list to_check tdecl) tdecls;
+  List.iter (fun (id, decl) ->
+    check_unboxed_recursion_decl ~abs_env new_env (List.assoc id id_loc_list)
+      (Path.Pident id)
+      decl to_check)
+    decls;
   (* Now that we've ruled out ill-formed types, we can perform the delayed
      jkind checks *)
   List.iter (fun (checks,loc) ->
@@ -3438,6 +3543,7 @@ let check_recmod_typedecl env loc recmod_ids path decl =
      (path, decl) is the type declaration to be checked. *)
   let to_check path = Path.exists_free recmod_ids path in
   check_well_founded_decl ~abs_env:env env loc path decl to_check;
+  check_unboxed_recursion_decl ~abs_env:env env loc path decl to_check;
   check_regularity ~abs_env:env env loc path decl to_check;
   (* additional coherence check, as one might build an incoherent signature,
      and use it to build an incoherent module, cf. #7851 *)
@@ -3492,8 +3598,10 @@ module Reaching_path = struct
 
   (* Simplify a reaching path before showing it in error messages. *)
   let simplify path =
+    let is_tconstr ty = match get_desc ty with Tconstr _ -> true | _ -> false in
     let rec simplify : t -> t = function
-      | Contains (ty1, _ty2) :: Contains (_ty2', ty3) :: rest ->
+      | Contains (ty1, _ty2) :: Contains (ty2', ty3) :: rest
+        when not (is_tconstr ty2') ->
           (* If t1 contains t2 and t2 contains t3, then t1 contains t3
              and we don't need to show t2. *)
           simplify (Contains (ty1, ty3) :: rest)
@@ -3579,6 +3687,14 @@ let report_error ppf = function
       Printtyp.reset ();
       Reaching_path.add_to_preparation reaching_path;
       fprintf ppf "@[<v>The definition of %a contains a cycle%a@]"
+        Style.inline_code s
+        Reaching_path.pp_colon reaching_path
+  | Unboxed_recursion (s, env, reaching_path) ->
+      let reaching_path = Reaching_path.simplify reaching_path in
+      Printtyp.wrap_printing_env ~error:true env @@ fun () ->
+      Printtyp.reset ();
+      Reaching_path.add_to_preparation reaching_path;
+      fprintf ppf "@[<v>The definition of %a is recursive without boxing%a@]"
         Style.inline_code s
         Reaching_path.pp_colon reaching_path
   | Definition_mismatch (ty, _env, None) ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2095,6 +2095,11 @@ let check_well_founded_decl  ~abs_env env loc path decl to_check =
    4. Types not in the group contain the parameters indicated by their layout.
 
       ['a t] contains ['a] if [layout_of 'a] or [any] occurs in ['a t]'s layout.
+
+      For example, if [('a, 'b) t] has layout [layout_of 'a], it may contain
+      ['a], but not ['b]. If it has layout [any], we must conservatively
+      consider it to contain both ['a] and ['b].
+
       Note: We don't yet have [layout_of], so currently only consider [any].
 
    If a path starting from the type expression on the LHS of a declaration

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -125,6 +125,7 @@ type error =
   | Unboxed_mutable_label
   | Recursive_abbrev of string * Env.t * reaching_type_path
   | Cycle_in_def of string * Env.t * reaching_type_path
+  | Unboxed_recursion of string * Env.t * reaching_type_path
   | Definition_mismatch of type_expr * Env.t * Includecore.type_mismatch option
   | Constraint_failed of Env.t * Errortrace.unification_error
   | Inconsistent_constraint of Env.t * Errortrace.unification_error


### PR DESCRIPTION
## Summary

We only allow recursion in unboxed types to occur through boxes, otherwise the type is uninhabitable and usually also infinite-size.

Because `check_well_founded` already ruled out recursion through structural types (in our case, we care about unboxed tuples and aliases), we just look for a cycle in nominal unboxed types (`[@@unboxed]` types and unboxed records), tracking the set of seen paths. This gives an algorithm that is simpler than `check_well_founded` (whose correctness relies on some subtle properties of `Tconstr`'s `abbrev_memo`).

We newly disallow recursive singleton `[@@unboxed]` types (`type t = { t : t } [@@unboxed]`), which are uninhabitable anyway.

## Specification

For each group of mutually recursive type declarations, we define the following "type contains" transitive relation on type expressions:
- Unboxed records and variants defined in the group contain their fields
  - If `type 'a t = #{ ...; lbl : u;  ... }`, `type 'a t = { lbl : u } [@@unboxed]`, or `type 'a t = U of u [@@unboxed]` is in the recursive group, then `'a t` contains `u`
- Abbreviations defined in the group contain their expansions
  - If `type 'a t = u` is in the recursive group then `'a t` contains `u`
- Types not in the recursive group contain the parameters indicated by their layout
  - `'a t` contains `'a` if `layout_of 'a` or `any` occurs in `'a t`'s layout
  - We don't yet have `layout_of`, so currently only consider `any`
- Unboxed tuples contain their components: `#(u_1 * u_2 * ...)` contains all `u_i`

(`'a` is a metavariable for zero or more type parameters; `t` is a metavariable for type constructors; `u` is a metavariable for type expressions)

If a path starting from the type expression on the LHS of a declaration contains two types with the same head type constructor, and that repeated type is an unboxed record or variant, then we give an error.

## Examples
```ocaml
type t = #{ t : t list }
(* Allowed, [t list] is not in this recursive group, and
   has layout [value] so it doesn't contain anything *)

type t = #{ x : #(int * u) }
and u = T of t [@@unboxed]
(* Banned, t -> #(int * u) -> u -> t *)

type 'a id = #{ a : 'a }
type t = int id id
(* Allowed, [int id] is not in this recursive group, and
   has layout [value] so it doesn't contain anything *)

type 'a id = #{ a : 'a }
and t = int id id
(* Sadly, banned. t -> int id id -> int id; id appears twice *)
```

See [`typing-layouts-unboxed-records/recursive.ml`](https://github.com/ocaml-flambda/flambda-backend/blob/rtjoa.check-type-recursion-without-indirection/testsuite/tests/typing-layouts-unboxed-records/recursive.ml) for more.

## Alternatives

**Layout variables.** We could introduce layout variables (for this check only), finding infinite-size types via the occurs check. Such an implementation might be more principled, accepting finite-size recursive types like `type t = #{ t : t }`. The current implementation gives more informative error traces, and leaves the flexiblity to switch to a less restrictive check in the future.

**The algorithm from the [Unboxed data constructors](https://arxiv.org/pdf/2311.07369) paper.** This would accept types like `type 'a id = #{ a : 'a } and t = int id id`. I think this could be an appealing final solution, but some details are a bit subtle. See discussion on https://github.com/ocaml/ocaml/pull/10479.

**Generalize `check_well_founded`.** My first implementation, which roughly generalizes `check_well_founded` over the "type contains" relation, accepts `type 'a id = #{ a : 'a } and t = int id id`. (On [`rtjoa.check-well-founded-unboxed-recursion`](https://github.com/ocaml-flambda/flambda-backend/tree/rtjoa.check-well-founded-unboxed-recursion), unpolished.) I'd hesitate to increase our reliance on `check_well_founded`, which I believe roughly implements the same algorithm as the paper above in a tricky way.

---

Review: @goldfirere 