### PR TITLE
Add environment variable FLAMBDA2_UNTRUSTED_KINDS

### DIFF
--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -378,7 +378,10 @@ let add_parameters_with_unknown_types ?alloc_modes ?name_mode t params =
   in
   let param_types =
     ListLabels.map2 params alloc_modes ~f:(fun param alloc_mode ->
-        T.unknown_with_subkind ~alloc_mode (BP.kind param))
+        if Flambda_features.untrusted_kinds () then
+          T.unknown (Flambda_kind.With_subkind.kind (BP.kind param))
+        else
+          T.unknown_with_subkind ~alloc_mode (BP.kind param))
   in
   add_parameters ?name_mode t params' ~param_types
 

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -378,10 +378,9 @@ let add_parameters_with_unknown_types ?alloc_modes ?name_mode t params =
   in
   let param_types =
     ListLabels.map2 params alloc_modes ~f:(fun param alloc_mode ->
-        if Flambda_features.untrusted_kinds () then
-          T.unknown (Flambda_kind.With_subkind.kind (BP.kind param))
-        else
-          T.unknown_with_subkind ~alloc_mode (BP.kind param))
+        if Flambda_features.untrusted_kinds ()
+        then T.unknown (Flambda_kind.With_subkind.kind (BP.kind param))
+        else T.unknown_with_subkind ~alloc_mode (BP.kind param))
   in
   add_parameters ?name_mode t params' ~param_types
 

--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -157,7 +157,8 @@ let add_equations_on_params typing_env ~is_recursive ~params:params'
         let name = Bound_parameter.name param in
         let kind = Bound_parameter.kind param in
         let typing_env =
-          if Flambda_kind.With_subkind.has_useful_subkind_info kind
+          if not (Flambda_features.untrusted_kinds ())
+          && Flambda_kind.With_subkind.has_useful_subkind_info kind
           then
             let raw_kind = Flambda_kind.With_subkind.kind kind in
             let type_from_kind = T.unknown_with_subkind kind in

--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -157,8 +157,8 @@ let add_equations_on_params typing_env ~is_recursive ~params:params'
         let name = Bound_parameter.name param in
         let kind = Bound_parameter.kind param in
         let typing_env =
-          if not (Flambda_features.untrusted_kinds ())
-          && Flambda_kind.With_subkind.has_useful_subkind_info kind
+          if (not (Flambda_features.untrusted_kinds ()))
+             && Flambda_kind.With_subkind.has_useful_subkind_info kind
           then
             let raw_kind = Flambda_kind.With_subkind.kind kind in
             let type_from_kind = T.unknown_with_subkind kind in

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -41,6 +41,11 @@ let join_points () =
   !Flambda_backend_flags.Flambda2.join_points
   |> with_default ~f:(fun d -> d.join_points)
 
+let untrusted_kinds () =
+  match Sys.getenv_opt "FLAMBDA2_UNTRUSTED_KINDS" with
+  | None | Some "" -> false
+  | Some _ -> true
+
 let unbox_along_intra_function_control_flow () =
   !Flambda_backend_flags.Flambda2.unbox_along_intra_function_control_flow
   |> with_default ~f:(fun d -> d.unbox_along_intra_function_control_flow)

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -28,6 +28,8 @@ val mode : unit -> any_mode
 
 val join_points : unit -> bool
 
+val untrusted_kinds : unit -> bool
+
 val unbox_along_intra_function_control_flow : unit -> bool
 
 val backend_cse_at_toplevel : unit -> bool


### PR DESCRIPTION
When set to a non-empty string, this tells Flambda2 to ignore the subkind information from the type-checker. This can be used if the value kinds in lambda are known to be wrong.
