### PR TITLE
mode crossing values from modules

### DIFF
--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -284,7 +284,7 @@ val foo : unit -> unit = <fun>
 
 (* Closing over nonportable forces nonportable. *)
 let foo () =
-    let r @ nonportable = best_bytes () in
+    let r @ nonportable = fun x -> x in
     let bar () = let _ = r in () in
     let _ @ portable = bar in
     ()

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -256,7 +256,7 @@ module Inclusion_match : sig module M : sig val x : int ref end end
 (* [foo] closes over [M.x] instead of [M]. This is better ergonomics. *)
 module Close_over_value = struct
   module M = struct
-    let x @ portable uncontended = "hello"
+    let x @ portable uncontended = fun x -> x
   end
   let (foo @ portable) () =
     let _ = M.x in
@@ -265,7 +265,7 @@ end
 [%%expect{|
 module Close_over_value :
   sig
-    module M : sig val x : string @@ portable end
+    module M : sig val x : 'a -> 'a @@ portable end
     val foo : unit -> unit
   end
 |}]
@@ -299,7 +299,7 @@ Error: This value is "contended" but expected to be "uncontended".
 
 module Close_over_value_comonadic = struct
   module M = struct
-    let x @ nonportable = "hello"
+    let x @ nonportable = fun x -> x
   end
   let (foo @ portable) () =
     let _ = M.x in
@@ -944,7 +944,6 @@ Line 2, characters 25-26:
 Error: The value "m" is nonportable, so cannot be used inside a function that is portable.
 |}]
 
-(* CR zqian: this mode crossing should work *)
 module M : sig
   val x : int
 end = struct
@@ -956,8 +955,5 @@ let (foo @ portable) () =
   ()
 [%%expect{|
 module M : sig val x : int end
-Line 8, characters 10-13:
-8 |   let _ = M.x in
-              ^^^
-Error: The value "M.x" is nonportable, so cannot be used inside a function that is portable.
+val foo : unit -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-unique/unique.ml
+++ b/testsuite/tests/typing-unique/unique.ml
@@ -133,7 +133,7 @@ val f : unit -> unit = <fun>
 
 (* The following is bad, because k is once and cannot be used more than once*)
 let f () =
-  let once_ k = "foo" in
+  let once_ k = fun x -> x in
   for i = 1 to 5 do
     k
   done

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -430,7 +430,7 @@ let reg_show_prim name to_sig doc =
 let () =
   reg_show_prim "show_val"
     (fun env loc id lid ->
-       let _path, desc, _ = Env.lookup_value ~loc lid env in
+       let _path, desc, _, _= Env.lookup_value ~loc lid env in
        [ Sig_value (id, desc, Exported) ]
     )
     "Print the signature of the corresponding value."

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -277,7 +277,7 @@ val walk_locks : loc:Location.t -> env:t -> item:lock_item -> lid:Longident.t ->
 
 val lookup_value:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
-  Path.t * value_description * actual_mode
+  Path.t * value_description * Mode.Value.l * locks
 val lookup_type:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
   Path.t * type_declaration

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7035,7 +7035,7 @@ and type_ident env ?(recarg=Rejected) lid =
   (* There can be locks between the definition and a use of a value. For
   example, if a function closes over a value, there will be Closure_lock between
   the value's definition and the value's use in the function. Walking the locks
-  will constrain the function and the value's modes accrodingly.
+  will constrain the function and the value's modes accordingly.
 
   Note that the value could be from a module, and we have choices to make:
   - We can walk the locks using the module's mode. That means the closures are

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7044,7 +7044,19 @@ and type_ident env ?(recarg=Rejected) lid =
   closing over the value.
 
   We pick the second for better ergonomics. It could be dangerous as it doesn't
-  reflect the real runtime behaviour. With the current set-up, it is sound. *)
+  reflect the real runtime behaviour. With the current set-up, it is sound:
+
+  - Locality: Modules are always global (the strongest mode), so it's fine.
+  - Linearity: Modules are always many (the strongest mode), so it's fine.
+  - Portability: Closing over a nonportable module only to extract a portable
+  value is fine.
+  - Yielding: Modules are always unyielding (the strongest mode), so it's fine.
+  - All monadic axes: values are in a module via some join_with_m modality.
+  Meanwhile, walking locks causes the mode to go through several join_with_m
+  where [m] is the mode of a closure lock. Since join is commutative and
+  associative, the order of which we apply those join does not matter.
+  *)
+  (* CR modes: codify the above per-axis argument. *)
   let actual_mode =
     Env.walk_locks ~loc:lid.loc ~env ~item:Value ~lid:lid.txt mode
       (Some desc.val_type) locks

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7021,10 +7021,39 @@ and type_constraint_expect
   ret, ty, exp_extra
 
 and type_ident env ?(recarg=Rejected) lid =
-  let path, desc, actual_mode = Env.lookup_value ~loc:lid.loc lid.txt env in
-  (* Mode crossing here is needed only because of the strange behaviour of
-  [type_let] - it checks the LHS before RHS. Had it checks the RHS before LHS,
-  identifiers would be mode crossed when being added to the environment. *)
+  let path, desc, mode, locks = Env.lookup_value ~loc:lid.loc lid.txt env in
+  (* We cross modes when typing [Ppat_ident], before adding new variables into
+  the environment. Therefore, one might think all values in the environment are
+  already mode-crossed. That is not true for several reasons:
+  - [type_let] checks the LHS and adds bound variables to the environment
+  without the type information from the RHS.
+  - The identifer is [M.x], whose signature might not reflect mode crossing.
+
+  Therefore, we need to cross modes upon look-up. Ideally that should be done in
+  [Env], but that is difficult due to cyclic dependency between jkind and env. *)
+  let mode = mode_cross_left_value env desc.val_type mode in
+  (* There can be locks between the definition and a use of a value. For
+  example, if a function closes over a value, there will be Closure_lock between
+  the value's definition and the value's use in the function. Walking the locks
+  will constrain the function and the value's modes accrodingly.
+
+  Note that the value could be from a module, and we have choices to make:
+  - We can walk the locks using the module's mode. That means the closures are
+  closing over the module.
+  - We can walk the locks using the value's mode. That means the closures are
+  closing over the value.
+
+  We pick the second for better ergonomics. It could be dangerous as it doesn't
+  reflect the real runtime behaviour. With the current set-up, it is sound. *)
+  let actual_mode =
+    Env.walk_locks ~loc:lid.loc ~env ~item:Value ~lid:lid.txt mode
+      (Some desc.val_type) locks
+  in
+  (* We need to cross again, because the monadic fragment might have been
+  weakened by the locks. Ideally, the first crossing only deals with comonadic,
+  and the second only deals with monadic. *)
+  (* CR layouts: allow to cross comonadic fragment and monadic fragment
+     separately. *)
   let actual_mode = actual_mode_cross_left env desc.val_type actual_mode in
   let is_recarg =
     match get_desc desc.val_type with
@@ -9929,7 +9958,7 @@ let type_expression env jkind sexp =
       Pexp_ident lid ->
         let loc = sexp.pexp_loc in
         (* Special case for keeping type variables when looking-up a variable *)
-        let (_path, desc, _actual_mode) =
+        let (_path, desc, _, _) =
           Env.lookup_value ~use:false ~loc lid.txt env
         in
         {exp with exp_type = desc.val_type}


### PR DESCRIPTION
This follows #3398 and make `Env.lookup_value` return locks (instead of walking them immediately). The caller of that function, which is `Typecore.type_ident`, can then mode-cross the value before walking the locks.

Ideally this should be done in `Env.components_of_module_maker`, but would require some refactoring to remove the dependency cycle between jkind and env.