### PR TITLE
Ensure that pool owners are correctly set on pool adoption

### DIFF
--- a/testsuite/tests/compaction/test_compact_manydomains.ml
+++ b/testsuite/tests/compaction/test_compact_manydomains.ml
@@ -1,0 +1,21 @@
+(* TEST
+ flags += "-alert -unsafe_parallelism";
+ runtime5;
+ { bytecode; }
+ { native; }
+*)
+
+let num_domains = 20
+
+let go () =
+  let n = 50_000 in
+  let c = Array.make n None in
+  for i = 0 to n-1 do
+    c.(i) <- Some (i, i)
+  done;
+  Gc.compact ()
+
+let () =
+  Array.init num_domains (fun _ -> Domain.spawn go)
+  |> Array.iter Domain.join
+


### PR DESCRIPTION
Shared heap pools have an "owner" field referring to the `caml_domain_state` which owns them. It's `NULL` for free pools. We weren't setting the owner correctly sometimes when acquiring a pool from the global free list.
(This bug was harmless on the current main sources but caused a hard-to-fix bug in the new compaction #3179 for some workloads such as the test also included here).
This is @stedolan's fix.