### PR TITLE
ASR 64-bit lane not available in sse instruction

### DIFF
--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -589,13 +589,14 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
       let sse_op =
         match width_type with
         | W128 -> assert false
-        | W64 -> assert false
-        | W32 -> SRA_i32
-        | W16 -> SRA_i16
-        | W8 -> assert false
+        | W64 -> None
+        | W32 -> Some SRA_i32
+        | W16 -> Some SRA_i16
+        | W8 -> None
       in
-      Operation.Specific (Isimd (SSE2 sse_op))
-      |> make_default ~arg_count ~res_count
+      Option.bind sse_op (fun sse_op ->
+          Operation.Specific (Isimd (SSE2 sse_op))
+          |> make_default ~arg_count ~res_count)
     | Icomp (Isigned intcomp) -> (
       match intcomp with
       | Ceq ->


### PR DESCRIPTION
Packed shift right arithmetic instruction `PSRA` is only available for 32 and 16 bit elements. Handling 64-bit elements requires AVX512, which is not currently supported in flambda-backend. The vectorizer is able to identify 64x2 group correctly for `Iasr` instruction, but `Simd_selection.vectorize_operation` fails with an asssert. This PR fixes it to return `None` for this case that is not yet vectorizable.  

There are many other cases with `assert false` that should be either `None` or `Misc.fatal_error`, but I'll leave them for a separate PR, as part of the planned refactoring of `vectorize_operation`. For now, this PR just fixes a common case (due to untagging), so we can continue testing the vectorizer.