### PR TITLE
Track quality of jkinds

### DIFF
--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1576,6 +1576,9 @@ module Builtin = struct
         layouts
     in
     fresh_jkind_poly desc ~annotation:None ~why:(Product_creation why)
+    (* [mark_best] is correct here because the with-bounds of a product jkind include all
+       the components of the product. Accordingly, looking through the product, by one
+       step, never loses any information. *)
     |> mark_best
 
   let product_of_sorts ~why arity =
@@ -1587,6 +1590,9 @@ module Builtin = struct
       { layout; mod_bounds = Mod_bounds.max; with_bounds = No_with_bounds }
     in
     fresh_jkind_poly desc ~annotation:None ~why:(Product_creation why)
+  (* We do not [mark_best] here because the resulting jkind is used (only) in the middle of
+     type-checking mutually recursive type declarations. See Note [Default jkind in
+     transl_declaration] for more commentary on why we don't want [Best] jkinds there. *)
 end
 
 let add_nullability_crossing t =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1510,10 +1510,7 @@ let mk_annot name =
 let mark_best (type l r) (t : (l * r) Types.jkind) =
   { (disallow_right t) with quality = Best }
 
-let is_best t =
-  match t.quality with
-  | Best -> true
-  | Not_best -> false
+let is_best t = match t.quality with Best -> true | Not_best -> false
 
 module Builtin = struct
   let any_dummy_jkind =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1772,7 +1772,7 @@ let for_boxed_variant cstrs =
        (* CR layouts v2.8: This is sad, but I don't know how to account for
           existentials in the with_bounds. See doc named "Existential
           with_bounds". *)
-    then Builtin.value ~why:Boxed_variant |> mark_best
+    then Builtin.value ~why:Boxed_variant
     else
       let base =
         (if is_mutable then Builtin.mutable_data else Builtin.immutable_data)

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2471,7 +2471,8 @@ let intersection_or_error ~type_equal ~jkind_of_type ~reason t1 t2 =
           combine_histories ~type_equal ~jkind_of_type reason (Pack_jkind t1)
             (Pack_jkind t2);
         has_warned = t1.has_warned || t2.has_warned;
-        quality = Not_best (* As required by the fact that this is a [jkind_r] *)
+        quality =
+          Not_best (* As required by the fact that this is a [jkind_r] *)
       }
 
 let round_up (type l r) ~type_equal ~jkind_of_type (t : (allowed * r) jkind) :

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -733,31 +733,92 @@ end
 
 (*********************************)
 
+module Quality = struct
+  include Allowance.Magic_allow_disallow (struct
+    type (_, _, 'd) sided = 'd jkind_quality constraint 'd = 'l * 'r
+
+    let disallow_left :
+        type l r. (l * r) jkind_quality -> (disallowed * r) jkind_quality =
+      function
+      | Not_best -> Not_best
+      | Best -> Best
+
+    let disallow_right :
+        type l r. (l * r) jkind_quality -> (l * disallowed) jkind_quality =
+      function
+      | Not_best -> Not_best
+      | Best -> Best
+
+    let allow_left :
+        type l r. (allowed * r) jkind_quality -> (l * r) jkind_quality =
+      function
+      | Not_best -> Not_best
+      | Best -> Best
+
+    let allow_right :
+        type l r. (l * allowed) jkind_quality -> (l * r) jkind_quality =
+      function
+      | Not_best -> Not_best
+  end)
+
+  let try_allow_r :
+      type l r. (l * r) jkind_quality -> (l * allowed) jkind_quality option =
+    function
+    | Not_best -> Some Not_best
+    | Best -> None
+end
+
 include Allowance.Magic_allow_disallow (struct
   type (_, _, 'd) sided = 'd jkind
 
   let disallow_right t =
-    { t with jkind = Layout_and_axes.disallow_right t.jkind }
+    { t with
+      jkind = Layout_and_axes.disallow_right t.jkind;
+      quality = Quality.disallow_right t.quality
+    }
 
-  let disallow_left t = { t with jkind = Layout_and_axes.disallow_left t.jkind }
+  let disallow_left t =
+    { t with
+      jkind = Layout_and_axes.disallow_left t.jkind;
+      quality = Quality.disallow_left t.quality
+    }
 
-  let allow_right t = { t with jkind = Layout_and_axes.allow_right t.jkind }
+  let allow_right t =
+    { t with
+      jkind = Layout_and_axes.allow_right t.jkind;
+      quality = Quality.allow_right t.quality
+    }
 
-  let allow_left t = { t with jkind = Layout_and_axes.allow_left t.jkind }
+  let allow_left t =
+    { t with
+      jkind = Layout_and_axes.allow_left t.jkind;
+      quality = Quality.allow_left t.quality
+    }
 end)
 
 let try_allow_r t =
-  Option.map
-    (fun jkind -> { t with jkind })
-    (Layout_and_axes.try_allow_r t.jkind)
+  let open Misc.Stdlib.Monad.Option.Syntax in
+  let* jkind = Layout_and_axes.try_allow_r t.jkind in
+  let* quality = Quality.try_allow_r t.quality in
+  Some { t with jkind; quality }
 
 let fresh_jkind jkind ~annotation ~why =
-  { jkind; annotation; history = Creation why; has_warned = false }
+  { jkind;
+    annotation;
+    history = Creation why;
+    has_warned = false;
+    quality = Not_best
+  }
   |> allow_left |> allow_right
 
 (* This version propagates the allowances from the [jkind] to the output. *)
 let fresh_jkind_poly jkind ~annotation ~why =
-  { jkind; annotation; history = Creation why; has_warned = false }
+  { jkind;
+    annotation;
+    history = Creation why;
+    has_warned = false;
+    quality = Not_best
+  }
 
 (***********************)
 (*** constant jkinds ***)
@@ -789,7 +850,11 @@ let set_outcometree_of_modalities_new p = outcometree_of_modalities_new := p
 module Const = struct
   type 'd t = (Layout.Const.t, 'd) Types.layout_and_axes
 
-  include Layout_and_axes.Allow_disallow
+  include Allowance.Magic_allow_disallow (struct
+    include Layout_and_axes.Allow_disallow
+
+    type (_, _, 'd) sided = 'd t
+  end)
 
   let max =
     Types.
@@ -1442,13 +1507,17 @@ end
 let mk_annot name =
   Some Parsetree.{ pjkind_loc = Location.none; pjkind_desc = Abbreviation name }
 
+let mark_best (type l r) (t : (l * r) Types.jkind) =
+  { (disallow_right t) with quality = Best }
+
 module Builtin = struct
   let any_dummy_jkind =
     { jkind = Jkind_desc.max;
       annotation = None;
       (* this should never get printed: it's a dummy *)
       history = Creation (Any_creation Dummy_jkind);
-      has_warned = false
+      has_warned = false;
+      quality = Not_best
     }
 
   (* CR layouts: Should we be doing more memoization here? *)
@@ -1465,12 +1534,14 @@ module Builtin = struct
     { jkind = Jkind_desc.Builtin.value_or_null;
       annotation = mk_annot "value";
       history = Creation (Value_or_null_creation V1_safety_check);
-      has_warned = false
+      has_warned = false;
+      quality = Not_best
     }
 
   let void ~why =
     fresh_jkind Jkind_desc.Builtin.void ~annotation:(mk_annot "void")
       ~why:(Void_creation why)
+    |> mark_best
 
   let value_or_null ~why =
     match (why : History.value_or_null_creation_reason) with
@@ -1495,6 +1566,7 @@ module Builtin = struct
   let immediate ~why =
     fresh_jkind Jkind_desc.Builtin.immediate ~annotation:(mk_annot "immediate")
       ~why:(Immediate_creation why)
+    |> mark_best
 
   let product ~jkind_of_first_type ~jkind_of_type ~why tys_modalities layouts =
     let desc =
@@ -1502,6 +1574,7 @@ module Builtin = struct
         layouts
     in
     fresh_jkind_poly desc ~annotation:None ~why:(Product_creation why)
+    |> mark_best
 
   let product_of_sorts ~why arity =
     let layout =
@@ -1512,6 +1585,7 @@ module Builtin = struct
       { layout; mod_bounds = Mod_bounds.max; with_bounds = No_with_bounds }
     in
     fresh_jkind_poly desc ~annotation:None ~why:(Product_creation why)
+    |> mark_best
 end
 
 let add_nullability_crossing t =
@@ -1556,19 +1630,24 @@ let of_new_legacy_sort_var ~why =
 
 let of_new_legacy_sort ~why = fst (of_new_legacy_sort_var ~why)
 
-let of_const ~annotation ~why (c : 'd Const.t) =
+let of_const (type l r) ~annotation ~why ~(quality : (l * r) jkind_quality)
+    (c : (l * r) Const.t) =
   { jkind = Layout_and_axes.map Layout.of_const c;
     annotation;
     history = Creation why;
-    has_warned = false
+    has_warned = false;
+    quality
   }
 
 let of_builtin ~why Const.Builtin.{ jkind; name } =
-  of_const ~annotation:(mk_annot name) ~why jkind |> allow_left |> allow_right
+  jkind |> Layout_and_axes.allow_left |> Layout_and_axes.disallow_right
+  |> of_const ~annotation:(mk_annot name) ~why ~quality:Best
 
 let of_annotated_const ~context ~annotation ~const ~const_loc =
   let context = Context_with_transl.get_context context in
-  of_const ~annotation ~why:(Annotated (context, const_loc)) const
+  of_const ~annotation
+    ~why:(Annotated (context, const_loc))
+    const ~quality:Not_best
 
 let of_annotation_lr ~context (annot : Parsetree.jkind_annotation) =
   let const = Const.of_user_written_annotation ~context annot in
@@ -1641,6 +1720,7 @@ let for_boxed_record lbls =
     let base =
       (if is_mutable then Builtin.mutable_data else Builtin.immutable_data)
         ~why:Boxed_record
+      |> mark_best
     in
     add_labels_as_with_bounds lbls base
   else Builtin.value ~why:Boxed_record
@@ -1688,11 +1768,12 @@ let for_boxed_variant cstrs =
        (* CR layouts v2.8: This is sad, but I don't know how to account for
           existentials in the with_bounds. See doc named "Existential
           with_bounds". *)
-    then Builtin.value ~why:Boxed_variant
+    then Builtin.value ~why:Boxed_variant |> mark_best
     else
       let base =
         (if is_mutable then Builtin.mutable_data else Builtin.immutable_data)
           ~why:Boxed_variant
+        |> mark_best
       in
       let add_cstr_args cstr jkind =
         match cstr.cd_args with
@@ -1718,6 +1799,7 @@ let for_arrow =
       with_bounds = No_with_bounds
     }
     ~annotation:None ~why:(Value_creation Arrow)
+  |> mark_best
 
 let for_object =
   let ({ linearity;
@@ -2314,8 +2396,9 @@ end
 (* relations *)
 
 let equate_or_equal ~allow_mutation
-    { jkind = jkind1; annotation = _; history = _; has_warned = _ }
-    { jkind = jkind2; annotation = _; history = _; has_warned = _ } =
+    { jkind = jkind1; annotation = _; history = _; has_warned = _; quality = _ }
+    { jkind = jkind2; annotation = _; history = _; has_warned = _; quality = _ }
+    =
   Jkind_desc.equate_or_equal ~allow_mutation jkind1 jkind2
 
 (* CR layouts v2.8: Switch this back to ~allow_mutation:false *)
@@ -2384,7 +2467,8 @@ let intersection_or_error ~type_equal ~jkind_of_type ~reason t1 t2 =
         history =
           combine_histories ~type_equal ~jkind_of_type reason (Pack_jkind t1)
             (Pack_jkind t2);
-        has_warned = t1.has_warned || t2.has_warned
+        has_warned = t1.has_warned || t2.has_warned;
+        quality = Not_best
       }
 
 let round_up (type l r) ~type_equal ~jkind_of_type (t : (allowed * r) jkind) :
@@ -2395,7 +2479,10 @@ let round_up (type l r) ~type_equal ~jkind_of_type (t : (allowed * r) jkind) :
           (fun ~axis -> upper_bound_for_axis ~type_equal ~jkind_of_type ~axis t)
       }
   in
-  { t with jkind = { t.jkind with mod_bounds; with_bounds = No_with_bounds } }
+  { t with
+    jkind = { t.jkind with mod_bounds; with_bounds = No_with_bounds };
+    quality = Not_best
+  }
 
 let map_type_expr f t = { t with jkind = Jkind_desc.map_type_expr f t.jkind }
 
@@ -2690,14 +2777,20 @@ module Debug_printers = struct
         history1 jkind_desc jkind2 (history ~print_type_expr) history2
     | Creation c -> fprintf ppf "Creation (%a)" creation_reason c
 
-  let t ~print_type_expr ppf
-      ({ jkind; annotation = a; history = h; has_warned = _ } : 'd jkind) : unit
-      =
-    fprintf ppf "@[<v 2>{ jkind = %a@,; annotation = %a@,; history = %a }@]"
+  let t (type l r) ~print_type_expr ppf
+      ({ jkind; annotation = a; history = h; has_warned = _; quality = q } :
+        (l * r) jkind) : unit =
+    fprintf ppf
+      "@[<v 2>{ jkind = %a@,\
+       ; annotation = %a@,\
+       ; history = %a@,\
+       ; quality = %s@,\
+      \ }@]"
       (Jkind_desc.Debug_printers.t ~print_type_expr)
       jkind
       (pp_print_option Pprintast.jkind_annotation)
       a (history ~print_type_expr) h
+      (match q with Best -> "Best" | Not_best -> "Not_best")
 
   module Const = struct
     let t ~print_type_expr ppf ({ layout; mod_bounds; with_bounds } : _ Const.t)

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1641,7 +1641,10 @@ let of_const (type l r) ~annotation ~why ~(quality : (l * r) jkind_quality)
 
 let of_builtin ~why Const.Builtin.{ jkind; name } =
   jkind |> Layout_and_axes.allow_left |> Layout_and_axes.disallow_right
-  |> of_const ~annotation:(mk_annot name) ~why ~quality:Best
+  |> of_const ~annotation:(mk_annot name)
+       ~why
+         (* The [Best] is OK here because this function is used only in Predef. *)
+       ~quality:Best
 
 let of_annotated_const ~context ~annotation ~const ~const_loc =
   let context = Context_with_transl.get_context context in
@@ -2468,7 +2471,7 @@ let intersection_or_error ~type_equal ~jkind_of_type ~reason t1 t2 =
           combine_histories ~type_equal ~jkind_of_type reason (Pack_jkind t1)
             (Pack_jkind t2);
         has_warned = t1.has_warned || t2.has_warned;
-        quality = Not_best
+        quality = Not_best (* As required by the fact that this is a [jkind_r] *)
       }
 
 let round_up (type l r) ~type_equal ~jkind_of_type (t : (allowed * r) jkind) :
@@ -2481,7 +2484,7 @@ let round_up (type l r) ~type_equal ~jkind_of_type (t : (allowed * r) jkind) :
   in
   { t with
     jkind = { t.jkind with mod_bounds; with_bounds = No_with_bounds };
-    quality = Not_best
+    quality = Not_best (* As required by the fact that this is a [jkind_r] *)
   }
 
 let map_type_expr f t = { t with jkind = Jkind_desc.map_type_expr f t.jkind }

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1473,7 +1473,8 @@ module Jkind_desc = struct
           let { jkind = { layout; mod_bounds; with_bounds = _ };
                 annotation = _;
                 history = _;
-                has_warned = _
+                has_warned = _;
+                quality = _
               } =
             jkind_of_type ty
           in

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1590,7 +1590,6 @@ module Builtin = struct
       { layout; mod_bounds = Mod_bounds.max; with_bounds = No_with_bounds }
     in
     fresh_jkind_poly desc ~annotation:None ~why:(Product_creation why)
-    |> mark_best
 end
 
 let add_nullability_crossing t =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1510,6 +1510,11 @@ let mk_annot name =
 let mark_best (type l r) (t : (l * r) Types.jkind) =
   { (disallow_right t) with quality = Best }
 
+let is_best t =
+  match t.quality with
+  | Best -> true
+  | Not_best -> false
+
 module Builtin = struct
   let any_dummy_jkind =
     { jkind = Jkind_desc.max;

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -348,6 +348,9 @@ val has_with_bounds : Types.jkind_l -> bool
     about it that will cause it to become lower in the preorder of kinds*)
 val mark_best : ('l * 'r) Types.jkind -> ('l * disallowed) Types.jkind
 
+(** Is the given kind best? *)
+val is_best : ('l * disallowed) Types.jkind -> bool
+
 (******************************)
 (* construction *)
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -344,8 +344,8 @@ val add_with_bounds :
 (** Does this jkind have with-bounds? *)
 val has_with_bounds : Types.jkind_l -> bool
 
-(** Mark the given jkind as {ibest}, meaning we can never learn any more information about
-    it that will cause it to become lower in the preorder of kinds*)
+(** Mark the given jkind as {i best}, meaning we can never learn any more information
+    about it that will cause it to become lower in the preorder of kinds*)
 val mark_best : ('l * 'r) Types.jkind -> ('l * disallowed) Types.jkind
 
 (******************************)
@@ -378,6 +378,8 @@ val of_const :
   'd Const.t ->
   'd Types.jkind
 
+(** Construct a jkind from a builtin kind, at quality [Best]. Should only be used in
+    predef. *)
 val of_builtin :
   why:History.creation_reason ->
   Const.Builtin.t ->

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -371,6 +371,7 @@ val of_new_legacy_sort_var :
 val of_new_legacy_sort :
   why:History.concrete_legacy_creation_reason -> 'd Types.jkind
 
+(** Construct a jkind from a constant jkind, at quality [Not_best] *)
 val of_const :
   annotation:Parsetree.jkind_annotation option ->
   why:History.creation_reason ->
@@ -378,8 +379,7 @@ val of_const :
   'd Const.t ->
   'd Types.jkind
 
-(** Construct a jkind from a builtin kind, at quality [Best]. Should only be used in
-    predef. *)
+(** Construct a jkind from a builtin kind, at quality [Best]. *)
 val of_builtin :
   why:History.creation_reason ->
   Const.Builtin.t ->
@@ -402,7 +402,7 @@ val of_annotation_option_default :
     attributes, and [of_type_decl] needs to look in two different places on the
     [type_declaration] to account for these two alternatives.
 
-    Returns the jkind and the user-written annotation.
+    Returns the jkind (at quality [Not_best]) and the user-written annotation.
 
     Raises if a disallowed or unknown jkind is present.
 *)
@@ -413,7 +413,8 @@ val of_type_decl :
   (Types.jkind_l * Parsetree.jkind_annotation option) option
 
 (** Find a jkind from a type declaration in the same way as [of_type_decl],
-    defaulting to ~default.
+    defaulting to ~default. Returns a jkind at quality [Not_best]; call [mark_best] to
+    mark it as [Best].
 
     Raises if a disallowed or unknown jkind is present.
 *)

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -308,7 +308,10 @@ module Builtin : sig
       Precondition: both input lists are the same length.
 
       This returns an [jkind_l] simply as a matter of convenience; it can be
-      generalized if need be.  *)
+      generalized if need be.
+
+      The resulting jkind has quality [Best], because all the components of the product
+      are represented in the with-bounds. *)
   val product :
     jkind_of_first_type:(unit -> Types.jkind_l) ->
     jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
@@ -317,9 +320,9 @@ module Builtin : sig
     Sort.t Layout.t list ->
     Types.jkind_l
 
-  (** Build a jkind of unboxed products, given only an arity. This jkind
-      will not mode-cross, even though unboxed products generally should.
-      This is useful when creating an initial jkind in Typedecl. *)
+  (** Build a jkind of unboxed products, given only an arity. This jkind will not
+      mode-cross (and has kind [Not_best] accordingly), even though unboxed products
+      generally should. This is useful when creating an initial jkind in Typedecl. *)
   val product_of_sorts :
     why:History.product_creation_reason -> int -> Types.jkind_l
 end

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -528,6 +528,9 @@ let or_null_kind tvar =
   in
   Type_variant (cstrs, Variant_with_null, None)
 
+let or_null_jkind =
+  Jkind.Builtin.value_or_null ~why:(Primitive ident_or_null) |> Jkind.mark_best
+
 let add_or_null add_type env =
   let add_type1 = mk_add_type1 add_type in
   env
@@ -543,7 +546,7 @@ let add_or_null add_type env =
      In the future, we will track separability in the jkind system. *)
   (* CR layouts v2.8: Add baggage and more mode crossing here. *)
   ~kind:or_null_kind
-  ~jkind:(fun _ -> Jkind.Builtin.value_or_null ~why:(Primitive ident_or_null) |> Jkind.mark_best)
+  ~jkind:(fun _ -> or_null_jkind)
 
 let builtin_values =
   List.map (fun id -> (Ident.name id, id)) all_predef_exns

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -220,13 +220,14 @@ let option_argument_jkind = Jkind.Builtin.value ~why:(
 
 (* CR layouts v2.8: Simplify this once we have a real subsumption check. *)
 let list_jkind param =
+  Jkind.Builtin.immutable_data ~why:Boxed_variant |>
+  Jkind.add_with_bounds
+       ~modality:Mode.Modality.Value.Const.id
+       ~type_expr:(type_list param) |>
   Jkind.add_with_bounds
     ~modality:Mode.Modality.Value.Const.id
-    ~type_expr:param
-    (Jkind.add_with_bounds
-       ~modality:Mode.Modality.Value.Const.id
-       ~type_expr:(type_list param)
-       (Jkind.Builtin.immutable_data ~why:Boxed_variant))
+    ~type_expr:param |>
+  Jkind.mark_best
 
 let list_sort = Jkind.Sort.Const.value
 let list_argument_sort = Jkind.Sort.Const.value
@@ -245,7 +246,7 @@ let mk_add_type add_type =
       {type_params = [];
        type_arity = 0;
        type_kind = kind;
-       type_jkind = jkind;
+       type_jkind = Jkind.mark_best jkind;
        type_loc = Location.none;
        type_private = Asttypes.Public;
        type_manifest = manifest;
@@ -366,20 +367,22 @@ let build_initial_env add_type add_extension empty_env =
        ~param_jkind:(Jkind.add_nullability_crossing
                       (Jkind.Builtin.any ~why:Array_type_argument))
        ~jkind:(fun param ->
+         Jkind.Builtin.mutable_data ~why:(Primitive ident_array) |>
          Jkind.add_with_bounds
            ~modality:Mode.Modality.Value.Const.id
-           ~type_expr:param
-           (Jkind.Builtin.mutable_data ~why:(Primitive ident_array)))
+           ~type_expr:param |>
+         Jkind.mark_best)
   |> add_type1 ident_iarray
        ~variance:Variance.covariant
        ~separability:Separability.Ind
        ~param_jkind:(Jkind.add_nullability_crossing
                       (Jkind.Builtin.any ~why:Array_type_argument))
        ~jkind:(fun param ->
+         Jkind.Builtin.immutable_data ~why:(Primitive ident_iarray) |>
          Jkind.add_with_bounds
            ~modality:Mode.Modality.Value.Const.id
-           ~type_expr:param
-           (Jkind.Builtin.immutable_data ~why:(Primitive ident_iarray)))
+           ~type_expr:param |>
+         Jkind.mark_best)
   |> add_type ident_bool
        ~kind:(variant [ cstr ident_false []; cstr ident_true []])
        ~jkind:Jkind.Const.Builtin.immediate
@@ -399,7 +402,7 @@ let build_initial_env add_type add_extension empty_env =
           It might also cross portability, linearity, uniqueness subject to its
           parameter. But I'm also fine not doing that for now (and wait until
           users complains).  *)
-       ~jkind:(fun _ -> Jkind.Builtin.value ~why:(Primitive ident_lazy_t))
+       ~jkind:(fun _ -> Jkind.Builtin.value ~why:(Primitive ident_lazy_t) |> Jkind.mark_best)
   |> add_type1 ident_list
        ~variance:Variance.covariant
        ~separability:Separability.Ind
@@ -417,10 +420,11 @@ let build_initial_env add_type add_extension empty_env =
          variant [cstr ident_none [];
                   cstr ident_some [unrestricted tvar option_argument_sort]])
        ~jkind:(fun param ->
+         Jkind.Builtin.immutable_data ~why:Boxed_variant |>
          Jkind.add_with_bounds
            ~modality:Mode.Modality.Value.Const.id
-           ~type_expr:param
-           (Jkind.Builtin.immutable_data ~why:Boxed_variant))
+           ~type_expr:param |>
+         Jkind.mark_best)
   |> add_type_with_jkind ident_lexing_position
        ~kind:(
          let lbl (field, field_type) =
@@ -539,7 +543,7 @@ let add_or_null add_type env =
      In the future, we will track separability in the jkind system. *)
   (* CR layouts v2.8: Add baggage and more mode crossing here. *)
   ~kind:or_null_kind
-  ~jkind:(fun _ -> Jkind.Builtin.value_or_null ~why:(Primitive ident_or_null))
+  ~jkind:(fun _ -> Jkind.Builtin.value_or_null ~why:(Primitive ident_or_null) |> Jkind.mark_best)
 
 let builtin_values =
   List.map (fun id -> (Ident.name id, id)) all_predef_exns

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -282,7 +282,7 @@ let mk_add_type1 add_type type_ident
     {type_params = [param];
       type_arity = 1;
       type_kind = kind param;
-      type_jkind = jkind param;
+      type_jkind = Jkind.mark_best (jkind param);
       type_loc = Location.none;
       type_private = Asttypes.Public;
       type_manifest = None;
@@ -370,8 +370,7 @@ let build_initial_env add_type add_extension empty_env =
          Jkind.Builtin.mutable_data ~why:(Primitive ident_array) |>
          Jkind.add_with_bounds
            ~modality:Mode.Modality.Value.Const.id
-           ~type_expr:param |>
-         Jkind.mark_best)
+           ~type_expr:param)
   |> add_type1 ident_iarray
        ~variance:Variance.covariant
        ~separability:Separability.Ind
@@ -381,8 +380,7 @@ let build_initial_env add_type add_extension empty_env =
          Jkind.Builtin.immutable_data ~why:(Primitive ident_iarray) |>
          Jkind.add_with_bounds
            ~modality:Mode.Modality.Value.Const.id
-           ~type_expr:param |>
-         Jkind.mark_best)
+           ~type_expr:param)
   |> add_type ident_bool
        ~kind:(variant [ cstr ident_false []; cstr ident_true []])
        ~jkind:Jkind.Const.Builtin.immediate
@@ -402,7 +400,7 @@ let build_initial_env add_type add_extension empty_env =
           It might also cross portability, linearity, uniqueness subject to its
           parameter. But I'm also fine not doing that for now (and wait until
           users complains).  *)
-       ~jkind:(fun _ -> Jkind.Builtin.value ~why:(Primitive ident_lazy_t) |> Jkind.mark_best)
+       ~jkind:(fun _ -> Jkind.Builtin.value ~why:(Primitive ident_lazy_t))
   |> add_type1 ident_list
        ~variance:Variance.covariant
        ~separability:Separability.Ind
@@ -423,8 +421,7 @@ let build_initial_env add_type add_extension empty_env =
          Jkind.Builtin.immutable_data ~why:Boxed_variant |>
          Jkind.add_with_bounds
            ~modality:Mode.Modality.Value.Const.id
-           ~type_expr:param |>
-         Jkind.mark_best)
+           ~type_expr:param)
   |> add_type_with_jkind ident_lexing_position
        ~kind:(
          let lbl (field, field_type) =
@@ -529,7 +526,7 @@ let or_null_kind tvar =
   Type_variant (cstrs, Variant_with_null, None)
 
 let or_null_jkind =
-  Jkind.Builtin.value_or_null ~why:(Primitive ident_or_null) |> Jkind.mark_best
+  Jkind.Builtin.value_or_null ~why:(Primitive ident_or_null)
 
 let add_or_null add_type env =
   let add_type1 = mk_add_type1 add_type in

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -156,6 +156,11 @@ val add_or_null :
 (* CR layouts v3.5: remove this when users can define null constructors. *)
 val or_null_kind : type_expr -> ('a, 'b, constructor_declaration) type_kind
 
+(* Construct the [jkind] of [or_null]. For re-exporting [or_null]
+   while users can't define their own types with null constructors. *)
+(* CR layouts v3.5: remove this when users can define null constructors. *)
+val or_null_jkind : Types.jkind_l
+
 (* To initialize linker tables *)
 
 val builtin_values: (string * Ident.t) list

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -80,17 +80,58 @@ type additional_action_config =
   | Duplicate_variables
   | Prepare_for_saving
 
-let with_additional_action =
-  (* Memoize the built-in jkinds *)
-  let builtins =
+(* Memoize the built-in jkinds, either best or not-best *)
+module Builtins_memo : sig
+  val find :
+    quality:('l * 'r) jkind_quality ->
+    ('l * 'r) Jkind.Const.t ->
+    ('l * 'r) jkind option
+end = struct
+  open Allowance
+
+  type 'd builtins = ('d Jkind.Const.t * 'd jkind) list
+
+  let make_builtins (type l r) (quality : (l * r) jkind_quality) : (l * r) builtins =
     Jkind.Const.Builtin.all
     |> List.map (fun (builtin : Jkind.Const.Builtin.t) ->
-          builtin.jkind,
-          Jkind.of_const builtin.jkind
-            ~annotation:(Some { pjkind_loc = Location.none;
-                                pjkind_desc = Abbreviation builtin.name })
-            ~why:Jkind.History.Imported)
-  in
+      let const_jkind : (l * r) Jkind.Const.t =
+        builtin.jkind |> Jkind.Const.allow_left |> Jkind.Const.allow_right in
+      const_jkind,
+      Jkind.of_const
+        const_jkind
+        ~quality
+        ~annotation:(Some { pjkind_loc = Location.none;
+                            pjkind_desc = Abbreviation builtin.name })
+        ~why:Jkind.History.Imported)
+
+  let best_builtins : (allowed * disallowed) builtins = make_builtins Best
+  let not_best_builtins : (allowed * allowed) builtins = make_builtins Not_best
+
+  let find
+        (type l r)
+        ~(quality : (l * r) jkind_quality)
+        (const : (l * r) Jkind.Const.t)
+    : (l * r) jkind option
+    =
+    (match quality with
+     | Best ->
+       List.find_opt (fun ((builtin, _) : (allowed * disallowed) Jkind.Const.t * _) ->
+         Jkind.Const.no_with_bounds_and_equal
+           (const |> Jkind.Const.disallow_right)
+           (builtin |> Jkind.Const.allow_left))
+       best_builtins
+       |> Option.map (fun (_, jkind) -> jkind |> Jkind.allow_left)
+     | Not_best ->
+       List.find_opt (fun (builtin, _) ->
+         Jkind.Const.no_with_bounds_and_equal
+           const
+           (builtin |> Jkind.Const.allow_left |> Jkind.Const.allow_right))
+         not_best_builtins
+       |> Option.map (fun (_, jkind) -> jkind |> Jkind.allow_left |> Jkind.allow_right)
+    )
+end
+
+let with_additional_action =
   fun (config : additional_action_config) s ->
   (* CR layouts: it would be better to put all this stuff outside this
      function, but it's in here because we really want to tailor the reason
@@ -106,17 +147,12 @@ let with_additional_action =
     match config with
     | Duplicate_variables -> Duplicate_variables
     | Prepare_for_saving ->
-        let prepare_jkind loc jkind =
+        let prepare_jkind (type l r) loc (jkind : (l * r) jkind) =
           match Jkind.get_const jkind with
           | Some const ->
-            let builtin =
-              List.find_opt (fun (builtin, _) ->
-                  Jkind.Const.no_with_bounds_and_equal const builtin)
-                builtins
-            in
-            begin match builtin with
-            | Some (_, jkind) -> jkind |> Jkind.allow_left |> Jkind.allow_right
-            | None -> Jkind.of_const const ~annotation:None ~why:Imported
+            begin match Builtins_memo.find ~quality:jkind.quality const with
+            | Some jkind -> jkind
+            | None -> Jkind.of_const ~quality:jkind.quality const ~annotation:None ~why:Imported
             end
           | None -> raise(Error (loc, Unconstrained_jkind_variable))
         in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -957,7 +957,7 @@ let transl_declaration env sdecl (id, uid) =
           Type_record_unboxed_product(lbls', Record_unboxed_product, None), jkind
       | Ptype_open ->
         Ttype_open, Type_open,
-        (Jkind.Builtin.value ~why:Extensible_variant |> Jkind.mark_best)
+        Jkind.Builtin.value ~why:Extensible_variant
       in
     let jkind =
     (* - If there's an annotation, we use that. It's checked against
@@ -1800,10 +1800,7 @@ let update_decl_jkind env dpath decl =
       assert (not (Jkind.is_best decl.type_jkind));
       decl, decl.type_jkind
     | Type_open ->
-      let type_jkind =
-        Jkind.Builtin.value ~why:Extensible_variant
-        |> Jkind.mark_best
-      in
+      let type_jkind = Jkind.Builtin.value ~why:Extensible_variant in
       { decl with type_jkind }, type_jkind
     | Type_record (lbls, rep, umc) ->
       let lbls, rep, type_jkind = update_record_kind decl.type_loc lbls rep in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -899,8 +899,7 @@ let transl_declaration env sdecl (id, uid) =
         let tcstrs, cstrs = List.split (List.map make_cstr scstrs) in
         let rep, jkind =
           if unbox then
-            Variant_unboxed,
-            (Jkind.of_new_legacy_sort ~why:Old_style_unboxed_type |> Jkind.mark_best)
+            Variant_unboxed, Jkind.of_new_legacy_sort ~why:Old_style_unboxed_type
           else
             (* We mark all arg sorts "void" here.  They are updated later,
                after the circular type checks make it safe to check sorts.
@@ -919,8 +918,7 @@ let transl_declaration env sdecl (id, uid) =
                    Constructor_uniform_value, sorts)
                 (Array.of_list cstrs)
             ),
-            (Jkind.Builtin.value ~why:Boxed_variant
-             |> Jkind.mark_best)
+            Jkind.Builtin.value ~why:Boxed_variant
         in
           Ttype_variant tcstrs, Type_variant (cstrs, rep, None), jkind
       | Ptype_record lbls ->
@@ -931,15 +929,14 @@ let transl_declaration env sdecl (id, uid) =
           let rep, jkind =
             if unbox then
               Record_unboxed,
-              (Jkind.of_new_legacy_sort ~why:Old_style_unboxed_type
-               |> Jkind.mark_best)
+              (Jkind.of_new_legacy_sort ~why:Old_style_unboxed_type)
             else
             (* Note this is inaccurate, using `Record_boxed` in cases where the
                correct representation is [Record_float], [Record_ufloat], or
                [Record_mixed].  Those cases are fixed up after we can get
                accurate sorts for the fields, in [update_decl_jkind]. *)
               Record_boxed (Array.make (List.length lbls) Jkind.Sort.Const.void),
-              (Jkind.Builtin.value ~why:Boxed_record |> Jkind.mark_best)
+              Jkind.Builtin.value ~why:Boxed_record
           in
           Ttype_record lbls, Type_record(lbls', rep, None), jkind
       | Ptype_record_unboxed_product lbls ->
@@ -959,8 +956,7 @@ let transl_declaration env sdecl (id, uid) =
           Ttype_record_unboxed_product lbls,
           Type_record_unboxed_product(lbls', Record_unboxed_product, None), jkind
       | Ptype_open ->
-        Ttype_open, Type_open, (Jkind.Builtin.value ~why:Extensible_variant
-                                |> Jkind.mark_best)
+        Ttype_open, Type_open, Jkind.Builtin.value ~why:Extensible_variant
       in
     let jkind =
     (* - If there's an annotation, we use that. It's checked against
@@ -1799,10 +1795,7 @@ let update_decl_jkind env dpath decl =
   let new_decl, new_jkind = match decl.type_kind with
     | Type_abstract _ -> decl, decl.type_jkind
     | Type_open ->
-      let type_jkind =
-        Jkind.Builtin.value ~why:Extensible_variant
-        |> Jkind.mark_best
-      in
+      let type_jkind = Jkind.Builtin.value ~why:Extensible_variant in
       { decl with type_jkind }, type_jkind
     | Type_record (lbls, rep, umc) ->
       let lbls, rep, type_jkind = update_record_kind decl.type_loc lbls rep in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -838,8 +838,10 @@ let transl_declaration env sdecl (id, uid) =
           in
           let type_kind = Predef.or_null_kind param in
           let jkind =
-            Jkind.Builtin.value_or_null
-              ~why:(Primitive Predef.ident_or_null)
+            Jkind.Builtin.value_or_null ~why:(Primitive Predef.ident_or_null)
+            (* Even though this type is abstract, it's actually a reexport of ['a
+               or_null], which has a best kind *)
+            |> Jkind.mark_best
           in
           Ttype_abstract, type_kind, jkind
       | (Ptype_variant _ | Ptype_record _ | Ptype_record_unboxed_product _
@@ -903,7 +905,7 @@ let transl_declaration env sdecl (id, uid) =
         let rep, jkind =
           if unbox then
             Variant_unboxed,
-            Jkind.of_new_legacy_sort ~why:Old_style_unboxed_type
+            (Jkind.of_new_legacy_sort ~why:Old_style_unboxed_type |> Jkind.mark_best)
           else
             (* We mark all arg sorts "void" here.  They are updated later,
                after the circular type checks make it safe to check sorts.
@@ -922,7 +924,8 @@ let transl_declaration env sdecl (id, uid) =
                    Constructor_uniform_value, sorts)
                 (Array.of_list cstrs)
             ),
-            Jkind.Builtin.value ~why:Boxed_variant
+            (Jkind.Builtin.value ~why:Boxed_variant
+             |> Jkind.mark_best)
         in
           Ttype_variant tcstrs, Type_variant (cstrs, rep, None), jkind
       | Ptype_record lbls ->
@@ -933,14 +936,15 @@ let transl_declaration env sdecl (id, uid) =
           let rep, jkind =
             if unbox then
               Record_unboxed,
-              Jkind.of_new_legacy_sort ~why:Old_style_unboxed_type
+              (Jkind.of_new_legacy_sort ~why:Old_style_unboxed_type
+               |> Jkind.mark_best)
             else
             (* Note this is inaccurate, using `Record_boxed` in cases where the
                correct representation is [Record_float], [Record_ufloat], or
                [Record_mixed].  Those cases are fixed up after we can get
                accurate sorts for the fields, in [update_decl_jkind]. *)
               Record_boxed (Array.make (List.length lbls) Jkind.Sort.Const.void),
-              Jkind.Builtin.value ~why:Boxed_record
+              (Jkind.Builtin.value ~why:Boxed_record |> Jkind.mark_best)
           in
           Ttype_record lbls, Type_record(lbls', rep, None), jkind
       | Ptype_record_unboxed_product lbls ->
@@ -960,7 +964,8 @@ let transl_declaration env sdecl (id, uid) =
           Ttype_record_unboxed_product lbls,
           Type_record_unboxed_product(lbls', Record_unboxed_product, None), jkind
       | Ptype_open ->
-        Ttype_open, Type_open, Jkind.Builtin.value ~why:Extensible_variant
+        Ttype_open, Type_open, (Jkind.Builtin.value ~why:Extensible_variant
+                                |> Jkind.mark_best)
       in
     let jkind =
     (* - If there's an annotation, we use that. It's checked against
@@ -1799,7 +1804,10 @@ let update_decl_jkind env dpath decl =
   let new_decl, new_jkind = match decl.type_kind with
     | Type_abstract _ -> decl, decl.type_jkind
     | Type_open ->
-      let type_jkind = Jkind.Builtin.value ~why:Extensible_variant in
+      let type_jkind =
+        Jkind.Builtin.value ~why:Extensible_variant
+        |> Jkind.mark_best
+      in
       { decl with type_jkind }, type_jkind
     | Type_record (lbls, rep, umc) ->
       let lbls, rep, type_jkind = update_record_kind decl.type_loc lbls rep in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1800,7 +1800,13 @@ let update_decl_jkind env dpath decl =
       assert (not (Jkind.is_best decl.type_jkind));
       decl, decl.type_jkind
     | Type_open ->
-      let type_jkind = Jkind.Builtin.value ~why:Extensible_variant in
+      let type_jkind =
+        Jkind.Builtin.value ~why:Extensible_variant
+        (* It's unlikely we'll ever be able to give better kinds than [value] to
+           extensible variants, so we're not worried about backwards compatibility if we
+           mark them as best here, and we want to be able to normalize them away *)
+        |> Jkind.mark_best
+      in
       { decl with type_jkind }, type_jkind
     | Type_record (lbls, rep, umc) ->
       let lbls, rep, type_jkind = update_record_kind decl.type_loc lbls rep in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -837,12 +837,7 @@ let transl_declaration env sdecl (id, uid) =
               { definition = path; expected = Predef.path_or_null }))
           in
           let type_kind = Predef.or_null_kind param in
-          let jkind =
-            Jkind.Builtin.value_or_null ~why:(Primitive Predef.ident_or_null)
-            (* Even though this type is abstract, it's actually a reexport of ['a
-               or_null], which has a best kind *)
-            |> Jkind.mark_best
-          in
+          let jkind = Predef.or_null_jkind in
           Ttype_abstract, type_kind, jkind
       | (Ptype_variant _ | Ptype_record _ | Ptype_record_unboxed_product _
         | Ptype_open)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -143,11 +143,16 @@ and 'd jkind_desc = (Jkind_types.Sort.t Jkind_types.Layout.t, 'd) layout_and_axe
 
 and jkind_desc_packed = Pack_jkind_desc : ('l * 'r) jkind_desc -> jkind_desc_packed
 
+and 'd jkind_quality =
+  | Best : ('l * disallowed) jkind_quality
+  | Not_best : ('l * 'r) jkind_quality
+
 and 'd jkind =
   { jkind : 'd jkind_desc;
     annotation : Parsetree.jkind_annotation option;
     history : jkind_history;
-    has_warned : bool
+    has_warned : bool;
+    quality : 'd jkind_quality;
   }
   constraint 'd = 'l * 'r
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -281,11 +281,26 @@ and 'd jkind_desc = (Jkind_types.Sort.t Jkind_types.Layout.t, 'd) layout_and_axe
 
 and jkind_desc_packed = Pack_jkind_desc : ('l * 'r) jkind_desc -> jkind_desc_packed
 
+(** The "quality" of a jkind indicates whether we are able to learn more about the jkind
+    later.
+
+    We can never learn more about a [Best] jkind to make it "lower" (according to
+    [Jkind.sub] / [Jkind.sub_jkind_l]). A [Not_best], jkind, however, might have more
+    information provided about it later that makes it lower.
+
+    Note that only left jkinds can be [Best] (meaning we can never compare less than or
+    equal to a left jkind!)
+*)
+and 'd jkind_quality =
+  | Best : ('l * disallowed) jkind_quality
+  | Not_best : ('l * 'r) jkind_quality
+
 and 'd jkind =
   { jkind : 'd jkind_desc;
     annotation : Parsetree.jkind_annotation option;
     history : jkind_history;
-    has_warned : bool
+    has_warned : bool;
+    quality : 'd jkind_quality;
   }
   constraint 'd = 'l * 'r
 


### PR DESCRIPTION
Sometimes, inferred jkinds for a type are not exact, but instead *upper bounds*;
later, we might learn more about a type that causes us to lower that jkind
bound. For example, we might substitute a type variable, or perform `with`
substitution on an abstract type in a module type. It's important to know
whether this might happen, so that we can avoid normalizing away types with
jkinds that might get "better" later from with-bounds during jkind
normalization.

This commit adds a new "jkind_quality" type, and a "quality" field to jkind,
that tracks whether an inferred jkind is "best" or "not best", and sets this to
the correct value everywhere jkinds are constructed. Nothing actually /reads/
this field yet, but this will be used during normalization in a subsequent
commit.