### PR TITLE
Revert `caml_atomic_cas` primitive name

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4238,7 +4238,7 @@ let atomic_lxor ~dbg atomic i =
 let atomic_compare_and_set_extcall ~dbg atomic ~old_value ~new_value =
   Cop
     ( Cextcall
-        { func = "caml_atomic_compare_set";
+        { func = "caml_atomic_cas";
           builtin = false;
           returns = true;
           effects = Arbitrary_effects;

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -660,7 +660,7 @@ let comp_primitive stack_info p sz args =
   | Patomic_set _
   | Patomic_exchange _ -> Kccall("caml_atomic_exchange", 2)
   | Patomic_compare_exchange _ -> Kccall("caml_atomic_compare_exchange", 3)
-  | Patomic_compare_set _ -> Kccall("caml_atomic_compare_set", 3)
+  | Patomic_compare_set _ -> Kccall("caml_atomic_cas", 3)
   | Patomic_fetch_add -> Kccall("caml_atomic_fetch_add", 2)
   | Patomic_add -> Kccall("caml_atomic_add", 2)
   | Patomic_sub -> Kccall("caml_atomic_sub", 2)

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -393,7 +393,7 @@ CAMLprim value caml_atomic_compare_exchange (value ref, value oldv, value newv)
   }
 }
 
-CAMLprim value caml_atomic_compare_set (value ref, value oldv, value newv)
+CAMLprim value caml_atomic_cas (value ref, value oldv, value newv)
 {
   if (caml_atomic_compare_exchange(ref, oldv, newv) == oldv) {
     return Val_true;

--- a/runtime4/misc.c
+++ b/runtime4/misc.c
@@ -263,7 +263,7 @@ CAMLprim value caml_atomic_compare_exchange(value ref, value oldv, value newv)
   }
 }
 
-CAMLprim value caml_atomic_compare_set(value ref, value oldv, value newv)
+CAMLprim value caml_atomic_cas(value ref, value oldv, value newv)
 {
   if (caml_atomic_compare_exchange(ref, oldv, newv) == oldv) {
     return Val_true;


### PR DESCRIPTION
Reverts the primitive name from `caml_atomic_compare_set` to `caml_atomic_cas` to preserve compatibility with jsoo/upstream.