### PR TITLE
Add caml_runtime_parameters back

### DIFF
--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -402,16 +402,6 @@ CAMLprim value caml_runtime_variant (value unit)
 
 extern int caml_parser_trace;
 
-CAMLprim value caml_runtime_parameters (value unit)
-{
-#define F_Z ARCH_INTNAT_PRINTF_FORMAT
-#define F_S ARCH_SIZET_PRINTF_FORMAT
-
-  CAMLassert (unit == Val_unit);
-  /* TODO KC */
-  return caml_alloc_sprintf ("caml_runtime_parameters not implemented: %d", 0);
-}
-
 /* Control runtime warnings */
 
 CAMLprim value caml_ml_enable_runtime_warnings(value vbool)
@@ -498,4 +488,88 @@ CAMLprim value caml_gc_tweak_list_active(value unit)
     }
   }
   CAMLreturn(list);
+}
+
+#define F_Z ARCH_INTNAT_PRINTF_FORMAT
+
+/* Return the OCAMLRUNPARAMS form of any GC tweaks. Returns NULL if
+ * none are set, or if we can't allocate. */
+
+char *format_gc_tweaks(void)
+{
+  size_t len = 0;
+  for (size_t i = 0; i < N_GC_TWEAKS; i++) {
+    uintnat val = *gc_tweaks[i].ptr;
+    if (val != gc_tweaks[i].initial_value) {
+      len += (2 /* ',X' */
+              + strlen(gc_tweaks[i].name)+1 /* 'tweak_name=' */);
+      do { /* Count digits. We're not in any great hurry. */
+        val /= 10;
+        ++ len;
+      } while(val);
+    }
+  }
+  if (!len) { /* no gc_tweaks */
+    return NULL;
+  }
+  ++ len; /* trailing NUL */
+  char *buf = malloc(len);
+  if (!buf) {
+    goto fail_alloc;
+  }
+  char *p = buf;
+
+  for (size_t i = 0; i < N_GC_TWEAKS; i++) {
+    uintnat val = *gc_tweaks[i].ptr;
+    if (val != gc_tweaks[i].initial_value) {
+      int item_len = snprintf(p, len, ",X%s=%"F_Z"u",
+                              gc_tweaks[i].name, val);
+      if (item_len >= len) {
+         /* surprise truncation: could be a race; just stop trying. */
+        goto fail_truncate;
+      }
+      p += item_len;
+      len -= item_len;
+    }
+  }
+  return buf;
+
+fail_truncate:
+  free(buf);
+fail_alloc:
+  return NULL;
+}
+
+CAMLprim value caml_runtime_parameters (value unit)
+{
+  CAMLassert (unit == Val_unit);
+  char *tweaks = format_gc_tweaks();
+  char *no_tweaks = "";
+  value res = caml_alloc_sprintf
+      ("b=%d,c=%"F_Z"u,e=%"F_Z"u,i=%"F_Z"u,j=%"F_Z"u,"
+       "l=%"F_Z"u,M=%"F_Z"u,m=%"F_Z"u,n=%"F_Z"u,"
+       "o=%"F_Z"u,p=%"F_Z"u,s=%"F_Z"u,t=%"F_Z"u,v=%"F_Z"u,V=%"F_Z"u,W=%"F_Z"u%s",
+       /* b */ (int) Caml_state->backtrace_active,
+       /* c */ caml_params->cleanup_on_exit,
+       /* e */ caml_params->runtime_events_log_wsize,
+       /* i */ caml_params->init_main_stack_wsz,
+       /* j */ caml_params->init_thread_stack_wsz, /* check: new ? */
+       /* l */ caml_max_stack_wsize,
+       /* M */ caml_custom_major_ratio,
+       /* m */ caml_custom_minor_ratio,
+       /* n */ caml_custom_minor_max_bsz,
+       /* o */ caml_percent_free,
+       /* p */ caml_params->parser_trace,
+       /* R */ /* missing */
+       /* s */ caml_minor_heap_max_wsz,
+       /* t */ caml_params->trace_level,
+       /* v */ caml_verb_gc,
+       /* V */ caml_params->verify_heap,
+       /* W */ caml_runtime_warnings,
+       /* X */ tweaks ? tweaks : no_tweaks
+       );
+  if (tweaks) {
+    free(tweaks);
+  }
+  return res;
 }


### PR DESCRIPTION
`Sys.runtime_parameters()` is in OCaml 4 but not in 5. It's useful for debugging (for example, when looking at memtrace files, as memtrace records it). Upstream OCaml put it back in 2024-02. It's a bit harder in this repo as we have the `gc_tweaks`, but still a SMOP.