### PR TITLE
Vectorizer: xmm register can hold ocaml values

### DIFF
--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -375,7 +375,7 @@ let record_frame_label live dbg =
           live_offset := encode n :: encode (n + 1) :: !live_offset
       | {typ = Valx2; loc = Stack s} as reg ->
           let n = slot_offset s (stack_slot_class reg.typ)  in
-          live_offset := n :: n + 1 :: !live_offset
+          live_offset := n :: n + Arch.size_addr :: !live_offset
       | {typ = Addr} as r ->
           Misc.fatal_error ("bad GC root " ^ Reg.name r)
       | { typ = (Val | Valx2); loc = Unknown ; } as r ->
@@ -2252,7 +2252,7 @@ let emit_probe_handler_wrapper p =
         (match r.typ with
         | Val -> k::acc
         | Int | Float | Vec128 | Float32 -> acc
-        | Valx2 -> k::k+1::acc
+        | Valx2 -> k::k+Arch.size_addr::acc
         | Addr -> Misc.fatal_error ("bad GC root " ^ Reg.name r))
       | _ -> assert false)
     saved_live

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -364,13 +364,23 @@ let record_frame_label live dbg =
   let live_offset = ref [] in
   Reg.Set.iter
     (function
-      | {typ = Val; loc = Reg r} ->
+      | {typ = Val; loc = Reg r} as reg ->
+          assert (Proc.gc_regs_offset reg = r);
           live_offset := ((r lsl 1) + 1) :: !live_offset
       | {typ = Val; loc = Stack s} as reg ->
           live_offset := slot_offset s (stack_slot_class reg.typ) :: !live_offset
+      | {typ = Valx2; loc = Reg r} as reg ->
+          let n = Proc.gc_regs_offset reg in
+          let encode n = ((n lsl 1) + 1) in
+          live_offset := encode n :: encode (n + 1) :: !live_offset
+      | {typ = Valx2; loc = Stack s} as reg ->
+          let n = slot_offset s (stack_slot_class reg.typ)  in
+          live_offset := n :: n + 1 :: !live_offset
       | {typ = Addr} as r ->
           Misc.fatal_error ("bad GC root " ^ Reg.name r)
-      | _ -> ()
+      | { typ = (Val | Valx2); loc = Unknown ; } as r ->
+        Misc.fatal_error ("Unknown location " ^ Reg.name r)
+      | { typ = Int | Float | Float32 | Vec128; _ } -> ()
     )
     live;
   record_frame_descr ~label:lbl ~frame_size:(frame_size())
@@ -2242,6 +2252,7 @@ let emit_probe_handler_wrapper p =
         (match r.typ with
         | Val -> k::acc
         | Int | Float | Vec128 | Float32 -> acc
+        | Valx2 -> k::k+1::acc
         | Addr -> Misc.fatal_error ("bad GC root " ^ Reg.name r))
       | _ -> assert false)
     saved_live

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -811,8 +811,7 @@ let move (src : Reg.t) (dst : Reg.t) =
   begin match src.typ, src.loc, dst.typ, dst.loc with
   | Float, Reg _, Float, Reg _
   | Float32, Reg _, Float32, Reg _
-  | Valx2, _, Valx2, _
-  | Vec128, _, Vec128, _ (* Vec128 stack slots are always aligned. *) ->
+  | (Vec128 | Valx2), _, (Vec128 | Valx2), _ (* Vec128 stack slots are always aligned. *) ->
     if distinct then I.movapd (reg src) (reg dst)
   | Float, _, Float, _ ->
     if distinct then I.movsd (reg src) (reg dst)

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -811,7 +811,8 @@ let move (src : Reg.t) (dst : Reg.t) =
   begin match src.typ, src.loc, dst.typ, dst.loc with
   | Float, Reg _, Float, Reg _
   | Float32, Reg _, Float32, Reg _
-  | (Vec128 | Valx2), _, (Vec128 | Valx2), _ (* Vec128 stack slots are always aligned. *) ->
+  | Valx2, _, Valx2, _
+  | Vec128, _, Vec128, _ (* Vec128 stack slots are always aligned. *) ->
     if distinct then I.movapd (reg src) (reg dst)
   | Float, _, Float, _ ->
     if distinct then I.movsd (reg src) (reg dst)

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -53,7 +53,7 @@ let float_reg_name = Array.init 16 (fun i -> XMM i)
 let register_name typ r =
   match (typ : machtype_component) with
   | Int | Val | Addr -> Reg64 (int_reg_name.(r))
-  | Float | Float32 | Vec128 -> Regf (float_reg_name.(r - 100))
+  | Float | Float32 | Vec128 | Valx2 -> Regf (float_reg_name.(r - 100))
 
 let phys_rax = phys_reg Int 0
 let phys_rdx = phys_reg Int 4
@@ -292,6 +292,7 @@ let emit_Llabel fallthrough lbl section_name =
 let x86_data_type_for_stack_slot : machtype_component -> data_type = function
   | Float -> REAL8
   | Vec128 -> VEC128
+  | Valx2 -> VEC128
   | Int | Addr | Val -> QWORD
   | Float32 -> REAL4
 
@@ -800,7 +801,7 @@ let move (src : Reg.t) (dst : Reg.t) =
   begin match src.typ, src.loc, dst.typ, dst.loc with
   | Float, Reg _, Float, Reg _
   | Float32, Reg _, Float32, Reg _
-  | Vec128, _, Vec128, _ (* Vec128 stack slots are always aligned. *) ->
+  | (Vec128 | Valx2), _, (Vec128 | Valx2), _ (* Vec128 stack slots are always aligned. *) ->
     if distinct then I.movapd (reg src) (reg dst)
   | Float, _, Float, _ ->
     if distinct then I.movsd (reg src) (reg dst)
@@ -808,7 +809,7 @@ let move (src : Reg.t) (dst : Reg.t) =
     if distinct then I.movss (reg src) (reg dst)
   | (Int | Val | Addr), _, (Int | Val | Addr), _ ->
     if distinct then I.mov (reg src) (reg dst)
-  | (Float | Float32 | Vec128 | Int | Val | Addr), _, _, _ ->
+  | (Float | Float32 | Vec128 | Int | Val | Addr | Valx2), _, _, _ ->
     Misc.fatal_errorf
       "Illegal move between registers of differing types (%a to %a)\n"
       Printreg.reg src Printreg.reg dst
@@ -822,7 +823,7 @@ let stack_to_stack_move (src : Reg.t) (dst : Reg.t) =
       (* Not calling move because r15 is not in int_reg_name. *)
       I.mov (reg src) r15;
       I.mov r15 (reg dst)
-    | Float | Addr | Vec128 | Float32 ->
+    | Float | Addr | Vec128 | Valx2 | Float32 ->
       Misc.fatal_errorf
         "Unexpected register type for stack to stack move: from %s to %s\n"
         (Reg.name src) (Reg.name dst)
@@ -2143,7 +2144,7 @@ let size_of_regs regs =
       | Float | Float32 ->
         (* Float32 slots still take up a full word *)
         acc + size_float
-      | Vec128 -> acc + size_vec128)
+      | Vec128 | Valx2 -> acc + size_vec128)
     regs 0
 
 let stack_locations ~offset regs =
@@ -2153,7 +2154,7 @@ let stack_locations ~offset regs =
       | Float | Float32 ->
         (* Float32 slots still take up a full word *)
         size_float
-      | Vec128 -> size_vec128 in
+      | Vec128 | Valx2 -> size_vec128 in
     next, (make_stack_loc n r ~offset :: offsets)) regs (0, []) in
   locs |> Array.of_list
 

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -111,6 +111,19 @@ let stack_slot_class typ =
   | Float | Float32 -> 1
   | Vec128 | Valx2 -> 2
 
+let types_are_compatible left right =
+  match left.typ, right.typ with
+  | (Int | Val | Addr), (Int | Val | Addr)
+  | Float, Float
+  | Float32, Float32
+  | Vec128, Vec128 ->
+    true
+  | Valx2, Valx2 ->
+    true
+  | Valx2, Vec128 | Vec128, Valx2 ->
+    true
+  | (Int | Val | Addr | Float | Float32 | Vec128 | Valx2), _ -> false
+
 let stack_class_tag c =
   match c with
   | 0 -> "i"

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -116,11 +116,7 @@ let types_are_compatible left right =
   | (Int | Val | Addr), (Int | Val | Addr)
   | Float, Float
   | Float32, Float32
-  | Vec128, Vec128 ->
-    true
-  | Valx2, Valx2 ->
-    true
-  | Valx2, Vec128 | Vec128, Valx2 ->
+  | (Valx2 | Vec128), (Valx2 | Vec128) ->
     true
   | (Int | Val | Addr | Float | Float32 | Vec128 | Valx2), _ -> false
 

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -101,7 +101,7 @@ let num_register_classes = 2
 let register_class r =
   match r.typ with
   | Val | Int | Addr -> 0
-  | Float | Float32 | Vec128 -> 1
+  | Float | Float32 | Vec128 | Valx2 -> 1
 
 let num_stack_slot_classes = 3
 
@@ -109,7 +109,7 @@ let stack_slot_class typ =
   match (typ : machtype_component) with
   | Val | Addr | Int -> 0
   | Float | Float32 -> 1
-  | Vec128 -> 2
+  | Vec128 | Valx2 -> 2
 
 let stack_class_tag c =
   match c with
@@ -127,7 +127,7 @@ let register_name ty r =
   match (ty : machtype_component) with
   | Int | Addr | Val ->
     int_reg_name.(r - first_available_register.(0))
-  | Float | Float32 | Vec128 ->
+  | Float | Float32 | Vec128 | Valx2 ->
     float_reg_name.(r - first_available_register.(1))
 
 (* Pack registers starting at %rax so as to reduce the number of REX
@@ -235,6 +235,8 @@ let calling_conventions
         loc.(i) <- stack_slot (make_stack !ofs) Vec128;
         ofs := !ofs + size_vec128
       end
+    | Valx2 ->
+      Misc.fatal_error "Unexpected machtype_component Valx2"
     | Float32 ->
         if !float <= last_float then begin
           loc.(i) <- phys_reg Float32 !float;
@@ -386,6 +388,8 @@ let win64_loc_external_arguments arg =
     | Vec128 ->
         (* CR mslater: (SIMD) win64 calling convention requires pass by reference *)
         Misc.fatal_error "SIMD external arguments are not supported on Win64"
+    | Valx2 ->
+      Misc.fatal_error "Unexpected machtype_component Valx2"
   done;
   (loc, Misc.align !ofs 16)  (* keep stack 16-aligned *)
 

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -165,7 +165,7 @@ let record_frame_label live dbg =
           Misc.fatal_error ("bad GC root " ^ Reg.name r)
       | { typ = Valx2; } as r ->
           (* CR mslater: (SIMD) arm64 *)
-          Misc.fatal_error ("Unexpect Valx2 type of reg " ^ Reg.name r)
+          Misc.fatal_error ("Unexpected Valx2 type of reg " ^ Reg.name r)
       | { typ = Val; loc = Unknown ; } as r ->
           Misc.fatal_error ("Unknown location " ^ Reg.name r)
       | { typ = Int | Float | Float32 | Vec128; _ } -> ())

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -163,7 +163,12 @@ let record_frame_label live dbg =
           live_offset := slot_offset s (stack_slot_class reg.typ) :: !live_offset
       | {typ = Addr} as r ->
           Misc.fatal_error ("bad GC root " ^ Reg.name r)
-      | _ -> ())
+      | { typ = Valx2; } as r ->
+          (* CR mslater: (SIMD) arm64 *)
+          Misc.fatal_error ("Unexpect Valx2 type of reg " ^ Reg.name r)
+      | { typ = Val; loc = Unknown ; } as r ->
+          Misc.fatal_error ("Unknown location " ^ Reg.name r)
+      | { typ = Int | Float | Float32 | Vec128; _ } -> ())
     live;
   record_frame_descr ~label:lbl ~frame_size:(frame_size())
     ~live_offset:!live_offset dbg;

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -91,6 +91,22 @@ let stack_slot_class typ =
     (* CR mslater: (SIMD) arm64 *)
     fatal_error "arm64: got valx2 register"
 
+let types_are_compatible left right =
+  match left.typ, right.typ with
+  | (Int | Val | Addr), (Int | Val | Addr)
+  | Float, Float ->
+    true
+  | Float32, _ | _, Float32 ->
+    (* CR mslater: (float32) arm64 *)
+    fatal_error "arm64: got float32 register"
+  | Vec128, _ | _, Vec128 ->
+    (* CR mslater: (SIMD) arm64 *)
+    fatal_error "arm64: got vec128 register"
+  | Valx2, _ | _, Valx2 ->
+    (* CR mslater: (SIMD) arm64 *)
+    fatal_error "arm64: got valx2 register"
+  | (Int | Val | Addr | Float), _ -> false
+
 let stack_class_tag c =
   match c with
   | 0 -> "i"

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -71,6 +71,9 @@ let register_class r =
   | Float32 ->
     (* CR mslater: (float32) arm64 *)
     fatal_error "arm64: got float32 register"
+  | Valx2 ->
+    (* CR mslater: (SIMD) arm64 *)
+    fatal_error "arm64: got valx2 register"
 
 let num_stack_slot_classes = 2
 
@@ -84,6 +87,9 @@ let stack_slot_class typ =
   | Float32 ->
     (* CR mslater: (float32) arm64 *)
     fatal_error "arm64: got float32 register"
+  | Valx2 ->
+    (* CR mslater: (SIMD) arm64 *)
+    fatal_error "arm64: got valx2 register"
 
 let stack_class_tag c =
   match c with
@@ -109,6 +115,9 @@ let register_name ty r =
   | Float32 ->
     (* CR mslater: (float32) arm64 *)
     fatal_error "arm64: got float32 register"
+  | Valx2 ->
+    (* CR mslater: (SIMD) arm64 *)
+    fatal_error "arm64: got valx2 register"
 
 let rotate_registers = true
 
@@ -145,6 +154,13 @@ let phys_reg ty n =
   | Float32 ->
     (* CR mslater: (float32) arm64 *)
     fatal_error "arm64: got float32 register"
+  | Valx2 ->
+    (* CR mslater: (SIMD) arm64 *)
+    fatal_error "arm64: got valx2 register"
+
+let gc_regs_offset _ =
+    (* CR mslater: (SIMD) arm64 *)
+    fatal_error "arm64: gc_reg_offset unreachable"
 
 let reg_x8 = phys_reg Int 8
 let reg_d7 = phys_reg Float 107
@@ -204,6 +220,9 @@ let calling_conventions
     | Float32 ->
         (* CR mslater: (float32) arm64 *)
         fatal_error "arm64: got float32 register"
+    | Valx2 ->
+      (* CR mslater: (SIMD) arm64 *)
+      fatal_error "arm64: got valx2 register"
   done;
   (loc, Misc.align (max 0 !ofs) 16)  (* keep stack 16-aligned *)
 

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -174,7 +174,7 @@ module Transfer = struct
             let reg_is_of_type_addr =
               match (RD.reg reg).typ with
               | Addr -> true
-              | Val | Int | Float | Vec128 | Float32 -> false
+              | Val | Int | Float | Vec128 | Float32 | Valx2 -> false
             in
             if remains_available
                || (not (extend_live ()))

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -2093,6 +2093,35 @@ end = struct
         in
         List.for_all is_isomorphic tl
 
+    let vectorizable_machtypes regs1 regs2 count =
+      let rec loop index =
+        if index = count
+        then true
+        else if Vectorize_utils.vectorizable_machtypes regs1.(index)
+                  regs2.(index)
+        then loop (index + 1)
+        else false
+      in
+      loop 0
+
+    let vectorizable_machtypes ~non_address_arg_count instructions =
+      match instructions with
+      | [] -> true
+      | hd :: tl ->
+        (* assumes the instructions are isomorphic, which guarantees the same
+           number of result registers for all instructions, and the same number
+           of argument registers for all instructions. *)
+        let res_count = get_res_count hd in
+        let res = Instruction.results hd in
+        let arg = Instruction.arguments hd in
+        List.for_all
+          (fun instr ->
+            vectorizable_machtypes res (Instruction.results instr) res_count
+            && vectorizable_machtypes arg
+                 (Instruction.arguments instr)
+                 non_address_arg_count)
+          tl
+
     let independent instructions deps =
       let res = Dependencies.all_independent deps instructions in
       State.dump_debug (Dependencies.state deps) "Group.independent: res=%b\n"
@@ -2129,9 +2158,16 @@ end = struct
         let arg_count = get_arg_count instruction in
         let res_count = get_res_count instruction in
         let mem_op = Dependencies.get_memory_operation deps instruction in
+        let non_address_arg_count =
+          match mem_op with
+          | None -> arg_count
+          | Some mem_op ->
+            Dependencies.Memory.Operation.first_memory_arg_index mem_op
+        in
         if not
              (same_stack_offset instructions
              && have_isomorphic_op instructions
+             && vectorizable_machtypes instructions ~non_address_arg_count
              && independent instructions deps
              && can_vectorize_memory_accesses mem_op instructions deps)
         then None
@@ -2146,12 +2182,6 @@ end = struct
           match vector_instructions with
           | None -> None
           | Some vector_instructions ->
-            let non_address_arg_count =
-              match mem_op with
-              | None -> arg_count
-              | Some mem_op ->
-                Dependencies.Memory.Operation.first_memory_arg_index mem_op
-            in
             assert (List.length vector_instructions > 0);
             Some
               { vector_instructions;
@@ -2845,9 +2875,15 @@ let augment_reg_map reg_map group =
     match pack with
     | [] -> ()
     | hd :: tl -> (
+      let packed_reg_typ = Vectorize_utils.vectorize_machtypes pack in
       match Substitution.get_reg_opt reg_map hd with
-      | None -> Substitution.fresh_reg_for_pack reg_map pack Vec128
+      | None -> Substitution.fresh_reg_for_pack reg_map pack packed_reg_typ
       | Some old_reg_for_hd ->
+        if not (Cmm.equal_machtype_component old_reg_for_hd.typ packed_reg_typ)
+        then
+          Misc.fatal_errorf "Expected %a but got %a for pack %a)"
+            Printcmm.machtype_component packed_reg_typ Printreg.reg
+            old_reg_for_hd Printreg.reglist pack;
         (* other registers in the pack must be mapped in the same way as
            [hd]. *)
         List.iter
@@ -2863,7 +2899,9 @@ let augment_reg_map reg_map group =
                 Misc.fatal_errorf
                   "augment_reg_map: %a is mapped to %a but %a is mapped to %a"
                   Printreg.reg hd Printreg.reg old_reg_for_hd Printreg.reg reg
-                  Printreg.reg old_reg)
+                  Printreg.reg old_reg;
+              assert (
+                Cmm.equal_machtype_component old_reg_for_hd.typ old_reg.typ))
           tl)
   in
   (* only some of the args are vectorizable, but all results are vectorizable. *)

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -695,6 +695,7 @@ class virtual selector_generic =
             (fun reg ->
               match reg.Reg.typ with
               | Addr -> assert false
+              | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
               | Val | Int | Float | Vec128 | Float32 -> ())
             src;
           self#insert_moves env src tmp_regs;

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -51,7 +51,7 @@ let typ_vec128 = [|Vec128|]
   then the result is treated as a derived pointer into the heap (i.e. [Addr]).
   (Such a result may not be live across any call site or a fatal compiler
   error will result.)
-  The order is used only in selection, Valx2 is generated after it from two Val.
+  The order is used only in selection, Valx2 is generated after selection.
 *)
 
 let lub_component comp1 comp2 =

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -22,6 +22,7 @@ type machtype_component = Cmx_format.machtype_component =
   | Float
   | Vec128
   | Float32
+  | Valx2
 
 (* - [Val] denotes a valid OCaml value: either a pointer to the beginning
      of a heap block, an infix pointer if it is preceded by the correct

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1577,6 +1577,7 @@ module Extended_machtype_component = struct
     | Float -> Float
     | Vec128 -> Vec128
     | Float32 -> Float32
+    | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
 
   let to_machtype_component t : machtype_component =
     match t with
@@ -1657,6 +1658,7 @@ let machtype_identifier t =
     | Float32 -> 'S'
     | Addr ->
       Misc.fatal_error "[Addr] is forbidden inside arity for generic functions"
+    | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
   in
   String.of_seq (Seq.map char_of_component (Array.to_seq t))
 
@@ -3101,6 +3103,7 @@ let machtype_stored_size t =
     (fun cur c ->
       match (c : machtype_component) with
       | Addr -> Misc.fatal_error "[Addr] cannot be stored"
+      | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
       | Val | Int -> cur + 1
       | Float -> cur + ints_per_float
       | Float32 ->
@@ -3114,6 +3117,7 @@ let machtype_non_scanned_size t =
     (fun cur c ->
       match (c : machtype_component) with
       | Addr -> Misc.fatal_error "[Addr] cannot be stored"
+      | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
       | Val -> cur
       | Int -> cur + 1
       | Float -> cur + ints_per_float
@@ -3135,6 +3139,7 @@ let value_slot_given_machtype vs =
         match (c : machtype_component) with
         | Int | Float | Float32 | Vec128 -> true
         | Val -> false
+        | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
         | Addr -> assert false)
       vs
   in
@@ -3162,6 +3167,7 @@ let read_from_closure_given_machtype t clos base_offset dbg =
           ( (non_scanned_pos + ints_per_vec128, scanned_pos),
             load Onetwentyeight_unaligned non_scanned_pos )
         | Val -> (non_scanned_pos, scanned_pos + 1), load Word_val scanned_pos
+        | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
         | Addr -> Misc.fatal_error "[Addr] cannot be read")
       (base_offset, base_offset + machtype_non_scanned_size t)
       (Array.to_list t)

--- a/backend/debug/available_regs.ml
+++ b/backend/debug/available_regs.ml
@@ -271,7 +271,7 @@ let rec available_regs (instr : M.instruction) ~all_regs_that_might_be_named
                 let reg_is_of_type_addr =
                   match (RD.reg reg).typ with
                   | Addr -> true
-                  | Val | Int | Float | Vec128 | Float32 -> false
+                  | Val | Int | Float | Vec128 | Float32 | Valx2 -> false
                 in
                 if remains_available
                    || (not (extend_live ()))

--- a/backend/debug/reg_with_debug_info.ml
+++ b/backend/debug/reg_with_debug_info.ml
@@ -106,7 +106,7 @@ let location t = t.reg.loc
 
 let holds_pointer t =
   match t.reg.typ with
-  | Addr | Val -> true
+  | Addr | Val | Valx2 -> true
   | Int | Float | Float32 | Vec128 -> false
 
 let holds_non_pointer t = not (holds_pointer t)

--- a/backend/interf.ml
+++ b/backend/interf.ml
@@ -23,7 +23,7 @@ let assert_no_collisions set =
   Misc.fatal_error "live set has physical register collisions"
 
 let assert_compatible src dst =
-  if not (Reg.types_are_compatible src dst) then
+  if not (Proc.types_are_compatible src dst) then
   Misc.fatal_errorf "found move between registers of incompatible types (%a to %a)"
   Printreg.reg src Printreg.reg dst
 

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -37,6 +37,7 @@ let machtype_component ppf (ty : machtype_component) =
   | Float -> fprintf ppf "float"
   | Vec128 -> fprintf ppf "vec128"
   | Float32 -> fprintf ppf "float32"
+  | Valx2 -> fprintf ppf "valx2"
 
 let machtype ppf mty =
   match Array.length mty with

--- a/backend/printreg.ml
+++ b/backend/printreg.ml
@@ -43,6 +43,7 @@ let reg ppf r =
     | Int -> "I"
     | Float -> "F"
     | Vec128 -> "X"
+    | Valx2 -> "VV"
     | Float32 -> "S");
   fprintf ppf "/%i" r.stamp;
   loc

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -36,6 +36,14 @@ val num_stack_slot_classes: int
 val stack_slot_class: Cmm.machtype_component -> int
 val stack_class_tag: int -> string
 
+(* If two registers have compatible types then we allow moves between them.
+   Note that we never allow moves between different register classes or
+   stack slot classes, so the following must hold:
+   if [machtypes_are_compatible r1 r2] = true then
+   [register_class r1] = [register_class r2]
+   and [stack_class r1.typ] = [stack_class r2.typ]. *)
+val types_are_compatible : Reg.t -> Reg.t -> bool
+
 (* Calling conventions *)
 val loc_arguments: Cmm.machtype -> Reg.t array * int
 val loc_results_call: Cmm.machtype -> Reg.t array * int

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -25,6 +25,7 @@ val num_available_registers: int array
 val first_available_register: int array
 val register_name: Cmm.machtype_component -> int -> string
 val phys_reg: Cmm.machtype_component -> int -> Reg.t
+val gc_regs_offset : Reg.t -> int
 val rotate_registers: bool
 val precolored_regs : unit -> Reg.Set.t
 

--- a/backend/reg.ml
+++ b/backend/reg.ml
@@ -334,19 +334,3 @@ let same left right =
 
 let compare left right =
   Int.compare left.stamp right.stamp
-
-(* Two registers have compatible types if we allow moves between them.
-   Note that we never allow moves between different register classes, so this
-   condition must be at least as strict as [class left = class right]. *)
-let types_are_compatible left right =
-  match left.typ, right.typ with
-  | (Int | Val | Addr), (Int | Val | Addr)
-  | Float, Float
-  | Float32, Float32
-  | Vec128, Vec128 ->
-    true
-  | Valx2, Valx2 ->
-    true
-  | Valx2, Vec128 | Vec128, Valx2 ->
-    true
-  | (Int | Val | Addr | Float | Float32 | Vec128 | Valx2), _ -> false

--- a/backend/reg.ml
+++ b/backend/reg.ml
@@ -345,4 +345,8 @@ let types_are_compatible left right =
   | Float32, Float32
   | Vec128, Vec128 ->
     true
-  | (Int | Val | Addr | Float | Float32 | Vec128), _ -> false
+  | Valx2, Valx2 ->
+    true
+  | Valx2, Vec128 | Vec128, Valx2 ->
+    true
+  | (Int | Val | Addr | Float | Float32 | Vec128 | Valx2), _ -> false

--- a/backend/reg.mli
+++ b/backend/reg.mli
@@ -122,7 +122,6 @@ val mark_visited : t -> unit
 val is_visited : t -> bool
 val clear_visited_marks : unit -> unit
 
-val types_are_compatible : t -> t -> bool
 val same_phys_reg : t -> t -> bool
 val same_loc : t -> t -> bool
 val same : t -> t -> bool

--- a/backend/regalloc/regalloc_irc_state.ml
+++ b/backend/regalloc/regalloc_irc_state.ml
@@ -473,7 +473,7 @@ let[@inline] rec find_alias state reg =
 let[@inline] add_alias _state v u =
   (* We should never generate moves between registers of different types.
      Bit-casting operations have specific instructions. *)
-  if not (Reg.types_are_compatible v u)
+  if not (Proc.types_are_compatible v u)
   then
     fatal
       "trying to create an alias between %a and %a but they have incompatible \

--- a/backend/vectorize_utils.ml
+++ b/backend/vectorize_utils.ml
@@ -121,11 +121,11 @@ let vectorize_machtypes (pack : Reg.t list) : Cmm.machtype_component =
       Misc.fatal_errorf "register pack with incompatible mach types:"
         Printreg.reglist pack;
     match hd.typ, List.length pack with
-    | (Int | Addr | Float | Float32), _ ->
+    | (Int | Addr | Float), 2 | Float32, 4 ->
       (* allows subregs, width should be correct by construction of [Group]. *)
       Vec128
     | Val, 2 -> Valx2
-    | Val, n ->
+    | (Val | Int | Addr | Float | Float32), n ->
       Misc.fatal_errorf "Unexpected pack size %d for %a" n Printreg.reglist pack
     | Vec128, _ | Valx2, _ ->
       Misc.fatal_errorf "Unexpected machtype for %a" Printreg.reg hd)

--- a/backend/vectorize_utils.mli
+++ b/backend/vectorize_utils.mli
@@ -88,6 +88,6 @@ end
 val vectorizable_machtypes : Reg.t -> Reg.t -> bool
 
 val vectorize_machtypes : Reg.t list -> Cmm.machtype_component
-(* CR-someday gyorsh: [vectorizable_machtypes] should take a [pack] instead of a
-   pair, to handle longer vectors, and to present a uniform interface with
-   [vectorize_machtypes]. *)
+(* CR-someday gyorsh: [vectorizable_machtypes] should take a [Reg.t list]
+   instead of a pair, to handle longer vectors, and to present a uniform
+   interface with [vectorize_machtypes]. *)

--- a/backend/vectorize_utils.mli
+++ b/backend/vectorize_utils.mli
@@ -81,3 +81,13 @@ module Vectorized_instruction : sig
 
   val make_default : arg_count:int -> res_count:int -> Operation.t -> t
 end
+
+(** Given two registers of non-vector types, return true iff there exist a vector type
+    that can contain both of them. Currently distinguishes between [Val] and other
+    types. Mixing [Val] with non-Val in a vector is not yet supported. *)
+val vectorizable_machtypes : Reg.t -> Reg.t -> bool
+
+val vectorize_machtypes : Reg.t list -> Cmm.machtype_component
+(* CR-someday gyorsh: [vectorizable_machtypes] should take a [pack] instead of a
+   pair, to handle longer vectors, and to present a uniform interface with
+   [vectorize_machtypes]. *)

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -32,7 +32,7 @@ open Misc
    of these infos *)
 
 (* Declare machtype here to avoid depending on [Cmm]. *)
-type machtype_component = Val | Addr | Int | Float | Vec128 | Float32
+type machtype_component = Val | Addr | Int | Float | Vec128 | Float32 | Valx2
 type machtype = machtype_component array
 
 (* [alloc_mode] should be isomorphic to [Cmm.Alloc_mode.t],


### PR DESCRIPTION
This PR adds a new variant `Valx2` to `Cmm.machtype_component` to represent a vector register that holds ocaml values and needs to be scanned by the GC, as opposed to the current `Vec128` machtype_component that is not scanned. 

- The first commit mechanically propagates the new variant through the backend. 
- The interesting part of recording these registers in the frame is in a separate commit. It requires https://github.com/ocaml-flambda/flambda-backend/pull/3453 to work correctly. 
- Finally, a separate commit fixes the vectorizer to correctly set the type of vector registers it creates. 

Currently, the vectorizer rejects candidates that would result in "mixed vectors". If we want to allow it, we can replace `Valx2`  and `Vec128` with `Vec128 of mask` where the mask indicates which parts are values. 