### PR TITLE
Implicit source position: allow caller to explicitly pass an argument as `[%call_pos]`

### DIFF
--- a/jane/doc/implicit_source_code_positions/readme.md
+++ b/jane/doc/implicit_source_code_positions/readme.md
@@ -50,6 +50,20 @@ let require_does_raise_helper ~(outer_call_pos : [%call_pos]) f =
   require_does_raise ~here:outer_call_pos f
 ```
 
+At callsites, you can specify that an argument is `[%call_pos]` to help type inference
+infer the right type for a function. Usually this is only relevant in higher-order
+functions:
+
+```ocaml
+let wrap_function b f g ~here =
+  if b
+  then f ~(here : [%call_pos]) ()
+  else g ~(here : [%call_pos]) ()
+```
+
+Without the `[%call_pos]` annotations above, `f` and `g` would be inferred to take a labeled
+argument `~here`, not a `[%call_pos]` argument `~here`.
+
 Type checking / how does this work?
 -----------------------------------
 You can think of `[%call_pos]` as an optional parameter. It is type checked and behaves in

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1259,3 +1259,26 @@ Alert Translcore: Overwrite not implemented.
 Uncaught exception: File "parsing/location.ml", line 1107, characters 2-8: Assertion failed
 
 |}]
+
+(************)
+(* call_pos *)
+
+let f ~(x : [%call_pos]) () = x;;
+
+[%%expect{|
+val f : x:[%call_pos] -> unit -> lexing_position = <fun>
+|}]
+
+type t = x:[%call_pos] -> int
+
+[%%expect{|
+type t = x:[%call_pos] -> int
+|}]
+
+let f g here = g ~(here : [%call_pos])
+
+[%%expect{|
+val f :
+  ('a : value_or_null). (here:[%call_pos] -> 'a) -> lexing_position -> 'a =
+  <fun>
+|}]

--- a/testsuite/tests/typing-implicit-source-positions/expressions.ml
+++ b/testsuite/tests/typing-implicit-source-positions/expressions.ml
@@ -52,6 +52,35 @@ let _ = wrap `G (fun ~here:_ -> assert false)
 {pos_fname = ""; pos_lnum = 4; pos_bol = 1164; pos_cnum = 1186}
 |}]
 
+(* call_pos type annotations not permitted anywhere other than labelled arg
+   position *)
+let error1 x = (x : [%call_pos])
+
+[%%expect{|
+Line 1, characters 22-30:
+1 | let error1 x = (x : [%call_pos])
+                          ^^^^^^^^
+Error: [%call_pos] can only exist as the type of a labelled argument
+|}]
+
+let error2 f x = f (x : [%call_pos])
+
+[%%expect{|
+Line 1, characters 24-35:
+1 | let error2 f x = f (x : [%call_pos])
+                            ^^^^^^^^^^^
+Error: A position argument must not be unlabelled.
+|}]
+
+let error3 f x = f ?x:(x : [%call_pos])
+
+[%%expect{|
+Line 1, characters 27-38:
+1 | let error3 f x = f ?x:(x : [%call_pos])
+                               ^^^^^^^^^^^
+Error: A position argument must not be optional.
+|}]
+
 (* TEST
  expect;
 *)

--- a/testsuite/tests/typing-implicit-source-positions/expressions.ml
+++ b/testsuite/tests/typing-implicit-source-positions/expressions.ml
@@ -27,6 +27,31 @@ let _ = f ~call_pos:[%src_pos] () ;;
 {pos_fname = ""; pos_lnum = 2; pos_bol = 438; pos_cnum = 458}
 |}]
 
+(* passing an argment explicitly as call_pos *)
+let wrap x f g h ~here =
+  match x with
+  | `F -> f ~here
+  | `G -> g ~(here : [%call_pos]) ()
+  | `H -> h ~h_arg:(here : [%call_pos]) ()
+;;
+
+[%%expect{|
+val wrap :
+  [< `F | `G | `H ] ->
+  (here:lexing_position -> 'a) ->
+  (here:[%call_pos] -> unit -> 'a) ->
+  (h_arg:[%call_pos] -> unit -> 'a) -> here:lexing_position -> 'a = <fun>
+|}]
+
+let _ = wrap `G (fun ~here:_ -> assert false)
+                (fun ~(here:[%call_pos]) () -> here)
+                (fun ~h_arg:(_ : [%call_pos]) () -> assert false)
+                ~here:[%src_pos]
+[%%expect{|
+- : lexing_position =
+{pos_fname = ""; pos_lnum = 4; pos_bol = 1164; pos_cnum = 1186}
+|}]
+
 (* TEST
  expect;
 *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8036,12 +8036,14 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
       let arg =
         type_expect env expected_mode sarg (mk_expected ty_arg_mono)
       in
-      if is_optional lbl then
-        (* CR layouts v5: relax value requirement *)
-        unify_exp env arg
-          (type_option(newvar Predef.option_argument_jkind));
-      if is_position lbl then
-        unify_exp env arg (instance Predef.type_lexing_position);
+      (match lbl with
+       | Labelled _ | Nolabel -> ()
+       | Optional _ ->
+           (* CR layouts v5: relax value requirement *)
+           unify_exp env arg
+             (type_option(newvar Predef.option_argument_jkind))
+       | Position _ ->
+           unify_exp env arg (instance Predef.type_lexing_position));
       (lbl, Arg (arg, mode_arg, sort_arg))
   | Arg (Known_arg { sarg; ty_arg; ty_arg0;
                      mode_arg; wrapped_in_some; sort_arg }) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8040,6 +8040,8 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
         (* CR layouts v5: relax value requirement *)
         unify_exp env arg
           (type_option(newvar Predef.option_argument_jkind));
+      if is_position lbl then
+        unify_exp env arg (instance Predef.type_lexing_position);
       (lbl, Arg (arg, mode_arg, sort_arg))
   | Arg (Known_arg { sarg; ty_arg; ty_arg0;
                      mode_arg; wrapped_in_some; sort_arg }) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8164,11 +8164,7 @@ and type_application env app_loc expected_mode position_and_mode
       let ty_ret, mode_ret, args, position_and_mode =
         with_local_level_if_principal begin fun () ->
           let sargs = List.map
-            (* Application will never contain Position labels, so no need to pass
-               argument type here. When checking against the function type,
-               Labelled arguments will be matched up to Position parameters
-               based on label names *)
-            (fun (label, e) -> Typetexp.transl_label label None, e) sargs
+            (fun (label, e) -> Typetexp.transl_label_from_expr label e) sargs
           in
           let ty_ret, mode_ret, untyped_args =
             collect_apply_args env funct ignore_labels ty (instance ty)

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -83,6 +83,13 @@ val transl_label_from_pat :
         Parsetree.arg_label -> Parsetree.pattern
         -> Types.arg_label * Parsetree.pattern
 
+(** Like [transl_label_from_pat], but with special handling for expressions
+    [(E : [%call_pos])] instead of for patterns.
+*)
+val transl_label_from_expr :
+  Parsetree.arg_label -> Parsetree.expression
+  -> Types.arg_label * Parsetree.expression
+
 (* Note about [new_var_jkind]
 
    This is exposed as an option because the same initialization doesn't work in all


### PR DESCRIPTION
Allow users to write wrapper functions that call call-pos functions:
```ocaml
let wrap b f g ~here x = if b then f ~(here : [%call_pos]) x else g ~(here : [%call_pos]) x
```
If you drop the `[%call_pos]` annotations, `f` and `g` are inferred as having a normal label, not a `%call_pos` label. Prior to this PR, the easiest way of getting the proper types was with a type annotation:
```ocaml
let wrap b (f: here:[%call_pos] -> _) (g: here:[%call_pos] -> _) ~here x = ...
```
which works out ok in this small example, but becomes more painful if there are many args before the `%call_pos` arg.

The new feature feels fairly similar to the lightweight way that you can tell the compiler to infer an optional label for a function arg: `let f g x = g ?label:(Some x)`, as opposed to `let f g x = g ~label:x`.

This is upstream-compatible. You can erase `f ~(here : [%call_pos])` to `f ?here:(Some here)`. I haven't written the ocamlformat feature, but I could do this.