### PR TITLE
Bump the version of `actions/upload-artifact`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,19 +285,19 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }} && matrix.os != 'macos-latest'
       with:
-        name: cores
+        name: cores-${{ artifact-id }}
         path: /cores
 
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }} && matrix.os != 'macos-latest'
       with:
-        name: _build
+        name: _build-${{ artifact-id }}
         path: $GITHUB_WORKSPACE/_build
 
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }} && matrix.os != 'macos-latest'
       with:
-        name: _runtest
+        name: _runtest-${{ artifact-id }}
         path: $GITHUB_WORKSPACE/_runtest
 
 concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,19 +285,19 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }} && matrix.os != 'macos-latest'
       with:
-        name: cores-${{ artifact-id }}
+        name: cores-${{ github.sha }}
         path: /cores
 
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }} && matrix.os != 'macos-latest'
       with:
-        name: _build-${{ artifact-id }}
+        name: _build-${{ github.sha }}
         path: $GITHUB_WORKSPACE/_build
 
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }} && matrix.os != 'macos-latest'
       with:
-        name: _runtest-${{ artifact-id }}
+        name: _runtest-${{ github.sha }}
         path: $GITHUB_WORKSPACE/_runtest
 
 concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,19 +282,19 @@ jobs:
       run: |
         PATH=$GITHUB_WORKSPACE/ocaml-414/_install/bin:$PATH make check_all_arches
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ failure() }} && matrix.os != 'macos-latest'
       with:
         name: cores
         path: /cores
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ failure() }} && matrix.os != 'macos-latest'
       with:
         name: _build
         path: $GITHUB_WORKSPACE/_build
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: ${{ failure() }} && matrix.os != 'macos-latest'
       with:
         name: _runtest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -91,6 +91,6 @@ jobs:
 #     - name: Publish coverage report
 #       uses: actions/upload-artifact@v4
 #       with:
-#         name: coverage-${{ artifact-id }}
+#         name: coverage-${{ github.sha }}
 #         path: flambda_backend/_coverage/**
 #

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -91,6 +91,6 @@ jobs:
 #     - name: Publish coverage report
 #       uses: actions/upload-artifact@v4
 #       with:
-#         name: coverage
+#         name: coverage-${{ artifact-id }}
 #         path: flambda_backend/_coverage/**
 #

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -89,7 +89,7 @@ jobs:
 #         BUILD_OCAMLPARAM: ${{ matrix.ocamlparam }}
 #
 #     - name: Publish coverage report
-#       uses: actions/upload-artifact@v3
+#       uses: actions/upload-artifact@v4
 #       with:
 #         name: coverage
 #         path: flambda_backend/_coverage/**


### PR DESCRIPTION
As briefly discussed off-line a couple
of weeks ago, v3 is deprecated and
we should not be affected by the
breaking changes of v4.