### PR TITLE
Support more `stack_` syntax

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -442,7 +442,9 @@ let f ~(x1 @ many)
   let (x15 @ local) y z : int = y + z in
   (* NO: let (x15 @ local) y z : int @@ local = y + z in *)
   let _ = ("hi" : string @@ global) in
-  stack_ (x1, x2, x3, x4, x5, x9, x10, x11, (* x12, *) x13, x14, x15)
+  let stack_ x16 : _ = (42, 24) in
+  let stack_ x17 a b c = a + b + c in
+  stack_ (x1, x2, x3, x4, x5, x9, x10, x11, (* x12, *) x13, x14, x15, x16, x17)
 
 [%%expect{|
 val f :
@@ -459,7 +461,8 @@ val f :
     local_ 'd -> local_
     'b * string * (string -> string) * ('e -> 'e) * 'c * string * string *
     int array * string * (int -> local_ (int -> int)) *
-    (int -> local_ (int -> int)) @ contended =
+    (int -> local_ (int -> int)) * (int * int) *
+    (int -> local_ (int -> int -> int)) @ contended =
   <fun>
 |}]
 

--- a/testsuite/tests/typing-modes/stack.ml
+++ b/testsuite/tests/typing-modes/stack.ml
@@ -299,3 +299,25 @@ Line 3, characters 2-5:
 Error: This value escapes its region.
   Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
+
+(* syntax support at more places. Only test that the parsetree is correct. *)
+let mk () =
+  let stack_ x : _ = "hello" in
+  x
+[%%expect{|
+Line 2, characters 21-28:
+2 |   let stack_ x : _ = "hello" in
+                         ^^^^^^^
+Error: This expression is not an allocation site.
+|}]
+
+let mk () =
+  let stack_ f a b c = a + b + c in
+  f
+[%%expect{|
+Line 3, characters 2-3:
+3 |   f
+      ^
+Error: This value escapes its region.
+  Hint: Cannot return a local value without an "exclave_" annotation.
+|}]


### PR DESCRIPTION
This PR allows `stack_` at more places:
```
let stack_ x = ...
let stack_ x : _ = ...
let stack_ f a b c = ...
```