### PR TITLE
Track types of variables bound by `as`

### DIFF
--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -297,10 +297,10 @@ type tpat_var_identifier = Value.l
 let mkTpat_var ?id:(mode = dummy_value_mode) (ident, name) =
   Tpat_var (ident, name, Uid.internal_not_actually_unique, mode)
 
-type tpat_alias_identifier = Value.l
+type tpat_alias_identifier = Value.l * Types.type_expr
 
-let mkTpat_alias ?id:(mode = dummy_value_mode) (p, ident, name) =
-  Tpat_alias (p, ident, name, Uid.internal_not_actually_unique, mode)
+let mkTpat_alias ~id:(mode, ty) (p, ident, name) =
+  Tpat_alias (p, ident, name, Uid.internal_not_actually_unique, mode, ty)
 
 type tpat_array_identifier = mutability * Jkind.sort
 
@@ -340,7 +340,8 @@ type 'a matched_pattern_desc =
 let view_tpat (type a) (p : a pattern_desc) : a matched_pattern_desc =
   match p with
   | Tpat_var (ident, name, _uid, mode) -> Tpat_var (ident, name, mode)
-  | Tpat_alias (p, ident, name, _uid, mode) -> Tpat_alias (p, ident, name, mode)
+  | Tpat_alias (p, ident, name, _uid, mode, ty) ->
+      Tpat_alias (p, ident, name, (mode, ty))
   | Tpat_array (mut, arg_sort, l) -> Tpat_array (l, (mut, arg_sort))
   | Tpat_tuple pats ->
       let labels, pats = List.split pats in

--- a/chamelon/compat.mli
+++ b/chamelon/compat.mli
@@ -121,7 +121,7 @@ val mkTpat_var :
   ?id:tpat_var_identifier -> Ident.t * string Location.loc -> value pattern_desc
 
 val mkTpat_alias :
-  ?id:tpat_alias_identifier ->
+  id:tpat_alias_identifier ->
   value general_pattern * Ident.t * string Location.loc ->
   value pattern_desc
 

--- a/chamelon/compat.upstream.ml
+++ b/chamelon/compat.upstream.ml
@@ -175,7 +175,7 @@ let mkTpat_var ?id:(() = ()) (ident, name) = Tpat_var (ident, name)
 
 type tpat_alias_identifier = unit
 
-let mkTpat_alias ?id:(() = ()) (p, ident, name) = Tpat_alias (p, ident, name)
+let mkTpat_alias ~id:() (p, ident, name) = Tpat_alias (p, ident, name)
 
 type tpat_array_identifier = unit
 

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -155,7 +155,7 @@ let create_object cl obj init =
 let name_pattern default p =
   match p.pat_desc with
   | Tpat_var (id, _, _, _) -> id
-  | Tpat_alias(_, id, _, _, _) -> id
+  | Tpat_alias(_, id, _, _, _, _) -> id
   | _ -> Ident.create_local default
 
 let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -322,7 +322,7 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
 let rec iter_exn_names f pat =
   match pat.pat_desc with
   | Tpat_var (id, _, _, _) -> f id
-  | Tpat_alias (p, id, _, _, _) ->
+  | Tpat_alias (p, id, _, _, _, _) ->
       f id;
       iter_exn_names f p
   | _ -> ()

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -51,7 +51,7 @@ module Typedtree_search =
     let iter_val_pattern = function
       | Typedtree.Tpat_any -> None
       | Typedtree.Tpat_var (name, _, _, _)
-      | Typedtree.Tpat_alias (_, name, _, _, _)  -> Some (Name.from_ident name)
+      | Typedtree.Tpat_alias (_, name, _, _, _, _)  -> Some (Name.from_ident name)
       | Typedtree.Tpat_tuple _ -> None (* FIXME when we will handle tuples *)
       | _ -> None
 
@@ -258,7 +258,7 @@ module Analyser =
                           sn_type = Odoc_env.subst_type env pat.pat_type
                         }
 
-        | Typedtree.Tpat_alias (pat, _, _, _, _) ->
+        | Typedtree.Tpat_alias (pat, _, _, _, _, _) ->
             iter_pattern pat
 
         | Typedtree.Tpat_tuple patlist ->

--- a/testsuite/tests/asmcomp/regression_value_kinds.ml
+++ b/testsuite/tests/asmcomp/regression_value_kinds.ml
@@ -1,0 +1,21 @@
+(* TEST
+ native;
+*)
+
+type r = { foo : float }
+
+type 'a t = Left of 'a | Right of r
+
+type 'a ty =
+  | Float : float ty
+  | Anything : 'a ty
+
+let f (type a) (ty : a ty) (x : a t) =
+  match ty, x with
+  | Float, Right { foo = (((3.5 : a) as a) : float) }
+  | _, Left a -> ignore (Sys.opaque_identity a)
+  | _, _ -> ()
+
+let f = Sys.opaque_identity f
+
+let () = f Anything (Left 0)

--- a/typing/cmt2annot.ml
+++ b/typing/cmt2annot.ml
@@ -23,7 +23,7 @@ let variables_iterator scope =
   let super = default_iterator in
   let pat sub (type k) (p : k general_pattern) =
     begin match p.pat_desc with
-    | Tpat_var (id, _, _, _) | Tpat_alias (_, id, _, _, _) ->
+    | Tpat_var (id, _, _, _) | Tpat_alias (_, id, _, _, _, _) ->
         Stypes.record (Stypes.An_ident (p.pat_loc,
                                         Ident.name id,
                                         Annot.Idef scope))

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -335,8 +335,8 @@ module Compat
   | ((Tpat_any|Tpat_var _),_)
   | (_,(Tpat_any|Tpat_var _)) -> true
 (* Structural induction *)
-  | Tpat_alias (p,_,_,_,_),_      -> compat p q
-  | _,Tpat_alias (q,_,_,_,_)      -> compat p q
+  | Tpat_alias (p,_,_,_,_,_),_      -> compat p q
+  | _,Tpat_alias (q,_,_,_,_,_)      -> compat p q
   | Tpat_or (p1,p2,_),_ ->
       (compat p1 q || compat p2 q)
   | _,Tpat_or (q1,q2,_) ->
@@ -1216,7 +1216,7 @@ let build_other ext env =
 let rec has_instance p = match p.pat_desc with
   | Tpat_variant (l,_,r) when is_absent l r -> false
   | Tpat_any | Tpat_var _ | Tpat_constant _ | Tpat_variant (_,None,_) -> true
-  | Tpat_alias (p,_,_,_,_) | Tpat_variant (_,Some p,_) -> has_instance p
+  | Tpat_alias (p,_,_,_,_,_) | Tpat_variant (_,Some p,_) -> has_instance p
   | Tpat_or (p1,p2,_) -> has_instance p1 || has_instance p2
   | Tpat_construct (_,_,ps, _) | Tpat_array (_, _, ps) ->
       has_instances ps
@@ -1676,7 +1676,7 @@ let is_var_column rs =
 (* Standard or-args for left-to-right matching *)
 let rec or_args p = match p.pat_desc with
 | Tpat_or (p1,p2,_) -> p1,p2
-| Tpat_alias (p,_,_,_,_)  -> or_args p
+| Tpat_alias (p,_,_,_,_,_)  -> or_args p
 | _                 -> assert false
 
 (* Just remove current column *)
@@ -1856,8 +1856,8 @@ and every_both pss qs q1 q2 =
 let rec le_pat p q =
   match (p.pat_desc, q.pat_desc) with
   | (Tpat_var _|Tpat_any),_ -> true
-  | Tpat_alias(p,_,_,_,_), _ -> le_pat p q
-  | _, Tpat_alias(q,_,_,_,_) -> le_pat p q
+  | Tpat_alias(p,_,_,_,_,_), _ -> le_pat p q
+  | _, Tpat_alias(q,_,_,_,_,_) -> le_pat p q
   | Tpat_constant(c1), Tpat_constant(c2) -> const_compare c1 c2 = 0
   | Tpat_construct(_,c1,ps,_), Tpat_construct(_,c2,qs,_) ->
       Types.equal_tag c1.cstr_tag c2.cstr_tag && le_pats ps qs
@@ -1917,8 +1917,8 @@ let get_mins le ps =
 *)
 
 let rec lub p q = match p.pat_desc,q.pat_desc with
-| Tpat_alias (p,_,_,_,_),_      -> lub p q
-| _,Tpat_alias (q,_,_,_,_)      -> lub p q
+| Tpat_alias (p,_,_,_,_,_),_      -> lub p q
+| _,Tpat_alias (q,_,_,_,_,_)      -> lub p q
 | (Tpat_any|Tpat_var _),_ -> q
 | _,(Tpat_any|Tpat_var _) -> p
 | Tpat_or (p1,p2,_),_     -> orlub p1 p2 q
@@ -2150,7 +2150,7 @@ let rec collect_paths_from_pat r p = match p.pat_desc with
     List.fold_left
       (fun r (_, _, p) -> collect_paths_from_pat r p)
       r lps
-| Tpat_variant (_, Some p, _) | Tpat_alias (p,_,_,_,_) ->
+| Tpat_variant (_, Some p, _) | Tpat_alias (p,_,_,_,_,_) ->
     collect_paths_from_pat r p
 | Tpat_or (p1,p2,_) ->
     collect_paths_from_pat (collect_paths_from_pat r p1) p2
@@ -2290,7 +2290,7 @@ let inactive ~partial pat =
             List.for_all (fun (_,p,_) -> loop p) ps
         | Tpat_construct (_, _, ps, _) | Tpat_array (Immutable, _, ps) ->
             List.for_all (fun p -> loop p) ps
-        | Tpat_alias (p,_,_,_,_) | Tpat_variant (_, Some p, _) ->
+        | Tpat_alias (p,_,_,_,_,_) | Tpat_variant (_, Some p, _) ->
             loop p
         | Tpat_record (ldps,_) ->
             List.for_all
@@ -2419,7 +2419,7 @@ type amb_row = { row : pattern list ; varsets : Ident.Set.t list; }
 let simplify_head_amb_pat head_bound_variables varsets ~add_column p ps k =
   let rec simpl head_bound_variables varsets p ps k =
     match (Patterns.General.view p).pat_desc with
-    | `Alias (p,x,_,_,_) ->
+    | `Alias (p,x,_,_,_,_) ->
       simpl (Ident.Set.add x head_bound_variables) varsets p ps k
     | `Var (x, _, _, _) ->
       simpl (Ident.Set.add x head_bound_variables) varsets Patterns.omega ps k

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -85,7 +85,8 @@ module General = struct
   type view = [
     | Half_simple.view
     | `Var of Ident.t * string loc * Uid.t * Mode.Value.l
-    | `Alias of pattern * Ident.t * string loc * Uid.t * Mode.Value.l
+    | `Alias of pattern * Ident.t * string loc
+                * Uid.t * Mode.Value.l * Types.type_expr
   ]
   type pattern = view pattern_data
 
@@ -94,8 +95,8 @@ module General = struct
        `Any
     | Tpat_var (id, str, uid, mode) ->
        `Var (id, str, uid, mode)
-    | Tpat_alias (p, id, str, uid, mode) ->
-       `Alias (p, id, str, uid, mode)
+    | Tpat_alias (p, id, str, uid, mode, ty) ->
+       `Alias (p, id, str, uid, mode, ty)
     | Tpat_constant cst ->
        `Constant cst
     | Tpat_tuple ps ->
@@ -120,7 +121,8 @@ module General = struct
   let erase_desc = function
     | `Any -> Tpat_any
     | `Var (id, str, uid, mode) -> Tpat_var (id, str, uid, mode)
-    | `Alias (p, id, str, uid, mode) -> Tpat_alias (p, id, str, uid, mode)
+    | `Alias (p, id, str, uid, mode, ty) ->
+       Tpat_alias (p, id, str, uid, mode, ty)
     | `Constant cst -> Tpat_constant cst
     | `Tuple ps -> Tpat_tuple ps
     | `Unboxed_tuple ps -> Tpat_unboxed_tuple ps
@@ -141,7 +143,7 @@ module General = struct
 
   let rec strip_vars (p : pattern) : Half_simple.pattern =
     match p.pat_desc with
-    | `Alias (p, _, _, _, _) -> strip_vars (view p)
+    | `Alias (p, _, _, _, _, _) -> strip_vars (view p)
     | `Var _ -> { p with pat_desc = `Any }
     | #Half_simple.view as view -> { p with pat_desc = view }
 end

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -69,7 +69,8 @@ module General : sig
   type view = [
     | Half_simple.view
     | `Var of Ident.t * string loc * Uid.t * Mode.Value.l
-    | `Alias of pattern * Ident.t * string loc * Uid.t * Mode.Value.l
+    | `Alias of pattern * Ident.t * string loc * Uid.t
+                * Mode.Value.l * Types.type_expr
   ]
   type pattern = view pattern_data
 

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -114,7 +114,7 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
       fprintf ppf "@[[%c %a %c]@]" punct (pretty_vals " ;") vs punct
   | Tpat_lazy v ->
       fprintf ppf "@[<2>lazy@ %a@]" pretty_arg v
-  | Tpat_alias (v, x, _, _, _) ->
+  | Tpat_alias (v, x, _, _, _, _) ->
       fprintf ppf "@[(%a@ as %a)@]" pretty_val v Ident.print x
   | Tpat_value v ->
       fprintf ppf "%a" pretty_val (v :> pattern)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -327,7 +327,7 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
   | Tpat_var (s,_,_,m) ->
       line i ppf "Tpat_var \"%a\"\n" fmt_ident s;
       value_mode i ppf m
-  | Tpat_alias (p, s,_,_,m) ->
+  | Tpat_alias (p, s,_,_,m,_) ->
       line i ppf "Tpat_alias \"%a\"\n" fmt_ident s;
       value_mode i ppf m;
       pattern i ppf p;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -270,7 +270,7 @@ let pat
   | Tpat_record_unboxed_product (l, _) ->
       List.iter (fun (lid, _, i) -> iter_loc sub lid; sub.pat sub i) l
   | Tpat_array (_, _, l) -> List.iter (sub.pat sub) l
-  | Tpat_alias (p, _, s, _, _) -> sub.pat sub p; iter_loc sub s
+  | Tpat_alias (p, _, s, _, _, _) -> sub.pat sub p; iter_loc sub s
   | Tpat_lazy p -> sub.pat sub p
   | Tpat_value p -> sub.pat sub (p :> pattern)
   | Tpat_exception p -> sub.pat sub p

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -319,8 +319,8 @@ let pat
         Tpat_record_unboxed_product
           (List.map (tuple3 (map_loc sub) id (sub.pat sub)) l, closed)
     | Tpat_array (am, arg_sort, l) -> Tpat_array (am, arg_sort, List.map (sub.pat sub) l)
-    | Tpat_alias (p, id, s, uid, m) ->
-        Tpat_alias (sub.pat sub p, id, map_loc sub s, uid, m)
+    | Tpat_alias (p, id, s, uid, m, ty) ->
+        Tpat_alias (sub.pat sub p, id, map_loc sub s, uid, m, ty)
     | Tpat_lazy p -> Tpat_lazy (sub.pat sub p)
     | Tpat_value p ->
        (as_computation_pattern (sub.pat sub (p :> pattern))).pat_desc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1449,7 +1449,7 @@ and build_as_type_aux (env : Env.t) p ~mode =
     ty, mode
   in
   match p.pat_desc with
-    Tpat_alias(p1,_, _, _, _) -> build_as_type_and_mode env p1 ~mode
+    Tpat_alias(p1,_, _, _, _, _) -> build_as_type_and_mode env p1 ~mode
   | Tpat_tuple pl ->
       let labeled_tyl =
         List.map (fun (label, p) -> label, build_as_type env p) pl in
@@ -2860,7 +2860,7 @@ and type_pat_aux
         enter_variable ~is_as_variable:true tps name.loc name mode ty_var
           sp.ppat_attributes
       in
-      rvp { pat_desc = Tpat_alias(q, id, name, uid, mode);
+      rvp { pat_desc = Tpat_alias(q, id, name, uid, mode, ty_var);
             pat_loc = loc; pat_extra=[];
             pat_type = q.pat_type;
             pat_attributes = sp.ppat_attributes;
@@ -3509,7 +3509,7 @@ let rec check_counter_example_pat
           in
           check_rec ~info:(decrease 5) tp expected_ty k
       end
-  | Tpat_alias (p, _, _, _, _) -> check_rec ~info p expected_ty k
+  | Tpat_alias (p, _, _, _, _, _) -> check_rec ~info p expected_ty k
   | Tpat_constant cst ->
       let cst = constant_or_raise !!penv loc (Untypeast.constant cst) in
       k @@ solve_expected (mp (Tpat_constant cst) ~pat_type:(type_constant cst))
@@ -4868,7 +4868,7 @@ let rec name_pattern default = function
   | p :: rem ->
     match p.pat_desc with
       Tpat_var (id, _, _, _) -> id
-    | Tpat_alias(_, id, _, _, _) -> id
+    | Tpat_alias(_, id, _, _, _, _) -> id
     | _ -> name_pattern default rem
 
 let name_cases default lst =
@@ -9187,7 +9187,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         let pat_name =
           match p.pat_desc with
             Tpat_var (id, _, _, _) -> Some id
-          | Tpat_alias(_, id, _, _, _) -> Some id
+          | Tpat_alias(_, id, _, _, _, _) -> Some id
           | _ -> None in
         Ctype.check_and_update_generalized_ty_jkind
           ?name:pat_name ~loc:exp.exp_loc env exp.exp_type

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -149,7 +149,8 @@ and 'k pattern_desc =
   | Tpat_any : value pattern_desc
   | Tpat_var : Ident.t * string loc * Uid.t * Mode.Value.l -> value pattern_desc
   | Tpat_alias :
-      value general_pattern * Ident.t * string loc * Uid.t * Mode.Value.l -> value pattern_desc
+      value general_pattern * Ident.t * string loc * Uid.t * Mode.Value.l
+      * Types.type_expr -> value pattern_desc
   | Tpat_constant : constant -> value pattern_desc
   | Tpat_tuple : (string option * value general_pattern) list -> value pattern_desc
   | Tpat_unboxed_tuple :
@@ -978,7 +979,7 @@ type pattern_action =
 let shallow_iter_pattern_desc
   : type k . pattern_action -> k pattern_desc -> unit
   = fun f -> function
-  | Tpat_alias(p, _, _, _, _) -> f.f p
+  | Tpat_alias(p, _, _, _, _, _) -> f.f p
   | Tpat_tuple patl -> List.iter (fun (_, p) -> f.f p) patl
   | Tpat_unboxed_tuple patl -> List.iter (fun (_, p, _) -> f.f p) patl
   | Tpat_construct(_, _, patl, _) -> List.iter f.f patl
@@ -1001,8 +1002,8 @@ type pattern_transformation =
 let shallow_map_pattern_desc
   : type k . pattern_transformation -> k pattern_desc -> k pattern_desc
   = fun f d -> match d with
-  | Tpat_alias (p1, id, s, uid, m) ->
-      Tpat_alias (f.f p1, id, s, uid, m)
+  | Tpat_alias (p1, id, s, uid, m, ty) ->
+      Tpat_alias (f.f p1, id, s, uid, m, ty)
   | Tpat_tuple pats ->
       Tpat_tuple (List.map (fun (label, pat) -> label, f.f pat) pats)
   | Tpat_unboxed_tuple pats ->
@@ -1071,9 +1072,9 @@ let rec iter_bound_idents
   match pat.pat_desc with
   | Tpat_var (id, s, uid, _mode) ->
      f (id,s,pat.pat_type, uid)
-  | Tpat_alias(p, id, s, uid, _mode) ->
+  | Tpat_alias(p, id, s, uid, _mode, ty) ->
       iter_bound_idents f p;
-      f (id,s,pat.pat_type, uid)
+      f (id, s, ty, uid)
   | Tpat_or(p1, _, _) ->
       (* Invariant : both arguments bind the same variables *)
       iter_bound_idents f p1
@@ -1112,9 +1113,9 @@ let iter_pattern_full ~of_sort ~of_const_sort ~both_sides_of_or f sort pat =
       (* Cases where we push the sort inwards: *)
       | Tpat_var (id, s, uid, mode) ->
           f id s pat.pat_type uid mode sort
-      | Tpat_alias(p, id, s, uid, mode) ->
+      | Tpat_alias(p, id, s, uid, mode, ty) ->
           loop f sort p;
-          f id s pat.pat_type uid mode sort
+          f id s ty uid mode sort
       | Tpat_or (p1, p2, _) ->
         if both_sides_of_or then (loop f sort p1; loop f sort p2)
         else loop f sort p1
@@ -1252,10 +1253,11 @@ let rec alpha_pat
       {p with pat_desc =
        try Tpat_var (alpha_var env id, s, uid, mode) with
        | Not_found -> Tpat_any}
-  | Tpat_alias (p1, id, s, uid, mode) ->
+  | Tpat_alias (p1, id, s, uid, mode, ty) ->
       let new_p =  alpha_pat env p1 in
       begin try
-        {p with pat_desc = Tpat_alias (new_p, alpha_var env id, s, uid, mode)}
+        {p with pat_desc =
+           Tpat_alias (new_p, alpha_var env id, s, uid, mode, ty)}
       with
       | Not_found -> new_p
       end

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -161,6 +161,7 @@ and 'k pattern_desc =
         (** x *)
   | Tpat_alias :
       value general_pattern * Ident.t * string loc * Uid.t * Mode.Value.l
+      * Types.type_expr
         -> value pattern_desc
         (** P as a *)
   | Tpat_constant : constant -> value pattern_desc

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -1932,7 +1932,7 @@ and pattern_match_single pat paths : Ienv.Extension.t * UF.t =
       Ienv.Extension.disjunct ext0 ext1, UF.choose uf0 uf1
     | Tpat_any -> Ienv.Extension.empty, UF.unused
     | Tpat_var (id, _, _, _) -> Ienv.Extension.singleton id paths, UF.unused
-    | Tpat_alias (pat', id, _, _, _) ->
+    | Tpat_alias (pat', id, _, _, _, _) ->
       let ext0 = Ienv.Extension.singleton id paths in
       let ext1, uf = pattern_match_single pat' paths in
       Ienv.Extension.conjunct ext0 ext1, uf

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -351,11 +351,11 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
        The compiler transforms (x:t) into (_ as x : t).
        This avoids transforming a warning 27 into a 26.
      *)
-    | Tpat_alias ({pat_desc = Tpat_any; pat_loc}, _id, name, _uid, _mode)
+    | Tpat_alias ({pat_desc = Tpat_any; pat_loc}, _id, name, _uid, _mode, _ty)
          when pat_loc = pat.pat_loc ->
        Ppat_var name
 
-    | Tpat_alias (pat, _id, name, _uid, _mode) ->
+    | Tpat_alias (pat, _id, name, _uid, _mode, _ty) ->
         Ppat_alias (sub.pat sub pat, name)
     | Tpat_constant cst -> Ppat_constant (constant cst)
     | Tpat_tuple list ->
@@ -1006,7 +1006,7 @@ let core_type sub ct =
 
 let class_structure sub cs =
   let rec remove_self = function
-    | { pat_desc = Tpat_alias (p, id, _s, _uid, _mode) }
+    | { pat_desc = Tpat_alias (p, id, _s, _uid, _mode, _ty) }
       when string_is_prefix "selfpat-" (Ident.name id) ->
         remove_self p
     | p -> p
@@ -1036,7 +1036,7 @@ let object_field sub {of_loc; of_desc; of_attributes;} =
   Of.mk ~loc ~attrs desc
 
 and is_self_pat = function
-  | { pat_desc = Tpat_alias(_pat, id, _, _uid, _mode) } ->
+  | { pat_desc = Tpat_alias(_pat, id, _, _uid, _mode, _ty) } ->
       string_is_prefix "self-" (Ident.name id)
   | _ -> false
 

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -1457,7 +1457,7 @@ and is_destructuring_pattern : type k . k general_pattern -> bool =
   fun pat -> match pat.pat_desc with
     | Tpat_any -> false
     | Tpat_var (_, _, _, _) -> false
-    | Tpat_alias (pat, _, _, _, _) -> is_destructuring_pattern pat
+    | Tpat_alias (pat, _, _, _, _, _) -> is_destructuring_pattern pat
     | Tpat_constant _ -> true
     | Tpat_tuple _ -> true
     | Tpat_unboxed_tuple _ -> true


### PR DESCRIPTION
Keep the types of variables bound by `as` because they may not equal the types of the `as` patterns themselves. This fixes some incorrect value kinds that can lead to miscompilation.

Currently the following is miscompiled with `-O3`:
```ocaml
let[@inline never] use_error _error = ()

let f x =
  match x with
  | Error ( `A as error )
  | Ok ( `B () as error ) -> use_error error
  | Ok `C -> ()

let () = f (Ok (`B ()))
```