### PR TITLE
Port upstream PRs 11542 and 12505 to runtime4

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1769,15 +1769,11 @@ let make_alloc_generic ~block_kind ~mode dbg tag wordsize args
            fields and memory chunks"
     in
     let caml_alloc_func, caml_alloc_args =
-      match Config.runtime5, block_kind with
-      | true, Regular_block -> "caml_alloc_shr_check_gc", [wordsize; tag]
-      | false, Regular_block -> "caml_alloc", [wordsize; tag]
-      | true, Mixed_block { scannable_prefix } ->
+      match block_kind with
+      | Regular_block -> "caml_alloc_shr_check_gc", [wordsize; tag]
+      | Mixed_block { scannable_prefix } ->
         Mixed_block_support.assert_mixed_block_support ();
         "caml_alloc_mixed_shr_check_gc", [wordsize; tag; scannable_prefix]
-      | false, Mixed_block { scannable_prefix } ->
-        Mixed_block_support.assert_mixed_block_support ();
-        "caml_alloc_mixed", [wordsize; tag; scannable_prefix]
     in
     Clet
       ( VP.create id,

--- a/runtime4/caml/alloc.h
+++ b/runtime4/caml/alloc.h
@@ -37,6 +37,9 @@ CAMLextern value caml_alloc_mixed (mlsize_t wosize, tag_t,
 CAMLextern value caml_alloc_small (mlsize_t wosize, tag_t);
 CAMLextern value caml_alloc_small_with_reserved (mlsize_t wosize, tag_t,
                                                  reserved_t);
+CAMLextern value caml_alloc_shr_check_gc (mlsize_t, tag_t);
+CAMLextern value caml_alloc_mixed_shr_check_gc (mlsize_t, tag_t,
+                                                mlsize_t scannable_wosize);
 CAMLextern value caml_alloc_tuple (mlsize_t wosize);
 CAMLextern value caml_alloc_float_array (mlsize_t len);
 CAMLextern value caml_alloc_string (mlsize_t len);  /* len in bytes (chars) */


### PR DESCRIPTION
As title.

Both PRs fix bugs that are very uncommon and only matter in `-no-naked-pointers` mode, so they were never backported to the 4.x upstream branch.
We do want to support runtime4 for a little longer though, and @mshinwell has stumbled upon issues that look related, so it makes sense to port the corresponding changes to the runtime4 folder.

The commit started as a cherry-pick of ocaml/ocaml#11542, but in practice I ended up copying the relevant runtime5 code into `runtime4/`, which also got me the port of ocaml/ocaml#12505 for free (and I didn't have to write any new runtime code).
