### PR TITLE
Add `Capsule.with_password`

### DIFF
--- a/otherlibs/stdlib_alpha/capsule.ml
+++ b/otherlibs/stdlib_alpha/capsule.ml
@@ -381,14 +381,13 @@ exception Protected : 'k Mutex.t * (exn, 'k) Data.t -> exn
 let protect_local f = exclave_
   let (P name) = Name.make () in
   let password = Password.unsafe_mk name in
+  let reraise data = reraise (Protected ({ name; mutex = M.create (); poisoned = false }, data)) in
   try f (Password.P password) with
   | Encapsulated (inner, data) as exn ->
     (match Name.equality_witness name inner with
-     | Some Equal ->
-       reraise (Protected ({ name; mutex = M.create (); poisoned = false }, data))
-     | None -> reraise exn)
-  | exn ->
-    reraise (Protected ({ name; mutex = M.create (); poisoned = false }, Data.unsafe_mk exn))
+     | Some Equal -> reraise data
+     | None -> reraise (Data.unsafe_mk exn))
+  | exn -> reraise (Data.unsafe_mk exn)
 
 let with_password_local f = exclave_
   let (P name) = Name.make () in

--- a/otherlibs/stdlib_alpha/capsule.mli
+++ b/otherlibs/stdlib_alpha/capsule.mli
@@ -429,11 +429,11 @@ val protect : ('k. 'k Password.t @ local -> 'a) @ local portable -> 'a @@ portab
     it as [Protected]. If [f] raises any other exception, [protect] re-raises
     it as [Protected]. *)
 
-val with_password : ('k. 'k Password.t @ local -> 'a) @ local -> 'a @@ portable
+val with_password : ('k. 'k Password.t @ local -> 'a) @ local portable -> 'a @@ portable
 (** [with_password f] runs [f] in a fresh capsule. *)
 
 val protect_local : ('k. 'k Password.t @ local -> 'a @ local) @ local portable -> 'a @ local @@ portable
 (** See [protect]. *)
 
-val with_password_local : ('k. 'k Password.t @ local -> 'a @ local) @ local -> 'a @ local @@ portable
+val with_password_local : ('k. 'k Password.t @ local -> 'a @ local) @ local portable -> 'a @ local @@ portable
 (** See [with_password]. *)

--- a/otherlibs/stdlib_alpha/capsule.mli
+++ b/otherlibs/stdlib_alpha/capsule.mli
@@ -428,14 +428,17 @@ exception Protected : 'k Mutex.t * (exn, 'k) Data.t -> exn
     be used to access the [Data.t]. *)
 
 val protect : (Password.packed @ local -> 'a) @ local portable -> 'a @@ portable
-(** [protect f] runs [f] in a fresh capsule. If [f] returns normally, [protect]
-    merges this capsule into the caller's capsule. If [f] raises an [Encapsulated]
-    exception in the capsule ['k], [protect] unwraps the exception and re-raises
-    it as [Protected]. If [f] raises any other exception, [protect] re-raises
-    it as [Protected]. *)
+(** [protect f] runs [f password] in a fresh capsule represented by [password].
+    If [f] returns normally, [protect] merges the capsule into the caller's capsule.
+    If [f] raises an [Encapsulated] exception in the capsule represented by [password],
+    [protect] unwraps the exception and re-raises it as [Protected].
+    If [f] raises any other exception, [protect] re-raises it as [Protected]. *)
 
 val with_password : (Password.packed @ local -> 'a) @ local portable -> 'a @@ portable
-(** [with_password f] runs [f] in a fresh capsule. *)
+(** [with_password f] runs [f password] in a fresh capsule represented by [password].
+    If [f] returns normally, [with_password] merges the capsule into the caller's capsule.
+    If [f] raises an [Encapsulated] exception in the capsule represented by [password],
+    [with_password] unwraps the exception and re-raises it directly. *)
 
 val protect_local : (Password.packed @ local -> 'a @ local) @ local portable -> 'a @ local @@ portable
 (** See [protect]. *)

--- a/otherlibs/stdlib_alpha/capsule.mli
+++ b/otherlibs/stdlib_alpha/capsule.mli
@@ -104,6 +104,11 @@ module Password : sig
      mutex. This guarantees that uncontended access to the capsule is
      only granted to a single domain at once. *)
 
+  type packed = P : 'k t -> packed
+  (** [packed] is the type of a password for some unknown capsule.
+      Unpacking one provides a ['k t] together with a fresh existential
+      type brand for ['k]. *)
+
   val name : 'k t @ local -> 'k Name.t @@ portable
   (** [name t] identifies the capsule that [t] is associated with. *)
 
@@ -422,18 +427,18 @@ exception Protected : 'k Mutex.t * (exn, 'k) Data.t -> exn
     in [Protected] to avoid leaking access to the data. The [Mutex.t] can
     be used to access the [Data.t]. *)
 
-val protect : ('k. 'k Password.t @ local -> 'a) @ local portable -> 'a @@ portable
+val protect : (Password.packed @ local -> 'a) @ local portable -> 'a @@ portable
 (** [protect f] runs [f] in a fresh capsule. If [f] returns normally, [protect]
     merges this capsule into the caller's capsule. If [f] raises an [Encapsulated]
     exception in the capsule ['k], [protect] unwraps the exception and re-raises
     it as [Protected]. If [f] raises any other exception, [protect] re-raises
     it as [Protected]. *)
 
-val with_password : ('k. 'k Password.t @ local -> 'a) @ local portable -> 'a @@ portable
+val with_password : (Password.packed @ local -> 'a) @ local portable -> 'a @@ portable
 (** [with_password f] runs [f] in a fresh capsule. *)
 
-val protect_local : ('k. 'k Password.t @ local -> 'a @ local) @ local portable -> 'a @ local @@ portable
+val protect_local : (Password.packed @ local -> 'a @ local) @ local portable -> 'a @ local @@ portable
 (** See [protect]. *)
 
-val with_password_local : ('k. 'k Password.t @ local -> 'a @ local) @ local portable -> 'a @ local @@ portable
+val with_password_local : (Password.packed @ local -> 'a @ local) @ local portable -> 'a @ local @@ portable
 (** See [with_password]. *)

--- a/testsuite/tests/capsule-api/data.ml
+++ b/testsuite/tests/capsule-api/data.ml
@@ -204,7 +204,7 @@ let () =
 ;;
 
 let () =
-  match Capsule.protect (fun password ->
+  match Capsule.protect (fun (Capsule.Password.P password) ->
     let data = Capsule.Data.create (fun () -> "fail") in
     let msg = Capsule.Data.extract password (fun s : string -> s) data in
     reraise (Exn msg))
@@ -220,7 +220,7 @@ let () =
 ;;
 
 let () =
-  match Capsule.protect (fun password ->
+  match Capsule.protect (fun (Capsule.Password.P password) ->
     let data = Capsule.Data.create (fun () -> "fail") in
     let () = Capsule.Data.extract password (fun s -> reraise (Exn s)) data in
     ())
@@ -255,7 +255,7 @@ let () =
 ;;
 
 let () =
-  match Capsule.with_password (fun password ->
+  match Capsule.with_password (fun (Capsule.Password.P password) ->
     let data = Capsule.Data.create (fun () -> "fail") in
     let msg = Capsule.Data.extract password (fun s : string -> s) data in
     reraise (Exn msg))
@@ -265,7 +265,7 @@ let () =
 ;;
 
 let () =
-  match Capsule.with_password (fun password ->
+  match Capsule.with_password (fun (Capsule.Password.P password) ->
     let data = Capsule.Data.create (fun () -> "fail") in
     let () = Capsule.Data.extract password (fun s -> reraise (Exn s)) data in
     ())


### PR DESCRIPTION
`Capsule.protect f` and the new `Capsule.with_password f` should provide `f` with a password representing the fresh capsule. 
This allows us to create local-password-protected data in `f` and pass it downward. 

Additionally, `protect` will now unwrap `Encapsulated` exceptions that are in the same capsule as the provided password.
`with_password` will do the same, but destroys the `'k` capsule before returning the exn directly.

The two functions are implemented separately to avoid the overhead of creating/destroying the mutex in `with_password`.