### PR TITLE
Move two macOS CI controllers to runtime5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,14 +78,14 @@ jobs:
             config: --enable-middle-end=flambda2 --disable-warn-error
             os: macos-latest
 
-          - name: flambda2_macos_arm64_irc
-            config: --enable-middle-end=flambda2 --disable-warn-error
+          - name: flambda2_macos_arm64_runtime5_irc
+            config: --enable-middle-end=flambda2 --enable-runtime5 --disable-warn-error
             os: macos-latest
             build_ocamlparam: '_,w=-46,regalloc=irc'
             ocamlparam: '_,w=-46,regalloc=irc'
 
-          - name: flambda2_macos_arm64_ls
-            config: --enable-middle-end=flambda2 --disable-warn-error
+          - name: flambda2_macos_arm64_runtime5_ls
+            config: --enable-middle-end=flambda2 --enable-runtime5 --disable-warn-error
             os: macos-latest
             build_ocamlparam: '_,w=-46,regalloc=ls'
             ocamlparam: '_,w=-46,regalloc=ls'


### PR DESCRIPTION
We weren't previously checking macOS + runtime5, which has concealed at least one bug recently.