### PR TITLE
Make patricia trees big-endian

### DIFF
--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -247,6 +247,7 @@ let name_for_int_operation = function
   | Ilsl -> "lsl"
   | Ilsr -> "lsr"
   | Iasr -> "asr"
+  | Iclz -> "clz"
   | _ -> assert false
 
 (* Decompose an integer constant into four 16-bit shifted fragments.

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -1001,6 +1001,9 @@ let emit_instr i =
         `	smulh	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
     | Lop(Intop (Imulh { signed = false })) ->
         `	umulh	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
+    | Lop(Intop (Iclz _ as op)) ->
+        let instr = name_for_int_operation op in
+        `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
     | Lop(Intop op) ->
         let instr = name_for_int_operation op in
         `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -247,7 +247,7 @@ let name_for_int_operation = function
   | Ilsl -> "lsl"
   | Ilsr -> "lsr"
   | Iasr -> "asr"
-  | Iclz -> "clz"
+  | Iclz { arg_is_non_zero = _ } -> "clz"
   | _ -> assert false
 
 (* Decompose an integer constant into four 16-bit shifted fragments.

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -484,7 +484,7 @@ let assemble_file infile outfile =
 let init () = ()
 
 let operation_supported = function
-  | Cclz _ | Cctz _ | Cpopcnt
+  | Cctz _ | Cpopcnt
   | Cprefetch _ | Catomic _
   (* CR mslater: (float32) arm64 *)
   | Cnegf Float32 | Cabsf Float32 | Caddf Float32
@@ -497,7 +497,7 @@ let operation_supported = function
                   Int_of_float Float32 | Float_of_int Float32 |
                   V128_of_scalar _ | Scalar_of_v128 _)
     -> false   (* Not implemented *)
-  | Cbswap _
+  | Cclz _ | Cbswap _
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr

--- a/middle_end/flambda2/algorithms/builtin_stubs.c
+++ b/middle_end/flambda2/algorithms/builtin_stubs.c
@@ -5,7 +5,16 @@
 #include <intrin.h>
 #endif
 
-intnat caml_int_clz_tagged_to_untagged(value i) {
+// These are replaced with clz instructions by flambda2.
+//
+// Use weak symbols in order to allow compiler-libs and ocaml_intrinsics_kernel
+// to be shared dependencies of the same program.
+
+CAMLweakdef intnat caml_int_clz_tagged_to_untagged(value i) {
+    // Do not use Long_val(v1) conversion, instead preserving the tag.
+    // It guarantees that the input to builtin_clz / _BitScanReverse is
+    // non-zero, to guard against versions that are undefined for input 0. The
+    // tag does not change the number of leading zeros.
 #if defined(__GNUC__) || defined(__clang__)
     #if SIZEOF_PTR == SIZEOF_INT
     return __builtin_clz(i);
@@ -33,6 +42,6 @@ intnat caml_int_clz_tagged_to_untagged(value i) {
 #endif
 }
 
-value caml_int_clz_tagged_to_tagged(value i) {
+CAMLweakdef value caml_int_clz_tagged_to_tagged(value i) {
     return Val_int(caml_int_clz_tagged_to_untagged(i));
 }

--- a/middle_end/flambda2/algorithms/builtin_stubs.c
+++ b/middle_end/flambda2/algorithms/builtin_stubs.c
@@ -1,0 +1,38 @@
+#include "caml/mlvalues.h"
+#include "caml/fail.h"
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
+intnat caml_int_clz_tagged_to_untagged(value i) {
+#if defined(__GNUC__) || defined(__clang__)
+    #if SIZEOF_PTR == SIZEOF_INT
+    return __builtin_clz(i);
+    #elif SIZEOF_PTR == SIZEOF_LONG
+    return __builtin_clzl(i);
+    #elif SIZEOF_PTR == SIZEOF_LONGLONG
+    return __builtin_clzll(i);
+    #else
+    #error "No builtin clz function available"
+    #endif
+#elif defined(_MSC_VER)
+    unsigned long r = 0;
+    #ifdef SIZEOF_PTR == 8
+    _BitScanReverse64(&r, i);
+    r ^= 63;
+    #elif SIZEOF_PTR == 4
+    _BitScanReverse(&r, i);
+    r ^= 31;
+    #else
+    #error "No builtin bsr function available"
+    #endif
+    return r;
+#else
+    #error "Unsupported compiler"
+#endif
+}
+
+value caml_int_clz_tagged_to_tagged(value i) {
+    return Val_int(caml_int_clz_tagged_to_untagged(i));
+}

--- a/middle_end/flambda2/algorithms/dune
+++ b/middle_end/flambda2/algorithms/dune
@@ -4,6 +4,13 @@
  (name flambda2_algorithms)
  (wrapped true)
  (instrumentation (backend bisect_ppx))
+ (foreign_stubs
+  (language c)
+  (names builtin_stubs)
+  (flags
+   ((:include %{project_root}/oc_cflags.sexp)
+    (:include %{project_root}/sharedlib_cflags.sexp)
+    (:include %{project_root}/oc_cppflags.sexp))))
  (ocamlopt_flags
   (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries ocamlcommon))

--- a/middle_end/flambda2/algorithms/dune
+++ b/middle_end/flambda2/algorithms/dune
@@ -14,3 +14,9 @@
  (ocamlopt_flags
   (:standard -O3 -open Int_replace_polymorphic_compare))
  (libraries ocamlcommon))
+
+(install
+ (files
+  (dllflambda2_algorithms_stubs.so as stublibs/dllflambda2_algorithms_stubs.so))
+ (section lib)
+ (package ocaml))

--- a/middle_end/flambda2/algorithms/patricia_tree.ml
+++ b/middle_end/flambda2/algorithms/patricia_tree.ml
@@ -12,53 +12,50 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* The following is a "little endian" implementation. *)
-
-(* CR-someday mshinwell: Can we fix the traversal order by swapping endianness?
-   What other (dis)advantages might that have?
-
-   lmaurer: It would make [split] nearly as fast as [find]. One issue is we'd
-   want fast clz in order to implement [highest_bit]. *)
+(* The following is a "big endian" implementation. *)
 
 type key = int
+
+external int_clz : int -> (int[@untagged])
+  = "caml_int_clz_tagged_to_tagged" "caml_int_clz_tagged_to_untagged"
 
 (* A bit [b], represented as a bitmask with only [b] set. This makes testing an
    individual bit very cheap. *)
 type bit = int
 
-(* A sequence of bits matched by the beginning (little-endian!) of every key in
-   a subtree. It has some length, represented as the first [bit] after the
-   entire prefix. *)
+(* A sequence of bits matched by the beginning (big-endian) of every key in a
+   subtree. It has some length, represented as the first [bit] after the entire
+   prefix. *)
 type prefix = int
 
 let zero_bit i bit = i land bit = 0
 
-(* Least significant 1 bit *)
-let lowest_bit x = x land -x
+(* Most significant 1 bit *)
+let highest_bit x = 1 lsl (62 - int_clz x)
 
-(* Lowest bit at which [prefix0] and [prefix1] differ *)
-let branching_bit prefix0 prefix1 = lowest_bit (prefix0 lxor prefix1)
+(* Highest bit at which [prefix0] and [prefix1] differ *)
+let branching_bit prefix0 prefix1 = highest_bit (prefix0 lxor prefix1)
 
-(* Keep only the bits strictly lower than [i] *)
-let mask i bit = i land (bit - 1)
+(* Keep only the bits strictly higher than [i] *)
+let mask i bit = i land -(bit lsl 1)
 
 (* Does [i] match [prefix], whose length is [bit]? In other words, does [i]
-   match [prefix] at every position strictly lower than [bit]? *)
+   match [prefix] at every position strictly higher than [bit]? *)
 let match_prefix i prefix bit = mask i bit = prefix
 
 let equal_prefix prefix0 bit0 prefix1 bit1 = bit0 = bit1 && prefix0 = prefix1
 
-let lower bit0 bit1 =
+let higher bit0 bit1 =
   (* Need to do _unsigned_ int comparison *)
   match bit0 < 0, bit1 < 0 with
-  | false, false -> bit0 < bit1
-  | true, _ -> false (* the only bit < 0 is 0x4000..., which is the highest *)
-  | false, true -> true
+  | false, false -> bit0 > bit1
+  | _, true -> false (* the only bit < 0 is 0x4000..., which is the highest *)
+  | true, false -> true
 
 (* Is [prefix0], of length [bit0], a sub-prefix of [prefix1], of length
    [bit1]? *)
 let includes_prefix prefix0 bit0 prefix1 bit1 =
-  lower bit0 bit1 && match_prefix prefix1 prefix0 bit0
+  higher bit0 bit1 && match_prefix prefix1 prefix0 bit0
 
 (* Provides a total ordering over [(prefix, bit)] pairs. Not otherwise
    specified. (Only useful for implementing [compare], which is similarly
@@ -95,8 +92,8 @@ module type Tree = sig
 
   (* A tree with the given prefix, the length of the prefix, and two subtrees.
      If the prefix is P, we require that [t0] has prefix P0 and [t1] has prefix
-     P1 (note that this is little-endian notation). For efficiency, [t0] and
-     [t1] are assumed to be non-empty. *)
+     P1 (note that this is big-endian notation). For efficiency, [t0] and [t1]
+     are assumed to be non-empty. *)
   val branch : prefix -> bit -> 'a t -> 'a t -> 'a t
 
   (* A view on a given node, corresponding to which of [empty], [leaf], or
@@ -289,7 +286,7 @@ module Tree_operations (Tree : Tree) : sig
   val split :
     found:('a -> 'b) -> not_found:'b -> key -> 'a t -> 'a t * 'b * 'a t
 
-  val to_list_unordered : 'a t -> 'a Binding.t list
+  val to_list : 'a t -> 'a Binding.t list
 
   val merge :
     'c is_value ->
@@ -580,31 +577,71 @@ end = struct
     | Leaf _ -> 1
     | Branch (_, _, t0, t1) -> cardinal t0 + cardinal t1
 
-  let rec iter f t =
+  let rec unsigned_iter f t =
     match descr t with
     | Empty -> ()
     | Leaf (key, d) -> Callback.call f key d
     | Branch (_, _, t0, t1) ->
-      iter f t0;
-      iter f t1
+      unsigned_iter f t0;
+      unsigned_iter f t1
 
-  let rec fold f t acc =
+  let iter f t =
+    match descr t with
+    | Empty -> ()
+    | Leaf (key, d) -> Callback.call f key d
+    | Branch (_, bit, t0, t1) ->
+      if bit < 0
+      then (
+        unsigned_iter f t1;
+        unsigned_iter f t0)
+      else (
+        unsigned_iter f t0;
+        unsigned_iter f t1)
+
+  let rec unsigned_fold f t acc =
     match descr t with
     | Empty -> acc
     | Leaf (key, d) -> Callback.call f key d acc
-    | Branch (_, _, t0, t1) -> fold f t0 (fold f t1 acc)
+    | Branch (_, _, t0, t1) -> unsigned_fold f t1 (unsigned_fold f t0 acc)
 
-  let rec for_all p t =
+  let fold f t acc =
+    match descr t with
+    | Empty -> acc
+    | Leaf (key, d) -> Callback.call f key d acc
+    | Branch (_, bit, t0, t1) ->
+      if bit < 0
+      then unsigned_fold f t0 (unsigned_fold f t1 acc)
+      else unsigned_fold f t1 (unsigned_fold f t0 acc)
+
+  let rec unsigned_for_all p t =
     match descr t with
     | Empty -> true
     | Leaf (key, d) -> Callback.call p key d
-    | Branch (_, _, t0, t1) -> for_all p t0 && for_all p t1
+    | Branch (_, _, t0, t1) -> unsigned_for_all p t0 && unsigned_for_all p t1
 
-  let rec exists p t =
+  let for_all p t =
+    match descr t with
+    | Empty -> true
+    | Leaf (key, d) -> Callback.call p key d
+    | Branch (_, bit, t0, t1) ->
+      if bit < 0
+      then unsigned_for_all p t1 && unsigned_for_all p t0
+      else unsigned_for_all p t0 && unsigned_for_all p t1
+
+  let rec unsigned_exists p t =
     match descr t with
     | Empty -> false
     | Leaf (key, d) -> Callback.call p key d
-    | Branch (_, _, t0, t1) -> exists p t0 || exists p t1
+    | Branch (_, _, t0, t1) -> unsigned_exists p t0 || unsigned_exists p t1
+
+  let exists p t =
+    match descr t with
+    | Empty -> false
+    | Leaf (key, d) -> Callback.call p key d
+    | Branch (_, bit, t0, t1) ->
+      if bit < 0
+      then unsigned_exists p t1 || unsigned_exists p t0
+      else unsigned_exists p t0 || unsigned_exists p t1
 
   let filter p t =
     let rec loop t =
@@ -639,28 +676,34 @@ end = struct
   let choose_opt t =
     match choose t with exception Not_found -> None | choice -> Some choice
 
-  let[@inline always] min_binding_by ~compare_key (t : 'a t) : 'a Binding.t =
-    let rec loop t =
-      match descr t with
-      | Empty -> raise Not_found
-      | Leaf (i, d) -> Binding.create i d
-      | Branch (_, _, t0, t1) ->
-        let b0 = loop t0 in
-        let b1 = loop t1 in
-        if (compare_key [@inlined hint]) (Binding.key b0) (Binding.key b1) < 0
-        then b0
-        else b1
-    in
-    loop t
+  let rec unsigned_min_binding t =
+    match descr t with
+    | Empty -> raise Not_found
+    | Leaf (key, d) -> Binding.create key d
+    | Branch (_, _, t0, _) -> unsigned_min_binding t0
 
-  let min_binding t = min_binding_by ~compare_key:Int.compare t
+  let min_binding t =
+    match descr t with
+    | Empty -> raise Not_found
+    | Leaf (key, d) -> Binding.create key d
+    | Branch (_, bit, t0, t1) ->
+      unsigned_min_binding (if bit < 0 then t1 else t0)
 
   let min_binding_opt t =
     match min_binding t with exception Not_found -> None | min -> Some min
 
+  let rec unsigned_max_binding t =
+    match descr t with
+    | Empty -> raise Not_found
+    | Leaf (key, d) -> Binding.create key d
+    | Branch (_, _, _, t1) -> unsigned_max_binding t1
+
   let max_binding t =
-    let[@inline always] compare_key i1 i2 = Int.compare i2 i1 in
-    min_binding_by ~compare_key t
+    match descr t with
+    | Empty -> raise Not_found
+    | Leaf (key, d) -> Binding.create key d
+    | Branch (_, bit, t0, t1) ->
+      unsigned_max_binding (if bit < 0 then t0 else t1)
 
   let max_binding_opt t =
     match max_binding t with exception Not_found -> None | max -> Some max
@@ -701,32 +744,58 @@ end = struct
       | Branch _, Empty -> -1
       | Branch _, Leaf _ -> -1
 
-  (* CR-someday lmaurer: Make this O(n) rather than O(n log n). Easy if we make
-     a version of [partition] that can drop the element. Even easier if we
-     switch to big-endian. *)
-  let[@inline always] split ~found ~not_found i t =
-    let rec loop ((lt, mem, gt) as acc) t =
-      match descr t with
-      | Empty -> acc
-      | Leaf (j, d) ->
-        if i = j
-        then lt, (found [@inlined hint]) d, gt
-        else if j < i
-        then add j d lt, mem, gt
-        else lt, mem, add j d gt
-      | Branch (_, _, t0, t1) -> loop (loop acc t0) t1
-    in
-    let empty = empty (is_value_of t) in
-    loop (empty, not_found, empty) t
+  let rec unsigned_split ~found ~not_found i t =
+    match descr t with
+    | Empty ->
+      let iv = is_value_of t in
+      empty iv, not_found, empty iv
+    | Leaf (j, d) ->
+      let iv = is_value_of t in
+      if i = j
+      then empty iv, (found [@inlined hint]) d, empty iv
+      else if j < i
+      then singleton iv j d, not_found, empty iv
+      else empty iv, not_found, singleton iv j d
+    | Branch (prefix, bit, t0, t1) ->
+      if match_prefix i prefix bit
+      then
+        if zero_bit i bit
+        then
+          let lt, mem, gt = unsigned_split ~found ~not_found i t0 in
+          lt, mem, branch prefix bit gt t1
+        else
+          let lt, mem, gt = unsigned_split ~found ~not_found i t1 in
+          branch prefix bit t0 lt, mem, gt
+      else if i < prefix
+      then empty (is_value_of t), not_found, t
+      else t, not_found, empty (is_value_of t)
 
-  let to_list_unordered t =
+  let split ~found ~not_found i t =
+    match descr t with
+    | Branch (_, bit, t0, t1) when bit < 0 ->
+      (* prefix is necessarily empty *)
+      if i < 0
+      then
+        let lt, mem, gt = unsigned_split ~found ~not_found i t1 in
+        lt, mem, branch 0 bit t0 gt
+      else
+        let lt, mem, gt = unsigned_split ~found ~not_found i t0 in
+        branch 0 bit lt t1, mem, gt
+    | Empty | Leaf _ | Branch _ ->
+      (unsigned_split [@inlined hint]) ~found ~not_found i t
+
+  let to_list t =
     let rec loop acc t =
       match descr t with
       | Empty -> acc
       | Leaf (i, d) -> Binding.create i d :: acc
-      | Branch (_, _, t0, t1) -> loop (loop acc t0) t1
+      | Branch (_, _, t0, t1) -> loop (loop acc t1) t0
     in
-    loop [] t
+    match descr t with
+    | Empty -> []
+    | Leaf (i, d) -> [Binding.create i d]
+    | Branch (_, bit, t0, t1) ->
+      if bit < 0 then loop (loop [] t0) t1 else loop (loop [] t1) t0
 
   (* CR-someday lmaurer: We could borrow Haskell's trick and generalize this
      function quite a bit, giving us a single implementation of [union],
@@ -881,7 +950,12 @@ end = struct
         | Leaf (key, value) -> Seq.Cons (Binding.create key value, aux r)
         | Branch (_, _, t1, t2) -> aux (t1 :: t2 :: r) ())
     in
-    aux [t]
+    fun () ->
+      match descr t with
+      | Empty -> Seq.Nil
+      | Leaf (key, value) -> Seq.Cons (Binding.create key value, aux [])
+      | Branch (_, bit, t0, t1) ->
+        if bit < 0 then aux [t1; t0] () else aux [t0; t1] ()
 
   let[@inline always] of_list iv l =
     List.fold_left
@@ -913,7 +987,7 @@ end = struct
     let rec check_deep prefix bit t =
       match descr t with
       | Empty -> false (* [Empty] should only occur at top level *)
-      | Leaf (i, _) -> bit = 0 || match_prefix i prefix bit
+      | Leaf (i, _) -> (bit = 0 && prefix = i) || match_prefix i prefix bit
       | Branch (prefix', bit', t0, t1) ->
         (* CR-someday lmaurer: Should check that [bit'] has a POPCOUNT of 1 *)
         let prefix0 =
@@ -922,14 +996,15 @@ end = struct
           prefix' land lnot bit'
         in
         let prefix1 = prefix' lor bit' in
-        let bit0 = bit' lsl 1 in
+        let bit0 = bit' lsr 1 in
         let bit1 = bit0 in
         prefix0 = prefix'
-        && (bit = bit' || lower bit bit')
-        && (bit = 0 || match_prefix prefix' prefix bit)
+        && (bit = bit' || higher bit bit')
+        && bit <> 0
+        && match_prefix prefix' prefix bit
         && check_deep prefix0 bit0 t0 && check_deep prefix1 bit1 t1
     in
-    is_empty t || check_deep 0 0 t
+    is_empty t || check_deep 0 min_int t
 end
 [@@inline always]
 
@@ -969,7 +1044,7 @@ module Set = struct
     in
     loop f Empty t
 
-  let elements = Ops.to_list_unordered
+  let elements = Ops.to_list
 
   let min_elt = Ops.min_binding
 
@@ -1005,10 +1080,7 @@ module Map = struct
 
   let split i t = Ops.split ~found:(fun a -> Some a) ~not_found:None i t
 
-  let bindings s =
-    List.sort
-      (fun (id1, _) (id2, _) -> Int.compare id1 id2)
-      (Ops.to_list_unordered s)
+  let bindings s = Ops.to_list s
 
   let map f t = Ops.map Any f t
 

--- a/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
+++ b/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
@@ -757,7 +757,8 @@ module Types = struct
   let generate_key =
     Generator.choose
       [ 1, Generator.one_of [0; 1; 2; 3; -1; Int.min_int; Int.max_int];
-        2, Generator.log_int ]
+        1, Generator.log_int;
+        1, Generator.map Generator.log_int ~f:(~-) ]
 
   let drop_leading_digits key : key Seq.t =
     let rec next mask : key Seq.node =

--- a/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
+++ b/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
@@ -281,15 +281,13 @@ module Set_specs = struct
 
   let of_list_then_elements l =
     List.equal Int.equal
-      (l |> Set.of_list |> Set.elements |> List.sort Int.compare)
+      (l |> Set.of_list |> Set.elements)
       (l |> List.sort_uniq Int.compare)
 
   let elements_then_of_list s = Set.equal s (s |> Set.elements |> Set.of_list)
 
   let to_seq s =
-    List.equal Int.equal
-      (s |> Set.to_seq |> List.of_seq |> List.sort Int.compare)
-      (s |> Set.elements |> List.sort Int.compare)
+    List.equal Int.equal (s |> Set.to_seq |> List.of_seq) (s |> Set.elements)
 
   let union_list l =
     Set.equal (Set.union_list l) (List.fold_left Set.union Set.empty l)
@@ -316,9 +314,6 @@ module Map_specs (V : Value) = struct
   let valid m = Map.valid m
 
   let equal_bindings (k1, v1) (k2, v2) = Int.equal k1 k2 && V.equal v1 v2
-
-  let compare_bindings (k1, v1) (k2, v2) =
-    match Int.compare k1 k2 with 0 -> V.compare v1 v2 | c -> c
 
   let find_opt_vs_find k m =
     Map.find_opt k m =? option_of_not_found (Map.find k) m
@@ -528,7 +523,7 @@ module Map_specs (V : Value) = struct
 
   let to_seq_vs_bindings m =
     List.equal equal_bindings
-      (m |> Map.to_seq |> List.of_seq |> List.sort compare_bindings)
+      (m |> Map.to_seq |> List.of_seq)
       (m |> Map.bindings)
 
   let of_list_valid l = Map.valid (Map.of_list l)
@@ -536,7 +531,7 @@ module Map_specs (V : Value) = struct
   module Equality_on_bindings = struct
     let sort_by_key l = List.sort (fun (k1, _) (k2, _) -> Int.compare k1 k2) l
 
-    let sort_and_group_by_key l =
+    let group_by_key l =
       let rec groups l =
         match l with
         | [] -> []
@@ -552,11 +547,11 @@ module Map_specs (V : Value) = struct
           let g, l = group l in
           (k, v :: g) :: groups l
       in
-      groups (sort_by_key l)
+      groups l
 
     let same_bindings_up_to_duplicate_keys l1 l2 =
-      let l1 = l1 |> sort_and_group_by_key in
-      let l2 = l2 |> sort_and_group_by_key in
+      let l1 = l1 |> group_by_key in
+      let l2 = l2 |> group_by_key in
       let rec check l1 l2 =
         match l1, l2 with
         | [], [] -> true
@@ -572,7 +567,9 @@ module Map_specs (V : Value) = struct
   open Equality_on_bindings
 
   let of_list_then_bindings l =
-    same_bindings_up_to_duplicate_keys (l |> Map.of_list |> Map.bindings) l
+    same_bindings_up_to_duplicate_keys
+      (l |> Map.of_list |> Map.bindings)
+      (sort_by_key l)
 
   let bindings_then_of_list m =
     Map.equal V.equal (m |> Map.bindings |> Map.of_list) m
@@ -584,7 +581,7 @@ module Map_specs (V : Value) = struct
   let map_keys f m =
     same_bindings_up_to_duplicate_keys
       (Map.map_keys f m |> Map.bindings)
-      (List.map (fun (k, v) -> f k, v) (m |> Map.bindings))
+      (sort_by_key (List.map (fun (k, v) -> f k, v) (m |> Map.bindings)))
 
   let keys_vs_of_list m =
     Set.equal (Map.keys m) (m |> Map.bindings |> List.map fst |> Set.of_list)

--- a/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
+++ b/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
@@ -758,7 +758,7 @@ module Types = struct
     Generator.choose
       [ 1, Generator.one_of [0; 1; 2; 3; -1; Int.min_int; Int.max_int];
         1, Generator.log_int;
-        1, Generator.map Generator.log_int ~f:(~-) ]
+        1, Generator.map Generator.log_int ~f:( ~- ) ]
 
   let drop_leading_digits key : key Seq.t =
     let rec next mask : key Seq.node =


### PR DESCRIPTION
This patch switches up the implementation of the `Patricia_tree` module from little-endian to big-endian, with the main motivation to be able to implement in-order traversal. This also enables more efficient implementation for `min_binding`, `max_binding`, and `split`.

The `caml_int_clz_tagged_to_untagged` and `caml_int_tagged_to_tagged` C stubs are recognized and replaced with the `clz` instruction when compiling with flambda2, so they are only used in the boot compiler.

Note: this patch changes the implementation of various iteration functions to iterate in *signed* sorted order, by wrapping unsigned iteration functions, and the tests are updated to reflect that `to_list` and `to_seq` now return their bindings in (signed) sorted order. In-order traversal will only be needed through a new iterator API (to be added in a separate PR) and I think it would be confusing to have different interfaces use different orders; I am open to removing these wrappers if preferred.