### PR TITLE
Emit atomic compare and exchange

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -37,6 +37,16 @@ let pseudoregs_for_operation op arg res =
     let arg = Array.copy arg in
     arg.(0) <- rax;
     arg, res
+  | Intop_atomic { op = Compare_exchange; size = _; addr = _ } ->
+    (* first arg must be rax, res.(0) must be rax. *)
+    let arg = Array.copy arg in
+    arg.(0) <- rax;
+    arg, [| rax |]
+  | Intop_atomic { op = Exchange; size = _; addr = _ } ->
+    (* first arg must be the same as res.(0) *)
+    let arg = Array.copy arg in
+    arg.(0) <- res.(0);
+    arg, res
   | Intop_atomic { op = Fetch_and_add; size = _; addr = _ } ->
     (* first arg must be the same as res.(0) *)
     let arg = Array.copy arg in

--- a/backend/amd64/emit.mlp
+++ b/backend/amd64/emit.mlp
@@ -982,19 +982,44 @@ let emit_push_trap_label handler =
 (* Emit Code *)
 
 let emit_atomic instr op (size : Cmm.atomic_bitwidth) addr =
-  let src, dst = match op, size with
-  | Fetch_and_add, Thirtytwo -> arg32 instr 0, addressing addr DWORD instr 1
-  | Fetch_and_add, (Sixtyfour|Word) -> arg instr 0, addressing addr QWORD instr 1
-  | Compare_and_swap, Thirtytwo -> arg32 instr 1, addressing addr DWORD instr 2
-  | Compare_and_swap, (Sixtyfour|Word) -> arg instr 1, addressing addr QWORD instr 2 in
+  let first_memory_arg_index =
+    match op with
+    | Compare_and_swap -> 2
+    | Fetch_and_add -> 1
+    | Exchange -> 1
+    | Compare_exchange -> 2
+  in
+  let dst =
+    addressing addr DWORD instr first_memory_arg_index
+  in
+  let src_index = first_memory_arg_index - 1 in
+  let typ, src =
+    match size with
+    | Thirtytwo -> DWORD, arg32 instr src_index
+    | (Sixtyfour|Word) -> QWORD, arg instr src_index
+  in
   match op with
-  | Fetch_and_add -> I.lock_xadd src dst
+  | Fetch_and_add ->
+    assert (Reg.same_loc instr.res.(0) instr.arg.(0));
+    I.lock_xadd src dst
   | Compare_and_swap ->
     (* compare_with is already in rax, set_to is src *)
+    assert (Reg.is_reg instr.arg.(1));
+    assert (Reg.same_loc instr.arg.(0) phys_rax);
     let res8, res = res8 instr 0, res instr 0 in
     I.lock_cmpxchg src dst;
     I.set E res8;
     I.movzx res8 res
+  | Compare_exchange ->
+    (* compare_with is already in rax, set_to is src, res in rax *)
+    assert (Reg.is_reg instr.arg.(1));
+    assert (Reg.same_loc instr.arg.(0) phys_rax);
+    assert (Reg.same_loc instr.res.(0) phys_rax);
+    I.lock_cmpxchg src dst
+  | Exchange ->
+    (* no need for a "lock" prefix for XCHG with a memory operand *)
+    assert (Reg.is_reg instr.arg.(0));
+    I.xchg src dst
 
 let emit_reinterpret_cast (cast : Cmm.reinterpret_cast) i =
   let distinct = not (Reg.same_loc i.arg.(0) i.res.(0)) in

--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -31,6 +31,16 @@ let pseudoregs_for_operation op arg res =
     let arg = Array.copy arg in
     arg.(0) <- rax;
     arg, res
+  | Iintop_atomic { op = Compare_exchange; size = _; addr = _ } ->
+    (* first arg must be rax, res.(0) must be rax. *)
+    let arg = Array.copy arg in
+    arg.(0) <- rax;
+    arg, [| rax |]
+  | Iintop_atomic { op = Exchange; size = _; addr = _ } ->
+    (* first arg must be the same as res.(0) *)
+    let arg = Array.copy arg in
+    arg.(0) <- res.(0);
+    arg, res
   | Iintop_atomic { op = Fetch_and_add; size = _; addr = _ } ->
     (* first arg must be the same as res.(0) *)
     let arg = Array.copy arg in

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -1014,7 +1014,11 @@ end = struct
                 }
             in
             let first_memory_arg_index =
-              match op with Compare_and_swap -> 2 | Fetch_and_add -> 1
+              match op with
+              | Compare_and_swap -> 2
+              | Fetch_and_add -> 1
+              | Exchange -> 1
+              | Compare_exchange -> 2
             in
             create ~first_memory_arg_index desc
           | Specific s -> Vectorize_specific.memory_access s

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -282,7 +282,26 @@ class virtual selector_generic =
           in
           let addr, eloc = self#select_addressing dst_size dst in
           ( basic_op (Intop_atomic { op = Compare_and_swap; size; addr }),
-            [compare_with; set_to; eloc] ))
+            [compare_with; set_to; eloc] )
+        | Compare_exchange ->
+          let compare_with, set_to, dst = three_args () in
+          let dst_size =
+            match size with
+            | Word | Sixtyfour -> Word_int
+            | Thirtytwo -> Thirtytwo_signed
+          in
+          let addr, eloc = self#select_addressing dst_size dst in
+          ( basic_op (Intop_atomic { op = Compare_exchange; size; addr }),
+            [compare_with; set_to; eloc] )
+        | Exchange ->
+          let src, dst = two_args () in
+          let dst_size =
+            match size with
+            | Word | Sixtyfour -> Word_int
+            | Thirtytwo -> Thirtytwo_signed
+          in
+          let addr, eloc = self#select_addressing dst_size dst in
+          basic_op (Intop_atomic { op = Exchange; size; addr }), [src; eloc])
       | Cprobe { name; handler_code_sym; enabled_at_init } ->
         ( Terminator
             (Prim

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -156,7 +156,7 @@ type rec_flag = Nonrecursive | Recursive
 
 type prefetch_temporal_locality_hint = Nonlocal | Low | Moderate | High
 
-type atomic_op = Fetch_and_add | Compare_and_swap
+type atomic_op = Fetch_and_add | Compare_and_swap | Exchange | Compare_exchange
 
 type atomic_bitwidth = Thirtytwo | Sixtyfour | Word
 

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -111,7 +111,7 @@ type rec_flag = Nonrecursive | Recursive
 
 type prefetch_temporal_locality_hint = Nonlocal | Low | Moderate | High
 
-type atomic_op = Fetch_and_add | Compare_and_swap
+type atomic_op = Fetch_and_add | Compare_and_swap | Exchange | Compare_exchange
 
 type atomic_bitwidth = Thirtytwo | Sixtyfour | Word
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4183,7 +4183,8 @@ let atomic_exchange ~dbg (_ : Lambda.immediate_or_pointer) atomic new_value =
 let atomic_fetch_and_add ~dbg atomic i =
   let op = Catomic { op = Fetch_and_add; size = Word } in
   if Proc.operation_supported op
-  then Cop (op, [add_const i (-1) dbg; atomic], dbg)
+  then (* addition of tagged integers *)
+    Cop (op, [decr_int i dbg; atomic], dbg)
   else
     Cop
       ( Cextcall

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4165,7 +4165,7 @@ let atomic_load ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) atomic =
   in
   Cop (mk_load_atomic memory_chunk, [atomic], dbg)
 
-let atomic_exchange ~dbg (_ : Lambda.immediate_or_pointer) atomic new_value =
+let atomic_exchange_extcall ~dbg atomic ~new_value =
   Cop
     ( Cextcall
         { func = "caml_atomic_exchange";
@@ -4179,6 +4179,16 @@ let atomic_exchange ~dbg (_ : Lambda.immediate_or_pointer) atomic new_value =
         },
       [atomic; new_value],
       dbg )
+
+let atomic_exchange ~dbg (imm_or_ptr : Lambda.immediate_or_pointer) atomic
+    ~new_value =
+  match imm_or_ptr with
+  | Immediate ->
+    let op = Catomic { op = Exchange; size = Word } in
+    if Proc.operation_supported op
+    then Cop (op, [new_value; atomic], dbg)
+    else atomic_exchange_extcall ~dbg atomic ~new_value
+  | Pointer -> atomic_exchange_extcall ~dbg atomic ~new_value
 
 let atomic_fetch_and_add ~dbg atomic i =
   let op = Catomic { op = Fetch_and_add; size = Word } in
@@ -4229,8 +4239,7 @@ let atomic_compare_and_set ~dbg (imm_or_ptr : Lambda.immediate_or_pointer)
     else atomic_compare_and_set_extcall ~dbg atomic ~old_value ~new_value
   | Pointer -> atomic_compare_and_set_extcall ~dbg atomic ~old_value ~new_value
 
-let atomic_compare_exchange ~dbg (_ : Lambda.immediate_or_pointer) atomic
-    ~old_value ~new_value =
+let atomic_compare_exchange_extcall ~dbg atomic ~old_value ~new_value =
   Cop
     ( Cextcall
         { func = "caml_atomic_compare_exchange";
@@ -4244,6 +4253,16 @@ let atomic_compare_exchange ~dbg (_ : Lambda.immediate_or_pointer) atomic
         },
       [atomic; old_value; new_value],
       dbg )
+
+let atomic_compare_exchange ~dbg (_ : Lambda.immediate_or_pointer) atomic
+    ~old_value ~new_value =
+  match imm_or_ptr with
+  | Immediate ->
+    let op = Catomic { op = Compare_exchange; size = Word } in
+    if Proc.operation_supported op
+    then Cop (op, [old_value; new_value; atomic], dbg)
+    else atomic_compare_exchange_extcall ~dbg atomic ~old_value ~new_value
+  | Pointer -> atomic_compare_exchange_extcall ~dbg atomic ~old_value ~new_value
 
 type even_or_odd =
   | Even

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4254,8 +4254,8 @@ let atomic_compare_exchange_extcall ~dbg atomic ~old_value ~new_value =
       [atomic; old_value; new_value],
       dbg )
 
-let atomic_compare_exchange ~dbg (_ : Lambda.immediate_or_pointer) atomic
-    ~old_value ~new_value =
+let atomic_compare_exchange ~dbg (imm_or_ptr : Lambda.immediate_or_pointer)
+    atomic ~old_value ~new_value =
   match imm_or_ptr with
   | Immediate ->
     let op = Catomic { op = Compare_exchange; size = Word } in

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1003,7 +1003,7 @@ val atomic_exchange :
   dbg:Debuginfo.t ->
   Lambda.immediate_or_pointer ->
   expression ->
-  expression ->
+  new_value:expression ->
   expression
 
 val atomic_fetch_and_add :

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -123,9 +123,6 @@ let intcomp (comp : Simple_operation.integer_comparison) =
   | Isigned c -> Printf.sprintf " %ss " (Printcmm.integer_comparison c)
   | Iunsigned c -> Printf.sprintf " %su " (Printcmm.integer_comparison c)
 
-let intop_atomic (op : Cmm.atomic_op) =
-  match op with Fetch_and_add -> " += " | Compare_and_swap -> " cas "
-
 let intop (op : Simple_operation.integer_operation) =
   match op with
   | Iadd -> " + "
@@ -173,7 +170,7 @@ let dump ppf op =
   | Intop op -> Format.fprintf ppf "intop %s" (intop op)
   | Intop_imm (op, n) -> Format.fprintf ppf "intop %s %d" (intop op) n
   | Intop_atomic { op; size = _; addr = _ } ->
-    Format.fprintf ppf "intop atomic %s" (intop_atomic op)
+    Format.fprintf ppf "intop atomic %s" (Printcmm.atomic_op op)
   | Floatop (Float64, op) -> Format.fprintf ppf "floatop %a" floatop op
   | Floatop (Float32, op) -> Format.fprintf ppf "float32op %a" floatop op
   | Csel _ -> Format.fprintf ppf "csel"

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -133,6 +133,8 @@ let temporal_locality = function
 let atomic_op = function
   | Fetch_and_add -> "fetch_and_add"
   | Compare_and_swap -> "compare_and_swap"
+  | Exchange -> "exchange"
+  | Compare_exchange -> "compare_exchange"
 
 let phantom_defining_expr ppf defining_expr =
   match defining_expr with

--- a/backend/printcmm.mli
+++ b/backend/printcmm.mli
@@ -27,6 +27,7 @@ val integer_comparison : Cmm.integer_comparison -> string
 val float_comparison : Cmm.float_comparison -> string
 val trap_action_list : formatter -> Cmm.trap_action list -> unit
 val chunk : Cmm.memory_chunk -> string
+val atomic_op : Cmm.atomic_op -> string
 val atomic_bitwidth : Cmm.atomic_bitwidth -> string
 val operation : Debuginfo.t -> Cmm.operation -> string
 val expression : formatter -> Cmm.expression -> unit

--- a/backend/printmach.ml
+++ b/backend/printmach.ml
@@ -97,6 +97,16 @@ let operation' ?(print_reg = Printreg.reg) op arg ppf res =
       (Printcmm.atomic_bitwidth size)
       (Arch.print_addressing reg addr) (Array.sub arg 2 (Array.length arg - 2))
       reg arg.(0) reg arg.(1)
+  | Iintop_atomic {op = Compare_exchange; size; addr} ->
+    fprintf ppf "lock compare_exchange %s[%a] ?%a %a"
+      (Printcmm.atomic_bitwidth size)
+      (Arch.print_addressing reg addr) (Array.sub arg 2 (Array.length arg - 2))
+      reg arg.(0) reg arg.(1)
+  | Iintop_atomic {op = Exchange; size; addr} ->
+    fprintf ppf "lock exchange %s[%a] %a"
+      (Printcmm.atomic_bitwidth size)
+      (Arch.print_addressing reg addr) (Array.sub arg 1 (Array.length arg - 1))
+      reg arg.(0)
   | Iintop_atomic {op = Fetch_and_add; size; addr} ->
     fprintf ppf "lock %s[%a] += %a"
       (Printcmm.atomic_bitwidth size)

--- a/backend/printoperation.ml
+++ b/backend/printoperation.ml
@@ -67,6 +67,18 @@ let operation ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf res =
       (Arch.print_addressing reg addr)
       (Array.sub arg 1 (Array.length arg - 1))
       reg arg.(0)
+  | Intop_atomic { op = Compare_exchange; size; addr } ->
+    fprintf ppf "lock compare_exchange %s[%a] ?%a %a"
+      (Printcmm.atomic_bitwidth size)
+      (Arch.print_addressing reg addr)
+      (Array.sub arg 2 (Array.length arg - 2))
+      reg arg.(0) reg arg.(1)
+  | Intop_atomic { op = Exchange; size; addr } ->
+    fprintf ppf "lock exchange %s[%a] %a"
+      (Printcmm.atomic_bitwidth size)
+      (Arch.print_addressing reg addr)
+      (Array.sub arg 1 (Array.length arg - 1))
+      reg arg.(0)
   | Floatop (_, ((Icompf _ | Iaddf | Isubf | Imulf | Idivf) as op)) ->
     fprintf ppf "%a %a %a" reg arg.(0) Simple_operation.format_float_operation
       op reg arg.(1)

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -156,7 +156,10 @@ let oper_result_type = function
   | Cstore (_c, _) -> typ_void
   | Cdls_get -> typ_val
   | Cprefetch _ -> typ_void
-  | Catomic { op = Fetch_and_add | Compare_and_swap; _ } -> typ_int
+  | Catomic
+      { op = Fetch_and_add | Compare_and_swap | Exchange | Compare_exchange; _ }
+    ->
+    typ_int
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor | Cxor | Clsl
   | Clsr | Casr | Cclz _ | Cctz _ | Cpopcnt | Cbswap _ | Ccmpi _ | Ccmpa _
   | Ccmpf _ ->

--- a/backend/selectgen.ml
+++ b/backend/selectgen.ml
@@ -258,6 +258,23 @@ class virtual selector_generic =
         let addr, eloc = self#select_addressing dst_size dst in
         ( Iintop_atomic { op = Compare_and_swap; size; addr },
           [compare_with; set_to; eloc] )
+      | Catomic { op = Compare_exchange; size }, [compare_with; set_to; dst] ->
+        let dst_size =
+          match size with
+          | Word | Sixtyfour -> Word_int
+          | Thirtytwo -> Thirtytwo_signed
+        in
+        let addr, eloc = self#select_addressing dst_size dst in
+        ( Iintop_atomic { op = Compare_exchange; size; addr },
+          [compare_with; set_to; eloc] )
+      | Catomic { op = Exchange; size }, [src; dst] ->
+        let dst_size =
+          match size with
+          | Word | Sixtyfour -> Word_int
+          | Thirtytwo -> Thirtytwo_signed
+        in
+        let addr, eloc = self#select_addressing dst_size dst in
+        Iintop_atomic { op = Exchange; size; addr }, [src; eloc]
       | Cprobe { name; handler_code_sym; enabled_at_init }, _ ->
         Iprobe { name; handler_code_sym; enabled_at_init }, args
       | Cprobe_is_enabled { name }, _ -> Iprobe_is_enabled { name }, []

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -1017,7 +1017,7 @@ let binary_primitive env dbg f x y =
       | Any_value -> Pointer
       | Immediate -> Immediate
     in
-    C.atomic_exchange ~dbg imm_or_ptr x y
+    C.atomic_exchange ~dbg imm_or_ptr x ~new_value:y
   | Atomic_fetch_and_add -> C.atomic_fetch_and_add ~dbg x y
   | Poke kind ->
     let memory_chunk =


### PR DESCRIPTION
Follow up of https://github.com/ocaml-flambda/flambda-backend/pull/3477, emit instructions for `%atomic_compare_exchange` and `%atomic_exchange`  on immediates.