### PR TITLE
Reset the pacing of major collection after any synchronous major GC

### DIFF
--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -48,6 +48,11 @@ void caml_darken_cont(value);
 void caml_mark_root(value, value*);
 void caml_mark_roots_stw(int, caml_domain_state**);
 void caml_finish_major_cycle(int force_compaction);
+/* Reset any internal accounting the GC uses to set collection pacing.
+ * For use at times when we have disturbed the usual pacing, for
+ * example, after any synchronous major collection.
+ */
+void caml_reset_major_pacing(void);
 #ifdef DEBUG
 int caml_mark_stack_is_empty(void);
 #endif

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -253,6 +253,7 @@ static value gc_major_exn(int force_compaction)
   caml_gc_log ("Major GC cycle requested");
   caml_empty_minor_heaps_once();
   caml_finish_major_cycle(force_compaction);
+  caml_reset_major_pacing();
   value exn = caml_process_pending_actions_exn();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR);
   return exn;
@@ -275,6 +276,7 @@ static value gc_full_major_exn(void)
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(0);
+    caml_reset_major_pacing();
     exn = caml_process_pending_actions_exn();
     if (Is_exception_result(exn)) break;
   }
@@ -311,6 +313,7 @@ CAMLprim value caml_gc_compaction(value v)
      why this needs three iterations. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2);
+    caml_reset_major_pacing();
     exn = caml_process_pending_actions_exn();
     if (Is_exception_result(exn)) break;
   }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -635,6 +635,30 @@ static inline intnat diffmod (uintnat x1, uintnat x2)
   return (intnat) (x1 - x2);
 }
 
+/* Reset the work and alloc counters to be equal to each other, by
+ * setting them both equal to the "larger" (in the wrapping-around
+ * sense we are using here for work_counter and alloc_counter).
+ *
+ * For use at times when we have disturbed the major GC from its usual
+ * pacing and tempo, for example, after any synchronous major
+ * collection.
+ */
+
+void caml_reset_major_pacing(void)
+{
+  bool res;
+  do {
+    uintnat alloc = atomic_load(&alloc_counter);
+    uintnat work = atomic_load(&work_counter);
+    uintnat target = alloc;
+    if (diffmod(work, alloc) > 0) {
+      target = work;
+    }
+    res = (atomic_compare_exchange_strong(&alloc_counter, &alloc, target) &&
+           atomic_compare_exchange_strong(&work_counter, &work, target));
+  } while (!res);
+}
+
 static void update_major_slice_work(intnat howmuch,
                                     int may_access_gc_phase)
 {


### PR DESCRIPTION
During a full major collection (e.g. as part of a compaction), we do a lot of GC work and no allocation work. This causes the `work_counter` and `alloc_counter` used for GC pacing calculations to get out of sync with each other. This PR adds a function, `caml_reset_major_pacing()` which forces them into sync, and calls it after any forced major collection.