### PR TITLE
Faithfully print with-kinds by reconstructing modalities for types

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1117,19 +1117,30 @@ type 'a contended_with_int : immutable_data with 'a @@ contended with int
 
 [%%expect{|
 type 'a list
-  : value mod many with 'a uncontended with 'a portable with 'a
-              unyielding with 'a
+  : value mod many uncontended portable unyielding with 'a
+  @@
+  global
+  aliased
 type ('a, 'b) either
-  : value mod many with 'a * 'b uncontended with 'a * 'b
-              portable with 'a * 'b unyielding with 'a * 'b
+  : value mod many uncontended portable unyielding with 'a * 'b
+  @@
+  global
+  aliased
 type 'a contended
-  : value mod many with 'a uncontended portable with 'a unyielding with 'a
+  : value mod many uncontended portable unyielding with 'a
+  @@
+  global
+  aliased
+  contended
 type 'a contended_with_int
-  : value mod many with int
-'a uncontended with int portable with int
-'a
-              unyielding with int
-'a
+  : value mod many uncontended portable unyielding with int
+  @@
+  global
+  aliased with 'a
+  @@
+  global
+  aliased
+  contended
 |}]
 
 (* not yet supported *)

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1116,30 +1116,16 @@ type 'a contended : immutable_data with 'a @@ contended
 type 'a contended_with_int : immutable_data with 'a @@ contended with int
 
 [%%expect{|
-type 'a list
-  : value mod many uncontended portable unyielding with 'a
-  @@
-  global
-  aliased
+type 'a list : value mod many uncontended portable unyielding with 'a
 type ('a, 'b) either
   : value mod many uncontended portable unyielding with 'a * 'b
-  @@
-  global
-  aliased
 type 'a contended
   : value mod many uncontended portable unyielding with 'a
   @@
-  global
-  aliased
   contended
 type 'a contended_with_int
-  : value mod many uncontended portable unyielding with int
+  : value mod many uncontended portable unyielding with int with 'a
   @@
-  global
-  aliased with 'a
-  @@
-  global
-  aliased
   contended
 |}]
 

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1118,15 +1118,16 @@ type 'a contended_with_int : immutable_data with 'a @@ contended with int
 [%%expect{|
 type 'a list : value mod many uncontended portable unyielding with 'a
 type ('a, 'b) either
-  : value mod many uncontended portable unyielding with 'a * 'b
+  : value mod many uncontended portable unyielding
+  with 'a * 'b
 type 'a contended
-  : value mod many uncontended portable unyielding with 'a
-  @@
-  contended
+  : value mod many uncontended portable unyielding
+  with 'a @@ contended
 type 'a contended_with_int
-  : value mod many uncontended portable unyielding with int with 'a
-  @@
-  contended
+  : value mod many uncontended portable unyielding
+  with 'a @@ contended
+
+  with int
 |}]
 
 (* not yet supported *)

--- a/testsuite/tests/typing-jkind-bounds/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/modalities.ml
@@ -97,11 +97,11 @@ Error: This expression has type "string t"
          "('a : value mod global & value mod global)"
        The kind of string t is
          value_or_null mod global unique many uncontended portable unyielding
-                           external_ non_null with string
-         @@ global
+                           external_ non_null
+         with string @@ global
          & value_or_null mod global unique many uncontended portable
-                             unyielding external_ non_null with string
-         @@ global
+                             unyielding external_ non_null
+         with string @@ global
          because of the definition of t at line 4, characters 0-51.
        But the kind of string t must be a subkind of
          value mod global & value mod global
@@ -129,12 +129,11 @@ Error: This expression has type "(string -> string) t"
        but an expression was expected of type "('a : value & value)"
        The kind of (string -> string) t is
          value_or_null mod global unique many uncontended portable unyielding
-                           external_ non_null with string -> string
-         @@ global
+                           external_ non_null
+         with string -> string @@ global
          & value_or_null mod global unique many uncontended portable
-                             unyielding external_ non_null with string ->
-                                                                string
-         @@ global
+                             unyielding external_ non_null
+         with string -> string @@ global
          because of the definition of t at line 4, characters 0-51.
        But the kind of (string -> string) t must be a subkind of
          value & value

--- a/testsuite/tests/typing-jkind-bounds/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/modalities.ml
@@ -96,34 +96,12 @@ Error: This expression has type "string t"
        but an expression was expected of type
          "('a : value mod global & value mod global)"
        The kind of string t is
-         value_or_null mod global unique with string
-string
-                           many with string
-string
-                           uncontended with string
-string
-                           portable with string
-string
-                           unyielding with string
-string
-                           external_ with string
-string
-                           non_null with string
-string
-         & value_or_null mod global unique with string
-string
-                             many with string
-string
-                             uncontended with string
-string
-                             portable with string
-string
-                             unyielding with string
-string
-                             external_ with string
-string
-                             non_null with string
-string
+         value_or_null mod global unique many uncontended portable unyielding
+                           external_ non_null with string
+         @@ global
+         & value_or_null mod global unique many uncontended portable
+                             unyielding external_ non_null with string
+         @@ global
          because of the definition of t at line 4, characters 0-51.
        But the kind of string t must be a subkind of
          value mod global & value mod global
@@ -150,36 +128,13 @@ Line 1, characters 65-66:
 Error: This expression has type "(string -> string) t"
        but an expression was expected of type "('a : value & value)"
        The kind of (string -> string) t is
-         value_or_null mod global
-                           unique with string -> string
-string -> string
-                           many with string -> string
-string -> string
-                           uncontended with string -> string
-string -> string
-                           portable with string -> string
-string -> string
-                           unyielding with string -> string
-string -> string
-                           external_ with string -> string
-string -> string
-                           non_null with string -> string
-string -> string
-         & value_or_null mod global
-                             unique with string -> string
-string -> string
-                             many with string -> string
-string -> string
-                             uncontended with string -> string
-string -> string
-                             portable with string -> string
-string -> string
-                             unyielding with string -> string
-string -> string
-                             external_ with string -> string
-string -> string
-                             non_null with string -> string
-string -> string
+         value_or_null mod global unique many uncontended portable unyielding
+                           external_ non_null with string -> string
+         @@ global
+         & value_or_null mod global unique many uncontended portable
+                             unyielding external_ non_null with string ->
+                                                                string
+         @@ global
          because of the definition of t at line 4, characters 0-51.
        But the kind of (string -> string) t must be a subkind of
          value & value

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -48,6 +48,7 @@ module TypeHash = struct
   include TransientTypeHash
   let mem hash = wrap_repr (mem hash)
   let add hash = wrap_repr (add hash)
+  let replace hash = wrap_repr (replace hash)
   let remove hash = wrap_repr (remove hash)
   let find hash = wrap_repr (find hash)
   let find_opt hash = wrap_repr (find_opt hash)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -41,6 +41,7 @@ module TypeHash : sig
   include Hashtbl.S with type key = transient_expr
   val mem: 'a t -> type_expr -> bool
   val add: 'a t -> type_expr -> 'a -> unit
+  val replace: 'a t -> type_expr -> 'a -> unit
   val remove: 'a t -> type_expr -> unit
   val find: 'a t -> type_expr -> 'a
   val find_opt: 'a t -> type_expr -> 'a option

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -903,7 +903,7 @@ module Const = struct
               (fun (type axis) ~(axis : axis Jkind_axis.Axis.t) mentioned ->
                 match axis with
                 | Modal axis when not mentioned -> (
-                  let (P axis) = Mode.Const.Axis.alloc_as_value axis in
+                  let (P axis) = Mode.Const.Axis.alloc_as_value (P axis) in
                   match axis with
                   | Monadic ax ->
                     Mode.Modality.Value.Const.singleton

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -667,10 +667,13 @@ module Context_with_transl = struct
     | Left_jkind (_, ctx) -> ctx
 end
 
-let print_type_expr =
-  ref (fun ppf _ -> Format.fprintf ppf "ERROR: unset [Jkind.print_type_expr]")
+let outcometree_of_type_scheme = ref (fun _ -> assert false)
 
-let set_print_type_expr p = print_type_expr := p
+let set_outcometree_of_type_scheme p = outcometree_of_type_scheme := p
+
+let outcometree_of_modalities_new = ref (fun _ _ _ -> assert false)
+
+let set_outcometree_of_modalities_new p = outcometree_of_modalities_new := p
 
 module Const = struct
   open Jkind_types.Layout_and_axes
@@ -871,25 +874,51 @@ module Const = struct
 
   module To_out_jkind_const : sig
     (** Convert a [t] into a [Outcometree.out_jkind_const].
-        The jkind is written in terms of the built-in jkind that requires the least amount
-        of modes after the mod. For example,
-        [value mod global many unique portable uncontended external_ non_null] could be
-        written in terms of [value] (as it appears above), or in terms of [immediate]
-        (which would just be [immediate]). Since the latter requires less modes to be
-        printed, it is chosen. *)
+        The jkind is written in terms of the built-in jkind that requires the
+        least amount of modes after the mod. For example, [value mod global many
+        unique portable uncontended external_ non_null] could be written in
+        terms of [value] (as it appears above), or in terms of [immediate]
+        (which would just be [immediate]). Since the latter requires less modes
+        to be printed, it is chosen. *)
     val convert : 'd t -> Outcometree.out_jkind_const
   end = struct
     type printable_jkind =
       { base : string;
-        modal_bounds : string list
+        modal_bounds : string list;
+        with_tys :
+          (Outcometree.out_type * Outcometree.out_modality_new list) list
       }
 
-    let get_baggage : type l r. (l * r) Baggage.t -> _ = function
-      | No_baggage -> ""
-      | Baggage (ty, tys) ->
-        Format.asprintf " with %a"
-          (Format.pp_print_list ~pp_sep:Format.pp_print_space !print_type_expr)
-          (ty :: tys)
+    module Mentioned_in_bounds = struct
+      include Jkind_axis.Axis_collection (struct
+        type (+'type_expr, 'd, 'a) t = bool constraint 'd = 'l * 'r
+      end)
+
+      let empty = Create.f { f = (fun ~axis:_ -> false) }
+
+      let to_modality =
+        Fold.f
+          ~combine:(fun m1 m2 -> Mode.Modality.Value.Const.concat m1 ~then_:m2)
+          { f =
+              (fun (type axis) ~(axis : axis Jkind_axis.Axis.t) mentioned ->
+                match axis with
+                | Modal axis when not mentioned -> (
+                  let (P axis) = Mode.Const.Axis.alloc_as_value axis in
+                  match axis with
+                  | Monadic ax ->
+                    Mode.Modality.Value.Const.singleton
+                      (Atom
+                         ( Monadic ax,
+                           Join_with (Mode.Value.Monadic.Const.max_axis ax) ))
+                  | Comonadic ax ->
+                    Mode.Modality.Value.Const.singleton
+                      (Atom
+                         ( Comonadic ax,
+                           Meet_with (Mode.Value.Comonadic.Const.min_axis ax) ))
+                  )
+                | _ -> Mode.Modality.Value.Const.id)
+          }
+    end
 
     let get_modal_bound (type a) ~(axis : a Axis.t) ~(base : ('d1, a) Bound.t)
         (actual : ('d2, a) Bound.t) =
@@ -908,10 +937,7 @@ module Const = struct
         match less_or_equal base actual with
         | Some Less | Some Equal -> `Valid None
         | None | Some Not_le ->
-          `Valid
-            (Some
-               (Format.asprintf "%a%s" A.print actual.modifier
-                  (get_baggage actual.baggage))))
+          `Valid (Some (Format.asprintf "%a" A.print actual.modifier)))
       | None | Some Not_le -> `Invalid
 
     let get_modal_bounds ~(base : _ Bounds.t) (actual : _ Bounds.t) =
@@ -929,6 +955,36 @@ module Const = struct
              | Some acc, `Valid (Some mode) -> Some (mode :: acc))
            (Some [])
 
+    let get_with_tys upper_bounds =
+      let types = Btype.TypeHash.create 8 in
+      Jkind_types.Bounds.Iter.f
+        { f =
+            (fun ~axis { modifier = _; baggage } ->
+              List.iter
+                (fun ty ->
+                  let mentioned =
+                    Btype.TypeHash.find_opt types ty
+                    |> Option.value ~default:Mentioned_in_bounds.empty
+                  in
+                  let mentioned' =
+                    Mentioned_in_bounds.set ~axis mentioned true
+                  in
+                  Btype.TypeHash.replace types ty mentioned')
+                (Jkind_types.Baggage.as_list baggage))
+        }
+        upper_bounds;
+      Btype.TypeHash.to_seq types
+      |> Seq.map (fun (ty, mentioned) ->
+             let modality = Mentioned_in_bounds.to_modality mentioned in
+             let ty =
+               !outcometree_of_type_scheme (Types.Transient_expr.type_expr ty)
+             in
+             let modalities =
+               !outcometree_of_modalities_new Types.Immutable [] modality
+             in
+             ty, modalities)
+      |> List.of_seq
+
     (** Write [actual] in terms of [base] *)
     let convert_with_base ~(base : Builtin.t) actual =
       let matching_layouts =
@@ -937,8 +993,10 @@ module Const = struct
       let modal_bounds =
         get_modal_bounds ~base:base.jkind.upper_bounds actual.upper_bounds
       in
+      let with_tys = get_with_tys actual.upper_bounds in
       match matching_layouts, modal_bounds with
-      | true, Some modal_bounds -> Some { base = base.name; modal_bounds }
+      | true, Some modal_bounds ->
+        Some { base = base.name; modal_bounds; with_tys }
       | false, _ | _, None -> None
 
     (** Select the out_jkind_const with the least number of modal bounds to print *)
@@ -1013,12 +1071,19 @@ module Const = struct
                  modal bounds are all max *)
             Option.get out_jkind_verbose)
       in
-      match printable_jkind with
-      | { base; modal_bounds = _ :: _ as modal_bounds } ->
-        Outcometree.Ojkind_const_mod
-          (Ojkind_const_abbreviation base, modal_bounds)
-      | { base; modal_bounds = [] } ->
-        Outcometree.Ojkind_const_abbreviation base
+      let base, with_tys =
+        match printable_jkind with
+        | { base; modal_bounds = _ :: _ as modal_bounds; with_tys } ->
+          ( Outcometree.Ojkind_const_mod
+              (Ojkind_const_abbreviation base, modal_bounds),
+            with_tys )
+        | { base; modal_bounds = []; with_tys } ->
+          Outcometree.Ojkind_const_abbreviation base, with_tys
+      in
+      List.fold_left
+        (fun jkind (ty, modalities) ->
+          Outcometree.Ojkind_const_with (jkind, ty, modalities))
+        base with_tys
   end
 
   let to_out_jkind_const jkind = To_out_jkind_const.convert jkind

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -889,20 +889,22 @@ module Const = struct
           (Outcometree.out_type * Outcometree.out_modality_new list) list
       }
 
-    module Mentioned_in_bounds = struct
-      include Jkind_axis.Axis_collection (struct
-        type (+'type_expr, 'd, 'a) t = bool constraint 'd = 'l * 'r
-      end)
+    module Include_modality = struct
+      type include_modality =
+        | Include
+        | Don't_include
 
-      let empty = Create.f { f = (fun ~axis:_ -> false) }
+      include Jkind_axis.Axis_collection (struct
+        type (+'type_expr, 'd, 'a) t = include_modality constraint 'd = 'l * 'r
+      end)
 
       let to_modality =
         Fold.f
           ~combine:(fun m1 m2 -> Mode.Modality.Value.Const.concat m1 ~then_:m2)
           { f =
-              (fun (type axis) ~(axis : axis Jkind_axis.Axis.t) mentioned ->
-                match axis with
-                | Modal axis when not mentioned -> (
+              (fun (type axis) ~(axis : axis Jkind_axis.Axis.t) include_modality ->
+                match axis, include_modality with
+                | Modal axis, Include -> (
                   let (P axis) = Mode.Const.Axis.alloc_as_value (P axis) in
                   match axis with
                   | Monadic ax ->
@@ -955,27 +957,38 @@ module Const = struct
              | Some acc, `Valid (Some mode) -> Some (mode :: acc))
            (Some [])
 
-    let get_with_tys upper_bounds =
+    let get_with_tys ~base upper_bounds =
+      let default_include_modality =
+        Include_modality.Create.f
+          { f =
+              (fun ~axis ->
+                let base = Bounds.get ~axis base in
+                let actual = Bounds.get ~axis upper_bounds in
+                match get_modal_bound ~axis ~base actual with
+                | `Valid (Some _) -> Include
+                | `Valid None | `Invalid -> Don't_include)
+          }
+      in
       let types = Btype.TypeHash.create 8 in
       Jkind_types.Bounds.Iter.f
         { f =
             (fun ~axis { modifier = _; baggage } ->
               List.iter
                 (fun ty ->
-                  let mentioned =
+                  let include_modality =
                     Btype.TypeHash.find_opt types ty
-                    |> Option.value ~default:Mentioned_in_bounds.empty
+                    |> Option.value ~default:default_include_modality
                   in
-                  let mentioned' =
-                    Mentioned_in_bounds.set ~axis mentioned true
+                  let include_modality' =
+                    Include_modality.set ~axis include_modality Don't_include
                   in
-                  Btype.TypeHash.replace types ty mentioned')
+                  Btype.TypeHash.replace types ty include_modality')
                 (Jkind_types.Baggage.as_list baggage))
         }
         upper_bounds;
       Btype.TypeHash.to_seq types
       |> Seq.map (fun (ty, mentioned) ->
-             let modality = Mentioned_in_bounds.to_modality mentioned in
+             let modality = Include_modality.to_modality mentioned in
              let ty =
                !outcometree_of_type_scheme (Types.Transient_expr.type_expr ty)
              in
@@ -993,7 +1006,9 @@ module Const = struct
       let modal_bounds =
         get_modal_bounds ~base:base.jkind.upper_bounds actual.upper_bounds
       in
-      let with_tys = get_with_tys actual.upper_bounds in
+      let with_tys =
+        get_with_tys ~base:base.jkind.upper_bounds actual.upper_bounds
+      in
       match matching_layouts, modal_bounds with
       | true, Some modal_bounds ->
         Some { base = base.name; modal_bounds; with_tys }

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -516,8 +516,16 @@ val get_annotation : 'd t -> Parsetree.jkind_annotation option
 (*********************************)
 (* pretty printing *)
 
-(** Call this before trying to print. *)
-val set_print_type_expr : (Format.formatter -> Types.type_expr -> unit) -> unit
+(** Call these before trying to print. *)
+val set_outcometree_of_type_scheme :
+  (Types.type_expr -> Outcometree.out_type) -> unit
+
+val set_outcometree_of_modalities_new :
+  (Types.mutability ->
+  Parsetree.attributes ->
+  Mode.Modality.Value.Const.t ->
+  Outcometree.out_mode_new list) ->
+  unit
 
 val format : Format.formatter -> 'd t -> unit
 

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -290,6 +290,28 @@ module Axis_collection (T : Axed) = struct
     let[@inline] f f bounds = Monadic_identity.f f bounds
   end
 
+  module Iter = struct
+    type ('type_expr, 'd) f =
+      { f : 'axis. axis:'axis Axis.t -> ('type_expr, 'd, 'axis) T.t -> unit }
+
+    let[@inline] f { f }
+        { locality;
+          linearity;
+          uniqueness;
+          portability;
+          contention;
+          externality;
+          nullability
+        } =
+      f ~axis:Axis.(Modal (Comonadic Areality)) locality;
+      f ~axis:Axis.(Modal (Monadic Uniqueness)) uniqueness;
+      f ~axis:Axis.(Modal (Comonadic Linearity)) linearity;
+      f ~axis:Axis.(Modal (Monadic Contention)) contention;
+      f ~axis:Axis.(Modal (Comonadic Portability)) portability;
+      f ~axis:Axis.(Nonmodal Externality) externality;
+      f ~axis:Axis.(Nonmodal Nullability) nullability
+  end
+
   module Map2 = struct
     module Monadic (M : Misc.Stdlib.Monad.S) = struct
       type ('type_expr, 'd1, 'd2, 'd3) f =

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -145,6 +145,13 @@ module Axis_collection (T : Axed) : sig
       ('type_expr, 'd1, 'd2) f -> ('type_expr, 'd1) t -> ('type_expr, 'd2) t
   end
 
+  module Iter : sig
+    type ('type_expr, 'd) f =
+      { f : 'axis. axis:'axis Axis.t -> ('type_expr, 'd, 'axis) T.t -> unit }
+
+    val f : ('type_expr, 'd) f -> ('type_expr, 'd) t -> unit
+  end
+
   (** Map an operation over two sets of bounds *)
   module Map2 : sig
     module Monadic (M : Misc.Stdlib.Monad.S) : sig

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -306,7 +306,13 @@ module type S = sig
     module Areality : Common
 
     module Monadic : sig
-      module Const : Lattice with type t = monadic
+      module Const : sig
+        include Lattice with type t = monadic
+
+        val max_axis : (t, 'a) Axis.t -> 'a
+
+        val min_axis : (t, 'a) Axis.t -> 'a
+      end
 
       include Common with module Const := Const
 
@@ -320,6 +326,10 @@ module type S = sig
         val eq : t -> t -> bool
 
         val print_axis : (t, 'a) Axis.t -> Format.formatter -> 'a -> unit
+
+        val max_axis : (t, 'a) Axis.t -> 'a
+
+        val min_axis : (t, 'a) Axis.t -> 'a
       end
 
       type error = Error : (Const.t, 'a) Axis.t * 'a Solver.error -> error

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -633,7 +633,7 @@ and print_out_jkind_const ppf ojkind =
       Misc.pp_nested_list ~nested ~pp_element ~pp_sep ppf ts
     | Ojkind_const_with (base, ty, modalities) ->
         fprintf ppf "%a with @[%a@]%a"
-          (pp_element ~nested:true) base
+          (pp_element ~nested:false) base
           print_out_type ty
           print_out_modalities_new modalities
     | Ojkind_const_kind_of _ ->

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -105,7 +105,7 @@ type out_jkind_const =
   | Ojkind_const_default
   | Ojkind_const_abbreviation of string
   | Ojkind_const_mod of out_jkind_const * string list
-  | Ojkind_const_with of out_jkind_const * out_type
+  | Ojkind_const_with of out_jkind_const * out_type * out_modality_new list
   | Ojkind_const_kind_of of out_type
   | Ojkind_const_product of out_jkind_const list
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1368,7 +1368,11 @@ let rec out_jkind_of_desc (desc : 'd Jkind.Desc.t) =
 let out_jkind_option_of_jkind jkind =
   let desc = Jkind.get jkind in
   let elide =
-    Jkind.is_value_for_printing jkind (* C2.1 *)
+    (* CR layouts: We ignore nullability here to avoid needlessly printing
+       ['a : value_or_null] when it's not relevant (most cases).
+       Unfortunately, this makes error messages really confusing, because
+       we don't consider jkind annotations. *)
+    Jkind.is_value_for_printing ~ignore_null:true jkind (* C2.1 *)
     || (match desc.layout with
         | Sort (Var _) -> not !Clflags.verbose_types (* X1 *)
         | _ -> false)

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1340,6 +1340,41 @@ let add_type_to_preparation = prepare_type
 (* Disabled in classic mode when printing an unification error *)
 let print_labels = ref true
 
+let out_jkind_of_const_jkind jkind =
+  Ojkind_const (Jkind.Const.to_out_jkind_const jkind)
+
+(* CR layouts v2.8: This is just like [Jkind.format], and likely needs to
+   be overhauled with [with]-types. *)
+let rec out_jkind_of_desc (desc : 'd Jkind.Desc.t) =
+  match desc.layout with
+  | Sort (Var n) ->
+    Ojkind_var ("'_representable_layout_" ^
+                Int.to_string (Jkind.Sort.Var.get_print_number n))
+  (* Analyze a product before calling [get_const]: the machinery in
+     [Jkind.Const.to_out_jkind_const] works better for atomic layouts, not
+     products. *)
+  | Product lays ->
+    Ojkind_product
+      (List.map (fun layout -> out_jkind_of_desc { desc with layout }) lays)
+  | _ -> match Jkind.Desc.get_const desc with
+    | Some c -> out_jkind_of_const_jkind c
+    | None -> assert false (* handled above *)
+
+(* returns None for [value], according to (C2.1) from
+   Note [When to print jkind annotations] *)
+(* CR layouts v2.8: This should use the annotation in the jkind, if there
+   is one. But first that annotation needs to be in Typedtree, not in
+   Parsetree. *)
+let out_jkind_option_of_jkind jkind =
+  let desc = Jkind.get jkind in
+  let elide =
+    Jkind.is_value_for_printing jkind (* C2.1 *)
+    || (match desc.layout with
+        | Sort (Var _) -> not !Clflags.verbose_types (* X1 *)
+        | _ -> false)
+  in
+  if elide then None else Some (out_jkind_of_desc desc)
+
 let alias_nongen_row mode px ty =
     match get_desc ty with
     | Tvariant _ | Tobject _ ->
@@ -1534,7 +1569,7 @@ let rec tree_of_typexp mode alloc_mode ty =
 and tree_of_qtvs qtvs =
   let tree_of_qtv v : (string * out_jkind option) option =
     let tree jkind = Some (Names.name_of_type Names.new_name v,
-                           out_jkind_option_of_jkind jkind)
+                            out_jkind_option_of_jkind jkind)
     in
     match v.desc with
     | Tvar { jkind } when v.level = generic_level -> tree jkind
@@ -1634,106 +1669,6 @@ and tree_of_typfields mode rest = function
       let (fields, rest) = tree_of_typfields mode rest l in
       (field :: fields, rest)
 
-and tree_of_type_scheme ty =
-  prepare_for_printing [ty];
-  tree_of_typexp Type_scheme Alloc.Const.legacy ty
-
-and out_jkind_of_const_jkind jkind =
-  Ojkind_const (Jkind.Const.to_out_jkind_const jkind)
-
-(* CR layouts v2.8: This is just like [Jkind.format], and likely needs to
-   be overhauled with [with]-types. *)
-and out_jkind_of_desc (desc : ('l * 'r) Jkind.Desc.t) =
-  let base =
-    match desc.layout with
-    | Sort (Var n) ->
-        Ojkind_var ("'_representable_layout_" ^
-                    Int.to_string (Jkind.Sort.Var.get_print_number n))
-    (* Analyze a product before calling [get_const]: the machinery in
-       [Jkind.Const.to_out_jkind_const] works better for atomic layouts, not
-       products. *)
-    | Product lays ->
-        Ojkind_product
-          (List.map (fun layout -> out_jkind_of_desc { desc with layout }) lays)
-    | _ -> match Jkind.Desc.get_const desc with
-      | Some c -> out_jkind_of_const_jkind c
-      | None -> assert false (* handled above *)
-  in
-  match base with
-  | Ojkind_const base -> (
-    let module Mentioned_in_bounds = struct
-      include Jkind_axis.Axis_collection(struct
-        type (+'type_expr, 'd, 'a) t = bool constraint 'd = 'l * 'r
-      end)
-
-      let empty = Create.f { f = (fun ~axis:_ -> false) }
-
-      let to_modality =
-        Fold.f
-          ~combine:(fun m1 m2 -> Mode.Modality.Value.Const.concat m1 ~then_:m2)
-          { f =
-              fun (type axis) ~(axis : axis Jkind_axis.Axis.t) mentioned ->
-                match axis with
-                | Modal axis when not mentioned -> (
-                    let P axis = Mode.Const.Axis.alloc_as_value axis in
-                    match axis with
-                    | Monadic ax ->
-                        Mode.Modality.Value.Const.singleton
-                          (Atom
-                            (Monadic ax,
-                              Join_with (Mode.Value.Monadic.Const.max_axis ax)))
-                    | Comonadic ax ->
-                        Mode.Modality.Value.Const.singleton
-                          (Atom
-                            (Comonadic ax,
-                              Meet_with
-                                (Mode.Value.Comonadic.Const.min_axis ax))))
-                | _ -> Mode.Modality.Value.Const.id
-          }
-    end
-    in
-    let types = Btype.TypeHash.create 8 in
-    Jkind_types.Bounds.Iter.f
-      { f =
-          fun ~axis { modifier = _; baggage } ->
-            List.iter
-              (fun ty ->
-                let mentioned =
-                  Btype.TypeHash.find_opt types ty
-                  |> Option.value ~default:Mentioned_in_bounds.empty
-                in
-                let mentioned' = Mentioned_in_bounds.set ~axis mentioned true in
-                Btype.TypeHash.replace types ty mentioned'
-              )
-              (Jkind_types.Baggage.as_list baggage) }
-      desc.upper_bounds;
-    let const =
-      Btype.TypeHash.to_seq types
-      |> Seq.fold_left
-        (fun okind (ty, mentioned) ->
-           let modality = Mentioned_in_bounds.to_modality mentioned in
-           let ty = tree_of_type_scheme (Transient_expr.type_expr ty) in
-           let modalities = tree_of_modalities_new Immutable [] modality in
-           Ojkind_const_with (okind, ty, modalities))
-        base
-    in Ojkind_const const)
-  | k -> k
-
-(* returns None for [value], according to (C2.1) from
-   Note [When to print jkind annotations] *)
-(* CR layouts v2.8: This should use the annotation in the jkind, if there
-   is one. But first that annotation needs to be in Typedtree, not in
-   Parsetree. *)
-and out_jkind_option_of_jkind jkind =
-  let desc = Jkind.get jkind in
-  let elide =
-    Jkind.is_value_for_printing jkind (* C2.1 *)
-    || (match desc.layout with
-        | Sort (Var _) -> not !Clflags.verbose_types (* X1 *)
-        | _ -> false)
-  in
-  if elide then None else Some (out_jkind_of_desc desc)
-
 let tree_of_typexp mode ty = tree_of_typexp mode Alloc.Const.legacy ty
 
 let typexp mode ppf ty =
@@ -1754,10 +1689,6 @@ let type_expr ppf ty =
      we mark eventual loops ourself to avoid any misuse and stack overflow *)
   prepare_for_printing [ty];
   prepared_type_expr ppf ty
-
-let () =
-  Env.print_type_expr := type_expr;
-  Jkind.set_print_type_expr type_expr
 
 (* "Half-prepared" type expression: [ty] should have had its names reserved, but
    should not have had its loops marked. *)
@@ -1782,7 +1713,14 @@ let type_path ppf p =
   let t = tree_of_path (Some Type) p'' in
   !Oprint.out_ident ppf t
 
+let tree_of_type_scheme ty =
+  prepare_for_printing [ty];
+  tree_of_typexp Type_scheme ty
 
+let () =
+  Env.print_type_expr := type_expr;
+  Jkind.set_outcometree_of_type_scheme tree_of_type_scheme;
+  Jkind.set_outcometree_of_modalities_new tree_of_modalities_new
 
 (* Print one type declaration *)
 
@@ -2055,8 +1993,7 @@ let tree_of_type_decl id decl =
            Anything but the default must be user-written, so we print the
            user-written annotation. *)
         (* unsafe_mode_crossing corresponds to C1.2 *)
-        (* CR aspsmith: fixme *)
-        Some (out_jkind_of_desc (Jkind.get decl.type_jkind |> Obj.magic))
+        Some (out_jkind_of_desc (Jkind.get decl.type_jkind))
     | _ -> None (* other cases have no jkind annotation *)
   in
   let attrs =


### PR DESCRIPTION
Reconstruct a more faithful representation of `with`-kinds when constructing outcome jkinds from `Jkind.t`s, using constant modalities on axes to omit types from axes which don't have those types in their baggage.

This approach is pretty dumb (we just walk the baggage of each axis building up a map tracking which types are mentioned on which axes), but from reading the existing test cases it seems to do a pretty good job of constructing the jkind that the user would have written down themselves - plus it's vastly better than the previous approach of just printing a kind that wouldn't even parse, let alone be correct.

Plausibly this approach would need to be rethought completely once we introduce non-constant/identity modalities, but those are far enough off that I claim this should serve us fine for the time being.

Review the whole diff, rather than individual commits.