### PR TITLE
Builtin for [Atomic.set]

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -199,7 +199,7 @@ let preserve_tailcall_for_prim = function
   | Patomic_exchange _ | Patomic_compare_exchange _
   | Patomic_compare_set _ | Patomic_fetch_add | Patomic_add
   | Patomic_sub | Patomic_land | Patomic_lor
-  | Patomic_lxor | Patomic_load _
+  | Patomic_lxor | Patomic_load _ | Patomic_set _
   | Pdls_get | Preinterpret_tagged_int63_as_unboxed_int64
   | Preinterpret_unboxed_int64_as_tagged_int63 | Ppoll | Ppeek _ | Ppoke _ ->
       false
@@ -657,6 +657,7 @@ let comp_primitive stack_info p sz args =
   | Pget_header _ -> Kccall("caml_get_header", 1)
   | Pobj_dup -> Kccall("caml_obj_dup", 1)
   | Patomic_load _ -> Kccall("caml_atomic_load", 1)
+  | Patomic_set _
   | Patomic_exchange _ -> Kccall("caml_atomic_exchange", 2)
   | Patomic_compare_exchange _ -> Kccall("caml_atomic_compare_exchange", 3)
   | Patomic_compare_set _ -> Kccall("caml_atomic_compare_set", 3)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -311,6 +311,7 @@ type primitive =
   | Pint_as_pointer of locality_mode
   (* Atomic operations *)
   | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_set of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_exchange of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_compare_exchange of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_compare_set of {immediate_or_pointer : immediate_or_pointer}
@@ -1950,6 +1951,7 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Ppoll ->
     Some alloc_heap
   | Patomic_load _
+  | Patomic_set _
   | Patomic_exchange _
   | Patomic_compare_exchange _
   | Patomic_compare_set _
@@ -2126,7 +2128,7 @@ let primitive_can_raise prim =
   | Patomic_exchange _ | Patomic_compare_exchange _
   | Patomic_compare_set _ | Patomic_fetch_add | Patomic_add
   | Patomic_sub | Patomic_land | Patomic_lor
-  | Patomic_lxor | Patomic_load _ -> false
+  | Patomic_lxor | Patomic_load _ | Patomic_set _ -> false
   | Prunstack | Pperform | Presume | Preperform -> true (* XXX! *)
   | Pdls_get | Ppoll | Preinterpret_tagged_int63_as_unboxed_int64
   | Preinterpret_unboxed_int64_as_tagged_int63
@@ -2357,6 +2359,7 @@ let primitive_result_layout (p : primitive) =
   | Prunstack | Presume | Pperform | Preperform -> layout_any_value
   | Patomic_load { immediate_or_pointer = Immediate } -> layout_int
   | Patomic_load { immediate_or_pointer = Pointer } -> layout_any_value
+  | Patomic_set _ -> layout_unit
   | Patomic_exchange { immediate_or_pointer = Immediate } -> layout_int
   | Patomic_exchange { immediate_or_pointer = Pointer } -> layout_any_value
   | Patomic_compare_exchange { immediate_or_pointer = Immediate } -> layout_int

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -309,6 +309,7 @@ type primitive =
   | Pint_as_pointer of locality_mode
   (* Atomic operations *)
   | Patomic_load of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_set of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_exchange of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_compare_exchange of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_compare_set of {immediate_or_pointer : immediate_or_pointer}

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -913,6 +913,10 @@ let primitive ppf = function
       (match immediate_or_pointer with
         | Immediate -> fprintf ppf "atomic_load_imm"
         | Pointer -> fprintf ppf "atomic_load_ptr")
+  | Patomic_set {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> fprintf ppf "atomic_set_imm"
+        | Pointer -> fprintf ppf "atomic_set_ptr")
   | Patomic_exchange {immediate_or_pointer} ->
       (match immediate_or_pointer with
         | Immediate -> fprintf ppf "atomic_exchange_imm"
@@ -1109,6 +1113,10 @@ let name_of_primitive = function
       (match immediate_or_pointer with
         | Immediate -> "atomic_load_imm"
         | Pointer -> "atomic_load_ptr")
+  | Patomic_set {immediate_or_pointer} ->
+      (match immediate_or_pointer with
+        | Immediate -> "atomic_set_imm"
+        | Pointer -> "atomic_set_ptr")
   | Patomic_exchange {immediate_or_pointer} ->
       (match immediate_or_pointer with
         | Immediate -> "atomic_exchange_imm"

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -905,7 +905,7 @@ let rec choice ctx t =
     | Patomic_exchange _ | Patomic_compare_exchange _
     | Patomic_compare_set _ | Patomic_fetch_add
     | Patomic_add | Patomic_sub | Patomic_land
-    | Patomic_lor | Patomic_lxor | Patomic_load _
+    | Patomic_lor | Patomic_lxor | Patomic_load _ | Patomic_set _
     | Punbox_float _ | Pbox_float (_, _)
     | Punbox_int _ | Pbox_int _
     | Punbox_vector _ | Pbox_vector (_, _)

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -897,6 +897,8 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%get_header" -> Primitive (Pget_header mode, 1)
     | "%atomic_load" ->
         Primitive ((Patomic_load {immediate_or_pointer=Pointer}), 1)
+    | "%atomic_set" ->
+        Primitive (Patomic_set {immediate_or_pointer=Pointer}, 2)
     | "%atomic_exchange" ->
         Primitive (Patomic_exchange {immediate_or_pointer=Pointer}, 2)
     | "%atomic_compare_exchange" ->
@@ -1377,6 +1379,16 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
         | None -> Pointer
         | Some (_p1, rhs) -> maybe_pointer_type env rhs in
       Some (Primitive (Patomic_load {immediate_or_pointer = is_int}, arity))
+    end
+  | Primitive (Patomic_set { immediate_or_pointer = Pointer },
+               arity), [_; p2] -> begin
+      match maybe_pointer_type env p2 with
+      | Pointer -> None
+      | Immediate ->
+        Some
+          (Primitive
+             (Patomic_set
+                {immediate_or_pointer = Immediate}, arity))
     end
   | Primitive (Patomic_exchange { immediate_or_pointer = Pointer },
                arity), [_; p2] -> begin
@@ -1938,7 +1950,7 @@ let lambda_primitive_needs_event_after = function
   | Pprobe_is_enabled _
   | Patomic_exchange _ | Patomic_compare_exchange _
   | Patomic_compare_set _ | Patomic_fetch_add | Patomic_add | Patomic_sub
-  | Patomic_land | Patomic_lor | Patomic_lxor | Patomic_load _
+  | Patomic_land | Patomic_lor | Patomic_lxor | Patomic_load _ | Patomic_set _
   | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer _ | Popaque _
   | Pdls_get
   | Pobj_magic _ | Punbox_float _ | Punbox_int _ | Punbox_vector _

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -350,6 +350,7 @@ let compute_static_size lam =
     | Pbbswap _
     | Pint_as_pointer _
     | Patomic_load _
+    | Patomic_set _
     | Patomic_exchange _
     | Patomic_compare_exchange _
     | Patomic_compare_set _

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1049,7 +1049,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Patomic_exchange _ | Patomic_compare_exchange _ | Patomic_compare_set _
       | Patomic_fetch_add | Patomic_add | Patomic_sub | Patomic_land
       | Patomic_lor | Patomic_lxor | Pdls_get | Ppoll | Patomic_load _
-      | Preinterpret_tagged_int63_as_unboxed_int64
+      | Patomic_set _ | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _ ->
         (* Inconsistent with outer match *)
         assert false

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2382,6 +2382,11 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     [ Unary
         ( Atomic_load (convert_block_access_field_kind immediate_or_pointer),
           atomic ) ]
+  | Patomic_set { immediate_or_pointer }, [[atomic]; [new_value]] ->
+    [ Binary
+        ( Atomic_set (convert_block_access_field_kind immediate_or_pointer),
+          atomic,
+          new_value ) ]
   | Patomic_exchange { immediate_or_pointer }, [[atomic]; [new_value]] ->
     [ Binary
         ( Atomic_exchange (convert_block_access_field_kind immediate_or_pointer),
@@ -2507,8 +2512,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
             _,
             _ )
       | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
-      | Patomic_exchange _ | Patomic_fetch_add | Patomic_add | Patomic_sub
-      | Patomic_land | Patomic_lor | Patomic_lxor | Ppoke _ ),
+      | Patomic_exchange _ | Patomic_set _ | Patomic_fetch_add | Patomic_add
+      | Patomic_sub | Patomic_land | Patomic_lor | Patomic_lxor | Ppoke _ ),
       ( []
       | [_]
       | _ :: _ :: _ :: _

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -609,7 +609,8 @@ let binop env (op : Flambda_primitive.binary_primitive) : Fexpr.binop =
   | Float_comp (w, c) -> Infix (Float_comp (w, c))
   | String_or_bigstring_load (slv, saw) -> String_or_bigstring_load (slv, saw)
   | Bigarray_get_alignment align -> Bigarray_get_alignment align
-  | Bigarray_load _ | Atomic_exchange _ | Atomic_int_arith _ | Poke _ ->
+  | Bigarray_load _ | Atomic_exchange _ | Atomic_set _ | Atomic_int_arith _
+  | Poke _ ->
     Misc.fatal_errorf "TODO: Binary primitive: %a"
       Flambda_primitive.Without_args.print
       (Flambda_primitive.Without_args.Binary op)

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1011,6 +1011,12 @@ let simplify_bigarray_get_alignment _align ~original_prim dacc ~original_term
     (P.result_kind' original_prim)
     ~original_term
 
+let simplify_atomic_set ~original_prim dacc ~original_term _dbg ~arg1:_
+    ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
+  SPR.create_unknown dacc ~result_var
+    (P.result_kind' original_prim)
+    ~original_term
+
 let simplify_atomic_exchange ~original_prim dacc ~original_term _dbg ~arg1:_
     ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~result_var =
   SPR.create_unknown dacc ~result_var
@@ -1077,6 +1083,7 @@ let simplify_binary_primitive0 dacc original_prim (prim : P.binary_primitive)
         ~original_prim
     | Bigarray_get_alignment align ->
       simplify_bigarray_get_alignment align ~original_prim
+    | Atomic_set _ -> simplify_atomic_set ~original_prim
     | Atomic_exchange _ -> simplify_atomic_exchange ~original_prim
     | Atomic_int_arith op -> simplify_atomic_int_arith ~original_prim ~op
     | Poke _ -> simplify_poke
@@ -1089,7 +1096,7 @@ let recover_comparison_primitive dacc (prim : P.binary_primitive) ~arg1 ~arg2 =
   | Int_comp (_, Yielding_int_like_compare_functions _)
   | Float_arith _ | Float_comp _ | Phys_equal _ | String_or_bigstring_load _
   | Bigarray_load _ | Bigarray_get_alignment _ | Atomic_exchange _
-  | Atomic_int_arith _ | Poke _ ->
+  | Atomic_set _ | Atomic_int_arith _ | Poke _ ->
     None
   | Int_comp (kind, Yielding_bool op) -> (
     match kind with

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -404,7 +404,10 @@ let binary_prim_size prim =
   | Float_comp (_width, Yielding_int_like_compare_functions ()) -> 8
   | Bigarray_get_alignment _ -> 3 (* load data + add index + and *)
   | Atomic_int_arith _ -> 1
-  | Atomic_exchange _ -> does_not_need_caml_c_call_extcall_size
+  | Atomic_set Immediate -> 1
+  | Atomic_exchange Immediate -> 1
+  | Atomic_exchange Any_value | Atomic_set Any_value ->
+    does_not_need_caml_c_call_extcall_size
   | Poke _ -> 1
 
 let ternary_prim_size prim =
@@ -415,8 +418,9 @@ let ternary_prim_size prim =
     5 (* ~ 3 block_load + 2 block_set *)
   | Bigarray_set (_dims, _kind, _layout) -> 2
   (* ~ 1 block_load + 1 block_set *)
-  | Atomic_compare_and_set Immediate -> 1
-  | Atomic_compare_and_set Any_value | Atomic_compare_exchange _ ->
+  | Atomic_compare_and_set Immediate -> 3
+  | Atomic_compare_exchange Immediate -> 1
+  | Atomic_compare_and_set Any_value | Atomic_compare_exchange Any_value ->
     does_not_need_caml_c_call_extcall_size
 
 let variadic_prim_size prim args =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -511,6 +511,7 @@ type binary_primitive =
   | Float_arith of float_bitwidth * binary_float_arith_op
   | Float_comp of float_bitwidth * unit comparison_behaviour
   | Bigarray_get_alignment of int
+  | Atomic_set of Block_access_field_kind.t
   | Atomic_exchange of Block_access_field_kind.t
   | Atomic_int_arith of binary_int_atomic_op
   | Poke of Flambda_kind.Standard_int_or_float.t

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -17,6 +17,7 @@ type !'a t
 external make : 'a -> 'a t = "%makemutable"
 external make_contended : 'a -> 'a t = "caml_atomic_make_contended"
 external get : 'a t -> 'a = "%atomic_load"
+external set : 'a t -> 'a -> unit = "%atomic_set"
 external exchange : 'a t -> 'a -> 'a = "%atomic_exchange"
 external compare_and_set : 'a t -> 'a -> 'a -> bool = "%atomic_cas"
 external compare_exchange : 'a t -> 'a -> 'a -> 'a = "%atomic_compare_exchange"
@@ -27,8 +28,5 @@ external logand : int t -> int -> unit = "%atomic_land"
 external logor : int t -> int -> unit = "%atomic_lor"
 external logxor : int t -> int -> unit = "%atomic_lxor"
 
-external ignore : 'a -> unit = "%ignore"
-
-let set r x = ignore (exchange r x)
 let incr r = add r 1
 let decr r = sub r 1


### PR DESCRIPTION
`Atomic.set` was implemented in terms of `Atomic.exchange` and `ignore`:
```
let set r x = ignore (exchange r x)
```
After #3486 the compiler can recognize `Atomic.exchange` on immediates and emit an instruction for it, but `Atomic.set` it still  compiled to a C call. This PR improves code generation to emit an instruction instead of a C call. It adds a dedicated primitive `Lambda.Patomic_set` to track if the argument is an immediate and translate it to `exchange` instruction in the backend. 
