### PR TITLE
Mangle instance symbol names using `____` rather than `___`

### DIFF
--- a/utils/symbol.ml
+++ b/utils/symbol.ml
@@ -69,7 +69,7 @@ let this_is_ocamlc () = this_is_ocamlc := true
 let force_runtime4_symbols () = force_runtime4_symbols := true
 
 let pack_separator = separator
-let instance_separator = "___"
+let instance_separator = "____"
 let instance_separator_depth_char = '_'
 let member_separator = separator
 


### PR DESCRIPTION
Apparently there are libraries around that have names ending in single underscores, leading to ambiguous symbol names if we use triple underscores to delimit instances. Other choices are possible but this PR opts for newly-developed quadruple-underscore technology.