### PR TITLE
Remove remnants of caml_obj_truncate

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -534,7 +534,7 @@ int caml_runtime_warnings_active(void);
   00 -> free words in minor heap
   01 -> fields of free list blocks in major heap
   03 -> heap chunks deallocated by heap shrinking
-  04 -> fields deallocated by caml_obj_truncate: obsolete
+  04 -> fields deallocated by caml_obj_truncate, which is no longer available
   05 -> unused child pointers in large free blocks
   10 -> uninitialised fields of minor objects
   11 -> uninitialised fields of major objects

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -443,10 +443,7 @@ CAMLextern value caml_hash_variant(char const * tag);
 #define Byte_u(x, i) (((unsigned char *) (x)) [i]) /* Also an l-value. */
 
 /* Abstract things.  Their contents is not traced by the GC; therefore
-   they must not contain any [value]. Must have odd number so that
-   headers with this tag cannot be mistaken for pointers. Previously
-   used in caml_obj_truncate for a header of the truncated tail of the
-   object.
+   they must not contain any [value].
 */
 #define Abstract_tag 251
 #define Data_abstract_val(v) ((void*) Op_val(v))

--- a/runtime4/caml/misc.h
+++ b/runtime4/caml/misc.h
@@ -461,7 +461,7 @@ int caml_runtime_warnings_active(void);
   00 -> free words in minor heap
   01 -> fields of free list blocks in major heap
   03 -> heap chunks deallocated by heap shrinking
-  04 -> fields deallocated by [caml_obj_truncate]
+  04 -> fields deallocated by [caml_obj_truncate], which is no longer available
   05 -> unused child pointers in large free blocks
   10 -> uninitialised fields of minor objects
   11 -> uninitialised fields of major objects

--- a/runtime4/caml/mlvalues.h
+++ b/runtime4/caml/mlvalues.h
@@ -414,8 +414,7 @@ CAMLextern value caml_hash_variant(char const * tag);
 #define Byte_u(x, i) (((unsigned char *) (x)) [i]) /* Also an l-value. */
 
 /* Abstract things.  Their contents is not traced by the GC; therefore they
-   must not contain any [value]. Must have odd number so that headers with
-   this tag cannot be mistaken for pointers (see caml_obj_truncate).
+   must not contain any [value].
 */
 #define Abstract_tag 251
 #define Data_abstract_val(v) ((void*) Op_val(v))

--- a/runtime4/obj.c
+++ b/runtime4/obj.c
@@ -194,69 +194,6 @@ CAMLprim value caml_obj_dup(value arg)
   return caml_obj_with_tag(Val_long(Tag_val(arg)), arg);
 }
 
-/* Shorten the given block to the given size and return void.
-   Raise Invalid_argument if the given size is less than or equal
-   to 0 or greater than the current size.
-
-   algorithm:
-   Change the length field of the header.  Make up a black object
-   with the leftover part of the object: this is needed in the major
-   heap and harmless in the minor heap. The object cannot be white
-   because there may still be references to it in the ref table. By
-   using a black object we ensure that the ref table will be emptied
-   before the block is reallocated (since there must be a minor
-   collection within each major cycle).
-
-   [newsize] is a value encoding a number of fields (words, except
-   for float arrays on 32-bit architectures).
-*/
-CAMLprim value caml_obj_truncate (value v, value newsize)
-{
-  mlsize_t new_wosize = Long_val (newsize);
-  header_t hd = Hd_val (v);
-  tag_t tag = Tag_hd (hd);
-  color_t color = Color_hd (hd);
-  color_t frag_color = Is_young(v) ? 0 : Caml_black;
-  mlsize_t wosize = Wosize_hd (hd);
-  mlsize_t i;
-
-  if (tag == Double_array_tag) new_wosize *= Double_wosize;  /* PR#2520 */
-
-  if (new_wosize <= 0 || new_wosize > wosize){
-    caml_invalid_argument ("Obj.truncate");
-  }
-  if (new_wosize == wosize) return Val_unit;
-  /* PR#2400: since we're about to lose our references to the elements
-     beyond new_wosize in v, erase them explicitly so that the GC
-     can darken them as appropriate. */
-  if (tag < No_scan_tag) {
-    mlsize_t scannable_wosize = Scannable_wosize_hd(hd);
-    for (i = new_wosize; i < scannable_wosize; i++){
-      caml_modify(&Field(v, i), Val_unit);
-#ifdef DEBUG
-      Field (v, i) = Debug_free_truncate;
-#endif
-    }
-#ifdef DEBUG
-    /* Unless we're in debug mode, it's not necessary to empty out
-       the non-scannable suffix, as the GC knows not to look there
-       anyway.
-     */
-    for (; i < wosize; i++) {
-      Field (v, i) = Debug_free_truncate;
-    }
-#endif
-  }
-  /* We must use an odd tag for the header of the leftovers so it does not
-     look like a pointer because there may be some references to it in
-     ref_table. */
-  Field (v, new_wosize) =
-    Make_header (Wosize_whsize (wosize-new_wosize), Abstract_tag, frag_color);
-  Hd_val (v) =
-    Make_header_with_profinfo (new_wosize, tag, color, Profinfo_val(v));
-  return Val_unit;
-}
-
 CAMLprim value caml_obj_add_offset (value v, value offset)
 {
   return v + (unsigned long) Int32_val (offset);


### PR DESCRIPTION
The code for `caml_obj_truncate` (used to be exposed via `Obj.truncate`, which was removed some time ago) was still present in runtime4, and was broken in the presence of unboxed numbers in closures.  This PR also updates some comments, in both runtime4 and runtime5, notably removing a constraint that `Abstract_tag` has to be an odd number.