### PR TITLE
Vectorizer: rename New

### DIFF
--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -703,9 +703,9 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
       then (
         assert (arg_count = 1 && res_count = 1);
         const_instruction.results.(0)
-          <- Vectorize_utils.Vectorized_instruction.New 0;
+          <- Vectorize_utils.Vectorized_instruction.New_Vec128 0;
         intop_instruction.arguments.(1)
-          <- Vectorize_utils.Vectorized_instruction.New 0;
+          <- Vectorize_utils.Vectorized_instruction.New_Vec128 0;
         Some [const_instruction; intop_instruction])
       else None
     | _ -> None)
@@ -776,8 +776,8 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           (* reg + displ *)
           Some
             [ make_move (Argument 0) (Result 0);
-              make_const (New 0) displs;
-              make_binary_operation (Result 0) (New 0) (Result 0) add ]
+              make_const (New_Vec128 0) displs;
+              make_binary_operation (Result 0) (New_Vec128 0) (Result 0) add ]
         | None -> None)
       | Iindexed2 _ -> (
         match add_op with
@@ -788,8 +788,8 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           Some
             [ make_move (Argument 0) (Result 0);
               make_binary_operation (Result 0) (Argument 1) (Result 0) add;
-              make_const (New 0) displs;
-              make_binary_operation (Result 0) (New 0) (Result 0) add ]
+              make_const (New_Vec128 0) displs;
+              make_binary_operation (Result 0) (New_Vec128 0) (Result 0) add ]
         | None -> None)
       | Iscaled _ -> (
         match add_op, mul_op with
@@ -800,10 +800,10 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           (* reg * scale + displ *)
           Some
             [ make_move (Argument 0) (Result 0);
-              make_const (New 0) scales;
-              make_binary_operation (Result 0) (New 0) (Result 0) mul;
-              make_const (New 1) displs;
-              make_binary_operation (Result 0) (New 1) (Result 0) add ]
+              make_const (New_Vec128 0) scales;
+              make_binary_operation (Result 0) (New_Vec128 0) (Result 0) mul;
+              make_const (New_Vec128 1) displs;
+              make_binary_operation (Result 0) (New_Vec128 1) (Result 0) add ]
         | _ -> None)
       | Iindexed2scaled _ -> (
         match add_op, mul_op with
@@ -814,11 +814,11 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           (* reg + reg * scale + displ *)
           Some
             [ make_move (Argument 1) (Result 0);
-              make_const (New 0) scales;
-              make_binary_operation (Result 0) (New 0) (Result 0) mul;
+              make_const (New_Vec128 0) scales;
+              make_binary_operation (Result 0) (New_Vec128 0) (Result 0) mul;
               make_binary_operation (Result 0) (Argument 0) (Result 0) add;
-              make_const (New 1) displs;
-              make_binary_operation (Result 0) (New 1) (Result 0) add ]
+              make_const (New_Vec128 1) displs;
+              make_binary_operation (Result 0) (New_Vec128 1) (Result 0) add ]
         | _ -> None)
       | Ibased _ -> None)
     | Isextend32 -> (

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -2888,7 +2888,7 @@ let add_vector_instructions_for_group reg_map state group ~before:cell
     let get_register
         (simd_reg : Vectorize_utils.Vectorized_instruction.register) =
       match simd_reg with
-      | New n -> get_new_reg n
+      | New_Vec128 n -> get_new_reg n
       | Argument n ->
         let original_reg = (Instruction.arguments key_instruction).(n) in
         Substitution.get_reg_exn reg_map original_reg

--- a/backend/vectorize_utils.ml
+++ b/backend/vectorize_utils.ml
@@ -76,7 +76,7 @@ end
 
 module Vectorized_instruction = struct
   type register =
-    | New of int
+    | New_Vec128 of int
     | Argument of int
     | Result of int
     | Original of int

--- a/backend/vectorize_utils.mli
+++ b/backend/vectorize_utils.mli
@@ -59,7 +59,7 @@ module Vectorized_instruction : sig
   (** Registers used in vectorized instructions of one scalar instruction
      group. *)
   type register =
-    | New of int
+    | New_Vec128 of int
         (** The n-th new temporary register used in the vectorized instructions *)
     | Argument of int
         (** Vector version of the n-th argument's register of the scalar


### PR DESCRIPTION
Rename `New` to `New_vec128` to make the type clear and distinguish it from the upcoming `Valx2`. Later, we may need to make `machtype_component` into an argument of `New` , but for now we only use `Vec128`.