### PR TITLE
Add function [DLL.for_all_i]

### DIFF
--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -333,20 +333,20 @@ let exists t ~f =
   aux t f t.first
 
 let for_all t ~f =
-  let rec aux t f curr =
+  let rec aux f curr =
     match curr with
     | Empty -> true
-    | Node node -> if f node.value then aux t f node.next else false
+    | Node node -> if f node.value then aux f node.next else false
   in
-  aux t f t.first
+  aux f t.first
 
 let for_alli t ~f =
-  let rec aux t f i curr =
+  let rec aux f i curr =
     match curr with
     | Empty -> true
-    | Node node -> if f i node.value then aux t f (i + 1) node.next else false
+    | Node node -> if f i node.value then aux f (i + 1) node.next else false
   in
-  aux t f 0 t.first
+  aux f 0 t.first
 
 let to_list t = fold_right t ~f:(fun hd tl -> hd :: tl) ~init:[]
 

--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -340,7 +340,7 @@ let for_all t ~f =
   in
   aux t f t.first
 
-let for_all_i t ~f =
+let for_alli t ~f =
   let rec aux t f i curr =
     match curr with
     | Empty -> true

--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -340,6 +340,14 @@ let for_all t ~f =
   in
   aux t f t.first
 
+let for_all_i t ~f =
+  let rec aux t f i curr =
+    match curr with
+    | Empty -> true
+    | Node node -> if f i node.value then aux t f (i + 1) node.next else false
+  in
+  aux t f 0 t.first
+
 let to_list t = fold_right t ~f:(fun hd tl -> hd :: tl) ~init:[]
 
 let transfer ~to_ ~from () =

--- a/utils/doubly_linked_list.mli
+++ b/utils/doubly_linked_list.mli
@@ -78,7 +78,7 @@ val exists : 'a t -> f:('a -> bool) -> bool
 
 val for_all : 'a t -> f:('a -> bool) -> bool
 
-val for_all_i : 'a t -> f:(int -> 'a -> bool) -> bool
+val for_alli : 'a t -> f:(int -> 'a -> bool) -> bool
 
 val to_list : 'a t -> 'a list
 

--- a/utils/doubly_linked_list.mli
+++ b/utils/doubly_linked_list.mli
@@ -78,6 +78,8 @@ val exists : 'a t -> f:('a -> bool) -> bool
 
 val for_all : 'a t -> f:('a -> bool) -> bool
 
+val for_all_i : 'a t -> f:(int -> 'a -> bool) -> bool
+
 val to_list : 'a t -> 'a list
 
 (* Adds all of the elements of `from` to `to_`, and clears `from`. *)


### PR DESCRIPTION
I would like to add a slightly non-standard but convenient function `Doubly_link_list.for_all_i`.