### PR TITLE
 Added Cmm_helpers.Scalar_type

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4691,3 +4691,270 @@ let reperform ~dbg ~eff ~cont ~last_fiber =
       dbg )
 
 let poll ~dbg = return_unit dbg (Cop (Cpoll, [], dbg))
+
+module Scalar_type = struct
+  module Float_width = struct
+    type t = Cmm.float_width =
+      | Float64
+      | Float32
+
+    let[@inline] static_cast ~dbg ~src ~dst exp =
+      match src, dst with
+      | Float64, Float64 -> exp
+      | Float32, Float32 -> exp
+      | Float32, Float64 -> float_of_float32 ~dbg exp
+      | Float64, Float32 -> float32_of_float ~dbg exp
+  end
+
+  module Signedness = struct
+    type t =
+      | Signed
+      | Unsigned
+
+    let equal (x : t) (y : t) = x = y
+
+    let print ppf t =
+      match t with
+      | Signed -> Format.pp_print_string ppf "signed"
+      | Unsigned -> Format.pp_print_string ppf "unsigned"
+  end
+
+  module Bit_width_and_signedness : sig
+    (** An integer with signedness [signedness t] that fits into a general-purpose
+        register. It is canonically stored in twos-complement representation, in the lower
+        [bits] bits of its container (whether that be memory or a register), and is sign-
+        or zero-extended to fill the entire container. *)
+    type t [@@immediate]
+
+    val create_exn : bit_width:int -> signedness:Signedness.t -> t
+
+    val bit_width : t -> int
+
+    val signedness : t -> Signedness.t
+
+    val equal : t -> t -> bool
+  end = struct
+    (* [signedness t] is stored in the low bit of [t], and [bit_width t] is
+       stored in the remaining high bits of [t]. We use this encoding to fit [t]
+       into an immediate value. This is worth trying since we expect to create
+       one of these for ~every integer operation, so it should cut down on
+       garbage *)
+    type t = { bit_width_and_signedness : int } [@@unboxed]
+
+    let[@inline] equal { bit_width_and_signedness = x }
+        { bit_width_and_signedness = y } =
+      Int.equal x y
+
+    let[@inline] bit_width { bit_width_and_signedness } =
+      bit_width_and_signedness lsr 1
+
+    let[@inline] signedness { bit_width_and_signedness } =
+      match bit_width_and_signedness land 1 with
+      | 0 -> Signedness.Signed
+      | 1 -> Signedness.Unsigned
+      | _ -> assert false
+
+    let[@inline] int_of_signedness : Signedness.t -> int = function
+      | Signed -> 0
+      | Unsigned -> 1
+
+    let[@inline] create_exn ~bit_width ~signedness =
+      assert (0 < bit_width && bit_width <= arch_bits);
+      { bit_width_and_signedness =
+          (bit_width lsl 1) + int_of_signedness signedness
+      }
+  end
+
+  module Integral_type = struct
+    include Bit_width_and_signedness
+
+    let[@inline] with_signedness t ~signedness =
+      create_exn ~bit_width:(bit_width t) ~signedness
+
+    let[@inline] signed t = with_signedness t ~signedness:Signed
+
+    let[@inline] unsigned t = with_signedness t ~signedness:Unsigned
+
+    (** Determines whether [dst] can represent every value of [src], preserving sign *)
+    let[@inline] can_cast_without_losing_information ~src ~dst =
+      match signedness src, signedness dst with
+      | Signed, Signed | Unsigned, Unsigned -> bit_width src <= bit_width dst
+      | Unsigned, Signed -> bit_width src < bit_width dst
+      | Signed, Unsigned -> false
+
+    let[@inline] static_cast ~dbg ~src ~dst exp =
+      if can_cast_without_losing_information ~src ~dst
+      then
+        (* Since [Bit_width_and_signedness] represents sign- or zero-extended
+           expressions, this is a no-op *)
+        exp
+      else
+        match signedness dst with
+        | Signed -> sign_extend ~bits:(bit_width dst) exp ~dbg
+        | Unsigned -> zero_extend ~bits:(bit_width dst) exp ~dbg
+
+    let[@inline] conjugate ~outer ~inner ~dbg ~f x =
+      x
+      |> static_cast ~src:outer ~dst:inner ~dbg
+      |> f
+      |> static_cast ~src:inner ~dst:outer ~dbg
+  end
+
+  module Integer = struct
+    include Integral_type
+
+    let print ppf t =
+      Format.fprintf ppf "%a int%d" Signedness.print (signedness t)
+        (bit_width t)
+
+    let nativeint = create_exn ~bit_width:arch_bits ~signedness:Signed
+  end
+
+  (** An {!Integer.t} but with the additional stipulation that its container must
+      reserve its lowest bit to be 1. The [bit_width] field includes this bit. *)
+  module Tagged_integer = struct
+    include Integral_type
+
+    let[@inline] create_exn ~bit_width_including_tag_bit:bit_width ~signedness =
+      assert (bit_width > 1);
+      create_exn ~bit_width ~signedness
+
+    let immediate =
+      create_exn ~bit_width_including_tag_bit:arch_bits ~signedness:Signed
+
+    let[@inline] bit_width_including_tag_bit t = bit_width t
+
+    let[@inline] bit_width_excluding_tag_bit t = bit_width t - 1
+
+    let[@inline] untagged t =
+      Integer.create_exn
+        ~bit_width:(bit_width_excluding_tag_bit t)
+        ~signedness:(signedness t)
+
+    let[@inline] untag ~dbg t exp =
+      match signedness t with
+      | Signed -> asr_const exp 1 dbg
+      | Unsigned -> lsr_const exp 1 dbg
+
+    let print ppf t =
+      Format.fprintf ppf "tagged %a int%d" Signedness.print (signedness t)
+        (bit_width_excluding_tag_bit t)
+  end
+
+  module Integral = struct
+    type t =
+      | Untagged of Integer.t
+      | Tagged of Tagged_integer.t
+
+    let nativeint = Untagged Integer.nativeint
+
+    let[@inline] untagged_or_identity = function
+      | Untagged t -> t
+      | Tagged t -> Tagged_integer.untagged t
+
+    let signedness = function
+      | Untagged t -> Integer.signedness t
+      | Tagged t -> Tagged_integer.signedness t
+
+    let with_signedness t ~signedness =
+      match t with
+      | Untagged t -> Untagged (Integer.with_signedness t ~signedness)
+      | Tagged t -> Tagged (Tagged_integer.with_signedness t ~signedness)
+
+    let[@inline] signed t = with_signedness t ~signedness:Signed
+
+    let[@inline] unsigned t = with_signedness t ~signedness:Unsigned
+
+    let[@inline] equal x y =
+      match x, y with
+      | Untagged x, Untagged y -> Integer.equal x y
+      | Untagged _, _ -> false
+      | Tagged x, Tagged y -> Tagged_integer.equal x y
+      | Tagged _, _ -> false
+
+    let print ppf t =
+      match t with
+      | Untagged untagged -> Integer.print ppf untagged
+      | Tagged tagged -> Tagged_integer.print ppf tagged
+
+    let[@inline] can_cast_without_losing_information ~src ~dst =
+      Integer.can_cast_without_losing_information
+        ~src:(untagged_or_identity src) ~dst:(untagged_or_identity dst)
+
+    let static_cast ~dbg ~src ~dst exp =
+      match src, dst with
+      | Untagged src, Untagged dst -> Integer.static_cast ~dbg ~src ~dst exp
+      | Tagged src, Tagged dst -> Tagged_integer.static_cast ~dbg ~src ~dst exp
+      | Untagged src, Tagged dst ->
+        tag_int
+          (Integer.static_cast ~dbg ~src ~dst:(Tagged_integer.untagged dst) exp)
+          dbg
+      | Tagged src, Untagged dst ->
+        Integer.static_cast ~dbg
+          ~src:(Tagged_integer.untagged src)
+          ~dst
+          (Tagged_integer.untag ~dbg src exp)
+
+    let[@inline] conjugate ~outer ~inner ~dbg ~f x =
+      x
+      |> static_cast ~src:outer ~dst:inner ~dbg
+      |> f
+      |> static_cast ~src:inner ~dst:outer ~dbg
+  end
+
+  type t =
+    | Integral of Integral.t
+    | Float of Float_width.t
+
+  let static_cast ~dbg ~src ~dst exp =
+    match src, dst with
+    | Integral src, Integral dst -> Integral.static_cast ~dbg ~src ~dst exp
+    | Float src, Float dst -> Float_width.static_cast ~dbg ~src ~dst exp
+    | Integral src, Float dst ->
+      let float_of_int_arg = Integral.nativeint in
+      if not
+           (Integral.can_cast_without_losing_information ~src
+              ~dst:float_of_int_arg)
+      then
+        Misc.fatal_errorf "static_cast: casting %a to float is not implemented"
+          Integral.print src
+      else
+        unary (Cstatic_cast (Float_of_int dst)) ~dbg
+          (Integral.static_cast exp ~dbg ~src ~dst:float_of_int_arg)
+    | Float src, Integral dst -> (
+      match Integral.signedness dst with
+      | Unsigned ->
+        Misc.fatal_errorf
+          "static_cast: casting floats to unsigned values is not implemented"
+      | Signed ->
+        (* we can truncate because casting from float -> int is unspecified when
+           the rounded value doesn't fit in the integral type. We can't promote
+           since nativeint is already the largest integral type supported
+           here. *)
+        let exp = unary (Cstatic_cast (Int_of_float src)) exp ~dbg in
+        let src = Integral.nativeint in
+        (* assert that nativeint is indeed the largest integer width *)
+        assert (Integral.can_cast_without_losing_information ~src:dst ~dst:src);
+        Integral.static_cast exp ~dbg ~src ~dst)
+
+  let[@inline] conjugate ~outer ~inner ~dbg ~f x =
+    x
+    |> static_cast ~src:outer ~dst:inner ~dbg
+    |> f
+    |> static_cast ~src:inner ~dst:outer ~dbg
+
+  module Untagged = struct
+    type numeric = t
+
+    type t =
+      | Untagged of Integer.t
+      | Float of float_width
+
+    let to_numeric : t -> numeric = function
+      | Untagged width -> Integral (Untagged width)
+      | Float float -> Float float
+
+    let[@inline] static_cast ~dbg ~src ~dst exp =
+      static_cast ~dbg ~src:(to_numeric src) ~dst:(to_numeric dst) exp
+  end
+end

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -660,7 +660,7 @@ let max_with_zero ~size_int x =
   ret
 
 (* actual (strict) upper bound for an index in a string-like read/write *)
-let actual_max_length_for_string_like_access ~size_int
+let actual_max_length_for_string_like_access_as_nativeint ~size_int
     ~(access_size : Flambda_primitive.string_accessor_width) length =
   (* offset to subtract from the length depending on the size of the
      read/write *)
@@ -701,7 +701,8 @@ let string_like_access_validity_condition ~size_int ~access_size ~length
     ~index_kind index : H.expr_primitive =
   check_bound ~index_kind ~bound_kind:Naked_nativeint ~index
     ~bound:
-      (actual_max_length_for_string_like_access ~size_int ~access_size length)
+      (actual_max_length_for_string_like_access_as_nativeint ~size_int
+         ~access_size length)
 
 let string_or_bytes_access_validity_condition ~size_int str kind access_size
     ~index_kind index : H.expr_primitive =

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -520,34 +520,72 @@ let dead_slots_msg dbg function_slots value_slots =
 
 (* Arithmetic primitives *)
 
+let naked_int32 : C.Scalar_type.Integral.t =
+  Untagged (C.Scalar_type.Integer.create_exn ~bit_width:32 ~signedness:Signed)
+
+let naked_int64 : C.Scalar_type.Integral.t =
+  Untagged (C.Scalar_type.Integer.create_exn ~bit_width:64 ~signedness:Signed)
+
+let naked_nativeint : C.Scalar_type.Integral.t =
+  Untagged C.Scalar_type.Integer.nativeint
+
+let naked_immediate : C.Scalar_type.Integral.t =
+  Untagged C.Scalar_type.Tagged_integer.(untagged immediate)
+
+let tagged_immediate : C.Scalar_type.Integral.t =
+  Tagged C.Scalar_type.Tagged_integer.immediate
+
+let integral_of_standard_int : K.Standard_int.t -> C.Scalar_type.Integral.t =
+  function
+  | Naked_int32 -> naked_int32
+  | Naked_int64 -> naked_int64
+  | Naked_nativeint -> naked_nativeint
+  | Naked_immediate -> naked_immediate
+  | Tagged_immediate -> tagged_immediate
+
+let scalar_type_of_standard_int_or_float :
+    K.Standard_int_or_float.t -> C.Scalar_type.t = function
+  | Naked_int32 -> Integral naked_int32
+  | Naked_int64 -> Integral naked_int64
+  | Naked_nativeint -> Integral naked_nativeint
+  | Naked_immediate -> Integral naked_immediate
+  | Tagged_immediate -> Integral tagged_immediate
+  | Naked_float32 -> Float Float32
+  | Naked_float -> Float Float64
+
 let unary_int_arith_primitive _env dbg kind op arg =
-  match (kind : K.Standard_int.t), (op : P.unary_int_arith_op) with
-  | Tagged_immediate, Neg -> C.negint arg dbg
-  | Tagged_immediate, Swap_byte_endianness ->
-    (* This isn't currently needed since [Lambda_to_flambda_primitives] always
-       untags the integer first. *)
-    Misc.fatal_error "Not yet implemented"
-  | Naked_immediate, Swap_byte_endianness ->
-    (* This case should not have a sign extension, confusingly, because it
-       arises from the [Pbswap16] Lambda primitive. That operation does not
-       affect the sign of the resulting value. *)
-    C.bswap16 arg dbg
-  (* Negation needs a sign-extension for 32-bit and 63-bit values *)
-  | Naked_immediate, Neg ->
-    C.sign_extend ~bits:63 ~dbg
-      (C.sub_int (C.int ~dbg 0) (C.low_bits ~bits:63 ~dbg arg) dbg)
-  | Naked_int32, Neg ->
-    C.sign_extend ~bits:32 ~dbg
-      (C.sub_int (C.int ~dbg 0) (C.low_bits ~bits:32 ~dbg arg) dbg)
-  (* General case *)
-  | (Naked_int64 | Naked_nativeint), Neg -> C.sub_int (C.int ~dbg 0) arg dbg
-  (* Byte swaps of 32-bit integers on 64-bit targets need a sign-extension in
-     order to match the Lambda semantics (where the swap might affect the
-     sign). *)
-  | Naked_int32, Swap_byte_endianness ->
-    C.sign_extend ~bits:32 ~dbg (C.bbswap Unboxed_int32 arg dbg)
-  | Naked_int64, Swap_byte_endianness -> C.bbswap Unboxed_int64 arg dbg
-  | Naked_nativeint, Swap_byte_endianness -> C.bbswap Unboxed_nativeint arg dbg
+  match (op : P.unary_int_arith_op) with
+  | Neg -> (
+    match integral_of_standard_int kind with
+    | Tagged src ->
+      C.Scalar_type.Tagged_integer.conjugate ~dbg ~outer:src
+        ~inner:C.Scalar_type.Tagged_integer.immediate
+        ~f:(fun x -> C.negint x dbg)
+        arg
+    | Untagged src ->
+      let bits = C.Scalar_type.Integer.bit_width src in
+      C.Scalar_type.Integer.conjugate arg ~outer:src
+        ~inner:C.Scalar_type.Integer.nativeint ~dbg ~f:(fun arg ->
+          C.neg_int (C.low_bits ~bits arg ~dbg) dbg))
+  | Swap_byte_endianness -> (
+    match (kind : K.Standard_int.t) with
+    | Tagged_immediate ->
+      (* This isn't currently needed since [Lambda_to_flambda_primitives] always
+         untags the integer first. *)
+      Misc.fatal_error "Not yet implemented"
+    | Naked_immediate ->
+      (* This case should not have a sign extension, confusingly, because it
+         arises from the [Pbswap16] Lambda primitive. That operation does not
+         affect the sign of the resulting value. *)
+      C.bswap16 arg dbg
+    | Naked_int32 ->
+      C.sign_extend (C.bbswap Unboxed_int32 arg dbg) ~bits:32 ~dbg
+    (* int64 and nativeint don't require a sign-extension since they are already
+       register-size, but the code is here for consistency: *)
+    | Naked_int64 ->
+      C.sign_extend (C.bbswap Unboxed_int64 arg dbg) ~bits:64 ~dbg
+    | Naked_nativeint ->
+      C.sign_extend (C.bbswap Unboxed_nativeint arg dbg) ~bits:C.arch_bits ~dbg)
 
 let unary_float_arith_primitive _env dbg width op arg =
   match (width : P.float_bitwidth), (op : P.unary_float_arith_op) with
@@ -557,66 +595,24 @@ let unary_float_arith_primitive _env dbg width op arg =
   | Float32, Neg -> C.float32_neg ~dbg arg
 
 let arithmetic_conversion dbg src dst arg =
-  let open K.Standard_int_or_float in
-  match src, dst with
-  (* Float-Float conversions *)
-  | Naked_float32, Naked_float32 -> None, arg
-  | Naked_float, Naked_float -> None, arg
-  | Naked_float, Naked_float32 -> None, C.float32_of_float ~dbg arg
-  | Naked_float32, Naked_float -> None, C.float_of_float32 ~dbg arg
-  (* Conversions to and from tagged ints *)
-  | ( (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate),
-      Tagged_immediate ) ->
-    None, C.tag_int arg dbg
-  | Tagged_immediate, (Naked_int64 | Naked_nativeint) ->
-    Some (Env.Untag arg), C.untag_int arg dbg
-  (* Operations resulting in int32s must take care to sign extend the result *)
-  (* CR-someday xclerc: untag_int followed by sign_extend_32 sounds suboptimal,
-     as it performs asr 1; lsl 32; asr 32 while we could do lsl 31; asr 32
-     instead. (Beware of the optimizations / pattern matching in the helpers
-     though.) *)
-  | Tagged_immediate, Naked_int32 ->
-    None, C.sign_extend ~bits:32 ~dbg (C.untag_int arg dbg)
-  | Tagged_immediate, Naked_immediate ->
-    None, C.sign_extend ~bits:63 ~dbg (C.untag_int arg dbg)
-  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Naked_int32
-    ->
-    None, C.sign_extend ~bits:32 ~dbg arg
-  (* No-op conversions *)
-  | Tagged_immediate, Tagged_immediate
-  | Naked_int32, (Naked_int64 | Naked_nativeint | Naked_immediate)
-  | Naked_int64, (Naked_int64 | Naked_nativeint | Naked_immediate)
-  | Naked_nativeint, (Naked_int64 | Naked_nativeint | Naked_immediate)
-  | Naked_immediate, (Naked_int64 | Naked_nativeint | Naked_immediate) ->
-    None, arg
-  (* Int-Float32 conversions *)
-  | Tagged_immediate, Naked_float32 ->
-    None, C.float32_of_int ~dbg (C.untag_int arg dbg)
-  | ( (Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint),
-      Naked_float32 ) ->
-    None, C.float32_of_int ~dbg arg
-  | Naked_float32, Tagged_immediate ->
-    None, C.tag_int (C.int_of_float32 ~dbg arg) dbg
-  | Naked_float32, (Naked_int64 | Naked_nativeint) ->
-    None, C.int_of_float32 ~dbg arg
-  | Naked_float32, Naked_int32 ->
-    None, C.sign_extend ~bits:32 ~dbg (C.int_of_float32 ~dbg arg)
-  | Naked_float32, Naked_immediate ->
-    None, C.sign_extend ~bits:63 ~dbg (C.int_of_float32 ~dbg arg)
-    (* Int-Float conversions *)
-  | Tagged_immediate, Naked_float ->
-    None, C.float_of_int ~dbg (C.untag_int arg dbg)
-  | (Naked_immediate | Naked_int32 | Naked_int64 | Naked_nativeint), Naked_float
-    ->
-    None, C.float_of_int ~dbg arg
-  | Naked_float, Tagged_immediate ->
-    None, C.tag_int (C.int_of_float ~dbg arg) dbg
-  | Naked_float, (Naked_int64 | Naked_nativeint) ->
-    None, C.int_of_float ~dbg arg
-  | Naked_float, Naked_int32 ->
-    None, C.sign_extend ~bits:32 ~dbg (C.int_of_float ~dbg arg)
-  | Naked_float, Naked_immediate ->
-    None, C.sign_extend ~bits:63 ~dbg (C.int_of_float ~dbg arg)
+  if K.Standard_int_or_float.equal src dst
+  then None, arg
+  else
+    let src = scalar_type_of_standard_int_or_float src in
+    let dst = scalar_type_of_standard_int_or_float dst in
+    let extra =
+      (* CR-someday jvanburen: add Env.Tag? *)
+      match src, dst with
+      | Integral (Tagged src), Integral (Untagged dst)
+        when C.Scalar_type.Integer.equal
+               (C.Scalar_type.Tagged_integer.untagged src)
+               dst ->
+        Some (Env.Untag arg)
+      | ( (Integral (Tagged _ | Untagged _) | Float (Float32 | Float64)),
+          (Integral (Tagged _ | Untagged _) | Float (Float32 | Float64)) ) ->
+        None
+    in
+    extra, C.Scalar_type.static_cast ~dbg ~src ~dst arg
 
 let phys_equal _env dbg op x y =
   match (op : P.equality_comparison) with
@@ -624,126 +620,135 @@ let phys_equal _env dbg op x y =
   | Eq -> C.eq ~dbg x y
   | Neq -> C.neq ~dbg x y
 
+let requires_sign_extended_operands : P.binary_int_arith_op -> bool = function
+  | Div | Mod ->
+    (* Note that it would be wrong to apply [C.low_bits] to operands for div and
+       mod.
+
+       Some background: The problem arises in cases like: [(num1 * num2) /
+       num3]. If an overflow occurs in the multiplication, then we must deal
+       with it by sign-extending before the division. Whereas [ (num1 * num2) *
+       num3 ] can delay the sign-extension until the very end, even in the case
+       of overflow in the middle. So in a way, div and mod are regular
+       functions, while all the others are special as they can delay overflow
+       handling.
+
+       Cmm only has [Arch.size_int]-width virtual registers, so we must always
+       do operations on values of that size. (If we had smaller virtual
+       registers, we could use them in Cmm without sign-extension and let the
+       backend insert sign-extensions if it doesn't support operations on n-bit
+       physical registers. There was a prototype developed of this but it was
+       quite complicated and didn't get merged.) *)
+    true
+  | Add | Sub | Mul ->
+    (* https://en.wikipedia.org/wiki/Modular_arithmetic - these operations are
+       compatible with modular arithmetic *)
+    false
+  | And | Or | Xor ->
+    (* bitwise operations are clearly compatible *)
+    false
+
 let binary_int_arith_primitive _env dbg (kind : K.Standard_int.t)
     (op : P.binary_int_arith_op) x y =
+  let kind = integral_of_standard_int kind in
+  let[@local] wrap f =
+    (* We cast the operands to the width that the operator expects, apply the
+       operator, and cast the result back. *)
+    let operator_type : C.Scalar_type.Integral.t =
+      match kind with
+      | Untagged _ -> Untagged C.Scalar_type.Integer.nativeint
+      | Tagged _ -> Tagged C.Scalar_type.Tagged_integer.immediate
+    in
+    let[@inline] prepare_operand operand =
+      let operand =
+        C.Scalar_type.Integral.static_cast ~dbg ~src:kind ~dst:operator_type
+          operand
+      in
+      if requires_sign_extended_operands op
+      then operand
+      else
+        let bits =
+          match kind with
+          | Untagged untagged -> C.Scalar_type.Integer.bit_width untagged
+          | Tagged tagged ->
+            C.Scalar_type.Tagged_integer.bit_width_including_tag_bit tagged
+        in
+        C.low_bits ~bits operand ~dbg
+    in
+    let x = prepare_operand x in
+    let y = prepare_operand y in
+    let result = f x y dbg in
+    C.Scalar_type.Integral.static_cast ~dbg ~src:operator_type ~dst:kind result
+    (* Operations on integer arguments must return something in the range of
+       their values, hence the [static_cast] here. The [C.low_bits] operations
+       (see above in [prepare_operand]) are used to avoid unnecessary
+       sign-extensions, e.g. when chaining additions together. Also see comment
+       below about [C.low_bits] in the [Div] and [Mod] cases. *)
+  in
   match kind with
+  | Tagged _ -> (
+    match op with
+    | Add -> wrap C.add_int_caml
+    | Sub -> wrap C.sub_int_caml
+    | Mul -> wrap C.mul_int_caml
+    | Div -> wrap C.div_int_caml
+    | Mod -> wrap C.mod_int_caml
+    | And -> wrap C.and_int_caml
+    | Or -> wrap C.or_int_caml
+    | Xor -> wrap C.xor_int_caml)
+  | Untagged untagged -> (
+    let dividend_cannot_be_min_int =
+      C.Scalar_type.Integer.bit_width untagged < C.arch_bits
+    in
+    match op with
+    | Add -> wrap C.add_int
+    | Sub -> wrap C.sub_int
+    | Mul -> wrap C.mul_int
+    | Div -> wrap (C.div_int ~dividend_cannot_be_min_int)
+    | Mod -> wrap (C.mod_int ~dividend_cannot_be_min_int)
+    | And -> wrap C.and_int
+    | Or -> wrap C.or_int
+    | Xor -> wrap C.xor_int)
+
+let binary_int_shift_primitive _env dbg kind (op : P.int_shift_op) x y =
+  (* See comments on [binary_int_arity_primitive], above, about sign extension
+     and use of [C.low_bits]. *)
+  match[@warning "-fragile-match"] (kind : K.Standard_int.t) with
   | Tagged_immediate -> (
     match op with
-    | Add -> C.add_int_caml x y dbg
-    | Sub -> C.sub_int_caml x y dbg
-    | Mul -> C.mul_int_caml x y dbg
-    | Div -> C.div_int_caml x y dbg
-    | Mod -> C.mod_int_caml x y dbg
-    | And -> C.and_int_caml x y dbg
-    | Or -> C.or_int_caml x y dbg
-    | Xor -> C.xor_int_caml x y dbg)
-  | Naked_int32 -> (
-    (* Operations on 32-bit integer arguments must return something in the range
-       of 32-bit integers, hence the sign_extensions here. The [C.low_32]
-       operations (see above in [sign_extend_32_can_delay_overflow]) are used to
-       avoid unnecessary sign extensions, e.g. when chaining additions together.
-       Also see comment below about [C.low_32] in the [Div] and [Mod] cases. *)
-    let sign_extend_32_can_delay_overflow f =
-      C.sign_extend ~bits:32 ~dbg
-        (f (C.low_bits ~bits:32 ~dbg x) (C.low_bits ~bits:32 ~dbg y) dbg)
+    | Lsl -> C.lsl_int_caml_raw x y ~dbg
+    | Lsr -> C.lsr_int_caml_raw x y ~dbg
+    | Asr -> C.asr_int_caml_raw x y ~dbg)
+  | kind ->
+    let kind = integral_of_standard_int kind in
+    let right_shift_kind signedness =
+      (* right shifts can operate directly on any untagged integers of the
+         correct signedness, as they do not require sign- or zero-extension
+         after the shift, since the cmm scalar types are already stored sign- or
+         zero-extended *)
+      C.Scalar_type.Integer.with_signedness
+        (C.Scalar_type.Integral.untagged_or_identity kind)
+        ~signedness
     in
-    let dividend_cannot_be_min_int = C.arch_bits > 32 in
-    match op with
-    | Add -> sign_extend_32_can_delay_overflow C.add_int
-    | Sub -> sign_extend_32_can_delay_overflow C.sub_int
-    | Mul -> sign_extend_32_can_delay_overflow C.mul_int
-    | Xor -> sign_extend_32_can_delay_overflow C.xor_int
-    | And -> sign_extend_32_can_delay_overflow C.and_int
-    | Or -> sign_extend_32_can_delay_overflow C.or_int
-    | Div ->
-      (* Note that it would be wrong to apply [C.low_32] to [x] and/or [y] here
-         -- likewise in the next [Mod] case. [C.safe_div_bi] and [C.safe_mod_bi]
-         require sign-extended input for both the numerator and denominator.
-
-         Some background: The problem arises in cases like: (num1 * num2) /
-         num3. If an overflow occurs in the multiplication, then we must deal
-         with it by sign-extending before the division. Whereas (num1 * num2) *
-         num3 can delay the sign-extension until the very end, even in the case
-         of overflow in the middle. So in a way, div and mod are regular
-         functions, while all the others are special as they can delay overflow
-         handling.
-
-         We don't have 32-bit registers in Cmm, so sign extension really means
-         modulo 2^31. (If we had 32-bit virtual registers, we could use them in
-         Cmm without sign extension and let the backend insert sign extensions
-         if it doesn't support operations on 32-bit physical registers. There
-         was a prototype developed of this but it was quite complicated and
-         didn't get merged.) *)
-      C.sign_extend ~bits:32 ~dbg
-        (C.div_int x y ~dividend_cannot_be_min_int dbg)
-    | Mod ->
-      C.sign_extend ~bits:32 ~dbg
-        (C.mod_int x y ~dividend_cannot_be_min_int dbg))
-  | Naked_immediate -> (
-    let sign_extend_63_can_delay_overflow f =
-      C.sign_extend ~bits:63 ~dbg
-        (f (C.low_bits ~bits:63 ~dbg x) (C.low_bits ~bits:63 ~dbg y) dbg)
+    let f, (op_kind : C.Scalar_type.Integer.t) =
+      match op with
+      | Asr -> C.asr_int, right_shift_kind Signed
+      | Lsr -> C.lsr_int, right_shift_kind Unsigned
+      | Lsl ->
+        (* Left shifts operate on nativeints since they might shift arbitrary
+           bits into the high bits of the register. *)
+        C.lsl_int, C.Scalar_type.Integer.nativeint
     in
-    let dividend_cannot_be_min_int = C.arch_bits > 63 in
-    match op with
-    | Add -> sign_extend_63_can_delay_overflow C.add_int
-    | Sub -> sign_extend_63_can_delay_overflow C.sub_int
-    | Mul -> sign_extend_63_can_delay_overflow C.mul_int
-    | Xor -> sign_extend_63_can_delay_overflow C.xor_int
-    | And -> sign_extend_63_can_delay_overflow C.and_int
-    | Or -> sign_extend_63_can_delay_overflow C.or_int
-    | Div ->
-      C.sign_extend ~bits:63 ~dbg
-        (C.div_int x y dbg ~dividend_cannot_be_min_int)
-    | Mod ->
-      C.sign_extend ~bits:63 ~dbg
-        (C.mod_int x y dbg ~dividend_cannot_be_min_int))
-  | Naked_int64 | Naked_nativeint -> (
-    (* Machine-width integers, no sign extension required. *)
-    match op with
-    | Add -> C.add_int x y dbg
-    | Sub -> C.sub_int x y dbg
-    | Mul -> C.mul_int x y dbg
-    | And -> C.and_int x y dbg
-    | Or -> C.or_int x y dbg
-    | Xor -> C.xor_int x y dbg
-    | Div -> C.div_int x y dbg
-    | Mod -> C.mod_int x y dbg)
-
-let binary_int_shift_primitive _env dbg kind op x y =
-  match (kind : K.Standard_int.t), (op : P.int_shift_op) with
-  (* caml primitives for these have no native/unboxed version *)
-  (* Tagged integers *)
-  | Tagged_immediate, Lsl -> C.lsl_int_caml_raw ~dbg x y
-  | Tagged_immediate, Lsr -> C.lsr_int_caml_raw ~dbg x y
-  | Tagged_immediate, Asr -> C.asr_int_caml_raw ~dbg x y
-  (* See comments on [binary_int_arity_primitive], above, about sign extension
-     and use of [C.low_32]. *)
-  | Naked_int32, Lsl ->
-    C.sign_extend ~bits:32 ~dbg (C.lsl_int (C.low_bits ~bits:32 ~dbg x) y dbg)
-  | Naked_int32, Lsr ->
-    (* Ensure that the top half of the register is cleared, as some of those
-       bits are likely to get shifted into the result. *)
-    let arg = C.zero_extend ~bits:32 ~dbg x in
-    C.sign_extend ~bits:32 ~dbg (C.lsr_int arg y dbg)
-  | Naked_int32, Asr -> C.sign_extend ~bits:32 ~dbg (C.asr_int x y dbg)
-  | Naked_immediate, Lsl ->
-    C.sign_extend ~bits:63 ~dbg (C.lsl_int (C.low_bits ~bits:63 ~dbg x) y dbg)
-  | Naked_immediate, Lsr ->
-    (* Same comment as in the [Naked_int32] case above re. zero extension. *)
-    let arg = C.zero_extend ~bits:63 ~dbg x in
-    C.sign_extend ~bits:63 ~dbg (C.lsr_int arg y dbg)
-  | Naked_immediate, Asr -> C.sign_extend ~bits:63 ~dbg (C.asr_int x y dbg)
-  (* Naked ints *)
-  | (Naked_int64 | Naked_nativeint), Lsl -> C.lsl_int x y dbg
-  | (Naked_int64 | Naked_nativeint), Lsr -> C.lsr_int x y dbg
-  | (Naked_int64 | Naked_nativeint), Asr -> C.asr_int x y dbg
+    C.Scalar_type.Integral.conjugate ~outer:kind ~inner:(Untagged op_kind) ~dbg
+      ~f:(fun x ->
+        (* [kind] only applies to [x], the [y] argument is always a bare
+           register-sized integer *)
+        f x y dbg)
+      x
 
 let binary_int_comp_primitive _env dbg kind cmp x y =
-  let ignore_low_bit_int = C.ignore_low_bit_int in
   match
-    ( (kind : Flambda_kind.Standard_int.t),
-      (cmp : P.signed_or_unsigned P.comparison) )
+    integral_of_standard_int kind, (cmp : P.signed_or_unsigned P.comparison)
   with
   (* [x] and [y] are expressions yielding well-formed tagged immediates, that is
      to say, their least significant bit (LSB) is 1. However when comparing
@@ -755,47 +760,25 @@ let binary_int_comp_primitive _env dbg kind cmp x y =
 
      See middle_end/flambda2/z3/comparisons.smt2 for a Z3 script to prove
      this. *)
-  | Tagged_immediate, Lt Signed -> C.lt ~dbg x (ignore_low_bit_int y)
-  | Tagged_immediate, Le Signed -> C.le ~dbg (ignore_low_bit_int x) y
-  | Tagged_immediate, Gt Signed -> C.gt ~dbg (ignore_low_bit_int x) y
-  | Tagged_immediate, Ge Signed -> C.ge ~dbg x (ignore_low_bit_int y)
-  | Tagged_immediate, Lt Unsigned -> C.ult ~dbg x (ignore_low_bit_int y)
-  | Tagged_immediate, Le Unsigned -> C.ule ~dbg (ignore_low_bit_int x) y
-  | Tagged_immediate, Gt Unsigned -> C.ugt ~dbg (ignore_low_bit_int x) y
-  | Tagged_immediate, Ge Unsigned -> C.uge ~dbg x (ignore_low_bit_int y)
+  | Tagged _, Lt Signed -> C.lt ~dbg x (C.ignore_low_bit_int y)
+  | Tagged _, Le Signed -> C.le ~dbg (C.ignore_low_bit_int x) y
+  | Tagged _, Gt Signed -> C.gt ~dbg (C.ignore_low_bit_int x) y
+  | Tagged _, Ge Signed -> C.ge ~dbg x (C.ignore_low_bit_int y)
+  | Tagged _, Lt Unsigned -> C.ult ~dbg x (C.ignore_low_bit_int y)
+  | Tagged _, Le Unsigned -> C.ule ~dbg (C.ignore_low_bit_int x) y
+  | Tagged _, Gt Unsigned -> C.ugt ~dbg (C.ignore_low_bit_int x) y
+  | Tagged _, Ge Unsigned -> C.uge ~dbg x (C.ignore_low_bit_int y)
   (* Naked integers. *)
-  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Lt Signed
-    ->
-    C.lt ~dbg x y
-  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Le Signed
-    ->
-    C.le ~dbg x y
-  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Gt Signed
-    ->
-    C.gt ~dbg x y
-  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Ge Signed
-    ->
-    C.ge ~dbg x y
-  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Lt Unsigned
-    ->
-    C.ult ~dbg x y
-  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Le Unsigned
-    ->
-    C.ule ~dbg x y
-  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Gt Unsigned
-    ->
-    C.ugt ~dbg x y
-  | (Naked_int32 | Naked_int64 | Naked_nativeint | Naked_immediate), Ge Unsigned
-    ->
-    C.uge ~dbg x y
-  | ( ( Tagged_immediate | Naked_int32 | Naked_int64 | Naked_nativeint
-      | Naked_immediate ),
-      Eq ) ->
-    C.eq ~dbg x y
-  | ( ( Tagged_immediate | Naked_int32 | Naked_int64 | Naked_nativeint
-      | Naked_immediate ),
-      Neq ) ->
-    C.neq ~dbg x y
+  | Untagged _, Lt Signed -> C.lt ~dbg x y
+  | Untagged _, Le Signed -> C.le ~dbg x y
+  | Untagged _, Gt Signed -> C.gt ~dbg x y
+  | Untagged _, Ge Signed -> C.ge ~dbg x y
+  | Untagged _, Lt Unsigned -> C.ult ~dbg x y
+  | Untagged _, Le Unsigned -> C.ule ~dbg x y
+  | Untagged _, Gt Unsigned -> C.ugt ~dbg x y
+  | Untagged _, Ge Unsigned -> C.uge ~dbg x y
+  | (Tagged _ | Untagged _), Eq -> C.eq ~dbg x y
+  | (Tagged _ | Untagged _), Neq -> C.neq ~dbg x y
 
 let binary_int_comp_primitive_yielding_int _env dbg _kind
     (signed : P.signed_or_unsigned) x y =


### PR DESCRIPTION
`Cmm_helpers.Scalar_type` provides utilities for converting between integers types of different widths and signedness. This is in preparation for adding unboxed small integer types.