### PR TITLE
Delete Jkind_axis.Modal in favor of Mode.Alloc.axis

### DIFF
--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1204,10 +1204,10 @@ module Jkind_desc = struct
     in
     let upper_bounds = to_.upper_bounds in
     let upper_bounds, added1 =
-      add_crossing ~axis:(Modal Portability) upper_bounds
+      add_crossing ~axis:(Modal (Comonadic Portability)) upper_bounds
     in
     let upper_bounds, added2 =
-      add_crossing ~axis:(Modal Contention) upper_bounds
+      add_crossing ~axis:(Modal (Monadic Contention)) upper_bounds
     in
     { to_ with upper_bounds }, added1 || added2
 
@@ -1613,19 +1613,19 @@ let extract_layout jk = jk.jkind.layout
 let get_modal_upper_bounds ~type_equal ~jkind_of_type jk : Alloc.Const.t =
   let bounds = jk.jkind.upper_bounds in
   { areality =
-      Bound.reduce ~axis:(Modal Locality) ~type_equal ~jkind_of_type
+      Bound.reduce ~axis:(Modal (Comonadic Areality)) ~type_equal ~jkind_of_type
         bounds.locality;
     linearity =
-      Bound.reduce ~axis:(Modal Linearity) ~type_equal ~jkind_of_type
-        bounds.linearity;
+      Bound.reduce ~axis:(Modal (Comonadic Linearity)) ~type_equal
+        ~jkind_of_type bounds.linearity;
     uniqueness =
-      Bound.reduce ~axis:(Modal Uniqueness) ~type_equal ~jkind_of_type
+      Bound.reduce ~axis:(Modal (Monadic Uniqueness)) ~type_equal ~jkind_of_type
         bounds.uniqueness;
     portability =
-      Bound.reduce ~axis:(Modal Portability) ~type_equal ~jkind_of_type
-        bounds.portability;
+      Bound.reduce ~axis:(Modal (Comonadic Portability)) ~type_equal
+        ~jkind_of_type bounds.portability;
     contention =
-      Bound.reduce ~axis:(Modal Contention) ~type_equal ~jkind_of_type
+      Bound.reduce ~axis:(Modal (Monadic Contention)) ~type_equal ~jkind_of_type
         bounds.contention
   }
 

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -175,71 +175,13 @@ module Axis = struct
     | Nonmodal Externality -> true
     | Nonmodal Nullability -> false
 
-  (* CR aspsmith: This can get a lot simpler once we unify jkind axes with the axes in
-     Mode *)
-  let modality_is_const_for_axis (type a) (t : a t) modality =
+  let modality_is_const_for_axis (type a) (t : a t)
+      (modality : Mode.Modality.Value.Const.t) =
     match t with
     | Nonmodal Nullability | Nonmodal Externality -> false
     | Modal axis ->
-      let atoms = Mode.Modality.Value.Const.to_list modality in
-      List.exists
-        (fun (modality : Mode.Modality.t) ->
-          match axis, modality with
-          (* Constant modalities *)
-          | Comonadic Areality, Atom (Comonadic Areality, Meet_with Global) ->
-            true
-          | Comonadic Linearity, Atom (Comonadic Linearity, Meet_with Many) ->
-            true
-          | Monadic Uniqueness, Atom (Monadic Uniqueness, Join_with Aliased) ->
-            true
-          | ( Comonadic Portability,
-              Atom (Comonadic Portability, Meet_with Portable) ) ->
-            true
-          | Monadic Contention, Atom (Monadic Contention, Join_with Contended)
-            ->
-            true
-          (* Modalities which are actually identity *)
-          | Comonadic Areality, Atom (Comonadic Areality, Meet_with Local)
-          | Comonadic Linearity, Atom (Comonadic Linearity, Meet_with Once)
-          | Monadic Uniqueness, Atom (Monadic Uniqueness, Join_with Unique)
-          | ( Comonadic Portability,
-              Atom (Comonadic Portability, Meet_with Nonportable) )
-          | Monadic Contention, Atom (Monadic Contention, Join_with Uncontended)
-            ->
-            false
-          (* Modalities which are neither constant nor identiy *)
-          | Comonadic Areality, Atom (Comonadic Areality, Meet_with Regional)
-          | Monadic Contention, Atom (Monadic Contention, Join_with Shared) ->
-            Misc.fatal_error
-              "Don't yet know how to interpret non-constant, non-identity \
-               modalities"
-          (* Modalities which join or meet on an illegal axis *)
-          | _, Atom (Comonadic _, Join_with _) | _, Atom (Monadic _, Meet_with _)
-            ->
-            Misc.fatal_error "Illegal modality"
-          (* Mismatched axes *)
-          | Comonadic Areality, Atom (Monadic Uniqueness, _)
-          | Comonadic Areality, Atom (Monadic Contention, _)
-          | Comonadic Areality, Atom (Comonadic Linearity, _)
-          | Comonadic Areality, Atom (Comonadic Portability, _)
-          | Comonadic Linearity, Atom (Comonadic Areality, _)
-          | Comonadic Linearity, Atom (Monadic Uniqueness, _)
-          | Comonadic Portability, Atom (Monadic Uniqueness, _)
-          | Monadic Contention, Atom (Monadic Uniqueness, _)
-          | Comonadic Linearity, Atom (Comonadic Portability, _)
-          | Comonadic Linearity, Atom (Monadic Contention, _)
-          | Monadic Uniqueness, Atom (Comonadic Areality, _)
-          | Monadic Uniqueness, Atom (Comonadic Linearity, _)
-          | Monadic Uniqueness, Atom (Comonadic Portability, _)
-          | Monadic Contention, Atom (Comonadic Areality, _)
-          | Monadic Contention, Atom (Comonadic Linearity, _)
-          | Monadic Contention, Atom (Comonadic Portability, _)
-          | Monadic Uniqueness, Atom (Monadic Contention, _)
-          | Comonadic Portability, Atom (Comonadic Areality, _)
-          | Comonadic Portability, Atom (Comonadic Linearity, _)
-          | Comonadic Portability, Atom (Monadic Contention, _) ->
-            false)
-        atoms
+      let (P axis) = Mode.Const.Axis.alloc_as_value axis in
+      Mode.Modality.Value.Const.is_constant_for axis modality
 end
 
 module type Axed = sig

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -154,7 +154,7 @@ module Axis = struct
     match t with
     | Nonmodal Nullability | Nonmodal Externality -> false
     | Modal axis ->
-      let (P axis) = Mode.Const.Axis.alloc_as_value axis in
+      let (P axis) = Mode.Const.Axis.alloc_as_value (P axis) in
       let modality = Mode.Modality.Value.Const.proj axis modality in
       if Mode.Modality.is_constant modality
       then true

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -155,7 +155,15 @@ module Axis = struct
     | Nonmodal Nullability | Nonmodal Externality -> false
     | Modal axis ->
       let (P axis) = Mode.Const.Axis.alloc_as_value axis in
-      Mode.Modality.Value.Const.is_constant_for axis modality
+      let modality = Mode.Modality.Value.Const.proj axis modality in
+      if Mode.Modality.is_constant modality
+      then true
+      else if Mode.Modality.is_id modality
+      then false
+      else
+        Misc.fatal_error
+          "Don't yet know how to interpret non-constant, non-identity \
+           modalities"
 end
 
 module type Axed = sig

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -121,30 +121,8 @@ module Axis = struct
 
   type packed = Pack : 'a t -> packed
 
-  module Accent_lattice (M : Mode_intf.Lattice) = struct
-    (* A functor to add some convenient functions to modal axes *)
-    include M
-
-    let less_or_equal a b : Misc.Le_result.t =
-      match le a b, le b a with
-      | true, true -> Equal
-      | true, false -> Less
-      | false, _ -> Not_le
-
-    let equal a b = Misc.Le_result.is_equal (less_or_equal a b)
-  end
-
   let get (type a) : a t -> (module Lattice with type t = a) = function
-    | Modal (Comonadic Areality) ->
-      (module Accent_lattice (Mode.Locality.Const) : Lattice with type t = a)
-    | Modal (Comonadic Linearity) ->
-      (module Accent_lattice (Mode.Linearity.Const) : Lattice with type t = a)
-    | Modal (Monadic Uniqueness) ->
-      (module Accent_lattice (Mode.Uniqueness.Const) : Lattice with type t = a)
-    | Modal (Comonadic Portability) ->
-      (module Accent_lattice (Mode.Portability.Const) : Lattice with type t = a)
-    | Modal (Monadic Contention) ->
-      (module Accent_lattice (Mode.Contention.Const) : Lattice with type t = a)
+    | Modal axis -> Mode.Alloc.lattice_of_axis axis
     | Nonmodal Externality -> (module Externality : Lattice with type t = a)
     | Nonmodal Nullability -> (module Nullability : Lattice with type t = a)
 
@@ -158,11 +136,7 @@ module Axis = struct
       Pack (Nonmodal Nullability) ]
 
   let name (type a) : a t -> string = function
-    | Modal (Comonadic Areality) -> "locality"
-    | Modal (Comonadic Linearity) -> "linearity"
-    | Modal (Monadic Uniqueness) -> "uniqueness"
-    | Modal (Comonadic Portability) -> "portability"
-    | Modal (Monadic Contention) -> "contention"
+    | Modal axis -> Format.asprintf "%a" Mode.Alloc.print_axis axis
     | Nonmodal Externality -> "externality"
     | Nonmodal Nullability -> "nullability"
 

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -35,16 +35,6 @@ module Nullability : sig
 end
 
 module Axis : sig
-  (* CR zqian: remove this and use [Mode.Alloc.axis] instead *)
-  module Modal : sig
-    type 'a t =
-      | Locality : Mode.Locality.Const.t t
-      | Linearity : Mode.Linearity.Const.t t
-      | Uniqueness : Mode.Uniqueness.Const.t t
-      | Portability : Mode.Portability.Const.t t
-      | Contention : Mode.Contention.Const.t t
-  end
-
   module Nonmodal : sig
     type 'a t =
       | Externality : Externality.t t
@@ -53,8 +43,8 @@ module Axis : sig
 
   (** Represents an axis of a jkind *)
   type 'a t =
-    | Modal of 'a Modal.t
-    | Nonmodal of 'a Nonmodal.t
+    | Modal : ('m, 'a, 'd) Mode.Alloc.axis -> 'a t
+    | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2594,8 +2594,6 @@ module Modality = struct
 
       let id = { monadic = Monadic.id; comonadic = Comonadic.id }
 
-      let modality_is_id = is_id
-
       let is_id { monadic; comonadic } =
         Monadic.is_id monadic && Comonadic.is_id comonadic
 
@@ -2637,17 +2635,6 @@ module Modality = struct
         match ax with
         | Monadic ax -> Monadic.proj ax monadic
         | Comonadic ax -> Comonadic.proj ax comonadic
-
-      let is_constant_for (type m a d) (axis : (m, a, d) Value.axis) t =
-        let modality = proj axis t in
-        if is_constant modality
-        then true
-        else if modality_is_id modality
-        then false
-        else
-          Misc.fatal_error
-            "Don't yet know how to interpret non-constant, non-identity \
-             modalities"
     end
 
     type t = (Monadic.t, Comonadic.t) monadic_comonadic

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1742,6 +1742,8 @@ module Value_with (Areality : Areality) = struct
         (Comonadic.Const.t, 'a) Axis.t
         -> (('a, 'd) mode_comonadic, 'a, 'd) axis
 
+  type 'd axis_packed = P : ('m, 'a, 'd) axis -> 'd axis_packed
+
   let print_axis (type m a d) ppf (axis : (m, a, d) axis) =
     match axis with
     | Monadic ax -> Axis.print ppf ax
@@ -2199,16 +2201,13 @@ module Const = struct
     { areality; linearity; portability; uniqueness; contention }
 
   module Axis = struct
-    type 'd packed_value_axis =
-      | P : ('m, 'a, 'd) Value.axis -> 'd packed_value_axis
-
-    let alloc_as_value : type m a d. (m, a, d) Alloc.axis -> d packed_value_axis
-        = function
-      | Comonadic Areality -> P (Comonadic Areality)
-      | Comonadic Linearity -> P (Comonadic Linearity)
-      | Comonadic Portability -> P (Comonadic Portability)
-      | Monadic Uniqueness -> P (Monadic Uniqueness)
-      | Monadic Contention -> P (Monadic Contention)
+    let alloc_as_value : type d. d Alloc.axis_packed -> d Value.axis_packed =
+      function
+      | P (Comonadic Areality) -> P (Comonadic Areality)
+      | P (Comonadic Linearity) -> P (Comonadic Linearity)
+      | P (Comonadic Portability) -> P (Comonadic Portability)
+      | P (Monadic Uniqueness) -> P (Monadic Uniqueness)
+      | P (Monadic Contention) -> P (Monadic Contention)
   end
 
   let locality_as_regionality = C.locality_as_regionality

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -567,7 +567,7 @@ module Lattices_mono = struct
 
     let print : type p r. _ -> (p, r) t -> unit =
      fun ppf -> function
-      | Areality -> Format.fprintf ppf "areality"
+      | Areality -> Format.fprintf ppf "locality"
       | Linearity -> Format.fprintf ppf "linearity"
       | Portability -> Format.fprintf ppf "portability"
       | Uniqueness -> Format.fprintf ppf "uniqueness"

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -327,6 +327,8 @@ module type S = sig
           (Comonadic.Const.t, 'a) Axis.t
           -> (('a, 'd) mode_comonadic, 'a, 'd) axis
 
+    type 'd axis_packed = P : ('m, 'a, 'd) axis -> 'd axis_packed
+
     val print_axis : Format.formatter -> ('m, 'a, 'd) axis -> unit
 
     val lattice_of_axis : ('m, 'a, 'd) axis -> (module Lattice with type t = 'a)
@@ -447,10 +449,7 @@ module type S = sig
     val alloc_as_value : Alloc.Const.t -> Value.Const.t
 
     module Axis : sig
-      type 'd packed_value_axis =
-        | P : ('m, 'a, 'd) Value.axis -> 'd packed_value_axis
-
-      val alloc_as_value : ('m, 'a, 'd) Alloc.axis -> 'd packed_value_axis
+      val alloc_as_value : 'd Alloc.axis_packed -> 'd Value.axis_packed
     end
 
     val locality_as_regionality : Locality.Const.t -> Regionality.Const.t

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -286,6 +286,8 @@ module type S = sig
       | Contention : (monadic, Contention.Const.t) t
 
     val print : Format.formatter -> ('p, 'r) t -> unit
+
+    val eq : ('p, 'r0) t -> ('p, 'r1) t -> ('r0, 'r1) Misc.eq option
   end
 
   module type Mode := sig
@@ -440,6 +442,13 @@ module type S = sig
   module Const : sig
     val alloc_as_value : Alloc.Const.t -> Value.Const.t
 
+    module Axis : sig
+      type 'd packed_value_axis =
+        | P : ('m, 'a, 'd) Value.axis -> 'd packed_value_axis
+
+      val alloc_as_value : ('m, 'a, 'd) Alloc.axis -> 'd packed_value_axis
+    end
+
     val locality_as_regionality : Locality.Const.t -> Regionality.Const.t
   end
 
@@ -517,6 +526,10 @@ module type S = sig
             commutative. Post-condition: each axis is represented in the
             output list exactly once. *)
         val to_list : t -> atom list
+
+        (** Test if the given modality is a constant modality along the given
+            axis. *)
+        val is_constant_for : ('m, 'a, 'd) Value.axis -> t -> bool
 
         (** [equate t0 t1] checks that [t0 = t1].
             Definition: [t0 = t1] iff [t0 <= t1] and [t1 <= t0]. *)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -327,6 +327,10 @@ module type S = sig
           (Comonadic.Const.t, 'a) Axis.t
           -> (('a, 'd) mode_comonadic, 'a, 'd) axis
 
+    val print_axis : Format.formatter -> ('m, 'a, 'd) axis -> unit
+
+    val lattice_of_axis : ('m, 'a, 'd) axis -> (module Lattice with type t = 'a)
+
     type ('a, 'b, 'c, 'd, 'e) modes =
       { areality : 'a;
         linearity : 'b;

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -492,6 +492,9 @@ module type S = sig
     (** Test if the given modality is the identity modality. *)
     val is_id : t -> bool
 
+    (** Test if the given modality is a constant modality. *)
+    val is_constant : t -> bool
+
     (** Printing for debugging *)
     val print : Format.formatter -> t -> unit
 
@@ -531,9 +534,8 @@ module type S = sig
             output list exactly once. *)
         val to_list : t -> atom list
 
-        (** Test if the given modality is a constant modality along the given
-            axis. *)
-        val is_constant_for : ('m, 'a, 'd) Value.axis -> t -> bool
+        (** Project out the [atom] for the given axis in the given modality. *)
+        val proj : ('m, 'a, 'd) Value.axis -> t -> atom
 
         (** [equate t0 t1] checks that [t0 = t1].
             Definition: [t0 = t1] iff [t0 <= t1] and [t1 <= t0]. *)

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -25,25 +25,32 @@ exception Error of Location.t * error
 
 module Axis_pair = struct
   type 'm t =
-    | Modal_axis_pair : 'a Axis.Modal.t * 'a -> modal t
+    | Modal_axis_pair : ('m, 'a, 'd) Mode.Alloc.axis * 'a -> modal t
     | Any_axis_pair : 'a Axis.t * 'a -> maybe_nonmodal t
 
   let of_string s =
     let open Mode in
     match s with
-    | "local" -> Any_axis_pair (Modal Locality, Locality.Const.Local)
-    | "global" -> Any_axis_pair (Modal Locality, Locality.Const.Global)
-    | "unique" -> Any_axis_pair (Modal Uniqueness, Uniqueness.Const.Unique)
-    | "aliased" -> Any_axis_pair (Modal Uniqueness, Uniqueness.Const.Aliased)
-    | "once" -> Any_axis_pair (Modal Linearity, Linearity.Const.Once)
-    | "many" -> Any_axis_pair (Modal Linearity, Linearity.Const.Many)
+    | "local" -> Any_axis_pair (Modal (Comonadic Areality), Locality.Const.Local)
+    | "global" ->
+      Any_axis_pair (Modal (Comonadic Areality), Locality.Const.Global)
+    | "unique" ->
+      Any_axis_pair (Modal (Monadic Uniqueness), Uniqueness.Const.Unique)
+    | "aliased" ->
+      Any_axis_pair (Modal (Monadic Uniqueness), Uniqueness.Const.Aliased)
+    | "once" -> Any_axis_pair (Modal (Comonadic Linearity), Linearity.Const.Once)
+    | "many" -> Any_axis_pair (Modal (Comonadic Linearity), Linearity.Const.Many)
     | "nonportable" ->
-      Any_axis_pair (Modal Portability, Portability.Const.Nonportable)
-    | "portable" -> Any_axis_pair (Modal Portability, Portability.Const.Portable)
-    | "contended" -> Any_axis_pair (Modal Contention, Contention.Const.Contended)
-    | "shared" -> Any_axis_pair (Modal Contention, Contention.Const.Shared)
+      Any_axis_pair
+        (Modal (Comonadic Portability), Portability.Const.Nonportable)
+    | "portable" ->
+      Any_axis_pair (Modal (Comonadic Portability), Portability.Const.Portable)
+    | "contended" ->
+      Any_axis_pair (Modal (Monadic Contention), Contention.Const.Contended)
+    | "shared" ->
+      Any_axis_pair (Modal (Monadic Contention), Contention.Const.Shared)
     | "uncontended" ->
-      Any_axis_pair (Modal Contention, Contention.Const.Uncontended)
+      Any_axis_pair (Modal (Monadic Contention), Contention.Const.Uncontended)
     | "maybe_null" ->
       Any_axis_pair (Nonmodal Nullability, Nullability.Maybe_null)
     | "non_null" -> Any_axis_pair (Nonmodal Nullability, Nullability.Non_null)
@@ -109,7 +116,9 @@ let transl_modifier_annots annots =
 
 let transl_mode_annots annots : Alloc.Const.Option.t =
   let step modifiers_so_far annot =
-    let { txt = Modal_axis_pair (type a) ((axis, mode) : a Axis.Modal.t * a);
+    let { txt =
+            Modal_axis_pair (type m a d)
+              ((axis, mode) : (m, a, d) Mode.Alloc.axis * a);
           loc
         } =
       transl_annot ~annot_type:Mode ~required_mode_maturity:(Some Stable)
@@ -156,16 +165,16 @@ let transl_modality ~maturity { txt = Parsetree.Modality modality; loc } =
       { txt = modality; loc }
   in
   match axis_pair.txt with
-  | Modal_axis_pair (Locality, mode) ->
+  | Modal_axis_pair (Comonadic Areality, mode) ->
     Modality.Atom
       (Comonadic Areality, Meet_with (Const.locality_as_regionality mode))
-  | Modal_axis_pair (Linearity, mode) ->
+  | Modal_axis_pair (Comonadic Linearity, mode) ->
     Modality.Atom (Comonadic Linearity, Meet_with mode)
-  | Modal_axis_pair (Uniqueness, mode) ->
-    Modality.Atom (Monadic Uniqueness, Join_with mode)
-  | Modal_axis_pair (Portability, mode) ->
+  | Modal_axis_pair (Comonadic Portability, mode) ->
     Modality.Atom (Comonadic Portability, Meet_with mode)
-  | Modal_axis_pair (Contention, mode) ->
+  | Modal_axis_pair (Monadic Uniqueness, mode) ->
+    Modality.Atom (Monadic Uniqueness, Join_with mode)
+  | Modal_axis_pair (Monadic Contention, mode) ->
     Modality.Atom (Monadic Contention, Join_with mode)
 
 let untransl_modality (a : Modality.t) : Parsetree.modality loc =


### PR DESCRIPTION
Per zqian's CR to this effect. Also, this simplifies `modality_is_const_for_axis`, introduced in the previous PR, to more directly express the property rather than relying on a big ugly pattern match.

See the individual commits for more.