### PR TITLE
Expose externals in the interface of Atomic

### DIFF
--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -49,22 +49,22 @@ val make_contended : 'a -> 'a t
 val get : 'a t -> 'a
 
 (** Set a new value for the atomic reference. *)
-val set : 'a t -> 'a -> unit
+external set : 'a t -> 'a -> unit = "%atomic_exchange"
 
 (** Set a new value for the atomic reference, and return the current value. *)
-val exchange : 'a t -> 'a -> 'a
+external exchange : 'a t -> 'a -> 'a = "%atomic_exchange"
 
 (** [compare_and_set r seen v] sets the new value of [r] to [v] only
     if its current value is physically equal to [seen] -- the
     comparison and the set occur atomically. Returns [true] if the
     comparison succeeded (so the set happened) and [false]
     otherwise. *)
-val compare_and_set : 'a t -> 'a -> 'a -> bool
+external compare_and_set : 'a t -> 'a -> 'a -> bool = "%atomic_cas"
 
 (** [compare_exchange r seen v] sets the new value of [r] to [v] only
     if its current value is physically equal to [seen] -- the comparison
     and the set occur atomically. Returns the previous value. *)
-val compare_exchange : 'a t -> 'a -> 'a -> 'a
+external compare_exchange : 'a t -> 'a -> 'a -> 'a = "%atomic_compare_exchange"
 
 (** [fetch_and_add r n] atomically increments the value of [r] by [n],
     and returns the current value (before the increment). *)

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -49,7 +49,7 @@ val make_contended : 'a -> 'a t
 val get : 'a t -> 'a
 
 (** Set a new value for the atomic reference. *)
-external set : 'a t -> 'a -> unit = "%atomic_exchange"
+external set : 'a t -> 'a -> unit = "%atomic_set"
 
 (** Set a new value for the atomic reference, and return the current value. *)
 external exchange : 'a t -> 'a -> 'a = "%atomic_exchange"


### PR DESCRIPTION
To improve code generation, expose the `external` definitions of the following functions in the interface of `Atomic` in the standard library: `exchange`,`compare_set`,`compare_exchange`. 
It seems to be needed to get them specialized for immediates and emitted as instructions instead of C calls (even in an optimized build). Functions that operate directly on `int` do not need it.