### PR TITLE
`-dparsetree` should print kind annotations

### DIFF
--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -575,7 +575,9 @@ and type_declaration i ppf x =
   type_kind (i+1) ppf x.ptype_kind;
   line i ppf "ptype_private = %a\n" fmt_private_flag x.ptype_private;
   line i ppf "ptype_manifest =\n";
-  option (i+1) core_type ppf x.ptype_manifest
+  option (i+1) core_type ppf x.ptype_manifest;
+  line i ppf "ptype_jkind_annotation =\n";
+  option (i+1) jkind_annotation ppf x.ptype_jkind_annotation
 
 and attribute i ppf k a =
   line i ppf "%s \"%s\"\n" k a.attr_name.txt;

--- a/testsuite/tests/parsetree/locations_test.compilers.reference
+++ b/testsuite/tests/parsetree/locations_test.compilers.reference
@@ -58,6 +58,8 @@ Ptop_def
                   ]
                 Ptyp_constr "int" (//toplevel//[2,1+9]..[2,1+12])
                 []
+          ptype_jkind_annotation =
+            None
       ]
   ]
 
@@ -158,6 +160,8 @@ Ptop_def
                   ptype_private = Public
                   ptype_manifest =
                     None
+                  ptype_jkind_annotation =
+                    None
               ]
           ]
   ]
@@ -186,6 +190,8 @@ Ptop_def
                     core_type (//toplevel//[2,1+34]..[2,1+37])
                       Ptyp_constr "int" (//toplevel//[2,1+34]..[2,1+37])
                       []
+                ptype_jkind_annotation =
+                  None
           ]
   ]
 
@@ -213,6 +219,8 @@ Ptop_def
                     core_type (//toplevel//[2,1+35]..[2,1+38])
                       Ptyp_constr "int" (//toplevel//[2,1+35]..[2,1+38])
                       []
+                ptype_jkind_annotation =
+                  None
           ]
   ]
 

--- a/testsuite/tests/parsing/attributes.compilers.reference
+++ b/testsuite/tests/parsing/attributes.compilers.reference
@@ -90,6 +90,8 @@
         ptype_private = Public
         ptype_manifest =
           None
+        ptype_jkind_annotation =
+          None
     ]
   structure_item (attributes.ml[21,302+0]..[21,302+8])
     Pstr_attribute "foo"
@@ -131,6 +133,8 @@
                     ]
                 ptype_private = Public
                 ptype_manifest =
+                  None
+                ptype_jkind_annotation =
                   None
             ]
           structure_item (attributes.ml[31,399+2]..[31,399+10])
@@ -198,6 +202,8 @@
                         core_type (attributes.ml[39,498+58]..[39,498+61])
                           Ptyp_constr "M.t" (attributes.ml[39,498+58]..[39,498+61])
                           []
+                    ptype_jkind_annotation =
+                      None
               ]
               attribute "foo"
                 []
@@ -225,6 +231,8 @@
                   Ptype_abstract
                 ptype_private = Public
                 ptype_manifest =
+                  None
+                ptype_jkind_annotation =
                   None
             ]
         ]
@@ -267,6 +275,8 @@
                     core_type (attributes.ml[53,681+34]..[53,681+37])
                       Ptyp_constr "int" (attributes.ml[53,681+34]..[53,681+37])
                       []
+                ptype_jkind_annotation =
+                  None
           ]
   structure_item (attributes.ml[55,728+0]..[55,728+31])
     Pstr_value Nonrec

--- a/testsuite/tests/parsing/extensions.compilers.reference
+++ b/testsuite/tests/parsing/extensions.compilers.reference
@@ -108,6 +108,8 @@
                       core_type (extensions.ml[13,251+41]..[13,251+42])
                         Ptyp_constr "t" (extensions.ml[13,251+41]..[13,251+42])
                         []
+                  ptype_jkind_annotation =
+                    None
               ]
           ]
         expression (extensions.ml[13,251+47]..[13,251+74])
@@ -272,6 +274,8 @@
                           core_type (extensions.ml[23,534+35]..[23,534+36])
                             Ptyp_constr "t" (extensions.ml[23,534+35]..[23,534+36])
                             []
+                      ptype_jkind_annotation =
+                        None
                 ]
           ]
         core_type (extensions.ml[24,573+4]..[24,573+32])
@@ -311,6 +315,8 @@
                       core_type (extensions.ml[25,606+20]..[25,606+21])
                         Ptyp_constr "t" (extensions.ml[25,606+20]..[25,606+21])
                         []
+                  ptype_jkind_annotation =
+                    None
               ]
           ]
     ]

--- a/testsuite/tests/parsing/hash_ambiguity.compilers.reference
+++ b/testsuite/tests/parsing/hash_ambiguity.compilers.reference
@@ -43,6 +43,8 @@
                     Ptyp_constr "int" (hash_ambiguity.ml[9,169+12]..[9,169+15])
                     []
                 ]
+        ptype_jkind_annotation =
+          None
     ]
   structure_item (hash_ambiguity.ml[15,425+0]..[15,425+26])
     Pstr_type Rec
@@ -74,6 +76,8 @@
             ]
         ptype_private = Public
         ptype_manifest =
+          None
+        ptype_jkind_annotation =
           None
     ]
   structure_item (hash_ambiguity.ml[17,453+0]..[17,453+32])
@@ -110,6 +114,8 @@
             ]
         ptype_private = Public
         ptype_manifest =
+          None
+        ptype_jkind_annotation =
           None
     ]
 ]

--- a/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
+++ b/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
@@ -514,6 +514,8 @@
                   []
                 Ptyp_package "M" (shortcut_ext_attr.ml[61,1304+20]..[61,1304+21])
                 []
+        ptype_jkind_annotation =
+          None
     ]
   structure_item (shortcut_ext_attr.ml[64,1353+0]..[67,1409+22])
     Pstr_module
@@ -601,6 +603,8 @@
                 core_type (shortcut_ext_attr.ml[79,1615+19]..[79,1615+22])
                   Ptyp_constr "int" (shortcut_ext_attr.ml[79,1615+19]..[79,1615+22])
                   []
+            ptype_jkind_annotation =
+              None
           type_declaration "t" (shortcut_ext_attr.ml[80,1638+10]..[80,1638+11]) (shortcut_ext_attr.ml[80,1638+0]..[80,1638+17])
             attribute "foo"
               []
@@ -616,6 +620,8 @@
                 core_type (shortcut_ext_attr.ml[80,1638+14]..[80,1638+17])
                   Ptyp_constr "int" (shortcut_ext_attr.ml[80,1638+14]..[80,1638+17])
                   []
+            ptype_jkind_annotation =
+              None
         ]
     ]
   structure_item (shortcut_ext_attr.ml[81,1656+0]..[81,1656+21]) ghost
@@ -831,6 +837,8 @@
                         core_type (shortcut_ext_attr.ml[101,2020+21]..[101,2020+24])
                           Ptyp_constr "int" (shortcut_ext_attr.ml[101,2020+21]..[101,2020+24])
                           []
+                    ptype_jkind_annotation =
+                      None
                   type_declaration "t'" (shortcut_ext_attr.ml[102,2045+12]..[102,2045+14]) (shortcut_ext_attr.ml[102,2045+2]..[102,2045+20])
                     attribute "foo"
                       []
@@ -846,6 +854,8 @@
                         core_type (shortcut_ext_attr.ml[102,2045+17]..[102,2045+20])
                           Ptyp_constr "int" (shortcut_ext_attr.ml[102,2045+17]..[102,2045+20])
                           []
+                    ptype_jkind_annotation =
+                      None
                 ]
             ]
           signature_item (shortcut_ext_attr.ml[103,2066+2]..[103,2066+23]) ghost

--- a/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
+++ b/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
@@ -1,0 +1,93 @@
+[
+  structure_item (parsing_ambiguous_product.ml[12,327+0]..[12,327+49])
+    Pstr_type Rec
+    [
+      type_declaration "t1" (parsing_ambiguous_product.ml[12,327+5]..[12,327+7]) (parsing_ambiguous_product.ml[12,327+0]..[12,327+49])
+        ptype_params =
+          []
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_abstract
+        ptype_private = Public
+        ptype_manifest =
+          None
+        ptype_jkind_annotation =
+          Some
+            jkind (parsing_ambiguous_product.ml[12,327+10]..[12,327+49])
+            Product
+            [
+              jkind (parsing_ambiguous_product.ml[12,327+10]..[12,327+28])
+              Mod
+                jkind (parsing_ambiguous_product.ml[12,327+11]..[12,327+16])
+                Abbreviation "value"
+                mode "global" (parsing_ambiguous_product.ml[12,327+21]..[12,327+27])
+              jkind (parsing_ambiguous_product.ml[12,327+31]..[12,327+49])
+              Mod
+                jkind (parsing_ambiguous_product.ml[12,327+32]..[12,327+37])
+                Abbreviation "value"
+                mode "global" (parsing_ambiguous_product.ml[12,327+42]..[12,327+48])
+            ]
+    ]
+  structure_item (parsing_ambiguous_product.ml[14,380+0]..[14,380+45])
+    Pstr_type Rec
+    [
+      type_declaration "t2" (parsing_ambiguous_product.ml[14,380+5]..[14,380+7]) (parsing_ambiguous_product.ml[14,380+0]..[14,380+45])
+        ptype_params =
+          []
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_abstract
+        ptype_private = Public
+        ptype_manifest =
+          None
+        ptype_jkind_annotation =
+          Some
+            jkind (parsing_ambiguous_product.ml[14,380+10]..[14,380+45])
+            Mod
+              jkind (parsing_ambiguous_product.ml[14,380+10]..[14,380+34])
+              Product
+              [
+                jkind (parsing_ambiguous_product.ml[14,380+10]..[14,380+26])
+                Mod
+                  jkind (parsing_ambiguous_product.ml[14,380+10]..[14,380+15])
+                  Abbreviation "value"
+                  mode "global" (parsing_ambiguous_product.ml[14,380+20]..[14,380+26])
+                jkind (parsing_ambiguous_product.ml[14,380+29]..[14,380+34])
+                Abbreviation "value"
+              ]
+              mode "global" (parsing_ambiguous_product.ml[14,380+39]..[14,380+45])
+    ]
+  structure_item (parsing_ambiguous_product.ml[16,429+0]..[16,429+47])
+    Pstr_type Rec
+    [
+      type_declaration "t3" (parsing_ambiguous_product.ml[16,429+5]..[16,429+7]) (parsing_ambiguous_product.ml[16,429+0]..[16,429+47])
+        ptype_params =
+          []
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_abstract
+        ptype_private = Public
+        ptype_manifest =
+          None
+        ptype_jkind_annotation =
+          Some
+            jkind (parsing_ambiguous_product.ml[16,429+10]..[16,429+47])
+            Mod
+              jkind (parsing_ambiguous_product.ml[16,429+10]..[16,429+36])
+              Product
+              [
+                jkind (parsing_ambiguous_product.ml[16,429+11]..[16,429+27])
+                Mod
+                  jkind (parsing_ambiguous_product.ml[16,429+11]..[16,429+16])
+                  Abbreviation "value"
+                  mode "global" (parsing_ambiguous_product.ml[16,429+21]..[16,429+27])
+                jkind (parsing_ambiguous_product.ml[16,429+30]..[16,429+35])
+                Abbreviation "value"
+              ]
+              mode "global" (parsing_ambiguous_product.ml[16,429+41]..[16,429+47])
+    ]
+]
+

--- a/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.ml
+++ b/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.ml
@@ -1,0 +1,16 @@
+(* TEST
+   flags = "-stop-after parsing -dparsetree";
+   setup-ocamlc.byte-build-env;
+   ocamlc.byte;
+   check-ocamlc.byte-output;
+*)
+
+(* This test is to check that (a) type decl kind annotations get printed
+   appropriately and (b) product kinds are associated the way we think, and you
+   can see that in the parse tree. *)
+
+type t1 : (value mod global) & (value mod global);;
+
+type t2 : value mod global & value mod global;;
+
+type t3 : (value mod global & value) mod global


### PR DESCRIPTION
This makes `-dparsetree` print kind annotations in type declarations.

There is also a test for a particular case we were interested in, confirming it parses the way we believe.