### PR TITLE
Generate specific instructions for atomics on immediates

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4165,8 +4165,7 @@ let atomic_load ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) atomic =
   in
   Cop (mk_load_atomic memory_chunk, [atomic], dbg)
 
-let atomic_exchange
-    ~dbg (_ : Lambda.immediate_or_pointer) atomic new_value =
+let atomic_exchange ~dbg (_ : Lambda.immediate_or_pointer) atomic new_value =
   Cop
     ( Cextcall
         { func = "caml_atomic_exchange";
@@ -4183,9 +4182,9 @@ let atomic_exchange
 
 let atomic_fetch_and_add ~dbg atomic i =
   let op = Catomic { op = Fetch_and_add; size = Word } in
-  if Proc.operation_supported op then begin
-    Cop (op , [(add_const i (-1) dbg); atomic], dbg)
-  end else begin   
+  if Proc.operation_supported op
+  then Cop (op, [add_const i (-1) dbg; atomic], dbg)
+  else
     Cop
       ( Cextcall
           { func = "caml_atomic_fetch_add";
@@ -4199,38 +4198,38 @@ let atomic_fetch_and_add ~dbg atomic i =
           },
         [atomic; i],
         dbg )
-  end
 
 let atomic_compare_and_set_extcall ~dbg atomic ~old_value ~new_value =
-  Cop (Cextcall
-         { func = "caml_atomic_cas";
-           builtin = false;
-           returns = true;
-           effects = Arbitrary_effects;
-           coeffects = Has_coeffects;
-           ty = typ_int;
-           ty_args = [];
-           alloc = false
-         },
-       [atomic; old_value; new_value], dbg)
+  Cop
+    ( Cextcall
+        { func = "caml_atomic_cas";
+          builtin = false;
+          returns = true;
+          effects = Arbitrary_effects;
+          coeffects = Has_coeffects;
+          ty = typ_int;
+          ty_args = [];
+          alloc = false
+        },
+      [atomic; old_value; new_value],
+      dbg )
 
-let atomic_compare_and_set
-    ~dbg (imm_or_ptr : Lambda.immediate_or_pointer)
+let atomic_compare_and_set ~dbg (imm_or_ptr : Lambda.immediate_or_pointer)
     atomic ~old_value ~new_value =
   match imm_or_ptr with
   | Immediate ->
-      let op = Catomic { op = Compare_and_swap; size = Word } in
-      if Proc.operation_supported op then
-        (* Use a bind to ensure [tag_int] gets optimised. *)
-        bind "res" (Cop (op, [old_value; new_value; atomic], dbg))
-          (fun a2 -> tag_int a2 dbg)
-      else
-        atomic_compare_and_set_extcall ~dbg atomic ~old_value ~new_value
-  | Pointer ->
-      atomic_compare_and_set_extcall ~dbg atomic ~old_value ~new_value
+    let op = Catomic { op = Compare_and_swap; size = Word } in
+    if Proc.operation_supported op
+    then
+      (* Use a bind to ensure [tag_int] gets optimised. *)
+      bind "res"
+        (Cop (op, [old_value; new_value; atomic], dbg))
+        (fun a2 -> tag_int a2 dbg)
+    else atomic_compare_and_set_extcall ~dbg atomic ~old_value ~new_value
+  | Pointer -> atomic_compare_and_set_extcall ~dbg atomic ~old_value ~new_value
 
-let atomic_compare_exchange
-    ~dbg (_ : Lambda.immediate_or_pointer)atomic ~old_value ~new_value =
+let atomic_compare_exchange ~dbg (_ : Lambda.immediate_or_pointer) atomic
+    ~old_value ~new_value =
   Cop
     ( Cextcall
         { func = "caml_atomic_compare_exchange";

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1011,7 +1011,7 @@ val atomic_fetch_and_add :
 
 val atomic_compare_and_set :
   dbg:Debuginfo.t ->
-  Lambda.immediate_or_pointer -> 
+  Lambda.immediate_or_pointer ->
   expression ->
   old_value:expression ->
   new_value:expression ->
@@ -1019,7 +1019,7 @@ val atomic_compare_and_set :
 
 val atomic_compare_exchange :
   dbg:Debuginfo.t ->
-  Lambda.immediate_or_pointer -> 
+  Lambda.immediate_or_pointer ->
   expression ->
   old_value:expression ->
   new_value:expression ->

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -999,13 +999,19 @@ val apply_function :
 val atomic_load :
   dbg:Debuginfo.t -> Lambda.immediate_or_pointer -> expression -> expression
 
-val atomic_exchange : dbg:Debuginfo.t -> expression -> expression -> expression
+val atomic_exchange :
+  dbg:Debuginfo.t ->
+  Lambda.immediate_or_pointer ->
+  expression ->
+  expression ->
+  expression
 
 val atomic_fetch_and_add :
   dbg:Debuginfo.t -> expression -> expression -> expression
 
 val atomic_compare_and_set :
   dbg:Debuginfo.t ->
+  Lambda.immediate_or_pointer -> 
   expression ->
   old_value:expression ->
   new_value:expression ->
@@ -1013,6 +1019,7 @@ val atomic_compare_and_set :
 
 val atomic_compare_exchange :
   dbg:Debuginfo.t ->
+  Lambda.immediate_or_pointer -> 
   expression ->
   old_value:expression ->
   new_value:expression ->

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -156,7 +156,7 @@ let oper_result_type = function
   | Cstore (_c, _) -> typ_void
   | Cdls_get -> typ_val
   | Cprefetch _ -> typ_void
-  | Catomic { op = (Fetch_and_add | Compare_and_swap); _ } -> typ_int
+  | Catomic { op = Fetch_and_add | Compare_and_swap; _ } -> typ_int
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor | Cxor | Clsl
   | Clsr | Casr | Cclz _ | Cctz _ | Cpopcnt | Cbswap _ | Ccmpi _ | Ccmpa _
   | Ccmpf _ ->

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -156,7 +156,7 @@ let oper_result_type = function
   | Cstore (_c, _) -> typ_void
   | Cdls_get -> typ_val
   | Cprefetch _ -> typ_void
-  | Catomic _ -> typ_int
+  | Catomic { op = (Fetch_and_add | Compare_and_swap); _ } -> typ_int
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor | Cxor | Clsl
   | Clsr | Casr | Cclz _ | Cctz _ | Cpopcnt | Cbswap _ | Ccmpi _ | Ccmpa _
   | Ccmpf _ ->

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -196,8 +196,8 @@ let preserve_tailcall_for_prim = function
   | Pbigstring_set_64 _ | Pbigstring_set_128 _
   | Pprobe_is_enabled _ | Pobj_dup
   | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer _
-  | Patomic_exchange | Patomic_compare_exchange
-  | Patomic_cas | Patomic_fetch_add | Patomic_load _
+  | Patomic_exchange _ | Patomic_compare_exchange _
+  | Patomic_cas _ | Patomic_fetch_add | Patomic_load _
   | Pdls_get | Preinterpret_tagged_int63_as_unboxed_int64
   | Preinterpret_unboxed_int64_as_tagged_int63 | Ppoll | Ppeek _ | Ppoke _ ->
       false
@@ -655,9 +655,9 @@ let comp_primitive stack_info p sz args =
   | Pget_header _ -> Kccall("caml_get_header", 1)
   | Pobj_dup -> Kccall("caml_obj_dup", 1)
   | Patomic_load _ -> Kccall("caml_atomic_load", 1)
-  | Patomic_exchange -> Kccall("caml_atomic_exchange", 2)
-  | Patomic_compare_exchange -> Kccall("caml_atomic_compare_exchange", 3)
-  | Patomic_cas -> Kccall("caml_atomic_cas", 3)
+  | Patomic_exchange _ -> Kccall("caml_atomic_exchange", 2)
+  | Patomic_compare_exchange _ -> Kccall("caml_atomic_compare_exchange", 3)
+  | Patomic_cas _ -> Kccall("caml_atomic_cas", 3)
   | Patomic_fetch_add -> Kccall("caml_atomic_fetch_add", 2)
   | Pdls_get -> Kccall("caml_domain_dls_get", 1)
   | Ppoll -> Kccall("caml_process_pending_actions_with_root", 1)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -311,9 +311,9 @@ type primitive =
   | Pint_as_pointer of locality_mode
   (* Atomic operations *)
   | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
-  | Patomic_exchange
-  | Patomic_compare_exchange
-  | Patomic_cas
+  | Patomic_exchange of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_compare_exchange of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_cas of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_fetch_add
   (* Inhibition of optimisation *)
   | Popaque of layout
@@ -1945,9 +1945,9 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Ppoll ->
     Some alloc_heap
   | Patomic_load _
-  | Patomic_exchange
-  | Patomic_compare_exchange
-  | Patomic_cas
+  | Patomic_exchange _
+  | Patomic_compare_exchange _
+  | Patomic_cas _
   | Patomic_fetch_add
   | Pdls_get
   | Preinterpret_unboxed_int64_as_tagged_int63
@@ -2113,8 +2113,8 @@ let primitive_can_raise prim =
   | Punbox_vector _ | Punbox_int _ | Pbox_int _ | Pmake_unboxed_product _
   | Punboxed_product_field _ | Pget_header _ ->
     false
-  | Patomic_exchange | Patomic_compare_exchange
-  | Patomic_cas | Patomic_fetch_add | Patomic_load _ -> false
+  | Patomic_exchange _ | Patomic_compare_exchange _
+  | Patomic_cas _ | Patomic_fetch_add | Patomic_load _ -> false
   | Prunstack | Pperform | Presume | Preperform -> true (* XXX! *)
   | Pdls_get | Ppoll | Preinterpret_tagged_int63_as_unboxed_int64
   | Preinterpret_unboxed_int64_as_tagged_int63
@@ -2345,10 +2345,12 @@ let primitive_result_layout (p : primitive) =
   | Prunstack | Presume | Pperform | Preperform -> layout_any_value
   | Patomic_load { immediate_or_pointer = Immediate } -> layout_int
   | Patomic_load { immediate_or_pointer = Pointer } -> layout_any_value
-  | Patomic_exchange
-  | Patomic_compare_exchange
-  | Patomic_cas
-  | Patomic_fetch_add
+  | Patomic_exchange { immediate_or_pointer = Immediate } -> layout_int
+  | Patomic_exchange { immediate_or_pointer = Pointer } -> layout_any_value
+  | Patomic_compare_exchange { immediate_or_pointer = Immediate } -> layout_int
+  | Patomic_compare_exchange { immediate_or_pointer = Pointer } -> layout_any_value
+  | Patomic_cas _
+  | Patomic_fetch_add -> layout_int
   | Pdls_get -> layout_any_value
   | Ppoll -> layout_unit
   | Preinterpret_tagged_int63_as_unboxed_int64 -> layout_unboxed_int64

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -309,9 +309,9 @@ type primitive =
   | Pint_as_pointer of locality_mode
   (* Atomic operations *)
   | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
-  | Patomic_exchange
-  | Patomic_compare_exchange
-  | Patomic_cas
+  | Patomic_exchange of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_compare_exchange of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_cas of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_fetch_add
   (* Inhibition of optimisation *)
   | Popaque of layout

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -913,9 +913,18 @@ let primitive ppf = function
       (match immediate_or_pointer with
         | Immediate -> fprintf ppf "atomic_load_imm"
         | Pointer -> fprintf ppf "atomic_load_ptr")
-  | Patomic_exchange -> fprintf ppf "atomic_exchange"
-  | Patomic_compare_exchange -> fprintf ppf "atomic_compare_exchange"
-  | Patomic_cas -> fprintf ppf "atomic_cas"
+  | Patomic_exchange {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> fprintf ppf "atomic_exchange_imm"
+        | Pointer -> fprintf ppf "atomic_exchange_ptr")
+  | Patomic_compare_exchange {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> fprintf ppf "atomic_compare_exchange_imm"
+        | Pointer -> fprintf ppf "atomic_compare_exchange_ptr")
+  | Patomic_cas {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> fprintf ppf "atomic_cas_imm"
+        | Pointer -> fprintf ppf "atomic_cas_ptr")
   | Patomic_fetch_add -> fprintf ppf "atomic_fetch_add"
   | Popaque _ -> fprintf ppf "opaque"
   | Pdls_get -> fprintf ppf "dls_get"
@@ -1095,9 +1104,18 @@ let name_of_primitive = function
       (match immediate_or_pointer with
         | Immediate -> "atomic_load_imm"
         | Pointer -> "atomic_load_ptr")
-  | Patomic_exchange -> "Patomic_exchange"
-  | Patomic_compare_exchange -> "Patomic_compare_exchange"
-  | Patomic_cas -> "Patomic_cas"
+  | Patomic_exchange {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> "atomic_exchange_imm"
+        | Pointer -> "atomic_exchange_ptr")
+  | Patomic_compare_exchange {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> "atomic_compare_exchange_imm"
+        | Pointer -> "atomic_compare_exchange_ptr")
+  | Patomic_cas {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> "atomic_cas_imm"
+        | Pointer -> "atomic_cas_ptr")
   | Patomic_fetch_add -> "Patomic_fetch_add"
   | Popaque _ -> "Popaque"
   | Prunstack -> "Prunstack"

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -902,8 +902,8 @@ let rec choice ctx t =
     | Prunstack | Pperform | Presume | Preperform | Pdls_get
 
     (* we don't handle atomic primitives *)
-    | Patomic_exchange | Patomic_compare_exchange
-    | Patomic_cas | Patomic_fetch_add | Patomic_load _
+    | Patomic_exchange _ | Patomic_compare_exchange _
+    | Patomic_cas _ | Patomic_fetch_add | Patomic_load _
     | Punbox_float _ | Pbox_float (_, _)
     | Punbox_int _ | Pbox_int _
     | Punbox_vector _ | Pbox_vector (_, _)

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -897,9 +897,12 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%get_header" -> Primitive (Pget_header mode, 1)
     | "%atomic_load" ->
         Primitive ((Patomic_load {immediate_or_pointer=Pointer}), 1)
-    | "%atomic_exchange" -> Primitive (Patomic_exchange, 2)
-    | "%atomic_compare_exchange" -> Primitive (Patomic_compare_exchange, 3)
-    | "%atomic_cas" -> Primitive (Patomic_cas, 3)
+    | "%atomic_exchange" ->
+        Primitive (Patomic_exchange {immediate_or_pointer=Pointer}, 2)
+    | "%atomic_compare_exchange" ->
+        Primitive (Patomic_compare_exchange {immediate_or_pointer=Pointer}, 3)
+    | "%atomic_cas" ->
+        Primitive (Patomic_cas {immediate_or_pointer=Pointer}, 3)
     | "%atomic_fetch_add" -> Primitive (Patomic_fetch_add, 2)
     | "%runstack" ->
       if runtime5 then Primitive (Prunstack, 3) else Unsupported Prunstack
@@ -1369,6 +1372,36 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
         | None -> Pointer
         | Some (_p1, rhs) -> maybe_pointer_type env rhs in
       Some (Primitive (Patomic_load {immediate_or_pointer = is_int}, arity))
+    end
+  | Primitive (Patomic_exchange { immediate_or_pointer = Pointer },
+               arity), [_; p2] -> begin
+      match maybe_pointer_type env p2 with
+      | Pointer -> None
+      | Immediate ->
+          Some
+            (Primitive
+               (Patomic_exchange
+                  {immediate_or_pointer = Immediate}, arity))
+    end
+  | Primitive (Patomic_compare_exchange { immediate_or_pointer = Pointer },
+               arity), [_; p2; p3] -> begin
+      match maybe_pointer_type env p2, maybe_pointer_type env p3 with
+      | Pointer, _ | _, Pointer -> None
+      | Immediate, Immediate ->
+          Some
+            (Primitive
+               (Patomic_compare_exchange
+                  {immediate_or_pointer = Immediate}, arity))
+    end
+  | Primitive (Patomic_cas { immediate_or_pointer = Pointer },
+               arity), [_; p2; p3] -> begin
+      match maybe_pointer_type env p2, maybe_pointer_type env p3 with
+      | Pointer, _ | _, Pointer -> None
+      | Immediate, Immediate ->
+          Some
+            (Primitive
+               (Patomic_cas
+                  {immediate_or_pointer = Immediate}, arity))
     end
   | Comparison(comp, Compare_generic), p1 :: _ ->
     if (has_constant_constructor
@@ -1898,8 +1931,8 @@ let lambda_primitive_needs_event_after = function
   | Parrayblit _
   | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint _ | Pisnull | Pisout
   | Pprobe_is_enabled _
-  | Patomic_exchange | Patomic_compare_exchange
-  | Patomic_cas | Patomic_fetch_add | Patomic_load _
+  | Patomic_exchange _ | Patomic_compare_exchange _
+  | Patomic_cas _ | Patomic_fetch_add | Patomic_load _
   | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer _ | Popaque _
   | Pdls_get
   | Pobj_magic _ | Punbox_float _ | Punbox_int _ | Punbox_vector _

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -345,9 +345,9 @@ let compute_static_size lam =
     | Pbbswap _
     | Pint_as_pointer _
     | Patomic_load _
-    | Patomic_exchange
-    | Patomic_compare_exchange
-    | Patomic_cas
+    | Patomic_exchange _
+    | Patomic_compare_exchange _
+    | Patomic_cas _
     | Patomic_fetch_add
     | Popaque _
     | Pdls_get

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1046,7 +1046,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Punbox_int _ | Pbox_int _ | Pmake_unboxed_product _
       | Punboxed_product_field _ | Parray_element_size_in_bytes _
       | Pget_header _ | Prunstack | Pperform | Presume | Preperform
-      | Patomic_exchange | Patomic_compare_exchange | Patomic_cas
+      | Patomic_exchange _ | Patomic_compare_exchange _ | Patomic_cas _
       | Patomic_fetch_add | Pdls_get | Ppoll | Patomic_load _
       | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _ ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2383,21 +2383,26 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         ( Atomic_load (convert_block_access_field_kind immediate_or_pointer),
           atomic ) ]
   | Patomic_exchange { immediate_or_pointer }, [[atomic]; [new_value]] ->
-    [Binary
-       (Atomic_exchange (convert_block_access_field_kind immediate_or_pointer),
-        atomic, new_value)]
-  | Patomic_compare_exchange { immediate_or_pointer },
-    [[atomic]; [old_value]; [new_value]] ->
-    [Ternary
-       (Atomic_compare_exchange
-          (convert_block_access_field_kind immediate_or_pointer),
-        atomic, old_value, new_value)]
-  | Patomic_cas { immediate_or_pointer },
-    [[atomic]; [old_value]; [new_value]] ->
-    [Ternary
-       (Atomic_compare_and_set
-          (convert_block_access_field_kind immediate_or_pointer),
-        atomic, old_value, new_value)]
+    [ Binary
+        ( Atomic_exchange (convert_block_access_field_kind immediate_or_pointer),
+          atomic,
+          new_value ) ]
+  | ( Patomic_compare_exchange { immediate_or_pointer },
+      [[atomic]; [old_value]; [new_value]] ) ->
+    [ Ternary
+        ( Atomic_compare_exchange
+            (convert_block_access_field_kind immediate_or_pointer),
+          atomic,
+          old_value,
+          new_value ) ]
+  | Patomic_cas { immediate_or_pointer }, [[atomic]; [old_value]; [new_value]]
+    ->
+    [ Ternary
+        ( Atomic_compare_and_set
+            (convert_block_access_field_kind immediate_or_pointer),
+          atomic,
+          old_value,
+          new_value ) ]
   | Patomic_fetch_add, [[atomic]; [i]] ->
     [Binary (Atomic_fetch_and_add, atomic, i)]
   | Pdls_get, _ -> [Nullary Dls_get]
@@ -2496,8 +2501,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
             | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ),
             _,
             _ )
-      | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _ | Patomic_exchange _
-      | Patomic_fetch_add | Ppoke _ ),
+      | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
+      | Patomic_exchange _ | Patomic_fetch_add | Ppoke _ ),
       ( []
       | [_]
       | _ :: _ :: _ :: _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2382,12 +2382,22 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     [ Unary
         ( Atomic_load (convert_block_access_field_kind immediate_or_pointer),
           atomic ) ]
-  | Patomic_exchange, [[atomic]; [new_value]] ->
-    [Binary (Atomic_exchange, atomic, new_value)]
-  | Patomic_compare_exchange, [[atomic]; [old_value]; [new_value]] ->
-    [Ternary (Atomic_compare_exchange, atomic, old_value, new_value)]
-  | Patomic_cas, [[atomic]; [old_value]; [new_value]] ->
-    [Ternary (Atomic_compare_and_set, atomic, old_value, new_value)]
+  | Patomic_exchange { immediate_or_pointer }, [[atomic]; [new_value]] ->
+    [Binary
+       (Atomic_exchange (convert_block_access_field_kind immediate_or_pointer),
+        atomic, new_value)]
+  | Patomic_compare_exchange { immediate_or_pointer },
+    [[atomic]; [old_value]; [new_value]] ->
+    [Ternary
+       (Atomic_compare_exchange
+          (convert_block_access_field_kind immediate_or_pointer),
+        atomic, old_value, new_value)]
+  | Patomic_cas { immediate_or_pointer },
+    [[atomic]; [old_value]; [new_value]] ->
+    [Ternary
+       (Atomic_compare_and_set
+          (convert_block_access_field_kind immediate_or_pointer),
+        atomic, old_value, new_value)]
   | Patomic_fetch_add, [[atomic]; [i]] ->
     [Binary (Atomic_fetch_and_add, atomic, i)]
   | Pdls_get, _ -> [Nullary Dls_get]
@@ -2486,7 +2496,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
             | Pgcscannableproductarray_ref _ | Pgcignorableproductarray_ref _ ),
             _,
             _ )
-      | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _ | Patomic_exchange
+      | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _ | Patomic_exchange _
       | Patomic_fetch_add | Ppoke _ ),
       ( []
       | [_]
@@ -2516,8 +2526,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       | Pfloatarray_set_128 _ | Pfloat_array_set_128 _ | Pint_array_set_128 _
       | Punboxed_float_array_set_128 _ | Punboxed_float32_array_set_128 _
       | Punboxed_int32_array_set_128 _ | Punboxed_int64_array_set_128 _
-      | Punboxed_nativeint_array_set_128 _ | Patomic_cas
-      | Patomic_compare_exchange ),
+      | Punboxed_nativeint_array_set_128 _ | Patomic_cas _
+      | Patomic_compare_exchange _ ),
       ( []
       | [_]
       | [_; _]

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -609,7 +609,7 @@ let binop env (op : Flambda_primitive.binary_primitive) : Fexpr.binop =
   | Float_comp (w, c) -> Infix (Float_comp (w, c))
   | String_or_bigstring_load (slv, saw) -> String_or_bigstring_load (slv, saw)
   | Bigarray_get_alignment align -> Bigarray_get_alignment align
-  | Bigarray_load _ | Atomic_exchange | Atomic_fetch_and_add | Poke _ ->
+  | Bigarray_load _ | Atomic_exchange _ | Atomic_fetch_and_add | Poke _ ->
     Misc.fatal_errorf "TODO: Binary primitive: %a"
       Flambda_primitive.Without_args.print
       (Flambda_primitive.Without_args.Binary op)
@@ -645,7 +645,7 @@ let ternop env (op : Flambda_primitive.ternary_primitive) : Fexpr.ternop =
     let ask = fexpr_of_array_set_kind env ask in
     Array_set (ak, ask)
   | Bytes_or_bigstring_set (blv, saw) -> Bytes_or_bigstring_set (blv, saw)
-  | Bigarray_set _ | Atomic_compare_and_set | Atomic_compare_exchange ->
+  | Bigarray_set _ | Atomic_compare_and_set _ | Atomic_compare_exchange _ ->
     Misc.fatal_errorf "TODO: Ternary primitive: %a"
       Flambda_primitive.Without_args.print
       (Flambda_primitive.Without_args.Ternary op)

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1077,7 +1077,7 @@ let simplify_binary_primitive0 dacc original_prim (prim : P.binary_primitive)
         ~original_prim
     | Bigarray_get_alignment align ->
       simplify_bigarray_get_alignment align ~original_prim
-    | Atomic_exchange -> simplify_atomic_exchange ~original_prim
+    | Atomic_exchange _ -> simplify_atomic_exchange ~original_prim
     | Atomic_fetch_and_add -> simplify_atomic_fetch_and_add ~original_prim
     | Poke _ -> simplify_poke
   in
@@ -1088,7 +1088,7 @@ let recover_comparison_primitive dacc (prim : P.binary_primitive) ~arg1 ~arg2 =
   | Block_set _ | Array_load _ | Int_arith _ | Int_shift _
   | Int_comp (_, Yielding_int_like_compare_functions _)
   | Float_arith _ | Float_comp _ | Phys_equal _ | String_or_bigstring_load _
-  | Bigarray_load _ | Bigarray_get_alignment _ | Atomic_exchange
+  | Bigarray_load _ | Bigarray_get_alignment _ | Atomic_exchange _
   | Atomic_fetch_and_add | Poke _ ->
     None
   | Int_comp (kind, Yielding_bool op) -> (

--- a/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
@@ -89,8 +89,8 @@ let simplify_ternary_primitive dacc original_prim (prim : P.ternary_primitive)
       simplify_bytes_or_bigstring_set bytes_like_value string_accessor_width
     | Bigarray_set (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_set ~num_dimensions bigarray_kind bigarray_layout
-    | Atomic_compare_and_set -> simplify_atomic_compare_and_set ~original_prim
-    | Atomic_compare_exchange -> simplify_atomic_compare_exchange ~original_prim
+    | Atomic_compare_and_set _ -> simplify_atomic_compare_and_set ~original_prim
+    | Atomic_compare_exchange _ -> simplify_atomic_compare_exchange ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3
     ~arg3_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
@@ -90,7 +90,8 @@ let simplify_ternary_primitive dacc original_prim (prim : P.ternary_primitive)
     | Bigarray_set (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_set ~num_dimensions bigarray_kind bigarray_layout
     | Atomic_compare_and_set _ -> simplify_atomic_compare_and_set ~original_prim
-    | Atomic_compare_exchange _ -> simplify_atomic_compare_exchange ~original_prim
+    | Atomic_compare_exchange _ ->
+      simplify_atomic_compare_exchange ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3
     ~arg3_ty ~result_var

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -404,8 +404,7 @@ let binary_prim_size prim =
   | Float_comp (_width, Yielding_int_like_compare_functions ()) -> 8
   | Bigarray_get_alignment _ -> 3 (* load data + add index + and *)
   | Atomic_fetch_and_add -> 1
-  | Atomic_exchange _ ->
-    does_not_need_caml_c_call_extcall_size
+  | Atomic_exchange _ -> does_not_need_caml_c_call_extcall_size
   | Poke _ -> 1
 
 let ternary_prim_size prim =
@@ -417,8 +416,7 @@ let ternary_prim_size prim =
   | Bigarray_set (_dims, _kind, _layout) -> 2
   (* ~ 1 block_load + 1 block_set *)
   | Atomic_compare_and_set Immediate -> 1
-  | Atomic_compare_and_set Any_value
-  | Atomic_compare_exchange _ ->
+  | Atomic_compare_and_set Any_value | Atomic_compare_exchange _ ->
     does_not_need_caml_c_call_extcall_size
 
 let variadic_prim_size prim args =

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -403,7 +403,8 @@ let binary_prim_size prim =
     binary_float_comp_primitive width cmp
   | Float_comp (_width, Yielding_int_like_compare_functions ()) -> 8
   | Bigarray_get_alignment _ -> 3 (* load data + add index + and *)
-  | Atomic_exchange | Atomic_fetch_and_add ->
+  | Atomic_fetch_and_add -> 1
+  | Atomic_exchange _ ->
     does_not_need_caml_c_call_extcall_size
   | Poke _ -> 1
 
@@ -415,7 +416,9 @@ let ternary_prim_size prim =
     5 (* ~ 3 block_load + 2 block_set *)
   | Bigarray_set (_dims, _kind, _layout) -> 2
   (* ~ 1 block_load + 1 block_set *)
-  | Atomic_compare_and_set | Atomic_compare_exchange ->
+  | Atomic_compare_and_set Immediate -> 1
+  | Atomic_compare_and_set Any_value
+  | Atomic_compare_exchange _ ->
     does_not_need_caml_c_call_extcall_size
 
 let variadic_prim_size prim args =

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1716,9 +1716,8 @@ let compare_binary_primitive p1 p2 =
     if c <> 0 then c else Stdlib.compare comp1 comp2
   | Bigarray_get_alignment align1, Bigarray_get_alignment align2 ->
     Int.compare align1 align2
-  | Atomic_exchange block_access_field_kind1,
-    Atomic_exchange block_access_field_kind2
-    ->
+  | ( Atomic_exchange block_access_field_kind1,
+      Atomic_exchange block_access_field_kind2 ) ->
     Block_access_field_kind.compare block_access_field_kind1
       block_access_field_kind2
   | ( ( Block_set _ | Array_load _ | String_or_bigstring_load _
@@ -1761,8 +1760,8 @@ let print_binary_primitive ppf p =
   | Bigarray_get_alignment align ->
     fprintf ppf "@[(Bigarray_get_alignment[%d])@]" align
   | Atomic_exchange block_access_field_kind ->
-      Format.fprintf ppf "@[(Atomic_exchange@ %a)@]" Block_access_field_kind.print
-        block_access_field_kind
+    Format.fprintf ppf "@[(Atomic_exchange@ %a)@]" Block_access_field_kind.print
+      block_access_field_kind
   | Atomic_fetch_and_add -> fprintf ppf "Atomic_fetch_and_add"
   | Poke kind ->
     fprintf ppf "@[(Poke@ %a)@]"
@@ -1921,14 +1920,12 @@ let compare_ternary_primitive p1 p2 =
     else
       let c = Stdlib.compare kind1 kind2 in
       if c <> 0 then c else Stdlib.compare layout1 layout2
-  | Atomic_compare_and_set block_access_field_kind1,
-    Atomic_compare_and_set block_access_field_kind2
-    ->
+  | ( Atomic_compare_and_set block_access_field_kind1,
+      Atomic_compare_and_set block_access_field_kind2 ) ->
     Block_access_field_kind.compare block_access_field_kind1
       block_access_field_kind2
-  | Atomic_compare_exchange block_access_field_kind1,
-    Atomic_compare_exchange block_access_field_kind2
-    ->
+  | ( Atomic_compare_exchange block_access_field_kind1,
+      Atomic_compare_exchange block_access_field_kind2 ) ->
     Block_access_field_kind.compare block_access_field_kind1
       block_access_field_kind2
   | ( ( Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
@@ -1954,11 +1951,11 @@ let print_ternary_primitive ppf p =
       "@[(Bigarray_set (num_dimensions@ %d)@ (kind@ %a)@ (layout@ %a))@]"
       num_dimensions Bigarray_kind.print kind Bigarray_layout.print layout
   | Atomic_compare_and_set block_access_field_kind ->
-      Format.fprintf ppf "@[(Atomic_compare_and_set@ %a)@]"
-        Block_access_field_kind.print block_access_field_kind
+    Format.fprintf ppf "@[(Atomic_compare_and_set@ %a)@]"
+      Block_access_field_kind.print block_access_field_kind
   | Atomic_compare_exchange block_access_field_kind ->
-      Format.fprintf ppf "@[(Atomic_compare_exchange@ %a)@]"
-        Block_access_field_kind.print block_access_field_kind
+    Format.fprintf ppf "@[(Atomic_compare_exchange@ %a)@]"
+      Block_access_field_kind.print block_access_field_kind
 
 let args_kind_of_ternary_primitive p =
   match p with

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1629,7 +1629,7 @@ type binary_primitive =
   | Float_arith of float_bitwidth * binary_float_arith_op
   | Float_comp of float_bitwidth * unit comparison_behaviour
   | Bigarray_get_alignment of int
-  | Atomic_exchange
+  | Atomic_exchange of Block_access_field_kind.t
   | Atomic_fetch_and_add
   | Poke of Flambda_kind.Standard_int_or_float.t
 
@@ -1649,7 +1649,7 @@ let binary_primitive_eligible_for_cse p =
        floating-point arithmetic operations. See also the comment in
        effects_and_coeffects of unary primitives. *)
     Flambda_features.float_const_prop ()
-  | Atomic_exchange | Atomic_fetch_and_add | Poke _ -> false
+  | Atomic_exchange _ | Atomic_fetch_and_add | Poke _ -> false
 
 let compare_binary_primitive p1 p2 =
   let binary_primitive_numbering p =
@@ -1665,7 +1665,7 @@ let compare_binary_primitive p1 p2 =
     | Float_arith _ -> 8
     | Float_comp _ -> 9
     | Bigarray_get_alignment _ -> 10
-    | Atomic_exchange -> 11
+    | Atomic_exchange _ -> 11
     | Atomic_fetch_and_add -> 12
     | Poke _ -> 13
   in
@@ -1716,10 +1716,15 @@ let compare_binary_primitive p1 p2 =
     if c <> 0 then c else Stdlib.compare comp1 comp2
   | Bigarray_get_alignment align1, Bigarray_get_alignment align2 ->
     Int.compare align1 align2
+  | Atomic_exchange block_access_field_kind1,
+    Atomic_exchange block_access_field_kind2
+    ->
+    Block_access_field_kind.compare block_access_field_kind1
+      block_access_field_kind2
   | ( ( Block_set _ | Array_load _ | String_or_bigstring_load _
       | Bigarray_load _ | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _
       | Float_arith _ | Float_comp _ | Bigarray_get_alignment _
-      | Atomic_exchange | Atomic_fetch_and_add | Poke _ ),
+      | Atomic_exchange _ | Atomic_fetch_and_add | Poke _ ),
       _ ) ->
     Stdlib.compare
       (binary_primitive_numbering p1)
@@ -1755,7 +1760,9 @@ let print_binary_primitive ppf p =
     fprintf ppf "."
   | Bigarray_get_alignment align ->
     fprintf ppf "@[(Bigarray_get_alignment[%d])@]" align
-  | Atomic_exchange -> fprintf ppf "Atomic_exchange"
+  | Atomic_exchange block_access_field_kind ->
+      Format.fprintf ppf "@[(Atomic_exchange@ %a)@]" Block_access_field_kind.print
+        block_access_field_kind
   | Atomic_fetch_and_add -> fprintf ppf "Atomic_fetch_and_add"
   | Poke kind ->
     fprintf ppf "@[(Poke@ %a)@]"
@@ -1784,7 +1791,7 @@ let args_kind_of_binary_primitive p =
   | Float_arith (Float32, _) | Float_comp (Float32, _) ->
     K.naked_float32, K.naked_float32
   | Bigarray_get_alignment _ -> bigstring_kind, K.naked_immediate
-  | Atomic_exchange | Atomic_fetch_and_add -> K.value, K.value
+  | Atomic_exchange _ | Atomic_fetch_and_add -> K.value, K.value
   | Poke kind -> K.naked_nativeint, K.Standard_int_or_float.to_kind kind
 
 let result_kind_of_binary_primitive p : result_kind =
@@ -1807,7 +1814,7 @@ let result_kind_of_binary_primitive p : result_kind =
   | Float_arith (Float32, _) -> Singleton K.naked_float32
   | Phys_equal _ | Int_comp _ | Float_comp _ -> Singleton K.naked_immediate
   | Bigarray_get_alignment _ -> Singleton K.naked_immediate
-  | Atomic_exchange | Atomic_fetch_and_add -> Singleton K.value
+  | Atomic_exchange _ | Atomic_fetch_and_add -> Singleton K.value
   | Poke _ -> Unit
 
 let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
@@ -1836,7 +1843,7 @@ let effects_and_coeffects_of_binary_primitive p : Effects_and_coeffects.t =
     then No_effects, No_coeffects, Strict
     else No_effects, Has_coeffects, Strict
   | Bigarray_get_alignment _ -> No_effects, No_coeffects, Strict
-  | Atomic_exchange | Atomic_fetch_and_add ->
+  | Atomic_exchange _ | Atomic_fetch_and_add ->
     Arbitrary_effects, Has_coeffects, Strict
   | Poke _ -> Arbitrary_effects, No_coeffects, Strict
 
@@ -1845,7 +1852,7 @@ let binary_classify_for_printing p =
   | Array_load _ -> Destructive
   | Block_set _ | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _
   | Float_arith _ | Float_comp _ | Bigarray_load _ | String_or_bigstring_load _
-  | Bigarray_get_alignment _ | Atomic_exchange | Atomic_fetch_and_add | Poke _
+  | Bigarray_get_alignment _ | Atomic_exchange _ | Atomic_fetch_and_add | Poke _
     ->
     Neither
 
@@ -1853,7 +1860,7 @@ let free_names_binary_primitive p =
   match p with
   | Block_set _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Bigarray_get_alignment _ | Atomic_exchange
+  | Float_comp _ | Bigarray_get_alignment _ | Atomic_exchange _
   | Atomic_fetch_and_add
   | Poke (_ : Flambda_kind.Standard_int_or_float.t) ->
     Name_occurrences.empty
@@ -1862,7 +1869,7 @@ let apply_renaming_binary_primitive p _renaming =
   match p with
   | Block_set _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Bigarray_get_alignment _ | Atomic_exchange
+  | Float_comp _ | Bigarray_get_alignment _ | Atomic_exchange _
   | Atomic_fetch_and_add
   | Poke (_ : Flambda_kind.Standard_int_or_float.t) ->
     p
@@ -1871,7 +1878,7 @@ let ids_for_export_binary_primitive p =
   match p with
   | Block_set _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
   | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
-  | Float_comp _ | Bigarray_get_alignment _ | Atomic_exchange
+  | Float_comp _ | Bigarray_get_alignment _ | Atomic_exchange _
   | Atomic_fetch_and_add
   | Poke (_ : Flambda_kind.Standard_int_or_float.t) ->
     Ids_for_export.empty
@@ -1880,13 +1887,13 @@ type ternary_primitive =
   | Array_set of Array_kind.t * Array_set_kind.t
   | Bytes_or_bigstring_set of bytes_like_value * string_accessor_width
   | Bigarray_set of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
-  | Atomic_compare_and_set
-  | Atomic_compare_exchange
+  | Atomic_compare_and_set of Block_access_field_kind.t
+  | Atomic_compare_exchange of Block_access_field_kind.t
 
 let ternary_primitive_eligible_for_cse p =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_compare_and_set | Atomic_compare_exchange ->
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ ->
     false
 
 let compare_ternary_primitive p1 p2 =
@@ -1895,8 +1902,8 @@ let compare_ternary_primitive p1 p2 =
     | Array_set _ -> 0
     | Bytes_or_bigstring_set _ -> 1
     | Bigarray_set _ -> 2
-    | Atomic_compare_and_set -> 3
-    | Atomic_compare_exchange -> 4
+    | Atomic_compare_and_set _ -> 3
+    | Atomic_compare_exchange _ -> 4
   in
   match p1, p2 with
   | Array_set (kind1, set_kind1), Array_set (kind2, set_kind2) ->
@@ -1914,8 +1921,18 @@ let compare_ternary_primitive p1 p2 =
     else
       let c = Stdlib.compare kind1 kind2 in
       if c <> 0 then c else Stdlib.compare layout1 layout2
+  | Atomic_compare_and_set block_access_field_kind1,
+    Atomic_compare_and_set block_access_field_kind2
+    ->
+    Block_access_field_kind.compare block_access_field_kind1
+      block_access_field_kind2
+  | Atomic_compare_exchange block_access_field_kind1,
+    Atomic_compare_exchange block_access_field_kind2
+    ->
+    Block_access_field_kind.compare block_access_field_kind1
+      block_access_field_kind2
   | ( ( Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-      | Atomic_compare_and_set | Atomic_compare_exchange ),
+      | Atomic_compare_and_set _ | Atomic_compare_exchange _ ),
       _ ) ->
     Stdlib.compare
       (ternary_primitive_numbering p1)
@@ -1936,8 +1953,12 @@ let print_ternary_primitive ppf p =
     fprintf ppf
       "@[(Bigarray_set (num_dimensions@ %d)@ (kind@ %a)@ (layout@ %a))@]"
       num_dimensions Bigarray_kind.print kind Bigarray_layout.print layout
-  | Atomic_compare_and_set -> fprintf ppf "Atomic_compare_and_set"
-  | Atomic_compare_exchange -> fprintf ppf "Atomic_compare_exchange"
+  | Atomic_compare_and_set block_access_field_kind ->
+      Format.fprintf ppf "@[(Atomic_compare_and_set@ %a)@]"
+        Block_access_field_kind.print block_access_field_kind
+  | Atomic_compare_exchange block_access_field_kind ->
+      Format.fprintf ppf "@[(Atomic_compare_exchange@ %a)@]"
+        Block_access_field_kind.print block_access_field_kind
 
 let args_kind_of_ternary_primitive p =
   match p with
@@ -1967,13 +1988,13 @@ let args_kind_of_ternary_primitive p =
     bigstring_kind, bytes_or_bigstring_index_kind, K.naked_vec128
   | Bigarray_set (_, kind, _) ->
     bigarray_kind, bigarray_index_kind, Bigarray_kind.element_kind kind
-  | Atomic_compare_and_set | Atomic_compare_exchange ->
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ ->
     K.value, K.value, K.value
 
 let result_kind_of_ternary_primitive p : result_kind =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _ -> Unit
-  | Atomic_compare_and_set | Atomic_compare_exchange -> Singleton K.value
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ -> Singleton K.value
 
 let effects_and_coeffects_of_ternary_primitive p :
     Effects.t * Coeffects.t * Placement.t =
@@ -1981,31 +2002,31 @@ let effects_and_coeffects_of_ternary_primitive p :
   | Array_set _ -> writing_to_an_array
   | Bytes_or_bigstring_set _ -> writing_to_bytes_or_bigstring
   | Bigarray_set (_, kind, _) -> writing_to_a_bigarray kind
-  | Atomic_compare_and_set | Atomic_compare_exchange ->
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ ->
     Arbitrary_effects, Has_coeffects, Strict
 
 let ternary_classify_for_printing p =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_compare_and_set | Atomic_compare_exchange ->
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ ->
     Neither
 
 let free_names_ternary_primitive p =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_compare_and_set | Atomic_compare_exchange ->
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ ->
     Name_occurrences.empty
 
 let apply_renaming_ternary_primitive p _ =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_compare_and_set | Atomic_compare_exchange ->
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ ->
     p
 
 let ids_for_export_ternary_primitive p =
   match p with
   | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
-  | Atomic_compare_and_set | Atomic_compare_exchange ->
+  | Atomic_compare_and_set _ | Atomic_compare_exchange _ ->
     Ids_for_export.empty
 
 type variadic_primitive =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -502,7 +502,7 @@ type binary_primitive =
   | Float_arith of float_bitwidth * binary_float_arith_op
   | Float_comp of float_bitwidth * unit comparison_behaviour
   | Bigarray_get_alignment of int
-  | Atomic_exchange
+  | Atomic_exchange of Block_access_field_kind.t
   | Atomic_fetch_and_add
   | Poke of Flambda_kind.Standard_int_or_float.t
 
@@ -513,8 +513,8 @@ type ternary_primitive =
           for more details on the unarization. *)
   | Bytes_or_bigstring_set of bytes_like_value * string_accessor_width
   | Bigarray_set of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
-  | Atomic_compare_and_set
-  | Atomic_compare_exchange
+  | Atomic_compare_and_set of Block_access_field_kind.t
+  | Atomic_compare_exchange of Block_access_field_kind.t
 
 (** Primitives taking zero or more arguments. *)
 type variadic_primitive =

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -1011,7 +1011,13 @@ let binary_primitive env dbg f x y =
   | Float_comp (width, Yielding_int_like_compare_functions ()) ->
     binary_float_comp_primitive_yielding_int env dbg width x y
   | Bigarray_get_alignment align -> C.bigstring_get_alignment x y align dbg
-  | Atomic_exchange -> C.atomic_exchange ~dbg x y
+  | Atomic_exchange block_access_kind ->
+    let imm_or_ptr : Lambda.immediate_or_pointer =
+      match block_access_kind with
+      | Any_value -> Pointer
+      | Immediate -> Immediate
+    in
+    C.atomic_exchange ~dbg imm_or_ptr x y
   | Atomic_fetch_and_add -> C.atomic_fetch_and_add ~dbg x y
   | Poke kind ->
     let memory_chunk =
@@ -1029,10 +1035,20 @@ let ternary_primitive _env dbg f x y z =
     bytes_or_bigstring_set ~dbg kind width ~bytes:x ~index:y ~new_value:z
   | Bigarray_set (_dimensions, kind, _layout) ->
     bigarray_store ~dbg kind ~bigarray:x ~index:y ~new_value:z
-  | Atomic_compare_and_set ->
-    C.atomic_compare_and_set ~dbg x ~old_value:y ~new_value:z
-  | Atomic_compare_exchange ->
-    C.atomic_compare_exchange ~dbg x ~old_value:y ~new_value:z
+  | Atomic_compare_and_set block_access_kind ->
+    let imm_or_ptr : Lambda.immediate_or_pointer =
+      match block_access_kind with
+      | Any_value -> Pointer
+      | Immediate -> Immediate
+    in
+    C.atomic_compare_and_set ~dbg imm_or_ptr x ~old_value:y ~new_value:z
+  | Atomic_compare_exchange block_access_kind ->
+    let imm_or_ptr : Lambda.immediate_or_pointer =
+      match block_access_kind with
+      | Any_value -> Pointer
+      | Immediate -> Immediate
+    in
+    C.atomic_compare_exchange ~dbg imm_or_ptr x ~old_value:y ~new_value:z
 
 let variadic_primitive _env dbg f args =
   match (f : P.variadic_primitive) with

--- a/testsuite/tests/lib-atomic/test_atomic.ml
+++ b/testsuite/tests/lib-atomic/test_atomic.ml
@@ -37,3 +37,26 @@ let () =
   let cur = Atomic.get r in
   ignore (Atomic.incr r, Atomic.decr r);
   assert (Atomic.get r = cur)
+
+(* Test primitives with non-immediate types *)
+
+let a = ref 1
+let r = Atomic.make a
+let () = assert (Atomic.get r == a)
+
+let b = ref 2
+let () = Atomic.set r b
+let () = assert (Atomic.get r == b)
+
+let c = ref 3
+let () = assert (Atomic.exchange r c == b)
+
+let d = ref 4
+let () = assert (Atomic.compare_and_set r c d = true)
+let () = assert (Atomic.get r == d)
+
+let e = ref (-4)
+let () = assert (Atomic.compare_and_set r c e = false)
+let () = assert (Atomic.get r == d)
+
+let () = assert (Atomic.compare_and_set r c d = false)

--- a/testsuite/tests/lib-atomic/test_atomic_cmpxchg.ml
+++ b/testsuite/tests/lib-atomic/test_atomic_cmpxchg.ml
@@ -16,3 +16,27 @@ let () = assert (Atomic.get r = 4)
 
 let () = assert (Atomic.compare_exchange r 3 4 = 4)
 let () = assert (Atomic.get r = 4)
+
+(* Test primitives with non-immediate types *)
+
+let a = ref 1
+let r = Atomic.make a
+let () = assert (Atomic.get r == a)
+
+let b = ref 2
+let () = Atomic.set r b
+let () = assert (Atomic.get r == b)
+
+let c = ref 3
+let () = assert (Atomic.exchange r c == b)
+
+let d = ref 4
+let () = assert (Atomic.compare_exchange r c d == c)
+let () = assert (Atomic.get r == d)
+
+let e = ref (-4)
+let () = assert (Atomic.compare_exchange r c e == d)
+let () = assert (Atomic.get r == d)
+
+let () = assert (Atomic.compare_exchange r c d == d)
+let () = assert (Atomic.get r == d)


### PR DESCRIPTION
Currently the builtin atomic intrinsics (`%atomic_exchange`, `%atomic_cas`, `%atomic_compare_exchange` and `%atomic_fetch_add`) always generate a C call. When operating on data that is not immediate we need to do `caml_modify`-style logic on these operations, so the C call makes sense. But when operating on immediates we should just generate the equivalent machine instructions directly.

This PR adds the logic to plumb through whether these operations are working with immediates. For `%atomic_cas` and `%atomic_fectch_add` it uses that information to generate the right instructions, because those instructions could already be represented in cmm. The other two operations still end up as C calls, but now we only need a bit of work in the backend to get them generating instructions too.