### PR TITLE
Improve coherence of modality zapping

### DIFF
--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -67,24 +67,23 @@ module M : sig val x : string @@ portable contended end
 
 (* Testing the defaulting behaviour.
    "module type of" triggers the defaulting logic.
-    Note that the defaulting will mutate the original module type.
-*)
+    Note that the defaulting will mutate the original module type: it zaps the
+    inferred modalities and make them fully fixed. *)
 module Module_type_of_comonadic = struct
     module M = struct
         let x @ portable = fun x -> x
     end
     (* for comonadic axes, we default to id = meet_with_max, which is the
-    weakest. The original modality is not mutated. *)
+    weakest. *)
     module M' : module type of M = struct
         let x @ portable = fun x -> x
     end
-    let _ = portable_use M.x (* The original modality stays portable *)
-    let _ = portable_use M'.x
+    let _ = portable_use M.x (* The original inferred modality is zapped *)
 end
 [%%expect{|
-Line 11, characters 25-29:
-11 |     let _ = portable_use M'.x
-                              ^^^^
+Line 10, characters 25-28:
+10 |     let _ = portable_use M.x (* The original inferred modality is zapped *)
+                              ^^^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2424,21 +2424,6 @@ module Modality = struct
       | Diff (mm, m) ->
         (* For soundness, we want some [c] such that [m <= join c mm], which
            gives [subtract_mm m <= c]. To satisfy coherence conditions (see
-           [mode_intf.ml]), we must zap [mm] and [m] fully. First we zap [m] to
-           strongest. *)
-        let m = Mode.zap_to_floor m in
-        (* Note that [subtract] is antitone for [mm], so we zap [mm] to
-           strongest, to get the weakest [c]. *)
-        let mm = Mode.zap_to_floor mm in
-        let c = Mode.Const.subtract m mm in
-        Const.Join_const c
-
-    let zap_to_id = function
-      | Const c -> c
-      | Undefined -> Misc.fatal_error "modality Undefined should not be zapped."
-      | Diff (mm, m) ->
-        (* For soundness, we want some [c] such that [m <= join c mm], which
-           gives [subtract_mm m <= c]. To satisfy coherence conditions (see
            [mode_intf.ml]), we must zap [mm] and [m] fully. Note that [subtract]
            is antitone for [mm] and monotone for [m], so we zap [mm] to ceil,
            and [m] to floor, to get the floor of [c]. *)
@@ -2446,6 +2431,8 @@ module Modality = struct
         let mm = Mode.zap_to_ceil mm in
         let c = Mode.Const.subtract m mm in
         Const.Join_const c
+
+    let zap_to_id = zap_to_floor
 
     let to_const_exn = function
       | Const c -> c
@@ -2569,7 +2556,7 @@ module Modality = struct
 
     let max = Const Const.max
 
-    let zap_to_id = function
+    let zap_to_ceil = function
       | Const c -> c
       | Undefined -> Misc.fatal_error "modality Undefined should not be zapped."
       | Exactly (mm, m) ->
@@ -2578,25 +2565,21 @@ module Modality = struct
            conditions listed in [mode_intf.ml], we need to zap [mm] and [m]
            fully. [imply] is antitone in [mm] but monotone in [m] , so we zap
            [mm] to strongest and [m] to weakest, in order to get the weakest
-           [c].
-        *)
+           [c]. *)
         let m = Mode.zap_to_ceil m in
         let mm = Mode.zap_to_floor mm in
         let c = Mode.Const.imply mm m in
         Const.Meet_const c
 
+    let zap_to_id = zap_to_ceil
+
     let zap_to_floor = function
       | Const c -> c
       | Undefined -> Misc.fatal_error "modality Undefined should not be zapped."
       | Exactly (mm, m) ->
-        (* We want to return [c = imply mm m]. To satisfy the coherence
-           conditions listed in [mode_intf.ml], we need to zap [mm] and [m]
-           fully. First, we want the strongest mode for the value. *)
+        (* Opposite to [zap_to_ceil]. *)
         let m = Mode.zap_to_floor m in
-        (* Then, we want to return the weakest modality that will give the above
-           [m]. Since [imply mm m] is antitone in [mm], we zap [mm] to strongest.
-        *)
-        let mm = Mode.zap_to_floor mm in
+        let mm = Mode.zap_to_ceil mm in
         let c = Mode.Const.imply mm m in
         Const.Meet_const c
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2371,7 +2371,7 @@ module Modality = struct
 
     type t =
       | Const of Const.t
-      | Diff of Mode.lr * Mode.l
+      | Diff of Mode.lr * Mode.lr
           (** inferred modality. See [apply] for its behavior. *)
       | Undefined
 
@@ -2411,7 +2411,7 @@ module Modality = struct
       | Const c -> Const.apply c x |> Mode.disallow_right
       | Undefined ->
         Misc.fatal_error "modality Undefined should not be applied."
-      | Diff (_, m) -> Mode.join [m; Mode.disallow_right x]
+      | Diff (_, m) -> Mode.join [Mode.allow_right m; x]
 
     let print ppf = function
       | Const c -> Const.print ppf c
@@ -2422,15 +2422,30 @@ module Modality = struct
       | Const c -> c
       | Undefined -> Misc.fatal_error "modality Undefined should not be zapped."
       | Diff (mm, m) ->
-        let m = Mode.zap_to_floor m in
         (* For soundness, we want some [c] such that [m <= join c mm], which
-           gives [subtract_mm m <= c]. Note that [mm] is a variable, but we need
-           a constant. Therefore, we take its floor [mm' <= mm], and we have
-           [subtract_mm m <= subtract_mm' m <= c]. *)
-        let mm' = Mode.Guts.get_floor mm in
-        Const.Join_const (Mode.Const.subtract m mm')
+           gives [subtract_mm m <= c]. To satisfy coherence conditions (see
+           [mode_intf.ml]), we must zap [mm] and [m] fully. First we zap [m] to
+           strongest. *)
+        let m = Mode.zap_to_floor m in
+        (* Note that [subtract] is antitone for [mm], so we zap [mm] to
+           strongest, to get the weakest [c]. *)
+        let mm = Mode.zap_to_floor mm in
+        let c = Mode.Const.subtract m mm in
+        Const.Join_const c
 
-    let zap_to_id = zap_to_floor
+    let zap_to_id = function
+      | Const c -> c
+      | Undefined -> Misc.fatal_error "modality Undefined should not be zapped."
+      | Diff (mm, m) ->
+        (* For soundness, we want some [c] such that [m <= join c mm], which
+           gives [subtract_mm m <= c]. To satisfy coherence conditions (see
+           [mode_intf.ml]), we must zap [mm] and [m] fully. Note that [subtract]
+           is antitone for [mm] and monotone for [m], so we zap [mm] to ceil,
+           and [m] to floor, to get the floor of [c]. *)
+        let m = Mode.zap_to_floor m in
+        let mm = Mode.zap_to_ceil mm in
+        let c = Mode.Const.subtract m mm in
+        Const.Join_const c
 
     let to_const_exn = function
       | Const c -> c
@@ -2504,7 +2519,7 @@ module Modality = struct
     type t =
       | Const of Const.t
       | Undefined
-      | Exactly of Mode.lr * Mode.l
+      | Exactly of Mode.lr * Mode.lr
           (** inferred modality. See [apply] for its behavior. *)
 
     let sub_log left right ~log : (unit, error) Result.t =
@@ -2543,7 +2558,7 @@ module Modality = struct
       | Const c -> Const.apply c x |> Mode.disallow_right
       | Undefined ->
         Misc.fatal_error "modality Undefined should not be applied."
-      | Exactly (_mm, m) -> m
+      | Exactly (_mm, m) -> Mode.disallow_right m
 
     let print ppf = function
       | Const c -> Const.print ppf c
@@ -2554,50 +2569,35 @@ module Modality = struct
 
     let max = Const Const.max
 
-    let zap_to_ceil = function
+    let zap_to_id = function
       | Const c -> c
       | Undefined -> Misc.fatal_error "modality Undefined should not be zapped."
-      | Exactly _ -> Const.id
-
-    let zap_to_id = zap_to_ceil
+      | Exactly (mm, m) ->
+        (* For soundness and completeness, we need some [c] such that [meet_c mm
+           = m], or equivalently [c = imply mm m]. To satisfy the coherence
+           conditions listed in [mode_intf.ml], we need to zap [mm] and [m]
+           fully. [imply] is antitone in [mm] but monotone in [m] , so we zap
+           [mm] to strongest and [m] to weakest, in order to get the weakest
+           [c].
+        *)
+        let m = Mode.zap_to_ceil m in
+        let mm = Mode.zap_to_floor mm in
+        let c = Mode.Const.imply mm m in
+        Const.Meet_const c
 
     let zap_to_floor = function
       | Const c -> c
       | Undefined -> Misc.fatal_error "modality Undefined should not be zapped."
       | Exactly (mm, m) ->
+        (* We want to return [c = imply mm m]. To satisfy the coherence
+           conditions listed in [mode_intf.ml], we need to zap [mm] and [m]
+           fully. First, we want the strongest mode for the value. *)
         let m = Mode.zap_to_floor m in
-        (* We want some [c] such that:
-           - Soundness: [meet_with c mm >= m].
-           - Completeness: [meet_with c mm <= m].
-           - Simplicity: Optionally, we want [c] to be as high as possible to make
-            [meet_with c] a simpler modality.
-
-            We first rewrite completeness condition to [c <= imply_with mm m].
-            We will take [c] to be [imply_with mm m] and prove soundness for it.
-
-            To prove soundness [meet_with (imply_with mm m) mm >= m], we need to prove:
-            - [imply_with mm m >= m], or equivalently [meet mm m <= m] which is trivial.
-            - [mm >= m], which is guaranteed by the caller of [infer].
-            In fact, the soundness condition holds for any [c]  taken to be
-            [imply_with _ m] where the underscore can be anything.
-
-            Note that [imply_with] requires its first argument to be a constant, so we
-            need to get a constant out of [mm]. First recall that [imply_with] is antitone
-            in its first argument. Now, we have several choices:
-            - Take its floor [mm' <= mm], and then [c' = imply_with mm' m]. [c'] is higher
-              than [c] and thus might be incomplete.
-            - Take its ceil [mm' >= mm]. Then, [c'] is lower than [c] and thus complete,
-              but might be less simple than [c].
-            - Zap to floor. This gives us a [c' = c] that is complete and simple, but we
-               are imposing extra constraint to [mm] not requested by the caller.
-            - Zap to ceil. This gives us a [c' = c] that is complete, but less simple than
-              zapping it to floor. Also, we are imposing extra constraint.
-
-            We prioritize completeness and "not imposing extra constarint" over
-            simplicity. So we take its ceil [mm' >= mm].
+        (* Then, we want to return the weakest modality that will give the above
+           [m]. Since [imply mm m] is antitone in [mm], we zap [mm] to strongest.
         *)
-        let mm' = Mode.Guts.get_ceil mm in
-        let c = Mode.Const.imply mm' m in
+        let mm = Mode.zap_to_floor mm in
+        let c = Mode.Const.imply mm m in
         Const.Meet_const c
 
     let to_const_exn = function

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -571,16 +571,23 @@ module type S = sig
       value description in the inferred module type.
 
       The caller should ensure that for comonadic axes, [md_mode >= mode]. *)
-      val infer : md_mode:Value.lr -> mode:Value.l -> t
+      val infer : md_mode:Value.lr -> mode:Value.lr -> t
 
       (* The following zapping functions possibly mutate a potentially inferred
          modality [m] to a constant modality [c]. The constant modality is
-         returned. [m <= c] holds, even after further mutations to [m]. *)
+         returned. The following coherence conditions hold:
+         - [m <= c] always holds, even after further mutations to [m].
+         - [c0 <= c1] always holds, where [c0] and [c1] are results of two
+            abitrary zappings of some [m], even after further mutations to [m].
+            Essentially that means [c0 = c1].
+      *)
 
-      (** Returns a const modality weaker than the given modality. *)
+      (** Zap an inferred modality towards identity modality. *)
       val zap_to_id : t -> Const.t
 
-      (** Returns a const modality lowest (strongest) possible. *)
+      (** Zap an inferred modality, so that it would give the strongest mode of
+          the value. If multiple modalities can achieve that, choose the weakest
+          one. *)
       val zap_to_floor : t -> Const.t
 
       (** Asserts the given modality is a const modality, and returns it. *)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -580,14 +580,15 @@ module type S = sig
          - [c0 <= c1] always holds, where [c0] and [c1] are results of two
             abitrary zappings of some [m], even after further mutations to [m].
             Essentially that means [c0 = c1].
+
+         NB: zapping an inferred modality will zap both [md_mode] and [mode] that
+         it contains. The caller is reponsible for correct zapping order.
       *)
 
       (** Zap an inferred modality towards identity modality. *)
       val zap_to_id : t -> Const.t
 
-      (** Zap an inferred modality, so that it would give the strongest mode of
-          the value. If multiple modalities can achieve that, choose the weakest
-          one. *)
+      (** Zap an inferred modality towards the lowest (strongest) modality. *)
       val zap_to_floor : t -> Const.t
 
       (** Asserts the given modality is a const modality, and returns it. *)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2564,6 +2564,19 @@ let simplify_app_summary app_view = match app_view.arg with
 
 let maybe_infer_modalities ~loc ~env ~md_mode ~mode =
   if Language_extension.(is_at_least Mode Alpha) then begin
+    (* Values are packed into a structure at modes weaker than they actually
+      are. This is to allow our legacy zapping behavior. For example:
+
+      module M = struct
+        let foo x = x
+        let bar = use_portable foo
+      end
+      module type S = module type of M
+      use_portable M.foo
+
+      would type error at the last line.
+    *)
+    let mode, _ = Mode.Value.newvar_above mode in
     (* Upon construction, for comonadic (prescriptive) axes, module
     must be weaker than the values therein, for otherwise operations
     would be allowed to performed on the module (and extended to the


### PR DESCRIPTION
Given `c = zap m` where `m` is an inferred modality and `c` a constant modality, previously we ensure that `m <= c` will always hold, even after further mutation to `m`. This is to ensure the following example passes:
```
module type S = module type of M
..constrain modes in M by using it..
module N = M : S
```

This PR adds another condition:

> Given `c0 = zap m` and `c1 = zap' m`, where `zap` and `zap'` could be different zapping functions, we ensure `c0 <= c1` always holds, even after further mutation to `m`.

to ensure the following example passes:
```
module type S = module type of M
..constrain modes in M by using it..
module type S' = module type of M
..constrain modes in M by using it..
module N = (M : S) : S'
module N' = (M : S') : S
``` 