### PR TITLE
Bound stack size in expect tests

### DIFF
--- a/flambda-backend/testsuite/tools/expect.ml
+++ b/flambda-backend/testsuite/tools/expect.ml
@@ -385,6 +385,9 @@ let usage = "Usage: expect_test <options> [script-file [arguments]]\n\
              options are:"
 
 let () =
+  (* Some tricky typing tests cause stack overflows in the compiler.
+     Bounding the compiler's stack size makes that happen faster. *)
+  Gc.set {(Gc.get ()) with stack_limit = 1_000_000};
 (* Early disabling of colors in any output *)
   let () =
     Clflags.color := Some Misc.Color.Never;


### PR DESCRIPTION
In runtime5, the slowest test (by a long shot) is `constraints.ml`, which triggers a stack overflow in the typechecker. Since the default bytecode max stack size is 1GB, this takes a long time.

This patch changes the stack limit for expect tests to 1e6 words (8MB), so tests that trigger a stack overflow in typing fail faster.