### PR TITLE
Add "-ocamlrunparam" linker flag

### DIFF
--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -349,6 +349,16 @@ let sourcefile_for_dwarf ~named_startup_file filename =
   if named_startup_file then filename
   else ".startup"
 
+let emit_ocamlrunparam ~ppf_dump =
+  Asmgen.compile_phrase ~ppf_dump
+    (Cmm.Cdata [
+      Cmm.Cdefine_symbol {
+        sym_name = "caml_ocamlrunparam";
+        sym_global = Global
+      };
+      Cmm.Cstring !Clflags.ocamlrunparam
+    ])
+
 let make_startup_file unix ~ppf_dump ~sourcefile_for_dwarf genfns units cached_gen =
   Location.input_name := "caml_startup"; (* set name of "current" input *)
   let startup_comp_unit =
@@ -361,6 +371,7 @@ let make_startup_file unix ~ppf_dump ~sourcefile_for_dwarf genfns units cached_g
   let compile_phrase p = Asmgen.compile_phrase ~ppf_dump p in
   let name_list =
     List.flatten (List.map (fun u -> u.defines) units) in
+  emit_ocamlrunparam ~ppf_dump;
   List.iter compile_phrase (Cmm_helpers.entry_point name_list);
   List.iter compile_phrase
     (* Emit the GC roots table, for dynlink. *)
@@ -414,6 +425,7 @@ let make_shared_startup_file unix ~ppf_dump ~sourcefile_for_dwarf genfns units =
   Emitaux.Dwarf_helpers.init ~disable_dwarf:(not !Dwarf_flags.dwarf_for_startup_file)
     ~sourcefile:sourcefile_for_dwarf;
   Emit.begin_assembly unix;
+  emit_ocamlrunparam ~ppf_dump;
   List.iter compile_phrase
     (Cmm_helpers.emit_gc_roots_table ~symbols:[]
       (Generic_fns.compile ~shared:true genfns));

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -356,7 +356,7 @@ let emit_ocamlrunparam ~ppf_dump =
         sym_name = "caml_ocamlrunparam";
         sym_global = Global
       };
-      Cmm.Cstring !Clflags.ocamlrunparam
+      Cmm.Cstring (!Clflags.ocamlrunparam ^ "\000")
     ])
 
 let make_startup_file unix ~ppf_dump ~sourcefile_for_dwarf genfns units cached_gen =

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -480,6 +480,11 @@ let mk_runtime_variant f =
   "-runtime-variant", Arg.String f,
   "<str>  Use the <str> variant of the run-time system"
 
+let mk_ocamlrunparam f =
+  "-ocamlrunparam", Arg.String f,
+  "<settings>  Use the given OCAMLRUNPARAM settings as the default (ignored \
+    except when linking an executable)"
+
 let mk_with_runtime f =
   "-with-runtime", Arg.Unit f,
   "Include the runtime system in the generated program (default)"
@@ -1050,6 +1055,7 @@ module type Compiler_options = sig
   val _no_principal : unit -> unit
   val _rectypes : unit -> unit
   val _runtime_variant : string -> unit
+  val _ocamlrunparam : string -> unit
   val _with_runtime : unit -> unit
   val _without_runtime : unit -> unit
   val _short_paths : unit -> unit
@@ -1542,6 +1548,7 @@ struct
     mk_remove_unused_arguments F._remove_unused_arguments;
     mk_rounds F._rounds;
     mk_runtime_variant F._runtime_variant;
+    mk_ocamlrunparam F._ocamlrunparam;
     mk_with_runtime F._with_runtime;
     mk_without_runtime F._without_runtime;
     mk_S F._S;
@@ -2091,6 +2098,7 @@ module Default = struct
     let _plugin _p = plugin := true
     let _pp s = preprocessor := (Some s)
     let _runtime_variant s = runtime_variant := s
+    let _ocamlrunparam s = ocamlrunparam := s
     let _stop_after pass =
       let module P = Compiler_pass in
         match P.of_string pass with

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -128,6 +128,7 @@ module type Compiler_options = sig
   val _no_principal : unit -> unit
   val _rectypes : unit -> unit
   val _runtime_variant : string -> unit
+  val _ocamlrunparam : string -> unit
   val _with_runtime : unit -> unit
   val _without_runtime : unit -> unit
   val _short_paths : unit -> unit

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -168,6 +168,8 @@ static void parse_ocamlrunparam(char_os* opt)
 }
 
 #ifdef NATIVE_CODE
+// Any default parameters added to an ocaml executable by passing -ocamlrunparam
+// to the compiler.
 // See asmcomp/asmlink.ml
 extern char caml_ocamlrunparam[];
 #endif

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -111,14 +111,8 @@ static void scanmult (char_os *opt, uintnat *var)
   }
 }
 
-void caml_parse_ocamlrunparam(void)
+static void parse_ocamlrunparam(char_os* opt)
 {
-  init_startup_params();
-  caml_init_gc_tweaks();
-
-  char_os *opt = caml_secure_getenv (T("OCAMLRUNPARAM"));
-  if (opt == NULL) opt = caml_secure_getenv (T("CAMLRUNPARAM"));
-
   if (opt != NULL){
     while (*opt != '\0'){
       switch (*opt++){
@@ -173,6 +167,25 @@ void caml_parse_ocamlrunparam(void)
   }
 }
 
+#ifdef NATIVE_CODE
+// See asmcomp/asmlink.ml
+extern char caml_ocamlrunparam[];
+#endif
+
+void caml_parse_ocamlrunparam(void)
+{
+  init_startup_params();
+  caml_init_gc_tweaks();
+
+  char_os *opt = caml_secure_getenv (T("OCAMLRUNPARAM"));
+  if (opt == NULL) opt = caml_secure_getenv (T("CAMLRUNPARAM"));
+
+#ifdef NATIVE_CODE
+  parse_ocamlrunparam(caml_ocamlrunparam);
+#endif
+
+  parse_ocamlrunparam(opt);
+}
 
 /* The number of outstanding calls to caml_startup */
 static int startup_count = 0;

--- a/runtime4/startup_aux.c
+++ b/runtime4/startup_aux.c
@@ -100,13 +100,9 @@ static void scanmult (char_os *opt, uintnat *var)
   }
 }
 
-void caml_parse_ocamlrunparam(void)
+static void parse_ocamlrunparam(char_os* opt)
 {
-  char_os *opt = caml_secure_getenv (T("OCAMLRUNPARAM"));
   uintnat p;
-
-  if (opt == NULL) opt = caml_secure_getenv (T("CAMLRUNPARAM"));
-
   if (opt != NULL){
     while (*opt != '\0'){
       switch (*opt++){
@@ -136,6 +132,24 @@ void caml_parse_ocamlrunparam(void)
       }
     }
   }
+}
+
+#ifdef NATIVE_CODE
+// See asmcomp/asmlink.ml
+extern char caml_ocamlrunparam[];
+#endif
+
+void caml_parse_ocamlrunparam(void)
+{
+  char_os *opt = caml_secure_getenv (T("OCAMLRUNPARAM"));
+
+  if (opt == NULL) opt = caml_secure_getenv (T("CAMLRUNPARAM"));
+
+#ifdef NATIVE_CODE
+  parse_ocamlrunparam(caml_ocamlrunparam);
+#endif
+
+  parse_ocamlrunparam(opt);
 }
 
 

--- a/runtime4/startup_aux.c
+++ b/runtime4/startup_aux.c
@@ -135,6 +135,8 @@ static void parse_ocamlrunparam(char_os* opt)
 }
 
 #ifdef NATIVE_CODE
+// Any default parameters added to an ocaml executable by passing -ocamlrunparam
+// to the compiler.
 // See asmcomp/asmlink.ml
 extern char caml_ocamlrunparam[];
 #endif

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -208,6 +208,7 @@ let pic_code = ref (match Config.architecture with (* -fPIC *)
                      | _       -> false)
 
 let runtime_variant = ref ""
+let ocamlrunparam = ref ""
 
 let with_runtime = ref true         (* -with-runtime *)
 

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -198,6 +198,7 @@ val shared : bool ref
 val dlcode : bool ref
 val pic_code : bool ref
 val runtime_variant : string ref
+val ocamlrunparam : string ref
 val with_runtime : bool ref
 val force_slash : bool ref
 val keep_docs : bool ref


### PR DESCRIPTION
This adds a new option to `ocamlopt` called `-ocamlrunparam`.  It only has an effect when linking is taking place (this is not checked, but that is consistent with e.g. `-runtime-variant`).  It allows the specification of default `OCAMLRUNPARAM` values, which is very useful in systems where environment variables may be sanitized, or otherwise are difficult to have set correctly.  Any settings that are in the `OCAMLRUNPARAM` environment variables override any settings set via this new mechanism.

I wondered whether there might be difficulties with the shared linking mode, `-output-obj`, etc. but this follows what happens e.g. for the GC roots tables so I think it's ok.