### PR TITLE
Load code when printing it in objinfo

### DIFF
--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -21,6 +21,8 @@ type t = Code_or_metadata.t Code_id.Map.t
 
 let print ppf t = Code_id.Map.print Code_or_metadata.print ppf t
 
+let print_view ppf t = Code_id.Map.print Code_or_metadata.print_view ppf t
+
 let empty = Code_id.Map.empty
 
 let free_names t =

--- a/middle_end/flambda2/cmx/exported_code.mli
+++ b/middle_end/flambda2/cmx/exported_code.mli
@@ -23,6 +23,8 @@ val apply_renaming : Code_id.t Code_id.Map.t -> Renaming.t -> t -> t
 
 val print : Format.formatter -> t -> unit
 
+val print_view : Format.formatter -> t -> unit
+
 val empty : t
 
 val free_names : t -> Name_occurrences.t

--- a/middle_end/flambda2/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.ml
@@ -220,7 +220,7 @@ let print0 ~sections ~print_typing_env ~print_code ~print_offsets ppf t =
     Format.fprintf ppf "@[<hov>Typing env:@ %a@]@;"
       Flambda2_types.Typing_env.Serializable.print typing_env;
   if print_code
-  then Format.fprintf ppf "@[<hov>Code:@ %a@]@;" Exported_code.print code;
+  then Format.fprintf ppf "@[<hov>Code:@ %a@]@;" Exported_code.print_view code;
   if print_offsets
   then
     Format.fprintf ppf "@[<hov>Offsets:@ %a@]@;" Exported_offsets.print

--- a/middle_end/flambda2/terms/code_or_metadata.ml
+++ b/middle_end/flambda2/terms/code_or_metadata.ml
@@ -37,10 +37,23 @@ type raw =
     code_present : code_present
   }
 
+let print_loaded ppf code =
+  Format.fprintf ppf "@[<hov 1>(Code_present@ (@[<hov 1>(code@ %a)@]))@]"
+    Code.print code
+
+let print_metadata_only ppf code_metadata =
+  Format.fprintf ppf "@[<hov 1>(Metadata_only@ (code_metadata@ %a))@]"
+    Code_metadata.print code_metadata
+
 module View = struct
   type t =
     | Code_present of Code.t
     | Metadata_only of Code_metadata.t
+
+  let print ppf t =
+    match t with
+    | Code_present code -> print_loaded ppf code
+    | Metadata_only code_metadata -> print_metadata_only ppf code_metadata
 end
 
 let view t =
@@ -76,17 +89,15 @@ let get_code t =
 
 let print ppf t =
   match t with
-  | Code_present { code_status = Loaded code } ->
-    Format.fprintf ppf "@[<hov 1>(Code_present@ (@[<hov 1>(code@ %a)@]))@]"
-      Code.print code
+  | Code_present { code_status = Loaded code } -> print_loaded ppf code
   | Code_present { code_status = Not_loaded not_loaded } ->
     Format.fprintf ppf
       "@[<hov 1>(Present@ (@[<hov 1>(code@ Not_loaded)@]@[<hov 1>(metadata@ \
        %a)@]))@]"
       Code_metadata.print not_loaded.metadata
-  | Metadata_only code_metadata ->
-    Format.fprintf ppf "@[<hov 1>(Metadata_only@ (code_metadata@ %a))@]"
-      Code_metadata.print code_metadata
+  | Metadata_only code_metadata -> print_metadata_only ppf code_metadata
+
+let print_view ppf t = View.print ppf (view t)
 
 let code_status_metadata = function
   | Loaded code -> Code.code_metadata code

--- a/middle_end/flambda2/terms/code_or_metadata.mli
+++ b/middle_end/flambda2/terms/code_or_metadata.mli
@@ -21,6 +21,8 @@ module View : sig
   type t = private
     | Code_present of Code.t
     | Metadata_only of Code_metadata.t
+
+  val print : Format.formatter -> t -> unit
 end
 
 val view : t -> View.t
@@ -29,6 +31,8 @@ val view : t -> View.t
 val get_code : t -> Code.t
 
 val print : Format.formatter -> t -> unit
+
+val print_view : Format.formatter -> t -> unit
 
 val merge : Code_id.t -> t -> t -> t option
 


### PR DESCRIPTION
Currently `objinfo` displays all flambda2 code as `Not_loaded`, which is not useful. (If someone doesn't want to see code they can still use `-no-code` with this PR.)