### PR TITLE
Runtime: make types explicit when reading [gc_regs]

### DIFF
--- a/runtime4/roots_nat.c
+++ b/runtime4/roots_nat.c
@@ -651,8 +651,7 @@ void caml_do_local_roots_nat(scanning_action maj, scanning_action min,
   value * regs;
   frame_descr * d;
   uintnat h;
-  int i, j, n, ofs;
-  unsigned short * p;
+  int i, j;
   value * root;
   struct caml__roots_block *lr;
 
@@ -678,17 +677,21 @@ void caml_do_local_roots_nat(scanning_action maj, scanning_action min,
           for (p = dl->live_ofs, n = dl->num_live; n > 0; n--, p++) {
             uint32_t ofs = *p;
             if (ofs & 1) {
-              root = regs + (ofs >> 1);
+              /* Negative offset to scan xmm registers in amd64. */
+              root = regs + (((int32_t)ofs) >> 1);
             } else {
               root = (value *)(sp + ofs);
             }
             visit(maj, min, root);
           }
         } else {
+          unsigned short * p;
+          unsigned short n;
           for (p = d->live_ofs, n = d->num_live; n > 0; n--, p++) {
-            ofs = *p;
+            unsigned short ofs = *p;
             if (ofs & 1) {
-              root = regs + (ofs >> 1);
+              /* Negative offset to scan xmm registers in amd64. */
+              root = regs + (((signed short)ofs) >> 1);
             } else {
               root = (value *)(sp + ofs);
             }


### PR DESCRIPTION
This change is a `NOP`, I believe:
- move the declarations of variables `ofs`, `n`, `p` down to the inner scope where they are used,
- change the type of `ofs` from `int` to `unsigned short` because it's the result of dereferencing `p` of type `unsigned short *` and has enough space in the short `frame_descr` case.
- change the type of `n` to match the type of `num_live` field in the short `frame_descr`
- in the register case, cast `ofs` to `signed` before using it with `gc_regs`. 

The last part does not make any difference to the result in `root` because the number of registers is always small enough that an offset fits into `signed short`. The offset is always positive. 

Motivation: I'm about to post another PR that uses `xmm` registers to store ocaml values. In runtime5, the offsets of xmm register from `gc_regs` are positive. In runtime4, these offsets are negative, so the above `cast` is needed to scan `xmm` registers. Negative offsets can only be generated when the vectorizer pass is enabled and it is disabled by default. 
