### PR TITLE
Unbox_float32 should check custom ops name

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -802,9 +802,10 @@ let box_float32 dbg mode exp =
 
 let unbox_float32 dbg =
   map_tail ~kind:Any (function
-    | Cop (Calloc _, [Cconst_natint (hdr, _); _ops; c], _)
-      when Nativeint.equal hdr boxedfloat32_header
-           || Nativeint.equal hdr boxedfloat32_local_header ->
+    | Cop (Calloc _, [Cconst_natint (hdr, _); Cconst_symbol (sym, _); c], _)
+      when (Nativeint.equal hdr boxedfloat32_header
+           || Nativeint.equal hdr boxedfloat32_local_header)
+           && String.equal sym.sym_name caml_float32_ops ->
       c
     | Cconst_symbol (s, _dbg) as cmm -> (
       match Cmmgen_state.structured_constant_of_sym s.sym_name with


### PR DESCRIPTION
Checking for `boxedfloat32_header` is not sufficient to know that the block is a boxed float32; the custom ops symbol must also be `caml_float32_ops`. The check is now consistent with the int unboxing function.

I don't think this bug can be hit in a real program, since the expression passed to `%unbox_float32` must have type `float32`, so this function won't have the opportunity to misinterpret another single-field custom block.