### PR TITLE
Cleanup machtype_component size

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -2316,7 +2316,7 @@ let emit_probe_notes0 () =
         Misc.fatal_errorf "Cannot create probe: illegal argument: %a"
           Printreg.reg arg
     in
-    Printf.sprintf "%d@%s" (Reg.size_of_contents_in_bytes arg) arg_name
+    Printf.sprintf "%d@%s" (Select_utils.size_component arg.Reg.typ) arg_name
   in
   let describe_one_probe p =
     let probe_name, enabled_at_init =

--- a/backend/reg.ml
+++ b/backend/reg.ml
@@ -193,18 +193,6 @@ let is_reg t =
   | Reg _ -> true
   | _ -> false
 
-let size_of_contents_in_bytes t =
-  match t.typ with
-  | Vec128 -> Arch.size_vec128
-  | Float -> Arch.size_float
-  | Float32 ->
-    assert (Arch.size_float = 8);
-    Arch.size_float / 2
-  | Addr ->
-    assert (Arch.size_addr = Arch.size_int);
-    Arch.size_addr
-  | Int | Val -> Arch.size_int
-
 let reset() =
   (* When reset() is called for the first time, the current stamp reflects
      all hard pseudo-registers that have been allocated by Proc, so

--- a/backend/reg.mli
+++ b/backend/reg.mli
@@ -102,8 +102,6 @@ val name : t -> string
 val is_reg : t -> bool
 val is_stack :  t -> bool
 
-val size_of_contents_in_bytes : t -> int
-
 module Set: Set.S with type elt = t
 module Map: Map.S with type key = t
 module Tbl: Hashtbl.S with type key = t

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -208,6 +208,8 @@ let oper_result_type = function
 (* Infer the size in bytes of the result of an expression whose evaluation may
    be deferred (cf. [emit_parts]). *)
 
+(* [size_component] is placed here and not in [Cmm] to avoid cyclic
+   dependencies, because it uses [Arch]. *)
 let size_component : machtype_component -> int = function
   | Val | Addr -> Arch.size_addr
   | Int -> Arch.size_int


### PR DESCRIPTION
Simple cleanup. There are two copies of the same function, one in `Reg` and one in `Select_utils`. They are not identical due to (a) assertions and (b) handling of `Float32`. The one in `Reg` is only used to emit some meta-data for probes that is never used, so we can just use the one in `Select_utils`. 