### PR TITLE
Support `stack_` for primitives that allocate

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -450,6 +450,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         | None -> Zero_alloc_utils.Assume_info.none
         | Some assume -> Builtin_attributes.assume_zero_alloc ~inferred:false assume
       in
+      let stack =
+        List.exists (function (Texp_stack, _, _) -> true | _ -> false) e.exp_extra
+      in
       let lam =
         let loc =
           map_scopes (update_assume_zero_alloc ~assume_zero_alloc)
@@ -457,7 +460,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         in
         Translprim.transl_primitive_application
           loc p e.exp_env prim_type
-          ~poly_mode:pmode ~poly_sort:psort
+          ~poly_mode:pmode ~poly_sort:psort ~stack
           path prim_exp args (List.map fst arg_exps) position
       in
       if extra_args = [] then lam

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2067,7 +2067,7 @@ let report_error ppf = function
   | Invalid_stack_primitive Allocating_on_heap ->
       fprintf ppf
         "This primitive always allocates on heap@ \
-        (was it declared with %a or %a?)"
+        (maybe it should be declared with %a or %a?)"
         Style.inline_code "[@local_opt]" Style.inline_code "local_"
 
 let () =

--- a/lambda/translprim.mli
+++ b/lambda/translprim.mli
@@ -43,7 +43,7 @@ val transl_primitive :
 val transl_primitive_application :
   Lambda.scoped_location -> Primitive.description -> Env.t ->
   Types.type_expr ->
-  poly_mode:Mode.Locality.l option ->
+  poly_mode:Mode.Locality.l option -> stack:bool ->
   poly_sort:Jkind.Sort.t option -> Path.t ->
   Typedtree.expression option ->
   Lambda.lambda list -> Typedtree.expression list ->
@@ -59,6 +59,11 @@ val sort_of_native_repr :
 
 (* Errors *)
 
+type invalid_stack_primitive =
+  | Not_primitive
+  | Not_allocating
+  | Allocating_on_heap
+
 type error =
   | Unknown_builtin_primitive of string
   | Wrong_arity_builtin_primitive of string
@@ -66,6 +71,7 @@ type error =
   | Invalid_floatarray_glb
   | Product_iarrays_unsupported
   | Invalid_array_kind_for_uninitialized_makearray_dynamic
+  | Invalid_stack_primitive of invalid_stack_primitive
 
 exception Error of Location.t * error
 

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -727,10 +727,11 @@ Error: Mode annotations on modules are not supported yet.
 let f x = stack_ (ref x)
 
 [%%expect{|
-Line 1, characters 17-24:
+Line 1, characters 10-24:
 1 | let f x = stack_ (ref x)
-                     ^^^^^^^
-Error: This expression is not an allocation site.
+              ^^^^^^^^^^^^^^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
 type t = { a : int }

--- a/testsuite/tests/typing-modes/stack.ml
+++ b/testsuite/tests/typing-modes/stack.ml
@@ -347,7 +347,7 @@ Line 2, characters 17-30:
 2 |   let _ = stack_ (ref_heap 52) in
                      ^^^^^^^^^^^^^
 Error: This primitive always allocates on heap
-       (was it declared with "[@local_opt]" or "local_"?)
+       (maybe it should be declared with "[@local_opt]" or "local_"?)
 |}]
 
 let foo () =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6807,6 +6807,12 @@ and type_expect_
       | Texp_lazy _ -> unsupported Lazy
       | Texp_object _ -> unsupported Object
       | Texp_pack _ -> unsupported Module
+      | Texp_apply({ exp_desc = Texp_ident(_, _, {val_kind = Val_prim _}, _, _)},
+          _, _, _, _)
+          (* [stack_ (prim foo)] will be checked by [transl_primitive_application]. *)
+          (* CR zqian: Move/Copy [Lambda.primitive_may_allocate] to [typing], then we can
+          check primitive allocation here, and also improve the logic in [type_ident]. *)
+          -> ()
       | _ ->
         raise (Error (exp.exp_loc, env, Not_allocation))
       end;


### PR DESCRIPTION
This PR allows writing `stack_ (ref "hello")`.

See my comments below for details.