### PR TITLE
Maintain stack alignment in OCaml callbacks

### DIFF
--- a/flambda-backend/tests/simd/callback.ml
+++ b/flambda-backend/tests/simd/callback.ml
@@ -81,16 +81,12 @@ type _ Effect.t += E : unit Effect.t
 
 let eff0 () =
   try Effect.Deep.try_with (fun () -> Effect.perform E) ()
-    { effc = (fun (type a) (e : a Effect.t) ->
-        match e with
-        | e -> None) }
+    { effc = (fun (type a) (e : a Effect.t) -> None) }
   with Effect.Unhandled E -> callback ()
 
 let eff1 () =
   Effect.Deep.try_with (fun () -> callback ()) ()
-    { effc = (fun (type a) (e : a Effect.t) ->
-        match e with
-        | e -> None) };
+    { effc = (fun (type a) (e : a Effect.t) -> None) };
   callback ()
 
 let eff2 () =
@@ -99,7 +95,7 @@ let eff2 () =
         match e with
         | E -> callback ();
           Some (fun (k : (a, unit) Effect.Deep.continuation) -> callback ())
-        | e -> None) };
+        | _ -> None) };
   callback ()
 
 let eff3 () =
@@ -108,16 +104,14 @@ let eff3 () =
       match e with
       | E -> Some (fun (k : (a, unit) Effect.Deep.continuation) ->
           callback (); Effect.Deep.continue k ())
-      | e -> None) };
+      | _ -> None) };
   callback ()
 
 let eff4 () =
   Effect.Deep.match_with (fun () -> ()) ()
     { retc = (fun () -> callback ())
     ; exnc = (fun _ -> ())
-    ; effc = (fun (type a) (e : a Effect.t) ->
-        match e with
-        | e -> None)
+    ; effc = (fun (type a) (e : a Effect.t) -> None)
     };
   callback ()
 
@@ -125,9 +119,7 @@ let eff5 () =
   Effect.Deep.match_with (fun () -> assert false) ()
     { retc = (fun () -> assert false)
     ; exnc = (fun _ -> callback ())
-    ; effc = (fun (type a) (e : a Effect.t) ->
-        match e with
-        | e -> None)
+    ; effc = (fun (type a) (e : a Effect.t) -> None)
     };
   callback ()
 
@@ -137,9 +129,7 @@ let eff6 () =
   try Effect.Deep.match_with (fun () ->
     callback ();
     Effect.Deep.try_with (fun () -> callback (); Effect.perform E2; assert false) ()
-          { effc = (fun (type a) (e : a Effect.t) ->
-              match e with
-              | e -> None) }) ()
+          { effc = (fun (type a) (e : a Effect.t) -> None) }) ()
     { retc = (fun () -> callback (); Effect.perform E; assert false)
     ; exnc = (function
               | Effect.Unhandled E2 -> callback (); Effect.perform E
@@ -148,7 +138,7 @@ let eff6 () =
         match e with
         | E -> Some (fun (k : (a, unit) Effect.Deep.continuation) ->
           callback (); Effect.Deep.continue k ())
-        | e -> None)
+        | _ -> None)
     };
   with Effect.Unhandled E -> callback ();
   callback ()

--- a/flambda-backend/tests/simd/callback.ml
+++ b/flambda-backend/tests/simd/callback.ml
@@ -129,8 +129,8 @@ let eff6 () =
   try Effect.Deep.match_with (fun () ->
     callback ();
     Effect.Deep.try_with (fun () -> callback (); Effect.perform E2; assert false) ()
-          { effc = (fun (type a) (_ : a Effect.t) -> None) }) ()
-    { retc = (fun () -> callback (); Effect.perform E; assert false)
+          { effc = (fun (type a) (_ : a Effect.t) -> callback (); Effect.perform E; callback (); None) }) ()
+    { retc = (fun () -> assert false)
     ; exnc = (function
               | Effect.Unhandled E2 -> callback (); Effect.perform E
               | _ -> assert false)
@@ -143,18 +143,22 @@ let eff6 () =
   with Effect.Unhandled E -> callback ();
   callback ()
 
-let () = eff0 ()
-let () = eff1 ()
-let () = eff2 ()
-let () = eff3 ()
-let () = eff4 ()
-let () = eff5 ()
-let () = eff6 ()
+external runtime5 : unit -> bool = "%runtime5"
 
-let () = run_callback eff0
-let () = run_callback eff1
-let () = run_callback eff2
-let () = run_callback eff3
-let () = run_callback eff4
-let () = run_callback eff5
-let () = run_callback eff6
+let () =
+  if runtime5 () then (
+    eff0 ();
+    eff1 ();
+    eff2 ();
+    eff3 ();
+    eff4 ();
+    eff5 ();
+    eff6 ();
+    run_callback eff0;
+    run_callback eff1;
+    run_callback eff2;
+    run_callback eff3;
+    run_callback eff4;
+    run_callback eff5;
+    run_callback eff6)
+  else ()

--- a/flambda-backend/tests/simd/callback.ml
+++ b/flambda-backend/tests/simd/callback.ml
@@ -81,12 +81,12 @@ type _ Effect.t += E : unit Effect.t
 
 let eff0 () =
   try Effect.Deep.try_with (fun () -> Effect.perform E) ()
-    { effc = (fun (type a) (e : a Effect.t) -> None) }
+    { effc = (fun (type a) (_ : a Effect.t) -> None) }
   with Effect.Unhandled E -> callback ()
 
 let eff1 () =
   Effect.Deep.try_with (fun () -> callback ()) ()
-    { effc = (fun (type a) (e : a Effect.t) -> None) };
+    { effc = (fun (type a) (_ : a Effect.t) -> None) };
   callback ()
 
 let eff2 () =
@@ -94,7 +94,7 @@ let eff2 () =
     { effc = (fun (type a) (e : a Effect.t) ->
         match e with
         | E -> callback ();
-          Some (fun (k : (a, unit) Effect.Deep.continuation) -> callback ())
+          Some (fun (_ : (a, unit) Effect.Deep.continuation) -> callback ())
         | _ -> None) };
   callback ()
 
@@ -111,7 +111,7 @@ let eff4 () =
   Effect.Deep.match_with (fun () -> ()) ()
     { retc = (fun () -> callback ())
     ; exnc = (fun _ -> ())
-    ; effc = (fun (type a) (e : a Effect.t) -> None)
+    ; effc = (fun (type a) (_ : a Effect.t) -> None)
     };
   callback ()
 
@@ -119,7 +119,7 @@ let eff5 () =
   Effect.Deep.match_with (fun () -> assert false) ()
     { retc = (fun () -> assert false)
     ; exnc = (fun _ -> callback ())
-    ; effc = (fun (type a) (e : a Effect.t) -> None)
+    ; effc = (fun (type a) (_ : a Effect.t) -> None)
     };
   callback ()
 
@@ -129,7 +129,7 @@ let eff6 () =
   try Effect.Deep.match_with (fun () ->
     callback ();
     Effect.Deep.try_with (fun () -> callback (); Effect.perform E2; assert false) ()
-          { effc = (fun (type a) (e : a Effect.t) -> None) }) ()
+          { effc = (fun (type a) (_ : a Effect.t) -> None) }) ()
     { retc = (fun () -> callback (); Effect.perform E; assert false)
     ; exnc = (function
               | Effect.Unhandled E2 -> callback (); Effect.perform E

--- a/flambda-backend/tests/simd/callback.ml
+++ b/flambda-backend/tests/simd/callback.ml
@@ -1,0 +1,77 @@
+open Stdlib
+
+external run_callback : (unit -> unit) -> unit = "" "vec128_run_callback"
+
+external run_callback_stack_args :
+  int -> int -> int -> int -> int -> int -> int -> int ->
+  (int -> int -> int -> int -> int -> int -> int -> int -> unit) -> unit = "" "vec128_run_callback_stack_args"
+
+external low_of : float32 -> float32x4 = "caml_vec128_unreachable" "caml_float32x4_low_of_float32"
+  [@@noalloc] [@@unboxed] [@@builtin]
+external low_to : float32x4 -> float32 = "caml_vec128_unreachable" "caml_float32x4_low_to_float32"
+  [@@noalloc] [@@unboxed] [@@builtin]
+
+external add : float32x4 -> float32x4 -> float32x4 = "caml_vec128_unreachable" "caml_sse_float32x4_add"
+  [@@noalloc] [@@unboxed] [@@builtin]
+
+let callback () =
+  let x0 = low_of 0.0s in
+  let x1 = low_of 1.0s in
+  let x2 = low_of 2.0s in
+  let x3 = low_of 3.0s in
+  let x4 = low_of 4.0s in
+  let x5 = low_of 5.0s in
+  let x6 = low_of 6.0s in
+  let x7 = low_of 7.0s in
+  let x8 = low_of 8.0s in
+  let x9 = low_of 9.0s in
+  let x10 = low_of 10.0s in
+  let x11 = low_of 11.0s in
+  let x12 = low_of 12.0s in
+  let x13 = low_of 13.0s in
+  let x14 = low_of 14.0s in
+  let x15 = low_of 15.0s in
+  let x16 = low_of 16.0s in
+  let sum = add x16
+            (add (add (add (add x0 x1) (add x2 x3)) (add (add x4 x5) (add x6 x7)))
+                (add (add (add x8 x9) (add x10 x11)) (add (add x12 x13) (add x14 x15)))) in
+  assert (low_to sum = 136.s)
+
+let callback_n i0 i1 i2 i3 i4 i5 i6 i7 =
+  assert (i0 = 0 && i1 = 1 && i2 = 2 && i3 = 3 && i4 = 4 && i5 = 5 && i6 = 6 && i7 = 7);
+  callback ()
+
+(* Previously failing tests *)
+
+let () = run_callback callback
+
+let () = run_callback_stack_args 0 1 2 3 4 5 6 7 callback_n
+
+let () =
+  let[@inline never] finalizer () =
+    let x = ref () in
+    Gc.finalise (fun _ -> callback ()) x
+  in
+  finalizer ();
+  Gc.full_major ()
+
+let () = Sys.with_async_exns callback
+
+(* Additional checks *)
+
+let () = callback ()
+
+let () =
+  try Sys.with_async_exns (fun () -> raise Sys.Break) with
+  | Sys.Break -> callback ()
+  | _ -> assert false
+
+let[@loop never] rec stack_overflow () = stack_overflow () [@nontail]
+
+let () =
+  try Sys.with_async_exns stack_overflow with
+  | Stack_overflow -> callback ()
+  | _ -> assert false
+
+(* CR mslater: make sure this works with effects. I believe it will since caml_perform
+   only switches between existing stacks. *)

--- a/flambda-backend/tests/simd/dune
+++ b/flambda-backend/tests/simd/dune
@@ -95,7 +95,7 @@
     (run ./consts.exe))
    (with-outputs-to
     consts_u.out
-    (run ./callback.exe))
+    (run ./consts_u.exe))
    (with-outputs-to
     callback.out
     (run ./callback.exe)))))

--- a/flambda-backend/tests/simd/dune
+++ b/flambda-backend/tests/simd/dune
@@ -11,14 +11,35 @@
  (archive_name stubs)
  (language c)
  (names stubs)
- (flags (:standard -msse4.2))
+ (flags
+  (:standard -msse4.2))
  (include_dirs "../../../%{env:RUNTIME_DIR=runtime-dir-env-var-not-set}"))
 
 ; Tests with external assembler
 
 (executables
- (names basic basic_u ops ops_u arrays arrays_u scalar_ops consts consts_u)
- (modules basic basic_u ops ops_u arrays arrays_u scalar_ops consts consts_u)
+ (names
+  basic
+  basic_u
+  ops
+  ops_u
+  arrays
+  arrays_u
+  scalar_ops
+  consts
+  consts_u
+  callback)
+ (modules
+  basic
+  basic_u
+  ops
+  ops_u
+  arrays
+  arrays_u
+  scalar_ops
+  consts
+  consts_u
+  callback)
  (libraries simd_test_helpers stdlib_stable stdlib_upstream_compatible)
  (foreign_archives stubs))
 
@@ -34,7 +55,8 @@
   arrays_u.out
   scalar_ops.out
   consts.out
-  consts_u.out)
+  consts_u.out
+  callback.out)
  (deps
   basic.exe
   basic_u.exe
@@ -43,7 +65,8 @@
   arrays_u.exe
   scalar_ops.exe
   consts.exe
-  consts_u.exe)
+  consts_u.exe
+  callback.exe)
  (action
   (progn
    (with-outputs-to
@@ -72,7 +95,10 @@
     (run ./consts.exe))
    (with-outputs-to
     consts_u.out
-    (run ./consts_u.exe)))))
+    (run ./callback.exe))
+   (with-outputs-to
+    callback.out
+    (run ./callback.exe)))))
 
 (rule
  (alias runtest)
@@ -90,7 +116,8 @@
    (diff empty.expected arrays_u.out)
    (diff empty.expected scalar_ops.out)
    (diff empty.expected consts.out)
-   (diff empty.expected consts_u.out))))
+   (diff empty.expected consts_u.out)
+   (diff empty.expected callback.out))))
 
 ; Tests with nodynlink
 
@@ -104,7 +131,8 @@
   consts_u_nodynlink.ml
   arrays_nodynlink.ml
   arrays_u_nodynlink.ml
-  scalar_ops_nodynlink.ml)
+  scalar_ops_nodynlink.ml
+  callback_nodynlink.ml)
  (deps
   basic.ml
   basic_u.ml
@@ -114,7 +142,8 @@
   consts_u.ml
   arrays.ml
   arrays_u.ml
-  scalar_ops.ml)
+  scalar_ops.ml
+  callback.ml)
  (action
   (progn
    (copy basic.ml basic_nodynlink.ml)
@@ -125,7 +154,8 @@
    (copy consts_u.ml consts_u_nodynlink.ml)
    (copy arrays.ml arrays_nodynlink.ml)
    (copy arrays_u.ml arrays_u_nodynlink.ml)
-   (copy scalar_ops.ml scalar_ops_nodynlink.ml))))
+   (copy scalar_ops.ml scalar_ops_nodynlink.ml)
+   (copy callback.ml callback_nodynlink.ml))))
 
 (executables
  (names
@@ -137,7 +167,8 @@
   consts_u_nodynlink
   arrays_nodynlink
   arrays_u_nodynlink
-  scalar_ops_nodynlink)
+  scalar_ops_nodynlink
+  callback_nodynlink)
  (modules
   basic_nodynlink
   basic_u_nodynlink
@@ -147,7 +178,8 @@
   consts_u_nodynlink
   arrays_nodynlink
   arrays_u_nodynlink
-  scalar_ops_nodynlink)
+  scalar_ops_nodynlink
+  callback_nodynlink)
  (libraries simd_test_helpers stdlib_stable stdlib_upstream_compatible)
  (foreign_archives stubs)
  (ocamlopt_flags
@@ -165,7 +197,8 @@
   consts_u_nodynlink.out
   arrays_nodynlink.out
   arrays_u_nodynlink.out
-  scalar_ops_nodynlink.out)
+  scalar_ops_nodynlink.out
+  callback_nodynlink.out)
  (deps
   basic_nodynlink.exe
   ops_nodynlink.exe
@@ -173,7 +206,8 @@
   consts_u_nodynlink.exe
   arrays_nodynlink.exe
   arrays_u_nodynlink.exe
-  scalar_ops_nodynlink.exe)
+  scalar_ops_nodynlink.exe
+  callback_nodynlink.exe)
  (action
   (progn
    (with-outputs-to
@@ -202,7 +236,10 @@
     (run ./consts_nodynlink.exe))
    (with-outputs-to
     consts_u_nodynlink.out
-    (run ./consts_u_nodynlink.exe)))))
+    (run ./consts_u_nodynlink.exe))
+   (with-outputs-to
+    callback_nodynlink.out
+    (run ./callback_nodynlink.exe)))))
 
 (rule
  (alias runtest)
@@ -220,7 +257,8 @@
    (diff empty.expected arrays_u_nodynlink.out)
    (diff empty.expected scalar_ops_nodynlink.out)
    (diff empty.expected consts_nodynlink.out)
-   (diff empty.expected consts_u_nodynlink.out))))
+   (diff empty.expected consts_u_nodynlink.out)
+   (diff empty.expected callback_nodynlink.out))))
 
 ; Tests with probes / internal assembler - not supported on macOS
 
@@ -241,7 +279,8 @@
   consts_u_internal.ml
   arrays_internal.ml
   arrays_u_internal.ml
-  scalar_ops_internal.ml)
+  scalar_ops_internal.ml
+  callback_internal.ml)
  (deps
   basic.ml
   basic_u.ml
@@ -249,7 +288,8 @@
   ops_u.ml
   consts.ml
   consts_u.ml
-  scalar_ops.ml)
+  scalar_ops.ml
+  callback.ml)
  (action
   (progn
    (copy basic.ml basic_internal.ml)
@@ -260,7 +300,8 @@
    (copy consts_u.ml consts_u_internal.ml)
    (copy arrays.ml arrays_internal.ml)
    (copy arrays_u.ml arrays_u_internal.ml)
-   (copy scalar_ops.ml scalar_ops_internal.ml))))
+   (copy scalar_ops.ml scalar_ops_internal.ml)
+   (copy callback.ml callback_internal.ml))))
 
 (executables
  (names
@@ -272,7 +313,8 @@
   consts_u_internal
   arrays_internal
   arrays_u_internal
-  scalar_ops_internal)
+  scalar_ops_internal
+  callback_internal)
  (modules
   basic_internal
   basic_u_internal
@@ -282,7 +324,8 @@
   consts_u_internal
   arrays_internal
   arrays_u_internal
-  scalar_ops_internal)
+  scalar_ops_internal
+  callback_internal)
  (libraries simd_test_helpers stdlib_stable stdlib_upstream_compatible)
  (enabled_if
   (<> %{system} macosx))
@@ -305,7 +348,8 @@
   consts_u_internal.out
   arrays_internal.out
   arrays_u_internal.out
-  scalar_ops_internal.out)
+  scalar_ops_internal.out
+  callback_internal.out)
  (deps
   probes.exe
   basic_internal.exe
@@ -314,7 +358,8 @@
   consts_u_internal.exe
   arrays_internal.exe
   arrays_u_internal.exe
-  scalar_ops_internal.exe)
+  scalar_ops_internal.exe
+  callback_internal.exe)
  (action
   (progn
    (with-outputs-to
@@ -346,7 +391,10 @@
     (run ./consts_internal.exe))
    (with-outputs-to
     consts_u_internal.out
-    (run ./consts_u_internal.exe)))))
+    (run ./consts_u_internal.exe))
+   (with-outputs-to
+    callback_internal.out
+    (run ./callback_internal.exe)))))
 
 (rule
  (alias runtest)
@@ -366,4 +414,5 @@
    (diff empty.expected arrays_u_internal.out)
    (diff empty.expected scalar_ops_internal.out)
    (diff empty.expected consts_internal.out)
-   (diff empty.expected consts_u_internal.out))))
+   (diff empty.expected consts_u_internal.out)
+   (diff empty.expected callback_internal.out))))

--- a/flambda-backend/tests/simd/stubs.c
+++ b/flambda-backend/tests/simd/stubs.c
@@ -1,8 +1,22 @@
 
 #include <caml/memory.h>
 #include <caml/simd.h>
+#include <caml/callback.h>
 #include <smmintrin.h>
 #include <assert.h>
+
+value vec128_run_callback(value f)
+{
+  CAMLparam1(f);
+  CAMLreturn(caml_callback(f, Val_unit));
+}
+
+value vec128_run_callback_stack_args(value i0, value i1, value i2, value i3, value i4, value i5, value i6, value i7, value f)
+{
+  CAMLparam1(f); // Others are ints
+  value args[] = {i0, i1, i2, i3, i4, i5, i6, i7};
+  CAMLreturn(caml_callbackN(f, 8, args));
+}
 
 int64_t vec128_low_int64(__m128i v)
 {
@@ -19,7 +33,7 @@ __m128i vec128_of_int64s(int64_t low, int64_t high)
   return _mm_set_epi64x(high, low);
 }
 
-CAMLprim value boxed_combine(value v0, value v1)
+value boxed_combine(value v0, value v1)
 {
   CAMLparam2(v0, v1);
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1365,7 +1365,7 @@ LBL(frame_runstack):
         leaq    32(%rsp), %r11 /* SP with exn handler popped */
 #if Stack_padding_word
     /* Pop the additional alignment padding word *and* the stack padding word,
-       so that $r11 points to the handler struct. */
+       so that %r11 points to the handler struct. */
         addq    $16, %r11
 #endif
         movq    Handler_value(%r11), %rbx
@@ -1396,7 +1396,7 @@ LBL(fiber_exn_handler):
         leaq    16(%rsp), %r11
 #if Stack_padding_word
     /* Pop the additional alignment padding word *and* the stack padding word,
-       so that $r11 points to the handler struct. */
+       so that %r11 points to the handler struct. */
         addq    $16, %r11
 #endif
         movq    Handler_exception(%r11), %rbx

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -934,7 +934,7 @@ LBL(108):
         movq    %r11, Caml_state(gc_regs)
         addq    $16, %r10
 #if Stack_padding_word
-    /* Pop the additional alignment padding word. */
+    /* Pop the additional alignment padding word */
         addq    $8, %r10
 #endif
     /* Update alloc ptr */
@@ -1353,15 +1353,21 @@ CFI_STARTPROC
             16 /* exn */ +                            \
             8 /* gc_regs slot (unused) */ +           \
             8 /* C_STACK_SP for DWARF (unused) */ +   \
-            8 * Stack_padding_word +                  \
+            16 * Stack_padding_word +                  \
             Handler_parent, DW_OP_deref,              \
           DW_OP_plus_uconst, Stack_sp, DW_OP_deref,   \
           DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
 #endif
         movq    %rdi, %rax /* first argument */
+        CHECK_STACK_ALIGNMENT;
         callq   *(%rbx) /* closure in %rbx (second argument) */
 LBL(frame_runstack):
         leaq    32(%rsp), %r11 /* SP with exn handler popped */
+#if Stack_padding_word
+    /* Pop the additional alignment padding word *and* the stack padding word,
+       so that $r11 points to the handler struct. */
+        addq    $16, %r11
+#endif
         movq    Handler_value(%r11), %rbx
 1:      movq    Caml_state(current_stack), C_ARG_1 /* arg to caml_free_stack */
     /* restore parent stack and exn_handler into Caml_state */
@@ -1388,6 +1394,11 @@ LBL(frame_runstack):
         jmp     *(%rbx)
 LBL(fiber_exn_handler):
         leaq    16(%rsp), %r11
+#if Stack_padding_word
+    /* Pop the additional alignment padding word *and* the stack padding word,
+       so that $r11 points to the handler struct. */
+        addq    $16, %r11
+#endif
         movq    Handler_exception(%r11), %rbx
         jmp     1b
 CFI_ENDPROC

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -889,6 +889,11 @@ LBL(caml_start_program):
     /* Load the OCaml stack. */
         movq    Caml_state(current_stack), %r11
         movq    Stack_sp(%r11), %r10
+#if Stack_padding_word
+    /* If the stack has a padding word, advance an additional word so that it
+       will be 16-aligned when entering OCaml */
+        subq    $8, %r10
+#endif
     /* Store the stack pointer to allow DWARF unwind */
         subq    $16, %r10
         movq    %rsp, 0(%r10) /* C_STACK_SP */
@@ -917,6 +922,7 @@ LBL(caml_start_program):
              6*8 /* callee save regs */ +                             \
              8   /* ret addr */
 #endif
+        CHECK_STACK_ALIGNMENT;
         call    *%r12
 LBL(108):
     /* pop exn handler */
@@ -927,6 +933,10 @@ LBL(108):
         movq    8(%r10), %r11
         movq    %r11, Caml_state(gc_regs)
         addq    $16, %r10
+#if Stack_padding_word
+    /* Pop the additional alignment padding word. */
+        addq    $8, %r10
+#endif
     /* Update alloc ptr */
         movq    %r15, Caml_state(young_ptr)
     /* Return to C stack. */
@@ -1320,6 +1330,11 @@ CFI_STARTPROC
         movq    %rcx, Handler_parent(%r11)
         movq    %rax, Caml_state(current_stack)
         movq    Stack_sp(%rax), %r11
+#if Stack_padding_word
+    /* If the stack has a padding word, advance an additional word so that it
+       will be 16-aligned when entering OCaml */
+        subq    $8, %r11
+#endif
     /* Create an exception handler on the target stack
        after 16byte DWARF & gc_regs block (which is unused here) */
         subq    $32, %r11
@@ -1337,8 +1352,9 @@ CFI_STARTPROC
           DW_OP_breg + DW_REG_rsp,                    \
             16 /* exn */ +                            \
             8 /* gc_regs slot (unused) */ +           \
-            8 /* C_STACK_SP for DWARF (unused) */     \
-            + Handler_parent, DW_OP_deref,            \
+            8 /* C_STACK_SP for DWARF (unused) */ +   \
+            8 * Stack_padding_word +                  \
+            Handler_parent, DW_OP_deref,              \
           DW_OP_plus_uconst, Stack_sp, DW_OP_deref,   \
           DW_OP_plus_uconst, RETADDR_ENTRY_SIZE
 #endif

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -214,6 +214,13 @@ typedef uint64_t uintnat;
 #define Stack_ctx_words (6 + 2)
 #endif
 
+/* Whether to offset Stack_high to preserve alignment. */
+#if defined(TARGET_amd64) && !defined(WITH_FRAME_POINTERS)
+#define Stack_padding_word 1
+#else
+#define Stack_padding_word 0
+#endif
+
 /* Default maximum size of the stack (words). */
 /* (1 Gib for 64-bit platforms, 512 Mib for 32-bit platforms) */
 #define Max_stack_def (128 * 1024 * 1024)

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -64,8 +64,7 @@ struct stack_info {
 #define Stack_base(stk) ((value*)(stk + 1))
 #define Stack_threshold_ptr(stk) \
   (Stack_base(stk) + Stack_threshold / sizeof(value))
-#define Stack_high(stk) (value*)stk->handler
-
+#define Stack_high(stk) ((value*)stk->handler - Stack_padding_word)
 #define Stack_handle_value(stk) (stk)->handler->handle_value
 #define Stack_handle_exception(stk) (stk)->handler->handle_exn
 #define Stack_handle_effect(stk) (stk)->handler->handle_effect
@@ -75,10 +74,12 @@ struct stack_info {
  *
  * +------------------------+
  * |  struct stack_handler  |
+ * +------------------------+ <--- 16-aligned
+ * | pad word (amd64-no-fp) |
  * +------------------------+ <--- Stack_high
  * |    caml_runstack /     |
  * |   caml_start_program   |
- * +------------------------+
+ * +------------------------+ <--- 16-aligned
  * |                        |
  * .      OCaml frames      . <--- sp
  * |                        |

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -72,7 +72,7 @@
 #define First_frame(sp) ((sp) + 8)
 #endif
 #define Saved_gc_regs(sp) (*(value **)((sp) + 24))
-#define Stack_header_size 32
+#define Stack_header_size (32 + Stack_padding_word * 8)
 #endif
 
 #ifdef TARGET_arm64


### PR DESCRIPTION
In runtime5, invoking OCaml code using `caml_callback` switches to the current fiber's OCaml stack. 
However, `caml_c_call` / `caml_c_call_stack_args` / `caml_call_gc` do not align the stack before saving the OCaml stack pointer and switching to the C stack. 
This results in the callback running on a misaligned OCaml stack, which will crash if it tries to spill a SIMD variable.

Instead, we now have:
1) Newly allocated stacks start with `sp = 8 mod 16` 
2) `caml_c_call` and friends still don't align the stack, so write `sp = 8 mod 16`
3) `caml_start_program` (and therefore `caml_callback`) expects `sp = 8 mod 16` and adds another padding word so that `sp = 0 mod 16` when entering OCaml.  

Note this is not necessary when frame pointers are enabled because `caml_c_call` and friends will align `sp` by pushing rbp. This is also the case on arm64.