### PR TITLE
Basic Key API

### DIFF
--- a/otherlibs/stdlib_alpha/capsule.ml
+++ b/otherlibs/stdlib_alpha/capsule.ml
@@ -13,45 +13,28 @@
 (**************************************************************************)
 
 module Global = struct
-  type 'a t = { global : 'a @@ global } [@@unboxed]
+  (* CR dkalinichenko: [global] should imply [aliased]. *)
+  type 'a t = { global : 'a @@ global aliased } [@@unboxed]
 end
 
 open Global
 
-(* Like [int Stdlib.Atomic.t], but [portable]. *)
+(* Like [int Stdlib.Atomic.t], but supports [local]. *)
 module A = struct
-  type t : value mod portable contended
+  type t : value mod many portable contended
 
-  external make : int -> t @@ portable = "%makemutable"
-  external fetch_and_add : t -> int -> int @@ portable = "%atomic_fetch_add"
+  external make : int -> (t[@local_opt]) @@ portable = "%makemutable"
+
+  external get : (t[@local_opt]) -> int @@ portable = "%atomic_load"
+  external compare_exchange : (t[@local_opt]) -> int -> int -> int @@ portable = "%atomic_compare_exchange"
+  external fetch_and_add : (t[@local_opt]) -> int -> int @@ portable = "%atomic_fetch_add"
+
+  (* Unsafe unless [A.t] is only accessible by 1 thread. *)
+  external get_unsync : (t[@local_opt]) -> int @@ portable = "%field0"
+  external set_unsync : (t[@local_opt]) -> int -> unit @@ portable = "%setfield0"
 end
 
 (* Like [Stdlib.Magic], but [portable]. *)
-module O = struct
-  external magic : 'a -> 'b @@ portable = "%obj_magic"
-end
-
-(* Like [Stdlib.( = ), but [portable]. *)
-external ( = ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%equal"
-
-module Name : sig
-  type 'k t : value mod external_ global portable many contended aliased
-  type packed = P : 'k t -> packed [@@unboxed]
-
-  val make : unit -> packed @@ portable
-  val equality_witness : 'k1 t -> 'k2 t -> ('k1, 'k2) Type.eq option @@ portable
-end = struct
-  type 'k t = int
-  type packed = P : 'k t -> packed [@@unboxed]
-
-  let ctr = A.make 0
-  let[@inline] make () = P (A.fetch_and_add ctr 1)
-
-  let[@inline] equality_witness t1 t2 =
-    if t1 = t2
-    then Some (O.magic Type.Equal)
-    else None
-end
 
 module Access : sig
   (* CR layouts v5: this should have layout [void], but
@@ -87,89 +70,100 @@ type initial
 let initial = Access.unsafe_mk ()
 
 module Password : sig
-  (* CR layouts v5: this should have layout [void], but
-     [void] can't be used for function argument and return types yet. *)
-  type 'k t : value mod external_ portable many aliased contended
+  type 'k t : value mod many portable contended
 
-  type packed = P : 'k t -> packed [@@unboxed]
+  module Id : sig
+    type 'k t : immediate
+
+    val equality_witness : 'k1 t -> 'k2 t -> ('k1, 'k2) Type.eq option @@ portable
+  end
 
   (* Can break the soundness of the API. *)
-  val unsafe_mk : 'k Name.t -> 'k t @@ portable
-  val name : 'k t @ local -> 'k Name.t @@ portable
+  val unsafe_mk : unit -> 'k t @ local @@ portable
+  val id : 'k t @ local -> 'k Id.t @@ portable
 
   module Shared : sig
-    (* CR layouts v5: this should have layout [void], but
-       [void] can't be used for function argument and return types yet. *)
-    type 'k t : value mod external_ portable many aliased contended
+    type 'k t : value mod many portable contended
 
     (* Can break the soundness of the API. *)
-    val unsafe_mk : 'k Name.t -> 'k t @@ portable
-    val name : 'k t @ local -> 'k Name.t @@ portable
+    val unsafe_mk : unit -> 'k t @ local @@ portable
+    val id : 'k t @ local -> 'k Id.t @@ portable
   end
 
   val shared : 'k t @ local -> 'k Shared.t @ local @@ portable
 end = struct
-  type 'k t = 'k Name.t
+  module Id = struct
+    type 'k t = int
 
-  type packed = P : 'k t -> packed [@@unboxed]
+    let uninitialized = 0
+    let ctr = A.make (uninitialized + 1)
+    let[@inline] unsafe_mk () = A.fetch_and_add ctr 1
 
-  let[@inline] unsafe_mk name = name
-  let[@inline] name t = t
+    let[@inline] equality_witness t1 t2 =
+      if Int.equal t1 t2
+      then Some (Obj.magic Type.Equal)
+      else None
+  end
+
+  type 'k t = A.t
+
+  let[@inline] unsafe_mk () : _ @@ local = A.make Id.uninitialized
+  let[@inline] id t =
+    (* Safe since [Password.t] is only ever accessible by 1 fiber. *)
+    match A.get_unsync t with
+    | id when id = Id.uninitialized ->
+      let set_id = Id.unsafe_mk () in
+      A.set_unsync t set_id;
+      set_id
+    | set_id -> set_id
 
   module Shared = struct
-    type 'k t = 'k Name.t
+    type 'k t = A.t
 
-    let[@inline] unsafe_mk name = name
-    let[@inline] name t = t
+    (* Multiple fibers can access the same [Password.Shared.t] concurrently.
+       Therefore, we use atomic operations. *)
+    let[@inline] id t =
+      match A.get t with
+      | id when id = Id.uninitialized ->
+        let new_id = Id.unsafe_mk () in
+        (match A.compare_exchange t Id.uninitialized new_id with
+         | id when id = Id.uninitialized -> new_id
+         | already_set_id -> already_set_id)
+      | set_id -> set_id
+
+    let unsafe_mk () : _ @@ local = A.make Id.uninitialized
   end
 
   let[@inline] shared t = t
-
 end
 
 (* Like [Stdlib.raise], but [portable], and the value
-   it never returns is also [portable] *)
-external reraise : exn -> 'a @ portable @@ portable = "%reraise"
+   it never returns is also [portable unique] *)
+external raise : exn -> 'a @ portable unique @@ portable = "%raise"
 external raise_with_backtrace: exn -> Printexc.raw_backtrace -> 'a @ portable @@ portable = "%raise_with_backtrace"
 external get_raw_backtrace: unit -> Printexc.raw_backtrace @@ portable = "caml_get_exception_raw_backtrace"
 
 module Data = struct
   type ('a, 'k) t : value mod portable contended
 
-  exception Encapsulated : 'k Name.t * (exn, 'k) t -> exn
+  exception Encapsulated : 'k Password.Id.t * (exn, 'k) t -> exn
 
   external unsafe_mk : ('a[@local_opt]) -> (('a, 'k) t[@local_opt]) @@ portable = "%identity"
-
   external unsafe_get : (('a, 'k) t[@local_opt]) -> ('a[@local_opt]) @@ portable = "%identity"
 
   let[@inline] wrap _ t = unsafe_mk t
-  let[@inline] wrap_local _ t = exclave_ unsafe_mk t
-
   let[@inline] unwrap _ t = unsafe_get t
-  let[@inline] unwrap_local _ t = exclave_ unsafe_get t
-
   let[@inline] unwrap_shared _ t = unsafe_get t
-  let[@inline] unwrap_shared_local _ t = exclave_ unsafe_get t
 
   let[@inline] create f = unsafe_mk (f ())
-  let[@inline] create_local f = exclave_ unsafe_mk (f ())
 
   (* CR-soon mslater/tdelvecchio: copying the backtrace at each reraise can cause quadratic
      behavior when propagating the exception through nested handlers. This should use a
      new reraise-with-current-backtrace primitive that doesn't do the copy. *)
   let reraise_encapsulated password exn =
-    raise_with_backtrace (Encapsulated (Password.name password, unsafe_mk exn)) (get_raw_backtrace ())
-
-  let reraise_encapsulated_shared password exn =
-    raise_with_backtrace (Encapsulated (Password.Shared.name password, unsafe_mk exn)) (get_raw_backtrace ())
+    raise_with_backtrace (Encapsulated (Password.id password, unsafe_mk exn)) (get_raw_backtrace ())
 
   let[@inline] map pw f t =
-    let v = unsafe_get t in
-    match f v with
-    | res -> unsafe_mk res
-    | exception exn -> reraise_encapsulated pw exn
-
-  let[@inline] map_local pw f t = exclave_
     let v = unsafe_get t in
     match f v with
     | res -> unsafe_mk res
@@ -179,43 +173,21 @@ module Data = struct
     let t1, _ = unsafe_get t in
     unsafe_mk t1
 
-  let[@inline] fst_local t = exclave_
-    let t1, _ = unsafe_get t in
-    unsafe_mk t1
-
   let[@inline] snd t =
     let _, t2 = unsafe_get t in
     unsafe_mk t2
 
-  let[@inline] snd_local t = exclave_
-    let _, t2 = unsafe_get t in
-    unsafe_mk t2
-
   let[@inline] both t1 t2 = unsafe_mk (unsafe_get t1, unsafe_get t2)
-  let[@inline] both_local t1 t2 = exclave_ unsafe_mk (unsafe_get t1, unsafe_get t2)
 
   let[@inline] extract pw f t =
     let v = unsafe_get t in
     try f v with
-    |  exn -> reraise_encapsulated pw exn
-
-  let[@inline] extract_local pw f t = exclave_
-    let v = unsafe_get t in
-    try f v with
-    |  exn -> reraise_encapsulated pw exn
-
-  let inject = unsafe_mk
-  let inject_local = unsafe_mk
-
-  let project = unsafe_get
-  let project_local = unsafe_get
-
-  let[@inline] bind pw f t =
-    let v = unsafe_get t in
-    try f v with
     | exn -> reraise_encapsulated pw exn
 
-  let[@inline] bind_local pw f t = exclave_
+  let inject = unsafe_mk
+  let project = unsafe_get
+
+  let[@inline] bind pw f t =
     let v = unsafe_get t in
     try f v with
     | exn -> reraise_encapsulated pw exn
@@ -225,10 +197,120 @@ module Data = struct
     try f v with
     | exn -> reraise_encapsulated pw exn
 
-  let[@inline] iter_local pw f t =
-    let v = unsafe_get t in
-    try f v with
-    | exn -> reraise_encapsulated pw exn
+  module Shared = struct
+    type ('a, 'k) data = ('a, 'k) t
+
+    type ('a, 'k) t = ('a, 'k) data
+
+    exception Encapsulated_shared : 'k Password.Id.t * (exn, 'k) t -> exn
+
+    (* CR-soon mslater/tdelvecchio: copying the backtrace at each reraise can cause quadratic
+       behavior when propagating the exception through nested handlers. This should use a
+       new reraise-with-current-backtrace primitive that doesn't do the copy. *)
+    let reraise_encapsulated_shared p e =
+      raise_with_backtrace
+        (Encapsulated_shared (Password.Shared.id p, unsafe_mk e))
+        (get_raw_backtrace ())
+
+    let[@inline] wrap _ v = unsafe_mk v
+    let[@inline] unwrap _ t = unsafe_get t
+    let[@inline] expose _ t = unsafe_get t
+    let[@inline] create f = unsafe_mk (f ())
+
+    let[@inline] map p f t =
+      let v = unsafe_get t in
+      match f v with
+      | r -> unsafe_mk r
+      | exception e -> reraise_encapsulated_shared p e
+
+    let[@inline] both t1 t2 = unsafe_mk (unsafe_get t1, unsafe_get t2)
+
+    let[@inline] fst t =
+      let x, _ = unsafe_get t in
+      unsafe_mk x
+
+    let[@inline] snd t =
+      let _, y = unsafe_get t in
+      unsafe_mk y
+
+    let[@inline] extract p f t =
+      let v = unsafe_get t in
+      try f v with e -> reraise_encapsulated_shared p e
+
+    let[@inline] inject v = unsafe_mk v
+    let[@inline] project t = unsafe_get t
+
+    let[@inline] bind p f t =
+      let v = unsafe_get t in
+      try f v with e -> reraise_encapsulated_shared p e
+
+    let[@inline] iter p f t =
+      let v = unsafe_get t in
+      try f v with e -> reraise_encapsulated_shared p e
+
+    let[@inline] map_into pw f t =
+      let v = unsafe_get t in
+      match f v with
+      | res -> unsafe_mk res
+      | exception exn -> reraise_encapsulated_shared pw exn
+
+    module Local = struct
+      let[@inline] wrap _ v = exclave_ (unsafe_mk v)
+      let[@inline] unwrap _ t = exclave_ (unsafe_get t)
+      let[@inline] create f = exclave_ (unsafe_mk (f ()))
+
+      let[@inline] map p f t =
+        exclave_ (
+          let v = unsafe_get t in
+          match f v with
+          | r -> unsafe_mk r
+          | exception e -> reraise_encapsulated_shared p e
+        )
+
+      let[@inline] both t1 t2 =
+        exclave_ (unsafe_mk (unsafe_get t1, unsafe_get t2))
+
+      let[@inline] fst t =
+        exclave_ (
+          let x, _ = unsafe_get t in
+          unsafe_mk x
+        )
+
+      let[@inline] snd t =
+        exclave_ (
+          let _, y = unsafe_get t in
+          unsafe_mk y
+        )
+
+      let[@inline] extract p f t =
+        exclave_ (
+          let v = unsafe_get t in
+          try f v with e -> reraise_encapsulated_shared p e
+        )
+
+      let[@inline] inject v = exclave_ (unsafe_mk v)
+      let[@inline] project t = exclave_ (unsafe_get t)
+
+      let[@inline] bind p f t =
+        exclave_ (
+          let v = unsafe_get t in
+          try f v with e -> reraise_encapsulated_shared p e
+        )
+
+      let[@inline] iter p f t =
+        let v = unsafe_get t in
+        try f v with e -> reraise_encapsulated_shared p e
+
+      let[@inline] map_into pw f t = exclave_ (
+        let v = unsafe_get t in
+        match f v with
+        | res -> unsafe_mk res
+        | exception exn -> reraise_encapsulated_shared pw exn
+      )
+    end
+  end
+
+  let reraise_encapsulated_shared = Shared.reraise_encapsulated_shared
 
   let[@inline] map_shared pw f t =
     let v = unsafe_get t in
@@ -236,41 +318,233 @@ module Data = struct
     | res -> unsafe_mk res
     | exception exn -> reraise_encapsulated_shared pw exn
 
-  let[@inline] map_shared_local pw f t = exclave_
-    let v = unsafe_get t in
-    match f v with
-    | res -> unsafe_mk res
-    | exception exn -> reraise_encapsulated_shared pw exn
-
-
   let[@inline] extract_shared pw f t =
     let v = unsafe_get t in
     try f v with
     | exn -> reraise_encapsulated_shared pw exn
 
-  let[@inline] extract_shared_local pw f t = exclave_
-    let v = unsafe_get t in
-    try f v with
-    | exn -> reraise_encapsulated_shared pw exn
+  module Local = struct
+    let[@inline] wrap _ t = exclave_ unsafe_mk t
+    let[@inline] unwrap _ t = exclave_ unsafe_get t
+    let[@inline] unwrap_shared _ t = exclave_ unsafe_get t
+    let[@inline] create f = exclave_ unsafe_mk (f ())
 
+    let[@inline] map pw f t = exclave_ (
+      let v = unsafe_get t in
+      match f v with
+      | res -> unsafe_mk res
+      | exception exn -> reraise_encapsulated pw exn
+    )
+
+    let[@inline] fst t = exclave_ (
+      let t1, _ = unsafe_get t in
+      unsafe_mk t1
+    )
+
+    let[@inline] snd t = exclave_ (
+      let _, t2 = unsafe_get t in
+      unsafe_mk t2
+    )
+
+    let[@inline] both t1 t2 = exclave_ unsafe_mk (unsafe_get t1, unsafe_get t2)
+
+    let[@inline] extract pw f t = exclave_ (
+      let v = unsafe_get t in
+      try f v with
+      | exn -> reraise_encapsulated pw exn
+    )
+
+    let[@inline] inject v = exclave_ unsafe_mk v
+    let[@inline] project t = exclave_ unsafe_get t
+
+    let[@inline] bind pw f t = exclave_ (
+      let v = unsafe_get t in
+      try f v with
+      | exn -> reraise_encapsulated pw exn
+    )
+
+    let[@inline] iter pw f t =
+      let v = unsafe_get t in
+      try f v with
+      | exn -> reraise_encapsulated pw exn
+
+    let[@inline] map_shared pw f t = exclave_ (
+      let v = unsafe_get t in
+      match f v with
+      | res -> unsafe_mk res
+      | exception exn -> reraise_encapsulated_shared pw exn
+    )
+
+    let[@inline] extract_shared pw f t = exclave_ (
+      let v = unsafe_get t in
+      try f v with
+      | exn -> reraise_encapsulated_shared pw exn
+    )
+  end
 end
 
 exception Encapsulated = Data.Encapsulated
+exception Encapsulated_shared = Data.Shared.Encapsulated_shared
 
-let[@inline] access_local (type k) (pw : k Password.t) f = exclave_
-  let c : k Access.t = Access.unsafe_mk () in
-  match f c with
-  | res -> res
-  | exception exn -> Data.reraise_encapsulated pw exn
+module Key : sig
+  type 'k t : value mod external_ portable contended
+
+  type packed = P : 'k t -> packed [@@unboxed]
+
+  val unsafe_mk : unit -> 'k t @ unique @@ portable
+
+  val with_password :
+    'k t @ unique
+    -> ('k Password.t @ local -> 'a @ unique) @ local
+    -> 'a * 'k t @ unique @@ portable
+
+  val with_password_local :
+    'k t @ unique
+    -> ('k Password.t @ local -> 'a @ local) @ local
+    -> 'a @ local @@ portable
+
+  val with_password_shared :
+    'k t
+    -> ('k Password.Shared.t @ local -> 'a) @ local
+    -> 'a
+    @@ portable
+
+  val with_password_shared_local :
+    'k t
+    -> ('k Password.Shared.t @ local -> 'a @ local) @ local
+    -> 'a @ local
+    @@ portable
+
+  val access :
+    'k t @ unique
+    -> ('k Access.t -> 'a @ unique portable contended) @ local portable
+    -> 'a * 'k t @ unique portable contended @@ portable
+
+  val access_local :
+    'k t @ unique
+    -> ('k Access.t -> 'a @ local unique portable contended) @ local portable
+    -> 'a * 'k t @ local unique portable contended @@ portable
+
+  val access_shared :
+    'k t
+    -> ('k Access.t @ shared -> 'a @ portable contended) @ local portable
+    -> 'a @ portable contended
+    @@ portable
+
+  val access_shared_local :
+    'k t
+    -> ('k Access.t @ shared -> 'a @ local portable contended) @ local portable
+    -> 'a @ local portable contended
+    @@ portable
+
+  val globalize_unique : 'k t @ local unique -> 'k t @ unique @@ portable
+
+  val destroy : 'k t @ unique -> 'k Access.t @@ portable
+end = struct
+  type 'k t = unit
+
+  type packed = P : 'k t -> packed [@@unboxed]
+
+  let[@inline] unsafe_mk () = ()
+
+  let[@inline] with_password_shared (type k) _ f =
+    let pw : k Password.Shared.t = Password.Shared.unsafe_mk () in
+    try f pw with
+    | Encapsulated_shared (id, data) as exn ->
+      let exn =
+        match Password.Id.equality_witness (Password.Shared.id pw) id with
+        | Some Equal -> Data.unsafe_get data
+        | None -> exn
+      in
+      raise exn
+
+  let[@inline] with_password_shared_local (type k) _ f =
+    exclave_ (
+      let pw : k Password.Shared.t = Password.Shared.unsafe_mk () in
+      try f pw with
+      | Encapsulated_shared (id, data) as exn ->
+        let exn =
+          match Password.Id.equality_witness (Password.Shared.id pw) id with
+          | Some Equal -> Data.unsafe_get data
+          | None -> exn
+        in
+        raise exn
+    )
+
+  let[@inline] with_password (type k) k f =
+    let pw : k Password.t = Password.unsafe_mk () in
+    try f pw, k with
+    | exn ->
+      let exn =
+        match exn with
+        | Encapsulated (id, data) ->
+          (match Password.Id.equality_witness (Password.id pw) id with
+           | Some Equal -> Data.unsafe_get data
+           | None -> exn)
+        | Encapsulated_shared (id, data) ->
+          (match Password.Id.equality_witness (Password.id pw) id with
+           | Some Equal -> Data.unsafe_get data
+           | None -> exn)
+        | _ -> exn
+      in
+      raise exn
+
+  let[@inline] with_password_local (type k) _ f =
+    exclave_ (
+      let pw : k Password.t = Password.unsafe_mk () in
+      try f pw with
+      | exn ->
+        let exn =
+          match exn with
+          | Encapsulated (id, data) ->
+            (match Password.Id.equality_witness (Password.id pw) id with
+             | Some Equal -> Data.unsafe_get data
+             | None -> exn)
+          | Encapsulated_shared (id, data) ->
+            (match Password.Id.equality_witness (Password.id pw) id with
+             | Some Equal -> Data.unsafe_get data
+             | None -> exn)
+          | _ -> exn
+        in
+        raise exn
+    )
+
+  let[@inline] access k f = f (Access.unsafe_mk ()), k
+  let[@inline] access_local k f = exclave_ (f (Access.unsafe_mk ()), k)
+
+  let[@inline] access_shared _ f =
+    let c : 'k Access.t = Access.unsafe_mk () in
+    f c
+
+  let[@inline] access_shared_local _ f =
+    let c : 'k Access.t = Access.unsafe_mk () in
+    exclave_ (f c)
+
+  let[@inline] globalize_unique k = k
+
+  let[@inline] destroy _ = Access.unsafe_mk ()
+end
+
+let[@inline] create () = Key.P (Key.unsafe_mk ())
+
+let[@inline] access_local (type k) (pw : k Password.t) f =
+  exclave_ (
+    let c : k Access.t = Access.unsafe_mk () in
+    match f c with
+    | res -> res
+    | exception exn -> Data.reraise_encapsulated pw exn
+  )
 
 let[@inline] access pw f =
   (access_local pw (fun access -> { global = f access })).global
 
-let[@inline] access_shared_local (type k) (pw : k Password.Shared.t) f = exclave_
-  let c : k Access.t = Access.unsafe_mk () in
-  match f c with
-  | res -> res
-  | exception exn -> Data.reraise_encapsulated_shared pw exn
+let[@inline] access_shared_local (type k) (pw : k Password.Shared.t) f =
+  exclave_ (
+    let c : k Access.t = Access.unsafe_mk () in
+    match f c with
+    | res -> res
+    | exception exn -> Data.reraise_encapsulated_shared pw exn
+  )
 
 let[@inline] access_shared pw f =
   (access_shared_local pw (fun access -> { global = f access })).global
@@ -279,27 +553,23 @@ let[@inline] access_shared pw f =
 module M = struct
   type t : value mod portable contended
   external create: unit -> t @@ portable = "caml_capsule_mutex_new"
-  external lock: t -> unit @@ portable = "caml_capsule_mutex_lock"
-  external unlock: t -> unit @@ portable = "caml_capsule_mutex_unlock"
+  external lock: t @ local -> unit @@ portable = "caml_capsule_mutex_lock"
+  external unlock: t @ local -> unit @@ portable = "caml_capsule_mutex_unlock"
 end
 
 (* Reader writer lock *)
 module Rw = struct
   type t : value mod portable contended
   external create: unit -> t @@ portable = "caml_capsule_rwlock_new"
-  external lock_read: t -> unit @@ portable = "caml_capsule_rwlock_rdlock"
-  external lock_write: t -> unit @@ portable = "caml_capsule_rwlock_wrlock"
-  external unlock: t -> unit @@ portable = "caml_capsule_rwlock_unlock"
+  external lock_read: t @ local -> unit @@ portable = "caml_capsule_rwlock_rdlock"
+  external lock_write: t @ local -> unit @@ portable = "caml_capsule_rwlock_wrlock"
+  external unlock: t @ local -> unit @@ portable = "caml_capsule_rwlock_unlock"
 end
 
 module Mutex = struct
 
-  (* Illegal mode crossing: ['k t] has a mutable field [poisoned]. It's safe,
-     since [poisoned] protected by [mutex] and not exposed in the API, but
-     is not allowed by the type system. *)
   type 'k t : value mod portable contended =
-    { name : 'k Name.t
-    ; mutex : M.t
+    { mutex : M.t
     ; mutable poisoned : bool
     }
   [@@unsafe_allow_any_mode_crossing]
@@ -309,7 +579,7 @@ module Mutex = struct
     "CR layouts v2.8: illegal mode crossing on the current version of the compiler, but \
      should be legal."]
 
-  let[@inline] name t = t.name
+  let[@inline] create _ = { mutex = M.create (); poisoned = false }
 
   exception Poisoned
 
@@ -322,42 +592,46 @@ module Mutex = struct
     = fun t f ->
       M.lock t.mutex;
       match t.poisoned with
-      | true -> M.unlock t.mutex; reraise Poisoned
+      | true -> M.unlock t.mutex; raise Poisoned
       | false ->
-        match f (Password.unsafe_mk t.name) with
+        let pw : k Password.t = Password.unsafe_mk () in
+        match f pw with
         | x -> M.unlock t.mutex; x
         | exception exn ->
-          t.poisoned <- true;
-          (* NOTE: [unlock] does not poll for asynchronous exceptions *)
-          M.unlock t.mutex;
           let exn =
             match exn with
-            | Encapsulated (name, data) ->
-              (match Name.equality_witness name t.name with
+            | Encapsulated (id, data) ->
+              (match Password.Id.equality_witness (Password.id pw) id with
+               | Some Equal -> Data.unsafe_get data
+               | None -> exn)
+            | Encapsulated_shared (id, data) ->
+              (match Password.Id.equality_witness (Password.id pw) id with
                | Some Equal -> Data.unsafe_get data
                | None -> exn)
             | _ -> exn
           in
-          reraise exn
+          t.poisoned <- true;
+          M.unlock t.mutex;
+          raise exn
 
   let[@inline] destroy t =
     M.lock t.mutex;
     match t.poisoned with
     | true ->
       M.unlock t.mutex;
-      reraise Poisoned
+      raise Poisoned
     | false ->
       t.poisoned <- true;
       M.unlock t.mutex;
-      Access.unsafe_mk ()
+      Key.unsafe_mk ()
 end
 
 module Rwlock = struct
+  type state = Open | Frozen | Poisoned
 
   type 'k t : value mod portable contended =
-    { name : 'k Name.t
-    ; rwlock : Rw.t
-    ; mutable poisoned : bool
+    { rwlock : Rw.t
+    ; mutable state : state
     }
   [@@unsafe_allow_any_mode_crossing]
 
@@ -366,6 +640,9 @@ module Rwlock = struct
     "CR layouts v2.8: This can go away once we have proper mode crossing \
      inference for GADT constructors "]
 
+  let[@inline] create _ = { rwlock = Rw.create (); state = Open }
+
+  exception Frozen
   exception Poisoned
 
   let[@inline] with_write_lock :
@@ -376,56 +653,90 @@ module Rwlock = struct
     @@ portable
     = fun t f ->
       Rw.lock_write t.rwlock;
-      match t.poisoned with
-      | true -> Rw.unlock t.rwlock; reraise Poisoned
-      | false ->
-        match f (Password.unsafe_mk t.name) with
+      match t.state with
+      | Poisoned -> Rw.unlock t.rwlock; raise Poisoned
+      | Frozen -> Rw.unlock t.rwlock; raise Frozen
+      | Open ->
+        let pw : k Password.t = Password.unsafe_mk () in
+        match f pw with
         | x -> Rw.unlock t.rwlock; x
         | exception exn ->
-          t.poisoned <- true;
-          Rw.unlock t.rwlock;
           let exn =
             match exn with
-            | Encapsulated (name, data) ->
-              (match Name.equality_witness name t.name with
+            | Encapsulated (id, data) ->
+              (match Password.Id.equality_witness (Password.id pw) id with
+               | Some Equal -> Data.unsafe_get data
+               | None -> exn)
+            | Encapsulated_shared (id, data) ->
+              (match Password.Id.equality_witness (Password.id pw) id with
                | Some Equal -> Data.unsafe_get data
                | None -> exn)
             | _ -> exn
           in
-          reraise exn
+          Rw.unlock t.rwlock;
+          t.state <- Poisoned;
+          raise exn
 
   let[@inline] with_read_lock :
-    'k t
-    -> ('k Password.Shared.t @ local -> 'a) @ local
+    type k.
+    k t
+    -> (k Password.Shared.t @ local -> 'a) @ local
     -> 'a
     @@ portable
     = fun t f ->
       Rw.lock_read t.rwlock;
-      match t.poisoned with
-      | true -> Rw.unlock t.rwlock; reraise Poisoned
-      | false ->
-        match f (Password.Shared.unsafe_mk t.name) with
+      match t.state with
+      | Poisoned -> Rw.unlock t.rwlock; raise Poisoned
+      | Open | Frozen ->
+        let pw : k Password.Shared.t = Password.Shared.unsafe_mk () in
+        match f pw with
         | x -> Rw.unlock t.rwlock; x
         | exception exn ->
-          (* Here we are not poisoning the RwLock, see [capsule.mli] for explanation *)
+          let exn =
+            match exn with
+            | Encapsulated_shared (id, data) ->
+              (match Password.Id.equality_witness (Password.Shared.id pw) id with
+               | Some Equal -> Data.unsafe_get data
+               | None -> exn)
+            | _ -> exn
+          in
+          (* This racy write is ok according to the memory model, because:
+             1. All threads which race to write here are writing [Frozen],
+                and the only other write to this field in the program was
+                the initial write setting it to [Open].
+             2. All threads which race to read here do not distinguish between
+                [Open] and [Frozen].
+             All operations that distinguish between [Open] and [Frozen]
+             are protected by the write lock. *)
+          t.state <- Frozen;
           Rw.unlock t.rwlock;
-          reraise exn
+          raise exn
+
+  let[@inline] freeze t =
+    Rw.lock_write t.rwlock;
+    match t.state with
+    | Poisoned -> raise Poisoned
+    | Open | Frozen ->
+      t.state <- Frozen;
+      Rw.unlock t.rwlock;
+      Key.unsafe_mk ()
 
   let[@inline] destroy t =
     Rw.lock_write t.rwlock;
-    match t.poisoned with
-    | true ->
+    match t.state with
+    | Poisoned ->
       Rw.unlock t.rwlock;
-      reraise Poisoned
-    | false ->
-      t.poisoned <- true;
+      raise Poisoned
+    | Frozen ->
       Rw.unlock t.rwlock;
-      Access.unsafe_mk ()
-
+      raise Frozen
+    | Open ->
+      t.state <- Poisoned;
+      Rw.unlock t.rwlock;
+      Key.unsafe_mk ()
 end
 
 module Condition = struct
-
   type 'k t : value mod portable contended
 
   external create : unit -> 'k t @@ portable = "caml_capsule_condition_new"
@@ -436,25 +747,4 @@ module Condition = struct
   let[@inline] wait t (mut : 'k Mutex.t) _password =
     (* [mut] is locked, so we know it is not poisoned. *)
     wait t mut.mutex
-
 end
-
-let[@inline] create_with_mutex () =
-  let (P name) = Name.make () in
-  Mutex.P { name; mutex = M.create (); poisoned = false }
-
-let[@inline] create_with_rwlock () =
-  let (P name) = Name.make () in
-  Rwlock.P { name; rwlock = Rw.create (); poisoned = false }
-
-let[@inline] with_password_local f = exclave_
-  let (P name) = Name.make () in
-  let password = Password.unsafe_mk name in
-  try f (Password.P password) with
-  | Encapsulated (inner, data) as exn ->
-    (match Name.equality_witness name inner with
-     | Some Equal -> reraise (Data.unsafe_get data)
-     | None -> reraise exn)
-  | exn -> reraise exn
-
-let[@inline] with_password f = (with_password_local (fun password -> { global = f password })).global

--- a/testsuite/tests/capsule-api/basics.ml
+++ b/testsuite/tests/capsule-api/basics.ml
@@ -26,8 +26,9 @@ module Cell = struct
     | Mk : 'k Capsule.Mutex.t * ('a myref, 'k) Capsule.Data.t -> 'a t
 
   let create (type a : value mod portable contended) (x : a) : a t =
-    let (P m) = Capsule.create_with_mutex () in
-    let p = Capsule.Data.create (fun () -> {v = x})  in
+    let (P k) = Capsule.create () in
+    let m = Capsule.Mutex.create k in
+    let p = Capsule.Data.create (fun () -> {v = x}) in
     Mk (m, p)
 
   let read (type a : value mod portable contended) (t : a t) : a =

--- a/testsuite/tests/capsule-api/condition.ml
+++ b/testsuite/tests/capsule-api/condition.ml
@@ -15,7 +15,8 @@ external ( ! ) : 'a ref -> 'a @@ portable = "%field0"
 external ( := ) : 'a ref -> 'a -> unit @@ portable = "%setfield0"
 
 let () = (* Signal *)
-  let (P mut) = Capsule.create_with_mutex () in
+  let (P k) = Capsule.create () in
+  let mut = Capsule.Mutex.create k in
   let cond = Capsule.Condition.create () in
   let go = Capsule.Data.create (fun () -> ref true) in
   let wait = Atomic.make true in
@@ -34,7 +35,8 @@ let () = (* Signal *)
 ;;
 
 let () = (* Broadcast *)
-  let (P mut) = Capsule.create_with_mutex () in
+  let (P k) = Capsule.create () in
+  let mut = Capsule.Mutex.create k in
   let cond = Capsule.Condition.create () in
   let go = Capsule.Data.create (fun () -> ref true) in
   let ready = Atomic.make 0 in

--- a/testsuite/tests/capsule-api/key.ml
+++ b/testsuite/tests/capsule-api/key.ml
@@ -1,0 +1,170 @@
+(* TEST
+ include stdlib_alpha;
+ flags = "-extension-universe alpha";
+ { bytecode; }
+ { native; }
+*)
+
+module Capsule = Stdlib_alpha.Capsule
+
+external ( = ) : 'a @ local shared -> 'a @ local shared -> bool @@ portable = "%equal"
+
+external ref : 'a -> 'a ref @@ portable = "%makemutable"
+external ( ! ) : 'a ref -> 'a @@ portable = "%field0"
+external ( := ) : 'a ref -> 'a -> unit @@ portable = "%setfield0"
+
+external raise : exn -> 'a @ portable unique @@ portable = "%reraise"
+
+type 'a aliased = Aliased of 'a @@ aliased [@@unboxed]
+
+
+
+let () =
+  (* [Capsule.create] creates a new capsule with an unique key. *)
+  let packed : Capsule.Key.packed @@ unique = Capsule.create () in
+  let (P k) = packed in
+  (* [Capsule.Key.access] *)
+  let Aliased x, k =
+    Capsule.Key.access k (fun a ->
+      Aliased (Capsule.Data.wrap a (ref "Hello world!")))
+  in
+  (* [Capsule.Key.with_password] *)
+  let (), k =
+    Capsule.Key.with_password k (fun p ->
+      Capsule.Data.iter p (fun s -> assert (!s = "Hello world!")) x)
+  in
+  ()
+;;
+
+let () =
+  let (P k) = Capsule.create () in
+  let Aliased x, k =
+    Capsule.Key.access k (fun a ->
+      Aliased (Capsule.Data.wrap a (ref "My value")))
+  in
+  (* [Capsule.Mutex.create] takes the key. *)
+  let m = Capsule.Mutex.create k in
+  let () = Capsule.Mutex.with_lock m (fun p ->
+    Capsule.Data.iter p (fun s -> s := "Another value") x)
+  in
+  (* [Capsule.Mutex.destroy] returns the key. *)
+  let k = Capsule.Mutex.destroy m in
+  (* [Capsule.Key.destroy] merges the capsule into the current one. *)
+  let a = Capsule.Key.destroy k in
+  assert (!(Capsule.Data.unwrap a x) = "Another value")
+;;
+
+let () =
+  let exception E of string in
+  let (P k) = Capsule.create () in
+  (* On exception, it is re-raised and the key is destroyed.*)
+  try
+    let (), _k = Capsule.Key.access k (fun _ -> raise (E "Exception!")) in ()
+  with E s -> assert (s = "Exception!")
+;;
+
+let () =
+  let exception F of int in
+  let (P k) = Capsule.create () in
+  (* Encapsulated exceptions from inside [with_password] are unwrapped. *)
+  try
+    let (), _k = Capsule.Key.with_password k (fun p ->
+      let () = Capsule.access p (fun _ -> raise (F 1)) in ())
+    in ()
+  with F n -> assert (n = 1)
+;;
+
+let () =
+  let (P k) = Capsule.create () in
+  (* [with_password_local] destroys the key but returns a local value. *)
+  let x, p = Capsule.Key.with_password_local k (fun p ->
+    exclave_ (Capsule.access_local p (fun a ->
+      Capsule.Data.wrap a (ref "Local value")), p))
+  in
+  (* We can still access the data through the password. *)
+  let s =
+    Capsule.Data.Local.extract p
+      (fun x -> (x.contents : string @@ portable)) x
+  in
+  assert (s = "Local value")
+;;
+
+let () =
+  let exception E of string in
+  let (P k) = Capsule.create () in
+  (* On exception, it is re-raised and the key is destroyed. *)
+  try
+    Capsule.Key.with_password_local k (fun _ -> raise (E "Exception!"))
+  with E s -> assert (s = "Exception!")
+;;
+
+let () =
+  let exception F of int in
+  let (P k) = Capsule.create () in
+  (* Encapsulated exceptions from inside [with_password_local] are unwrapped. *)
+  try
+    Capsule.Key.with_password_local k (fun (type k) (p : k Capsule.Password.t) ->
+      (Capsule.access_local p (fun _ -> raise (F 2))[@nontail] : unit))
+  with F n -> assert (n = 2)
+;;
+
+let () =
+  let (P k) @ aliased = Capsule.create () in
+  (* Read-only access to the capsule. *)
+  let x = Capsule.Data.create (fun () -> "Shared value") in
+  (* Requires the type to be portable. *)
+  Capsule.Key.with_password_shared k (fun p ->
+    Capsule.Data.extract_shared p (fun s ->
+      assert (s = "Shared value")) x)
+;;
+
+let () =
+  let exception E of string in
+  let (P k) = Capsule.create () in
+  (* Exceptiosn are re-raised as is. *)
+  try
+    Capsule.Key.access_shared k (fun _ -> raise (E "Exception with access_shared"))
+  with E s -> assert (s = "Exception with access_shared")
+;;
+
+let () =
+  let exception E of string in
+  let (P k) = Capsule.create () in
+  (* Exceptiosn are re-raised as is. *)
+  try
+    Capsule.Key.with_password_shared k (fun _ ->
+      raise (E "Exception with with_password_shared"))
+  with E s -> assert (s = "Exception with with_password_shared")
+;;
+
+let () =
+  let exception E of string in
+  let (P k) = Capsule.create () in
+  (* Exceptiosn are re-raised as is. *)
+  try
+    Capsule.Key.with_password_shared_local k (fun _ ->
+      raise (E "Exception with with_password_shared_local"))
+  with E s -> assert (s = "Exception with with_password_shared_local")
+;;
+
+let () =
+  let exception F of int in
+  let (P k) = Capsule.create () in
+  (* Encapsulated exceptions from inside [with_password_shared] are unwrapped. *)
+  try
+    Capsule.Key.with_password_shared k
+      (fun (type k) (p : k Capsule.Password.Shared.t) ->
+        (Capsule.access_shared p (fun _ -> raise (F 2)) : unit))
+  with F n -> assert (n = 2)
+;;
+
+let () =
+  let exception F of int in
+  let (P k) = Capsule.create () in
+  (* Encapsulated exceptions from inside [with_password_shared_local] are unwrapped. *) 
+  try
+    Capsule.Key.with_password_shared_local k
+      (fun (type k) (p : k Capsule.Password.Shared.t) ->
+        (Capsule.access_shared_local p (fun _ -> raise (F 2)) : unit))
+  with F n -> assert (n = 2)
+;;

--- a/testsuite/tests/capsule-api/poisoning.ml
+++ b/testsuite/tests/capsule-api/poisoning.ml
@@ -7,7 +7,10 @@
 
 module Capsule = Stdlib_alpha.Capsule
 
-let m = Capsule.create_with_mutex ()
+let m = 
+  let (P k) = Capsule.create () in
+  Capsule.Mutex.P (Capsule.Mutex.create k)
+;;
 
 (* Normal execution. *)
 let () =
@@ -56,7 +59,10 @@ let () =
 ;;
 
 (* Reset *)
-let m = Capsule.create_with_mutex ()
+let m =
+  let (P k) = Capsule.create () in
+  Capsule.Mutex.P (Capsule.Mutex.create k)
+;;
 
 let () =
   let x = ref 1 in
@@ -67,10 +73,10 @@ let () =
   assert (!x = 2)
 ;;
 
-(* Destroying the mutex leaks a converter. *)
+(* Destroying the mutex leaks a key. *)
 let () =
   let (P m) = m in
-  let _k : _ Capsule.Access.t = Capsule.Mutex.destroy m in
+  let _k : _ Capsule.Key.t= Capsule.Mutex.destroy m in
   ()
 ;;
 

--- a/testsuite/tests/capsule-api/shared.ml
+++ b/testsuite/tests/capsule-api/shared.ml
@@ -1,0 +1,116 @@
+(* TEST
+ include stdlib_alpha;
+ flags = "-extension-universe alpha";
+ runtime5;
+ { bytecode; }
+ { native; }
+*)
+
+module Capsule = Stdlib_alpha.Capsule
+module Data = Capsule.Data
+
+external ( = ) : 'a -> 'a -> bool @@ portable = "%eq"
+external ( + ) : int -> int -> int @@ portable = "%addint"
+external ( * ) : int -> int -> int @@ portable = "%mulint"
+
+external reraise : exn -> 'a @ portable = "%reraise"
+
+type 'a myref = { mutable v : 'a }
+
+let mk_ref : ('a -> 'a myref) @@ portable = fun v -> {v}
+let read_ref : ('a : value mod portable) .
+  ('a myref -> 'a @ portable contended) @@ portable = fun r -> r.v
+let write_ref : ('a : value mod portable contended) .
+  'a -> ('a myref -> unit) @ portable = fun v r -> r.v <- v
+
+type 'a guarded =
+  | Mk : 'k Capsule.Rwlock.t * ('a, 'k) Data.Shared.t -> 'a guarded
+
+let with_guarded (Mk (rw, p)) (f : 'k . 'k Capsule.Password.Shared.t @ local -> ('a, 'k) Data.Shared.t -> 'b) =
+  Capsule.Rwlock.with_read_lock rw (fun k -> f k p)
+
+(* Create a reference in Data.Shared *)
+let ptr =
+  let Capsule.Key.P brand = Capsule.create () in
+  let rw = Capsule.Rwlock.create brand in
+  Mk (rw, Data.Shared.create (fun () -> mk_ref 42))
+
+(* Extract a value. *)
+let () =
+  with_guarded ptr (fun k p ->
+    assert (Data.Shared.extract k read_ref p = 42))
+
+(* Create another pointer. *)
+let ptr' =
+  let (Mk (rw, _)) = ptr in
+  Mk (rw, Data.Shared.create (fun () -> mk_ref 10))
+
+(* Write via iter, then read via extract. *)
+let () =
+  with_guarded ptr' (fun k p ->
+    Data.Shared.iter k (write_ref 25) p)
+
+let () =
+  with_guarded ptr' (fun k p ->
+    assert (Data.Shared.extract k read_ref p = 25))
+
+(* Test [map]. *)
+let ptr2 =
+  let (Mk (rw, p)) = ptr in
+  let p' =
+    Capsule.Rwlock.with_read_lock rw
+      (fun k -> Data.Shared.map k (fun _ -> mk_ref 3) p)
+  in
+  Mk (rw, p')
+
+(* Test [both], [fst], [snd]. *)
+let () =
+  let (Mk (rw, p)) = ptr' in
+  with_guarded (Mk (rw, p)) (fun k ptr_left ->
+    let ptr_right = Data.Shared.create (fun () -> mk_ref 999) in
+    let both_ptr = Data.Shared.both ptr_left ptr_right in
+    let left_part = Data.Shared.fst both_ptr in
+    let right_part = Data.Shared.snd both_ptr in
+    Data.Shared.iter k (fun l -> assert (l.v = 25)) left_part;
+    Data.Shared.iter k (fun r -> assert (r.v = 999)) right_part)
+
+(* Test [inject], [project]. *)
+let () =
+  let i = Data.Shared.inject 123 in
+  assert (Data.Shared.project i = 123);
+  let both_ = Data.Shared.both i i in
+  assert (Data.Shared.project (Data.Shared.fst both_) = 123);
+  assert (Data.Shared.project (Data.Shared.snd both_) = 123)
+
+(* Test [bind]. *)
+let bind_test =
+  let Capsule.Key.P brand = Capsule.create () in
+  let rw = Capsule.Rwlock.create brand in
+  Mk (rw, Data.Shared.inject 7)
+
+let () =
+  with_guarded bind_test (fun k p ->
+    let p2 =
+      Data.Shared.bind k (fun x -> Data.Shared.inject (x * 10)) p
+    in
+    assert (Data.Shared.project p2 = 70))
+
+(* Ensure that the Rwlock is frozen on exceptions. *)
+exception E
+
+let poison_test =
+  let Capsule.Key.P brand = Capsule.create () in
+  let rw = Capsule.Rwlock.create brand in
+  Mk (rw, Data.Shared.inject ())
+
+let () =
+  match with_guarded poison_test (fun _ _ -> raise E) with
+  | exception E -> () (* Original exception *)
+  | _ -> assert false
+
+(* Verify Rwlock is now frozen. *)
+let () =
+  let (Mk (rw, _)) = poison_test in
+  match Capsule.Rwlock.with_write_lock rw (fun k -> ()) with
+  | exception Capsule.Rwlock.Frozen -> ()
+  | _ -> assert false


### PR DESCRIPTION
Basic Capsule Key API.

Adds `'k Key.t`, a ghost type representing the ownership of a capsule `'k`. Keys can be converted to passwords or accesses using `with_password` and `access`. Exceptions raised from those are unwrapped to the original, destroying the key in process.

Mutexes and rw-locks are now created using keys and leak keys on destruction.

Shared keys are not implemented yet, pending discussion how to deal with exceptions.