### PR TITLE
Support `-open Foo` where `Foo` is parameterised

### DIFF
--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -31,6 +31,7 @@ type compilation_unit_or_inferred =
 let with_info ~native ~tool_name ~source_file ~output_prefix
       ~compilation_unit ~dump_ext k =
   Compmisc.init_path ();
+  Compmisc.init_parameters ();
   let target = Unit_info.make ~source_file output_prefix in
   let compilation_unit =
     match compilation_unit with

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -55,6 +55,18 @@ let init_path ?(auto_include=auto_include) ?(dir="") () =
   Load_path.init ~auto_include ~visible ~hidden;
   Env.reset_cache ~preserve_persistent_env:false
 
+(* Read any [-parameters] flags. Important to do this before [initial_env ()]
+   because someone might [-open] a parameterised module *)
+let init_parameters () =
+  let param_names = !Clflags.parameters in
+  List.iter
+    (fun param_name ->
+        (* We don't (yet!) support parameterised parameters *)
+        let param = Global_module.Name.create_no_args param_name in
+        Env.register_parameter param
+    )
+    param_names
+
 (* Return the initial environment in which compilation proceeds. *)
 
 (* Note: do not do init_path() in initial_env, this breaks

--- a/driver/compmisc.mli
+++ b/driver/compmisc.mli
@@ -15,6 +15,7 @@
 
 val init_path :
   ?auto_include:Load_path.auto_include_callback -> ?dir:string -> unit -> unit
+val init_parameters : unit -> unit
 val initial_env : unit -> Env.t
 
 (* Support for flags that can also be set from an environment variable *)

--- a/testsuite/tests/templates/basic/main-ocamlobjinfo.reference
+++ b/testsuite/tests/templates/basic/main-ocamlobjinfo.reference
@@ -26,8 +26,8 @@ Runtime parameters:
 	Monoid_utils[Monoid:Monoid_of_semigroup]
 	Monoid_of_semigroup
 	Chain[Category:Category_of_monoid[Monoid:List_monoid]]
-	Import
 	Category_of_monoid[Monoid:List_monoid]
+	Import
 	List_element
 	List_monoid
 	Category_utils[Category:Category_of_monoid[Monoid:List_monoid]]

--- a/testsuite/tests/templates/basic/main.mli
+++ b/testsuite/tests/templates/basic/main.mli
@@ -1,5 +1,3 @@
-open Import
-
 val append3_semi
    : Semigroup.t option
   -> Semigroup.t option

--- a/testsuite/tests/templates/basic/test.ml
+++ b/testsuite/tests/templates/basic/test.ml
@@ -434,11 +434,11 @@
            ocamlc.byte;
 
            {
-             flags = "-parameter Semigroup -parameter List_element -w -misplaced-attribute";
+             flags = "-open Import -parameter Semigroup -parameter List_element -w -misplaced-attribute";
              module = "main.mli";
              ocamlc.byte;
              {
-               flags = "-parameter Semigroup -parameter List_element -w -misplaced-attribute -i";
+               flags = "-open Import -parameter Semigroup -parameter List_element -w -misplaced-attribute -i";
                module = "main.ml";
                compiler_output = "main.output";
                ocamlc.byte;
@@ -919,11 +919,11 @@
            ocamlopt.byte;
 
            {
-             flags = "-parameter Semigroup -parameter List_element -w -misplaced-attribute";
+             flags = "-open Import -parameter Semigroup -parameter List_element -w -misplaced-attribute";
              module = "main.mli";
              ocamlopt.byte;
              {
-               flags = "-parameter Semigroup -parameter List_element -w -misplaced-attribute -i";
+               flags = "-open Import -parameter Semigroup -parameter List_element -w -misplaced-attribute -i";
                module = "main.ml";
                compiler_output = "main.output";
                ocamlopt.byte;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3627,18 +3627,6 @@ let () =
   type_module_type_of_fwd := type_module_type_of
 
 
-(* File-level details *)
-
-let register_params params =
-  List.iter
-    (fun param_name ->
-       (* We don't (yet!) support parameterised parameters *)
-       let param = Global_module.Name.create_no_args param_name in
-       Env.register_parameter param
-    )
-    params
-
-
 (* Typecheck an implementation file *)
 
 let gen_annot target annots =
@@ -3725,7 +3713,6 @@ let type_implementation target modulename initial_env ast =
         ignore @@ Warnings.parse_options false "-32-34-37-38-60";
       if !Clflags.as_parameter then
         error Cannot_compile_implementation_as_parameter;
-      register_params !Clflags.parameters;
       let (str, sg, names, shape, finalenv) =
         Profile.record_call "infer" (fun () ->
           type_structure initial_env ast) in
@@ -3913,7 +3900,6 @@ let type_interface ~sourcefile modulename env ast =
   if !Clflags.as_parameter && !Clflags.parameters <> [] then begin
     error Compiling_as_parameterised_parameter
   end;
-  register_params !Clflags.parameters;
   if !Clflags.binary_annotations_cms then begin
     let uid = Shape.Uid.of_compilation_unit_id modulename in
     cms_register_toplevel_signature_attributes ~uid ~sourcefile ast


### PR DESCRIPTION
The command line

```
ocamlopt -open Foo -parameter P -c bar.ml
```

should be fine, even if `Foo` is itself parameterised by `P`: as usual, we compile `bar.ml` as if it began with `open! Foo`, and by the subset rule, `Bar` can refer to `Foo` because it takes at least the same parameters. Unfortunately, currently we process `-open` before `-parameter`, so when we go to check the implicit reference to `Foo`, we think there are no parameters, and we report an error. (Confusingly, the error suggests that the user add `-parameter P` to the command line.)

The fix is simple: move the code that processes `-parameter` earlier so that the initial environment is constructed with the parameters already available.