### PR TITLE
Compute presence of calls after possibly removing poll instruction (CFG selection)

### DIFF
--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1160,14 +1160,11 @@ class virtual selector_generic =
       in
       self#emit_tail env f.Cmm.fun_body;
       let body = self#extract in
-      let fun_contains_calls =
-        Sub_cfg.exists_basic_blocks body ~f:Cfg.basic_block_contains_calls
-      in
       let cfg =
         Cfg.create ~fun_name:f.Cmm.fun_name.sym_name ~fun_args:loc_arg
           ~fun_codegen_options:
             (Cfg.of_cmm_codegen_option f.Cmm.fun_codegen_options)
-          ~fun_dbg:f.Cmm.fun_dbg ~fun_contains_calls
+          ~fun_dbg:f.Cmm.fun_dbg ~fun_contains_calls:true
           ~fun_num_stack_slots:(Array.make Proc.num_stack_slot_classes 0)
           ~fun_poll:f.Cmm.fun_poll
       in
@@ -1222,6 +1219,10 @@ class virtual selector_generic =
          `Cfg.register_predecessors_for_all_blocks`. *)
       Cfgize_utils.Stack_offset_and_exn.update_cfg cfg;
       Cfg.register_predecessors_for_all_blocks cfg;
+      let fun_contains_calls =
+        Sub_cfg.exists_basic_blocks body ~f:Cfg.basic_block_contains_calls
+      in
+      let cfg = { cfg with fun_contains_calls } in
       let cfg_with_layout =
         Cfg_with_layout.create cfg ~layout ~preserve_orig_labels:false
           ~new_labels:Label.Set.empty

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1161,6 +1161,10 @@ class virtual selector_generic =
       self#emit_tail env f.Cmm.fun_body;
       let body = self#extract in
       let cfg =
+        (* note: we set `fun_contains_calls` to `true` here, but will compute
+           its proper value below, after possibly removing the prologue poll
+           instruction. It is not very satisfactory, but as noted in the CR
+           below, we should revisit the way we handle polling points. *)
         Cfg.create ~fun_name:f.Cmm.fun_name.sym_name ~fun_args:loc_arg
           ~fun_codegen_options:
             (Cfg.of_cmm_codegen_option f.Cmm.fun_codegen_options)


### PR DESCRIPTION
Support for polling on the CFG selection pipeline
was added at the very end, and unfortunately
introduced a bug. The way polling was added
was to first unconditionally add a polling point
at the top of the function, and later remove it
if it happens to not be needed.

The bug stems from the fact we determine
whether there are calls in the function after
adding the polling point but before removing
it if unnecessary. The consequence is that we
will require frames everywhere.

This pull request fixes the issue by determining
whether calls are present at the very end. This
is not very satisfactory, but as noted in a CR we
should revisit the way we are inserting polling
point. In the meantime, I think it is better to
simply fix the issue with this unintrusive pull
request.
