### PR TITLE
Vectorize [Ifloatarithmem]

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -20,6 +20,12 @@ open Arch
 open Mach
 open CSE_utils
 
+let of_simd_class (cl : Simd.operation_class)  =
+  match cl with
+  | Pure -> Op_pure
+  | Load { is_mutable = true } -> Op_load Mutable
+  | Load { is_mutable = false } -> Op_load Immutable
+
 class cse = object
 
 inherit CSEgen.cse_generic as super
@@ -36,9 +42,9 @@ method! class_of_operation op =
     | Irdtsc | Irdpmc
     | Ilfence | Isfence | Imfence -> Op_other
     | Isimd op ->
-      begin match Simd.class_of_operation op with
-      | Pure -> Op_pure
-      end
+      of_simd_class (Simd.class_of_operation op)
+    | Isimd_mem (op,_addr) ->
+      of_simd_class (Simd.Mem.class_of_operation op)
     | Ipause
     | Icldemote _
     | Iprefetch _ -> Op_other
@@ -80,9 +86,9 @@ class cfg_cse = object
     | Irdtsc | Irdpmc
     | Ilfence | Isfence | Imfence -> Op_other
     | Isimd op ->
-      begin match Simd.class_of_operation op with
-      | Pure -> Op_pure
-      end
+      of_simd_class (Simd.class_of_operation op)
+    | Isimd_mem (op,_addr) ->
+      of_simd_class (Simd.Mem.class_of_operation op)
     | Ipause
     | Icldemote _
     | Iprefetch _ -> Op_other

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -152,6 +152,9 @@ type specific_operation =
   | Imfence                            (* memory fence *)
   | Ipause                             (* hint for spin-wait loops *)
   | Isimd of Simd.operation            (* SIMD instruction set operations *)
+  | Isimd_mem of Simd.Mem.operation * addressing_mode
+                                       (* SIMD instruction set operations
+                                          with memory args *)
   | Icldemote of addressing_mode       (* hint to demote a cacheline to L3 *)
   | Iprefetch of                       (* memory prefetching hint *)
       { is_write: bool;
@@ -272,6 +275,8 @@ let print_specific_operation printreg op ppf arg =
       fprintf ppf "rdpmc %a" printreg arg.(0)
   | Isimd simd ->
       Simd.print_operation printreg simd ppf arg
+  | Isimd_mem (simd, addr) ->
+      Simd.Mem.print_operation printreg (print_addressing printreg addr) simd ppf arg
   | Ipause ->
       fprintf ppf "pause"
   | Icldemote _ ->
@@ -298,13 +303,14 @@ let operation_is_pure = function
   | Istore_int (_, _, _) | Ioffset_loc (_, _)
   | Icldemote _ | Iprefetch _ -> false
   | Isimd op -> Simd.is_pure op
+  | Isimd_mem (op, _addr) -> Simd.Mem.is_pure op
 
 (* Specific operations that can raise *)
 (* Keep in sync with [Vectorize_specific] *)
 let operation_can_raise = function
   | Ilea _ | Ibswap _ | Isextend32 | Izextend32
   | Ifloatarithmem _
-  | Irdtsc | Irdpmc | Ipause | Isimd _
+  | Irdtsc | Irdpmc | Ipause | Isimd _ | Isimd_mem _
   | Ilfence | Isfence | Imfence
   | Istore_int (_, _, _) | Ioffset_loc (_, _)
   | Icldemote _ | Iprefetch _ -> false
@@ -313,7 +319,7 @@ let operation_can_raise = function
 let operation_allocates = function
   | Ilea _ | Ibswap _ | Isextend32 | Izextend32
   | Ifloatarithmem _
-  | Irdtsc | Irdpmc | Ipause | Isimd _
+  | Irdtsc | Irdpmc | Ipause | Isimd _ | Isimd_mem _
   | Ilfence | Isfence | Imfence
   | Istore_int (_, _, _) | Ioffset_loc (_, _)
   | Icldemote _ | Iprefetch _ -> false
@@ -404,9 +410,11 @@ let equal_specific_operation left right =
     && equal_addressing_mode left_addr right_addr
   | Isimd l, Isimd r ->
     Simd.equal_operation l r
+  | Isimd_mem (l,al), Isimd_mem (r,ar) ->
+    Simd.Mem.equal_operation l r && equal_addressing_mode al ar
   | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ |
      Isextend32 | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence |
-     Ipause | Isimd _ | Icldemote _ | Iprefetch _), _ ->
+     Ipause | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _), _ ->
     false
 
 (* addressing mode functions *)
@@ -511,7 +519,9 @@ let isomorphic_specific_operation op1 op2 =
     && equal_addressing_mode_without_displ left_addr right_addr
   | Isimd l, Isimd r ->
     Simd.equal_operation l r
+  | Isimd_mem (l,al), Isimd_mem (r,ar) ->
+    Simd.Mem.equal_operation l r && equal_addressing_mode_without_displ al ar
   | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ |
      Isextend32 | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence |
-     Ipause | Isimd _ | Icldemote _ | Iprefetch _), _ ->
+     Ipause | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _), _ ->
     false

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -85,6 +85,9 @@ type specific_operation =
   | Imfence                            (* memory fence *)
   | Ipause                             (* hint for spin-wait loops *)
   | Isimd of Simd.operation            (* SIMD instruction set operations *)
+  | Isimd_mem of Simd.Mem.operation * addressing_mode
+                                       (* SIMD instruction set operations
+                                          with memory args *)
   | Icldemote of addressing_mode       (* hint to demote a cacheline to L3 *)
   | Iprefetch of                       (* memory prefetching hint *)
       { is_write: bool;

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -86,7 +86,14 @@ let pseudoregs_for_operation op arg res =
        edx (high) and eax (low). Make it simple and force the argument in rcx,
        and rax and rdx clobbered *)
     [| rcx |], res
-  | Specific (Isimd op) -> Simd_selection.pseudoregs_for_operation op arg res
+  | Specific (Isimd op) ->
+    Simd_selection.pseudoregs_for_operation
+      (Simd_proc.register_behavior op)
+      arg res
+  | Specific (Isimd_mem (op, _addr)) ->
+    Simd_selection.pseudoregs_for_operation
+      (Simd_proc.Mem.register_behavior op)
+      arg res
   | Csel _ ->
     (* last arg must be the same as res.(0) *)
     let len = Array.length arg in

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -1034,8 +1034,8 @@ let emit_static_cast (cast : Cmm.static_cast) i =
        CR mslater: (SIMD) don't load 32 bits once we have unboxed int16/int8 *)
     I.movd (arg32 i 0) (res i 0)
 
-let emit_simd_instr op i =
-  (match Simd_proc.register_behavior op with
+let check_simd_instr (register_behavior : Simd_proc.register_behavior) i =
+  (match register_behavior with
   | R_to_fst ->
     assert (Reg.same_loc i.arg.(0) i.res.(0));
     assert (Reg.is_reg i.arg.(0))
@@ -1075,6 +1075,23 @@ let emit_simd_instr op i =
     assert (Reg.is_reg i.arg.(0));
     assert (Reg.same_loc i.res.(0) (phys_xmm0v ()))
   );
+  ()
+
+let emit_simd_instr_with_memory_arg op i addressing_mode =
+  check_simd_instr (Simd_proc.Mem.register_behavior op) i;
+  let addr = addressing addressing_mode VEC128 i 1 in
+  match (op : Simd.Mem.operation) with
+  | SSE2 Add_f64 -> I.addpd addr (res i 0)
+  | SSE2 Sub_f64 -> I.subpd addr (res i 0)
+  | SSE2 Mul_f64 -> I.mulpd addr (res i 0)
+  | SSE2 Div_f64 -> I.divpd addr (res i 0)
+  | SSE Add_f32 -> I.addps addr (res i 0)
+  | SSE Sub_f32 -> I.subps addr (res i 0)
+  | SSE Mul_f32 -> I.mulps addr (res i 0)
+  | SSE Div_f32 -> I.divps addr (res i 0)
+
+let emit_simd_instr op i =
+  check_simd_instr (Simd_proc.register_behavior op) i;
   match (op : Simd.operation) with
   | CLMUL (Clmul_64 n) -> I.pclmulqdq (X86_dsl.int n) (arg i 1) (res i 0)
   | BMI2 Extract_64 -> I.pext (arg i 1) (arg i 0) (res i 0)
@@ -1714,6 +1731,8 @@ let emit_instr ~first ~fallthrough i =
     I.mfence ()
   | Lop (Specific (Isimd op)) ->
     emit_simd_instr op i
+  | Lop (Specific (Isimd_mem (op, addressing_mode))) ->
+    emit_simd_instr_with_memory_arg op i addressing_mode
   | Lop (Static_cast cast) ->
     emit_static_cast cast i
   | Lop (Reinterpret_cast cast) ->

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -176,6 +176,21 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
       may_use_stack_operand_for_second_argument map instr ~num_args:3 ~res_is_fst:true
     | R_to_RM -> may_use_stack_operand_for_result map instr ~num_args:1
     | RM_to_R -> may_use_stack_operand_for_only_argument map instr ~has_result:true)
+  | Op (Specific (Isimd_mem (op,_))) ->
+    (match Simd_proc.Mem.register_behavior op with
+     | R_RM_to_fst -> May_still_have_spilled_registers
+     | R_to_fst
+     | R_to_R
+     | R_to_RM
+     | RM_to_R
+     | R_R_to_fst
+     | R_RM_to_R
+     | R_RM_xmm0_to_fst
+     | R_RM_rax_rdx_to_rcx
+     | R_RM_to_rcx
+     | R_RM_rax_rdx_to_xmm0
+     | R_RM_to_xmm0
+      -> Misc.fatal_error "Unexpected simd operation with memory arguments")
   | Op (Reinterpret_cast (Float_of_float32 | Float32_of_float | V128_of_v128))
   | Op (Static_cast (V128_of_scalar Float64x2 | Scalar_of_v128 Float64x2))
   | Op (Static_cast (V128_of_scalar Float32x4 | Scalar_of_v128 Float32x4)) ->

--- a/backend/amd64/reload.ml
+++ b/backend/amd64/reload.ml
@@ -126,6 +126,7 @@ method! reload_operation op arg res =
       then (let r = self#makereg res.(0) in (arg, [|r|]))
       else (arg, res)
   | Ispecific(Isimd op) -> Simd_reload.reload_operation self#makereg op arg res
+  | Ispecific(Isimd_mem (op,_)) -> Simd_reload.Mem.reload_operation self#makereg op arg res
   | Iconst_int n ->
       if n <= 0x7FFFFFFFn && n >= -0x80000000n
       then (arg, res)

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -80,7 +80,14 @@ let pseudoregs_for_operation op arg res =
        edx (high) and eax (low). Make it simple and force the argument in rcx,
        and rax and rdx clobbered *)
     [| rcx |], res
-  | Ispecific (Isimd op) -> Simd_selection.pseudoregs_for_operation op arg res
+  | Ispecific (Isimd op) ->
+    Simd_selection.pseudoregs_for_operation
+      (Simd_proc.register_behavior op)
+      arg res
+  | Ispecific (Isimd_mem (op, _addr)) ->
+    Simd_selection.pseudoregs_for_operation
+      (Simd_proc.Mem.register_behavior op)
+      arg res
   | Icsel _ ->
     (* last arg must be the same as res.(0) *)
     let len = Array.length arg in

--- a/backend/amd64/simd.ml
+++ b/backend/amd64/simd.ml
@@ -18,7 +18,9 @@
 
 open Format
 
-type operation_class = Pure
+type operation_class =
+  | Pure
+  | Load of { is_mutable : bool }
 
 type float_condition = X86_ast.float_condition =
   | EQf
@@ -1002,4 +1004,83 @@ let class_of_operation op =
   | SSE41 op -> class_of_operation_sse41 op
   | SSE42 op -> class_of_operation_sse42 op
 
-let is_pure op = match class_of_operation op with Pure -> true
+let is_pure op =
+  match class_of_operation op with Pure -> true | Load _ -> true
+
+module Mem = struct
+  (** Initial support for some operations with memory arguments.
+      Requires 16-byte aligned memory. *)
+
+  type sse_operation =
+    | Add_f32
+    | Sub_f32
+    | Mul_f32
+    | Div_f32
+
+  type sse2_operation =
+    | Add_f64
+    | Sub_f64
+    | Mul_f64
+    | Div_f64
+
+  type operation =
+    | SSE of sse_operation
+    | SSE2 of sse2_operation
+
+  let class_of_operation_sse (op : sse_operation) =
+    match op with
+    | Add_f32 | Sub_f32 | Mul_f32 | Div_f32 -> Load { is_mutable = true }
+
+  let class_of_operation_sse2 (op : sse2_operation) =
+    match op with
+    | Add_f64 | Sub_f64 | Mul_f64 | Div_f64 -> Load { is_mutable = true }
+
+  let class_of_operation (op : operation) =
+    match op with
+    | SSE op -> class_of_operation_sse op
+    | SSE2 op -> class_of_operation_sse2 op
+
+  let op_name_sse (op : sse_operation) =
+    match op with
+    | Add_f32 -> "add_f32"
+    | Sub_f32 -> "sub_f32"
+    | Mul_f32 -> "mul_f32"
+    | Div_f32 -> "div_f32"
+
+  let op_name_sse2 (op : sse2_operation) =
+    match op with
+    | Add_f64 -> "add_f64"
+    | Sub_f64 -> "sub_f64"
+    | Mul_f64 -> "mul_f64"
+    | Div_f64 -> "div_f64"
+
+  let print_operation printreg printaddr (op : operation) ppf arg =
+    let addr_args = Array.sub arg 1 (Array.length arg - 1) in
+    let op_name =
+      match op with SSE op -> op_name_sse op | SSE2 op -> op_name_sse2 op
+    in
+    fprintf ppf "%s %a [%a]" op_name printreg arg.(0) printaddr addr_args
+
+  let is_pure op =
+    match class_of_operation op with Pure -> true | Load _ -> true
+
+  let equal_operation_sse2 (l : sse2_operation) (r : sse2_operation) =
+    match l, r with
+    | Add_f64, Add_f64 | Sub_f64, Sub_f64 | Mul_f64, Mul_f64 | Div_f64, Div_f64
+      ->
+      true
+    | (Add_f64 | Sub_f64 | Mul_f64 | Div_f64), _ -> false
+
+  let equal_operation_sse (l : sse_operation) (r : sse_operation) =
+    match l, r with
+    | Add_f32, Add_f32 | Sub_f32, Sub_f32 | Mul_f32, Mul_f32 | Div_f32, Div_f32
+      ->
+      true
+    | (Add_f32 | Sub_f32 | Mul_f32 | Div_f32), _ -> false
+
+  let equal_operation (l : operation) (r : operation) =
+    match l, r with
+    | SSE l, SSE r -> equal_operation_sse l r
+    | SSE2 l, SSE2 r -> equal_operation_sse2 l r
+    | (SSE _ | SSE2 _), _ -> false
+end

--- a/backend/amd64/simd_proc.ml
+++ b/backend/amd64/simd_proc.ml
@@ -122,3 +122,16 @@ let register_behavior = function
   | SSSE3 op -> register_behavior_ssse3 op
   | SSE41 op -> register_behavior_sse41 op
   | SSE42 op -> register_behavior_sse42 op
+
+module Mem = struct
+  let register_behavior_sse (op : Simd.Mem.sse_operation) =
+    match op with Add_f32 | Sub_f32 | Mul_f32 | Div_f32 -> R_RM_to_fst
+
+  let register_behavior_sse2 (op : Simd.Mem.sse2_operation) =
+    match op with Add_f64 | Sub_f64 | Mul_f64 | Div_f64 -> R_RM_to_fst
+
+  let register_behavior (op : Simd.Mem.operation) =
+    match op with
+    | SSE op -> register_behavior_sse op
+    | SSE2 op -> register_behavior_sse2 op
+end

--- a/backend/amd64/simd_reload.ml
+++ b/backend/amd64/simd_reload.ml
@@ -16,11 +16,12 @@
 
 (* SIMD instruction reload for AMD64 *)
 
-let reload_operation makereg op arg res =
+let reload_operation makereg (register_behavior : Simd_proc.register_behavior)
+    arg res =
   let stackp r =
     match r.Reg.loc with Stack _ -> true | Reg _ | Unknown -> false
   in
-  match Simd_proc.register_behavior op with
+  match register_behavior with
   | R_to_fst ->
     (* Argument must be in a register; result must be the argument. *)
     let arg0 = if stackp arg.(0) then makereg arg.(0) else arg.(0) in
@@ -67,3 +68,11 @@ let reload_operation makereg op arg res =
        enforced by selection. *)
     let arg0 = if stackp arg.(0) then makereg arg.(0) else arg.(0) in
     [| arg0; arg.(1); arg.(2); arg.(3) |], res
+
+module Mem = struct
+  let reload_operation makereg (op : Simd.Mem.operation) arg res =
+    reload_operation makereg (Simd_proc.Mem.register_behavior op) arg res
+end
+
+let reload_operation makereg op arg res =
+  reload_operation makereg (Simd_proc.register_behavior op) arg res

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -439,12 +439,13 @@ let select_operation_cfg op args =
   select_simd_instr op args
   |> Option.map (fun (op, args) -> Operation.Specific (Isimd op), args)
 
-let pseudoregs_for_operation op arg res =
+let pseudoregs_for_operation (register_behavior : Simd_proc.register_behavior)
+    arg res =
   let rax = Proc.phys_reg Int 0 in
   let rcx = Proc.phys_reg Int 5 in
   let rdx = Proc.phys_reg Int 4 in
   let xmm0v () = Proc.phys_reg Vec128 100 in
-  match Simd_proc.register_behavior op with
+  match register_behavior with
   | R_to_R | RM_to_R | R_to_RM | R_RM_to_R -> arg, res
   | R_to_fst ->
     (* arg.(0) and res.(0) must be the same *)
@@ -737,7 +738,8 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
             | Ibased _ -> None, None)
           | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
           | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence
-          | Imfence | Ipause | Isimd _ | Iprefetch _ | Icldemote _ ->
+          | Imfence | Ipause | Isimd _ | Isimd_mem _ | Iprefetch _ | Icldemote _
+            ->
             assert false)
         | Move | Load _ | Store _ | Intop _ | Intop_imm _ | Alloc _
         | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Const_int _

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -867,7 +867,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           | Specific
               ( Ifloatarithmem _ | Ioffset_loc _ | Iprefetch _ | Icldemote _
               | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence | Ipause | Isimd _
-              | Ilea _ | Ibswap _ | Isextend32 | Izextend32 )
+              | Isimd_mem _ | Ilea _ | Ibswap _ | Isextend32 | Izextend32 )
           | Intop_imm _ | Move | Load _ | Store _ | Intop _ | Alloc _
           | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Const_int _
           | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
@@ -884,7 +884,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           assert (arg_count = num_args_addressing);
           assert (res_count = 0);
           assert (Array.length const_instruction.results = 1);
-          let new_reg = Vectorize_utils.Vectorized_instruction.New 0 in
+          let new_reg = Vectorize_utils.Vectorized_instruction.New_Vec128 0 in
           const_instruction.results.(0) <- new_reg;
           let address_args =
             Array.init num_args_addressing (fun i ->
@@ -949,7 +949,9 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           | Float32, Ifloatmul -> SSE Mul_f32
           | Float32, Ifloatdiv -> SSE Div_f32
         in
-        let new_reg = [| Vectorize_utils.Vectorized_instruction.New 0 |] in
+        let new_reg =
+          [| Vectorize_utils.Vectorized_instruction.New_Vec128 0 |]
+        in
         let load : Vectorize_utils.Vectorized_instruction.t =
           { operation =
               Operation.Load

--- a/backend/amd64/vectorize_specific.ml
+++ b/backend/amd64/vectorize_specific.ml
@@ -63,6 +63,6 @@ let is_seed_store :
   match op with
   | Istore_int _ -> Some W64
   | Ifloatarithmem _ | Ioffset_loc _ | Iprefetch _ | Icldemote _ | Irdtsc
-  | Irdpmc | Ilfence | Isfence | Imfence | Ipause | Isimd _ | Ilea _ | Ibswap _
-  | Isextend32 | Izextend32 ->
+  | Irdpmc | Ilfence | Isfence | Imfence | Ipause | Isimd _ | Isimd_mem _
+  | Ilea _ | Ibswap _ | Isextend32 | Izextend32 ->
     None

--- a/backend/amd64/vectorize_specific.ml
+++ b/backend/amd64/vectorize_specific.ml
@@ -52,6 +52,9 @@ let memory_access : Arch.specific_operation -> Memory_access.t option =
     (* Conservative. we don't have any simd operations with memory operations at
        the moment. *)
     if Simd.is_pure op then None else create Memory_access.Arbitrary
+  | Isimd_mem _ ->
+    Misc.fatal_errorf
+      "Unexpected simd instruction with memory operands before vectorization"
   | Ilea _ | Ibswap _ | Isextend32 | Izextend32 -> None
 
 let is_seed_store :


### PR DESCRIPTION
On top of https://github.com/ocaml-flambda/flambda-backend/pull/3451.

There are two ways to vectorize `Ifloatarithmem, for example for `add` operation, we can either 
- two vector instructions:  vector load followed by vector add with register arguments (effectively reverting the choice made during instruction selection).
- emit one vector add instruction with a memory argument, but only when the memory is known to be 128-bit aligned. 

This PR supports both options, although the more efficient one instruction cannot currently be emitted because we don't have the alignment guarantees. This can be enabled in the future if we propagate sufficient informaton about bigarrays for example, but may need runtime changes to ensure alignment. 

To emit SIMD instructions with memory arguments, this PR adds a bunch of machinery to SIMD selection and handling to keep track of the addressing mode. In particular, it adds `ISimd_mem` to specific operations. The rest is trivial propagation of the new variant to all the right places. This is in a separate commit, which I am happy to split out into a separate PR if the design choices don't seem obvious. The new instructions are lightly tested manually (except for binary emitter), but are never emitted even when the vectorizer is enabled. 
