### PR TITLE
all_deps is reflexive

### DIFF
--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -1807,6 +1807,8 @@ end = struct
               let (new_node : Node.t) = Instruction.Id.Tbl.find t new_id in
               Instruction.Id.Set.union new_node.all_dependencies acc)
             init init
+          |> (* reflexivity *)
+          Instruction.Id.Set.add id
         in
         let node = { node with all_dependencies } in
         Instruction.Id.Tbl.add t id node


### PR DESCRIPTION
All (transitive) dependencies of an instruction should include the instruction itself, to prevent the instruction from appearing more than once in a group. The following instruction sequence came up in an entry function in a large program and I haven't managed to reduce it yet:
```
region_return:I/394 := 1
val["camlX_Y__s144" + 16] := region_return:I/394 (init)
val["camlX_Y__s144" + 24 := region_return:I/394 (init)
```
This sequence can actually be vectorized by using the same constant twice as both the high and low part of the vector register but not worth it. However, the additional validation using `can_reorder` fails on this example. 

