### PR TITLE
Refactor new mode syntax

### DIFF
--- a/jane/doc/extensions/modes/syntax.md
+++ b/jane/doc/extensions/modes/syntax.md
@@ -1,12 +1,3 @@
-# Motivation
-Previously we have a fixed set of mode names in the parser. Everytime we want to
-add more modes we need to update the parser (and correspondingly ocamlformat).
-This is too costy in the long term.
-
-We introduce a new mode syntax that allows mode names (and mode expressions in
-the future) to enjoy a dedicated name space. As a result, any identifier can be
-used as a mode name.
-
 # Modes and modalities
 Currently a mode expression is simply a space-delimited list of modes.
 
@@ -23,55 +14,23 @@ local
 local unique
 ```
 
-Currently modalities have  the same syntax as modes:
+Modes are in a dedicated namespace separated from variable names or type names,
+which means you can continue to use `local` or `unique` as variable or type
+names.
+
+Currently a modality expression is simply a space-delimited list of modalities.
 
 ```
 modality := local | global | ..
 modalities := separated_nonempty_list(SPACE, modality)
 ```
+Similarly, modalities are in a dedicated namespace.
 
 # Where can they appear
 
-Mode expressions and modalities can appear after either `@` or `@@`. The former
-is used in most cases, while the latter is used for disambiguition. For example,
-in `val f : a -> b @ global`, the `@ global` could be annotating either `b` or
-`f`. To avoid the ambiguity, we will write `val f : a -> b @ local @@ global`
-where `local` is the mode of `b` and `global` is the modality on `f`.
-
-## Function parameter
-```ocaml
-let foo ?(label_let_pattern = default) = ..
-let foo ~(label_let_pattern) = ..
-let foo (x @ modes) = ..
-let foo (x : ty @@ modes) = ..
-```
-where `label_let_pattern` could be
-```ocaml
-x @ modes
-x : ty @@ modes
-x : a b c. a -> b -> c @@ modes
-```
-Patterns that are not directly function parameters can’t have modes. For
-example:
-```
-let foo ((x, y) @ modes) = .. (error)
-```
-
-## Let bindings
-```ocaml
-let x @ modes = ..
-let x : ty @@ modes = ..
-let x : type a b. ty @@ modes = ..
-```
-
-## Functions and their return
-```ocaml
-let (foo @ modes) x y = ..
-let foo x y @ modes = ..
-let foo x y : ty @@ modes = ..
-fun foo x y @ modes -> ..
-fun foo x y : ty @@ modes -> ..
-```
+To write a mode expression in program, it has to be prefixed by an `@` symbol.
+Similarly, a modality expression has to be prefixed by an `@@` symbol. They can
+appear in several places in a program as described below.
 
 ## Arrow types
 ```ocaml
@@ -80,55 +39,87 @@ foo:a * b @ modes -> b @ modes
 ?foo:a * b @ modes -> b @ modes
 ```
 
-## Record fields & Value descriptions
-The two are similar in both semantics and syntax, so we will consider them
-together.
+One should be careful about the precedence of `@`. In the following example,
+`modes` annotates `c`.
 ```ocaml
-type r = {x : string @@ global}
-type r = {x : string @ local -> string @ local @@ global}
-
-val foo : string -> string @ local @@ portable
+a -> b -> c @ modes
 ```
+
+You can use parentheses to override precedence. In the
+following example, `modes` annotates `b -> c`.
+```ocaml
+a -> (b -> c) @ modes
+```
+
+## Function parameter
+The rule of thumb is: wherever a type constraint `x : ty` is allowed, a similar
+mode constraint `x @ modes` or type-and-mode constraint `x : ty @ modes` will be
+allowed.
+```ocaml
+let foo ?(x : int @ modes = default) = ..
+let foo ?x:((a, b) : int @ modes = default)
+let foo ~(x : int @ modes) = ..
+let foo ~x:((a, b) : int @ modes) = ..
+let foo ((a, b) : int @ modes) = ..
+```
+Patterns that are not directly function parameters can’t have modes. For
+example, the following is not allowed, because `x @ local` is not a function
+parameter (but the first component of one).
+```ocaml
+let foo ((x @ local), y) = ..
+```
+
+Again, one should pay attention to the precedences. In the following example, the first
+`modes` annotates `'b`, while the second annotates `x`.
+```ocaml
+let foo (x : 'a -> 'b @ modes) = ..
+let foo (x : ('a -> 'b) @ modes) = ..
+```
+
+## Let bindings
+The rule of thumb is: wherever a type constraint `pat : ty` is allowed, a similar
+mode constraint `pat @ modes` and type-and-mode constraint `pat : ty @ modes` will be
+allowed.
+```ocaml
+  let a : int @ modes = 42 in
+  let (a, b) : int @ once portable = 42 in
+```
+
+## Functions and their body
+You can specify the mode of the function itself:
+```ocaml
+let (foo @ modes) x y = ..
+```
+You can also specify the mode of the function body:
+```ocaml
+let foo x y @ modes = ..
+let foo x y : ty @ modes = ..
+fun foo x y @ modes -> ..
+```
+We don't support `fun foo x y : ty @ modes -> ..`, because the parser can't
+tell if the arrow is instead an arrow type.
 
 ## Expressions
 ```ocaml
-(expression : _ @@ local)
+(expression : ty @ local)
+```
+We don't support `(expression @ modes)` because `@` might be a binary operator.
+
+## Record fields
+Record fields can have modalities, for example:
+```ocaml
+type r = {x : string @@ modalities}
+type r = {x : string @ modes -> string @ modes @@ modalities}
 ```
 
-# Future works
-## Unzipped syntax
-In the future we will support
+## Signature items
+Signature items such as values can have modalities, for example:
 ```ocaml
-type r = string -> string @@ local unique -> unique local
+val foo : string @@ modalities
+val bar : string @ modes -> string @ modes @@ modalities
 ```
-which corresponds to
-```ocaml
-type r = string @@ local unique -> string @@ unique local
-```
-This gets more complex when modalities are involved:
-```ocaml
-type r = { x : string -> string @@ (local -> unique) global}
-```
-which is equivalent to
-```ocaml
-type r = {x : string @ local -> string @ unique @@ global}
-```
-where `global` is a modality on the `x` field.
 
-## Syntax sugar
-Similar to
-```ocaml
-let foo x y : int = exp in
-```
-which unfolds to
-```ocaml
-let foo x y = exp : int in
-```
-We should allow
-```ocaml
-let foo x y @ local = exp in
-```
-unfold to
-```ocaml
-let foo x y = exp : _ @@ local in
-```
+## Modules
+Support for modules with modes is being worked on and not ready for compnay-wide adoption.
+For the few use sites, the syntax should be self-explanatory. More documentation will come
+as it becomes ready.

--- a/jane/doc/extensions/modes/syntax.md
+++ b/jane/doc/extensions/modes/syntax.md
@@ -96,14 +96,14 @@ let foo x y @ modes = ..
 let foo x y : ty @ modes = ..
 fun foo x y @ modes -> ..
 ```
-We don't support `fun foo x y : ty @ modes -> ..`, because the parser can't
-tell if the arrow is instead an arrow type.
+We don't support `fun foo x y : ty @ modes -> 42` due to a limitation in the
+parser.
 
 ## Expressions
 ```ocaml
 (expression : ty @ local)
 ```
-We don't support `(expression @ modes)` because `@` might be a binary operator.
+We don't support `(expression @ modes)` because `@` is already parsed as a binary operator.
 
 ## Record fields
 Record fields can have modalities, for example:
@@ -120,6 +120,6 @@ val bar : string @ modes -> string @ modes @@ modalities
 ```
 
 ## Modules
-Support for modules with modes is being worked on and not ready for compnay-wide adoption.
+Support for modules with modes is being worked on and not ready for company-wide adoption.
 For the few use sites, the syntax should be self-explanatory. More documentation will come
 as it becomes ready.

--- a/jane/doc/extensions/modes/syntax.md
+++ b/jane/doc/extensions/modes/syntax.md
@@ -113,10 +113,18 @@ type r = {x : string @ modes -> string @ modes @@ modalities}
 ```
 
 ## Signature items
-Signature items such as values can have modalities, for example:
+Signature items such as values can have modalities; for example:
 ```ocaml
 val foo : string @@ modalities
 val bar : string @ modes -> string @ modes @@ modalities
+```
+
+A signature can have default modalities that each item can override; for example:
+```ocaml
+sig @@ portable
+val foo : string (* have portable modality *)
+val bar : string -> string @@ nonportable (* not have portable modality *)
+end
 ```
 
 ## Modules

--- a/otherlibs/stdlib_alpha/capsule.ml
+++ b/otherlibs/stdlib_alpha/capsule.ml
@@ -107,7 +107,7 @@ end = struct
 
   type 'k t = A.t
 
-  let[@inline] unsafe_mk () : _ @@ local = A.make Id.uninitialized
+  let[@inline] unsafe_mk () : _ @ local = A.make Id.uninitialized
   let[@inline] id t =
     (* Safe since [Password.t] is only ever accessible by 1 fiber. *)
     match A.get_unsync t with
@@ -131,7 +131,7 @@ end = struct
          | already_set_id -> already_set_id)
       | set_id -> set_id
 
-    let unsafe_mk () : _ @@ local unyielding = A.make Id.uninitialized
+    let unsafe_mk () : _ @ local unyielding = A.make Id.uninitialized
   end
 
   let[@inline] shared t = t
@@ -584,11 +584,11 @@ module Mutex = struct
   exception Poisoned
 
   let[@inline] with_lock :
-    type k.
+    (type k.
     k t
     -> (k Password.t @ local -> 'a) @ local
-    -> 'a
-    @@ portable
+    -> 'a)
+    @ portable
     = fun t f ->
       M.lock t.mutex;
       match t.poisoned with
@@ -646,11 +646,11 @@ module Rwlock = struct
   exception Poisoned
 
   let[@inline] with_write_lock :
-    type k.
+    (type k.
     k t
     -> (k Password.t @ local -> 'a) @ local
-    -> 'a
-    @@ portable
+    -> 'a)
+    @ portable
     = fun t f ->
       Rw.lock_write t.rwlock;
       match t.state with
@@ -678,11 +678,11 @@ module Rwlock = struct
           raise exn
 
   let[@inline] with_read_lock :
-    type k.
+    (type k.
     k t
     -> (k Password.Shared.t @ local unyielding -> 'a) @ local
-    -> 'a
-    @@ portable
+    -> 'a)
+    @ portable
     = fun t f ->
       Rw.lock_read t.rwlock;
       match t.state with

--- a/otherlibs/stdlib_alpha/capsule.ml
+++ b/otherlibs/stdlib_alpha/capsule.ml
@@ -584,8 +584,8 @@ module Mutex = struct
   exception Poisoned
 
   let[@inline] with_lock :
-    (type k.
-    k t
+    type k.
+    (k t
     -> (k Password.t @ local -> 'a) @ local
     -> 'a)
     @ portable
@@ -646,8 +646,8 @@ module Rwlock = struct
   exception Poisoned
 
   let[@inline] with_write_lock :
-    (type k.
-    k t
+    type k.
+    (k t
     -> (k Password.t @ local -> 'a) @ local
     -> 'a)
     @ portable
@@ -678,8 +678,8 @@ module Rwlock = struct
           raise exn
 
   let[@inline] with_read_lock :
-    (type k.
-    k t
+    type k.
+    (k t
     -> (k Password.Shared.t @ local unyielding -> 'a) @ local
     -> 'a)
     @ portable

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -3487,8 +3487,12 @@ type_constraint:
   | COLON core_type_with_optional_modes {
     let cty, mm = $2 in
     Pconstraint cty, mm }
-  | COLON core_type COLONGREATER core_type      { Pcoerce (Some $2, $4), [] }
-  | COLONGREATER core_type                      { Pcoerce (None, $2), [] }
+  | COLON core_type COLONGREATER core_type_with_optional_modes {
+    let cty, mm = $4 in
+    Pcoerce (Some $2, cty), mm }
+  | COLONGREATER core_type_with_optional_modes {
+    let cty, mm = $2 in
+    Pcoerce (None, cty), mm }
   | COLON error                                 { syntax_error() }
   | COLONGREATER error                          { syntax_error() }
 ;

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -777,6 +777,18 @@ let mkfunction ~loc ~attrs params body_constraint body =
             attrs
     end
 
+let mk_functor_typ args mty_mm =
+  let mty, _ =
+    List.fold_left (fun (mty, mm) (startpos, arg) ->
+      let mty =
+        mkmty ~loc:(startpos, mty.pmty_loc.loc_end) (Pmty_functor (arg, mty, mm))
+      in
+      let mm = [] in
+      mty, mm)
+    mty_mm args
+  in
+  mty
+
 (* Alternatively, we could keep the generic module type in the Parsetree
    and extract the package type during type-checking. In that case,
    the assertions below should be turned into explicit checks. *)
@@ -1601,8 +1613,9 @@ functor_arg:
     LPAREN RPAREN
       { $startpos, Unit }
   | (* An argument accompanied with an explicit type. *)
-    LPAREN x = mkrhs(module_name) COLON mty = module_type mm = optional_atat_mode_expr RPAREN
-      { $startpos, Named (x, mty, mm) }
+    LPAREN x = mkrhs(module_name) COLON mty_mm = module_type_with_optional_modes RPAREN
+      { let mty, mm = mty_mm in
+        $startpos, Named (x, mty, mm) }
 ;
 
 module_name:
@@ -1671,10 +1684,9 @@ module_expr:
 
 paren_module_expr:
     (* A module expression annotated with a module type. *)
-    LPAREN me = module_expr COLON mty = module_type mm = optional_atat_mode_expr RPAREN
-      { mkmod ~loc:$sloc (Pmod_constraint(me, Some mty, mm)) }
-  | LPAREN me = module_expr mm = at_mode_expr RPAREN
-      { mkmod ~loc:$sloc (Pmod_constraint(me, None, mm)) }
+    LPAREN me = module_expr mty_mm = module_constraint RPAREN
+      { let mty, mm = mty_mm in
+        mkmod ~loc:$sloc (Pmod_constraint(me, mty, mm)) }
   | LPAREN module_expr COLON module_type error
       { unclosed "(" $loc($1) ")" $loc($5) }
   | (* A module expression within parentheses. *)
@@ -1803,6 +1815,14 @@ structure_item:
       Pstr_module body, ext }
 ;
 
+%inline module_constraint:
+    COLON mty_mm = module_type_with_optional_modes
+      { let mty, mm = mty_mm in
+        (Some mty, mm)
+      }
+  | at_mode_expr
+      { (None, $1) }
+
 (* The body (right-hand side) of a module binding. *)
 module_binding_body:
     EQUAL me = module_expr
@@ -1810,10 +1830,10 @@ module_binding_body:
   | COLON error
       { expecting $loc($1) "=" }
   | mkmod(
-      COLON mty = module_type mm = optional_atat_mode_expr EQUAL me = module_expr
-        { Pmod_constraint(me, Some mty, mm) }
-    | mm = at_mode_expr EQUAL me = module_expr
-        { Pmod_constraint(me, None, mm) }
+      mty_mm = module_constraint EQUAL me = module_expr
+        {
+          let mty, mm = mty_mm in
+          Pmod_constraint(me, mty, mm) }
     | arg_and_pos = functor_arg body = module_binding_body
         { let (_, arg) = arg_and_pos in
           Pmod_functor(arg, body) }
@@ -1952,48 +1972,48 @@ open_description:
 
 /* Module types */
 
-module_type:
+module_type_atomic:
   | SIG attrs = attributes s = signature END
       { mkmty ~loc:$sloc ~attrs (Pmty_signature s) }
   | SIG attributes signature error
       { unclosed "sig" $loc($1) "end" $loc($4) }
   | STRUCT error
       { expecting $loc($1) "sig" }
-  | FUNCTOR attrs = attributes args = functor_args
-    MINUSGREATER mty = module_type mm = optional_at_mode_expr
-      %prec below_WITH
-      { wrap_mty_attrs ~loc:$sloc attrs (
-          (* return modes go to the innermost functor arrow;
-            all other return modes are empty *)
-          let mty, mm =
-            List.fold_left (fun (acc, mm) (startpos, arg) ->
-              mkmty ~loc:(startpos, $endpos) (Pmty_functor (arg, acc, mm)), []
-            ) (mty, mm) args
-          in
-          match mm with
-          | [] -> mty
-          | _ :: _ -> assert false
-        ) }
-  | MODULE TYPE OF attributes module_expr %prec below_LBRACKETAT
-      { mkmty ~loc:$sloc ~attrs:$4 (Pmty_typeof $5) }
   | LPAREN module_type RPAREN
       { $2 }
   | LPAREN module_type error
       { unclosed "(" $loc($1) ")" $loc($3) }
-  | module_type attribute
-      { Mty.attr $1 $2 }
   | mkmty(
       mkrhs(mty_longident)
         { Pmty_ident $1 }
-    | LPAREN RPAREN MINUSGREATER module_type optional_at_mode_expr
-        { Pmty_functor(Unit, $4, $5) }
-    | module_type m1=optional_at_mode_expr MINUSGREATER module_type m2=optional_at_mode_expr
-        %prec below_WITH
-        { Pmty_functor(Named (mknoloc None, $1, m1), $4, m2) }
-    | module_type WITH separated_nonempty_llist(AND, with_constraint)
-        { Pmty_with($1, $3) }
 /*  | LPAREN MODULE mkrhs(mod_longident) RPAREN
         { Pmty_alias $3 } */
+    )
+    { $1 }
+;
+
+module_type:
+  | module_type_atomic { $1 }
+  | FUNCTOR attrs = attributes args = functor_args
+    MINUSGREATER mty_mm = module_type_with_optional_modes
+      %prec below_WITH
+      { wrap_mty_attrs ~loc:$sloc attrs (mk_functor_typ args mty_mm) }
+  | args = functor_args
+    MINUSGREATER mty_mm = module_type_with_optional_modes
+      %prec below_WITH
+      { mk_functor_typ args mty_mm }
+  | MODULE TYPE OF attributes module_expr %prec below_LBRACKETAT
+      { mkmty ~loc:$sloc ~attrs:$4 (Pmty_typeof $5) }
+  | module_type attribute
+      { Mty.attr $1 $2 }
+  | mkmty(
+      module_type_with_optional_modes MINUSGREATER module_type_with_optional_modes
+        %prec below_WITH
+        { let mty0, mm0 = $1 in
+          let mty1, mm1 = $3 in
+          Pmty_functor(Named (mknoloc None, mty0, mm0), mty1, mm1) }
+    | module_type WITH separated_nonempty_llist(AND, with_constraint)
+        { Pmty_with($1, $3) }
     | extension
         { Pmty_extension $1 }
     | module_type WITH mkrhs(mod_ext_longident)
@@ -2001,6 +2021,11 @@ module_type:
     )
     { $1 }
 ;
+
+%inline module_type_with_optional_modes:
+  | module_type { $1, [] }
+  | module_type_atomic at_mode_expr { $1, $2 }
+
 (* A signature, which appears between SIG and END (among other places),
    is a list of signature elements. *)
 signature:
@@ -2076,8 +2101,10 @@ signature_item:
 %inline module_declaration:
   MODULE
   ext = ext attrs1 = attributes
-  name_ = module_name_modal(at_modalities_expr)
-  body = module_declaration_body(optional_atat_modalities_expr)
+  name_ = module_name_modal(atat_modalities_expr)
+  body = module_declaration_body(
+    module_type optional_atat_modalities_expr { ($1, $2) }
+  )
   attrs2 = post_item_attributes
   {
     let attrs = attrs1 @ attrs2 in
@@ -2091,13 +2118,13 @@ signature_item:
 ;
 
 (* The body (right-hand side) of a module declaration. *)
-module_declaration_body(optional_atat_modal_expr):
-    COLON mty = module_type mm = optional_atat_modal_expr
-      { mty, mm }
+module_declaration_body(module_type_with_optional_modal_expr):
+    COLON mty_mm = module_type_with_optional_modal_expr
+      { mty_mm }
   | EQUAL error
       { expecting $loc($1) ":" }
   | mkmty(
-      arg_and_pos = functor_arg body = module_declaration_body(optional_atat_mode_expr)
+      arg_and_pos = functor_arg body = module_declaration_body(module_type_with_optional_modes)
         { let (_, arg) = arg_and_pos in
           let (ret, mret) = body in
           Pmty_functor(arg, ret, mret) }
@@ -2109,10 +2136,10 @@ module_declaration_body(optional_atat_modal_expr):
 %inline module_alias:
   MODULE
   ext = ext attrs1 = attributes
-  name_ = module_name_modal(at_modalities_expr)
+  name_ = module_name_modal(atat_modalities_expr)
   EQUAL
   body = module_expr_alias
-  modalities = optional_at_modalities_expr
+  modalities = optional_atat_modalities_expr
   attrs2 = post_item_attributes
   {
     let attrs = attrs1 @ attrs2 in
@@ -2619,73 +2646,22 @@ seq_expr:
 ;
 
 labeled_simple_pattern:
-    QUESTION LPAREN modes0=optional_mode_expr_legacy x=label_let_pattern opt_default RPAREN
-      { let lbl, pat, cty, modes = x in
-        let loc = $startpos(modes0), $endpos(x) in
-        (Optional lbl, $5,
-         mkpat_with_modes ~loc ~pat ~cty ~modes:(modes0 @ modes))
-      }
+    QUESTION LPAREN label_let_pattern opt_default RPAREN
+      { (Optional (fst $3), $4, snd $3) }
   | QUESTION label_var
       { (Optional (fst $2), None, snd $2) }
-  | OPTLABEL LPAREN modes0=optional_mode_expr_legacy x=let_pattern opt_default RPAREN
-      { let pat, cty, modes = x in
-        let loc = $startpos(modes0), $endpos(x) in
-        (Optional $1, $5,
-         mkpat_with_modes ~loc ~pat ~cty ~modes:(modes0 @ modes))
-      }
+  | OPTLABEL LPAREN let_pattern opt_default RPAREN
+      { (Optional $1, $4, $3) }
   | OPTLABEL pattern_var
       { (Optional $1, None, $2) }
-  | TILDE LPAREN modes0=optional_mode_expr_legacy x=label_let_pattern RPAREN
-      { let lbl, pat, cty, modes = x in
-        let loc = $startpos(modes0), $endpos(x) in
-        (Labelled lbl, None,
-         mkpat_with_modes ~loc ~pat ~cty ~modes:(modes0 @ modes))
-      }
+  | TILDE LPAREN label_let_pattern RPAREN
+      { (Labelled (fst $3), None, snd $3) }
   | TILDE label_var
       { (Labelled (fst $2), None, snd $2) }
-  | LABEL simple_pattern
+  | LABEL simple_pattern_extend_modes_or_poly
       { (Labelled $1, None, $2) }
-  | LABEL LPAREN modes0=optional_mode_expr_legacy x=let_pattern_required_modes RPAREN
-    { let pat, cty, modes = x in
-      let loc = $startpos(modes0), $endpos(x) in
-      (Labelled $1, None,
-       mkpat_with_modes ~loc ~pat ~cty ~modes:(modes0 @ modes))
-    }
-  | LABEL LPAREN modes=mode_expr_legacy pat=pattern RPAREN
-      { let loc = $startpos(modes), $endpos(pat) in
-        (Labelled $1, None,
-         mkpat_with_modes ~loc ~pat ~cty:None ~modes)
-      }
-  | simple_pattern
+  | simple_pattern_extend_modes_or_poly
       { (Nolabel, None, $1) }
-  | LPAREN modes=mode_expr_legacy x=let_pattern_no_modes RPAREN
-      { let pat, cty = x in
-        let loc = $startpos(modes), $endpos(x) in
-        (Nolabel, None,
-         mkpat_with_modes ~loc ~pat ~cty ~modes)
-      }
-  | LPAREN modes0=optional_mode_expr_legacy x=let_pattern_required_modes RPAREN
-      { let pat, cty, modes = x in
-        let loc = $startpos(modes0), $endpos(x) in
-        (Nolabel, None,
-        mkpat_with_modes ~loc ~pat ~cty ~modes:(modes0 @ modes))
-      }
-  | LABEL LPAREN x=poly_pattern_no_modes RPAREN
-      { let pat, cty = x in
-        (Labelled $1, None,
-        mkpat_with_modes ~loc:$loc(x) ~pat ~cty ~modes:[])
-      }
-  | LABEL LPAREN modes=mode_expr_legacy x=poly_pattern_no_modes RPAREN
-      { let pat, cty = x in
-        let loc = $startpos(modes), $endpos(x) in
-        (Labelled $1, None,
-         mkpat_with_modes ~loc ~pat ~cty ~modes)
-      }
-  | LPAREN x=poly_pattern_no_modes RPAREN
-      { let pat, cty = x in
-        (Nolabel, None,
-         mkpat_with_modes ~loc:$loc(x) ~pat ~cty ~modes:[])
-      }
 ;
 
 pattern_var:
@@ -2699,23 +2675,26 @@ pattern_var:
   preceded(EQUAL, seq_expr)?
     { $1 }
 ;
+
+optional_poly_type_and_modes:
+      { None, [] }
+  | at_mode_expr
+      { None, $1 }
+  | COLON cty_mm = poly_type_with_optional_modes
+      { let cty, mm = cty_mm in
+        Some cty, mm
+      }
+;
+
 label_let_pattern:
-    x = label_var modes = optional_at_mode_expr
+    modes0 = optional_mode_expr_legacy x = label_var
+    cty_modes1 = optional_poly_type_and_modes
       { let lab, pat = x in
-        lab, pat, None, modes
-      }
-  | x = label_var COLON cty = core_type modes = optional_atat_mode_expr
-      { let lab, pat = x in
-        lab, pat, Some cty, modes
-      }
-  | x = label_var COLON
-    cty = mktyp (bound_vars = typevar_list
-                 DOT
-                 inner_type = core_type
-            { Ptyp_poly (bound_vars, inner_type) })
-    modes = optional_atat_mode_expr
-      { let lab, pat = x in
-        lab, pat, Some cty, modes
+        let cty, modes1 = cty_modes1 in
+        let modes = modes0 @ modes1 in
+        let loc = $startpos(modes0), $endpos(cty_modes1) in
+        let pat = mkpat_with_modes ~loc ~pat ~cty ~modes in
+        lab, pat
       }
 ;
 %inline label_var:
@@ -2723,46 +2702,43 @@ label_let_pattern:
       { ($1.Location.txt, mkpat ~loc:$sloc (Ppat_var $1)) }
 ;
 let_pattern:
-    x=let_pattern_awaiting_at_modes modes=optional_at_mode_expr
-    { let pat, cty = x in pat, cty, modes }
-  | x=let_pattern_awaiting_atat_modes modes=optional_atat_mode_expr
-    { let pat, cty = x in pat, cty, modes }
-  | LPAREN let_pattern_required_modes RPAREN { $2 }
+    modes0 = optional_mode_expr_legacy pat = pattern
+    cty_modes1 = optional_poly_type_and_modes
+    {
+      let cty, modes1 = cty_modes1 in
+      let modes = modes0 @ modes1 in
+      let loc = $startpos(modes0), $endpos(cty_modes1) in
+      mkpat_with_modes ~loc ~pat ~cty ~modes
+    }
 ;
 
-let_pattern_required_modes:
-    x=let_pattern_awaiting_at_modes modes=at_mode_expr
-    { let pat, cty = x in pat, cty, modes }
-  | x=let_pattern_awaiting_atat_modes modes=atat_mode_expr
-    { let pat, cty = x in pat, cty, modes }
-  | LPAREN let_pattern_required_modes RPAREN { $2 }
-;
+(* simple_pattern extended with poly_type and modes *)
+simple_pattern_extend_modes_or_poly:
+    simple_pattern { $1 }
+  | LPAREN pattern_with_modes_or_poly RPAREN
+    { $2 }
 
-let_pattern_no_modes:
-    x=let_pattern_awaiting_at_modes { x }
-  | x=let_pattern_awaiting_atat_modes { x }
-;
-
-%inline let_pattern_awaiting_atat_modes:
-    pat=pattern COLON cty=core_type
-    { pat, Some cty }
-  | poly_pattern_no_modes
-    { $1 }
-;
-
-%inline let_pattern_awaiting_at_modes:
-    pat=pattern { pat, None }
-;
-
-%inline poly_pattern_no_modes:
-   pat = pattern
-   COLON
-   cty = mktyp(bound_vars = typevar_list
-               DOT
-               inner_type = core_type
-         { Ptyp_poly (bound_vars, inner_type) })
-   { pat, Some cty }
-;
+pattern_with_modes_or_poly:
+    modes0 = mode_expr_legacy pat = pattern cty_modes1 = optional_poly_type_and_modes
+      {
+        let cty, modes1 = cty_modes1 in
+        let modes = modes0 @ modes1 in
+        let loc = $startpos(modes0), $endpos(cty_modes1) in
+        mkpat_with_modes ~loc ~pat ~cty:cty ~modes
+      }
+  | pat = pattern COLON cty_modes = poly_type_with_modes
+      {
+        let cty, modes = cty_modes in
+        mkpat_with_modes ~loc:$sloc ~pat ~cty:(Some cty) ~modes
+      }
+  | pat = pattern modes = at_mode_expr
+      {
+        mkpat_with_modes ~loc:$sloc ~pat ~cty:None ~modes
+      }
+  | pat = pattern COLON cty = strictly_poly_type
+      {
+        mkpat_with_modes ~loc:$sloc ~pat ~cty:(Some cty) ~modes:[]
+      }
 
 %inline indexop_expr(dot, index, right):
   | array=simple_expr d=dot LPAREN i=index RPAREN r=right
@@ -2785,10 +2761,10 @@ let_pattern_no_modes:
 %inline qualified_dotop: ioption(DOT mod_longident {$2}) DOTOP { $1, $2 };
 
 optional_atomic_constraint_:
-  | COLON atomic_type optional_atat_mode_expr {
+  | COLON atomic_type {
     { ret_type_constraint = Some (Pconstraint $2)
     ; mode_annotations = []
-    ; ret_mode_annotations = $3
+    ; ret_mode_annotations = []
     }
    }
   | at_mode_expr {
@@ -3159,18 +3135,29 @@ labeled_simple_expr:
 ;
 %inline pvc_modes:
   | at_mode_expr {None, $1}
-  | COLON core_type optional_atat_mode_expr {
-      Some(Pvc_constraint { locally_abstract_univars=[]; typ=$2 }), $3
+  | COLON core_type_with_optional_modes {
+      let typ, mm = $2 in
+      Some(Pvc_constraint { locally_abstract_univars=[]; typ }), mm
     }
 ;
+
+%inline empty_list: { [] }
+
+%inline let_ident_with_modes:
+    optional_mode_expr_legacy let_ident
+      { ($2, $1) }
+  | LPAREN let_ident at_mode_expr RPAREN
+      { ($2, $3) }
+
 let_binding_body_no_punning:
-    let_ident strict_binding
-      { ($1, $2, None, []) }
-  | modes0 = optional_mode_expr_legacy let_ident constraint_ EQUAL seq_expr
+    let_ident_with_modes strict_binding_modes
+      { let v, modes = $1 in
+        (v, $2 modes, None, modes) }
+  | let_ident_with_modes constraint_ EQUAL seq_expr
       (* CR zqian: modes are duplicated, and one of them needs to be made ghost
          to make internal tools happy. We should try to avoid that. *)
-      { let v = $2 in (* PR#7344 *)
-        let typ, modes1 = $3 in
+      { let v, modes0 = $1 in
+        let typ, modes1 = $2 in
         let t =
           Option.map (function
           | Pconstraint t ->
@@ -3179,17 +3166,17 @@ let_binding_body_no_punning:
           ) typ
         in
         let modes = modes0 @ modes1 in
-        (v, $5, t, modes)
+        (v, $4, t, modes)
       }
-  | modes0 = optional_mode_expr_legacy let_ident COLON poly(core_type) modes1 = optional_atat_mode_expr EQUAL seq_expr
-      { let bound_vars, inner_type = $4 in
-        let ltyp = Ptyp_poly (bound_vars, inner_type) in
-        let typ = ghtyp ~loc:$loc($4) ltyp in
+  | let_ident_with_modes COLON strictly_poly_type_with_optional_modes EQUAL seq_expr
+      { let v, modes0 = $1 in
+        let typ, modes1 = $3 in
         let modes = modes0 @ modes1 in
-        ($2, $7, Some (Pvc_constraint { locally_abstract_univars = []; typ }),
+        (v, $5, Some (Pvc_constraint { locally_abstract_univars = []; typ }),
          modes)
       }
-  | let_ident COLON TYPE newtypes DOT core_type modes=optional_atat_mode_expr EQUAL seq_expr
+  | let_ident_with_modes COLON        TYPE ntys = newtypes DOT cty = core_type        modes1 = empty_list EQUAL e = seq_expr
+  | let_ident_with_modes COLON LPAREN TYPE ntys = newtypes DOT cty = core_type RPAREN modes1=at_mode_expr EQUAL e = seq_expr
       (* The code upstream looks like:
          {[
            let constraint' =
@@ -3206,10 +3193,12 @@ let_binding_body_no_punning:
          version, even though we are creating a slightly different [core_type].
       *)
       { let exp, poly =
-          wrap_type_annotation ~loc:$sloc ~modes:[] ~typloc:$loc($6) $4 $6 $9
+          wrap_type_annotation ~loc:$sloc ~modes:[] ~typloc:$loc(cty) ntys cty e
         in
-        let loc = ($startpos($1), $endpos($6)) in
-        (ghpat_with_modes ~loc ~pat:$1 ~cty:(Some poly) ~modes:[], exp, None, modes)
+        let v, modes0 = $1 in
+        let modes = modes0 @ modes1 in
+        let loc = ($startpos($1), $endpos(modes1)) in
+        (ghpat_with_modes ~loc ~pat:v ~cty:(Some poly) ~modes:[], exp, None, modes)
        }
   | pattern_no_exn EQUAL seq_expr
       { ($1, $3, None, []) }
@@ -3217,14 +3206,6 @@ let_binding_body_no_punning:
       {
         let pvc, modes = $2 in
         ($1, $4, pvc, modes)
-      }
-  | modes=mode_expr_legacy let_ident strict_binding_modes
-      {
-        ($2, $3 modes, None, modes)
-      }
-  | LPAREN let_ident modes=at_mode_expr RPAREN strict_binding_modes
-      {
-        ($2, $5 modes, None, modes)
       }
 ;
 let_binding_body:
@@ -3503,8 +3484,13 @@ type_constraint:
 ;
 
 %inline type_constraint_with_modes:
-  | type_constraint optional_atat_mode_expr
-    { $1, $2 }
+  | COLON core_type_with_optional_modes {
+    let cty, mm = $2 in
+    Pconstraint cty, mm }
+  | COLON core_type COLONGREATER core_type      { Pcoerce (Some $2, $4), [] }
+  | COLONGREATER core_type                      { Pcoerce (None, $2), [] }
+  | COLON error                                 { syntax_error() }
+  | COLONGREATER error                          { syntax_error() }
 ;
 
 %inline constraint_:
@@ -3720,24 +3706,8 @@ simple_pattern_not_ident:
   | extension
       { Ppat_extension $1 }
   ) { $1 }
-  (* CR modes: when modes on patterns are fully supported, replace the below
-     cases with these two *)
-  (* | LPAREN pattern modes=at_mode_expr RPAREN
-   *     { mkpat ~loc:$sloc (Ppat_constraint($2, None, modes)) }
-   * | LPAREN pattern COLON core_type modes=optional_atat_mode_expr RPAREN
-   *     { mkpat ~loc:$sloc (Ppat_constraint($2, Some $4, modes)) } *)
   | LPAREN pattern COLON core_type RPAREN
     { mkpat_with_modes ~loc:$sloc ~pat:$2 ~cty:(Some $4) ~modes:[] }
-  (* CR cgunn: figure out how to get these errors to work without reduce/reduce
-     conflicts *)
-  (* | LPAREN pattern COLON core_type ATAT error
-   *   {
-   *     raise (Syntaxerr.Error (Syntaxerr.Modes_on_pattern (make_loc $sloc)))
-   *   }
-   * | LPAREN pattern AT error
-   *   {
-   *     raise (Syntaxerr.Error (Syntaxerr.Modes_on_pattern (make_loc $sloc)))
-   *   } *)
 ;
 
 simple_delimited_pattern:
@@ -4305,17 +4275,47 @@ with_type_binder:
   typevar_list DOT X
     { ($1, $3) }
 ;
-possibly_poly(X):
-  X
-    { $1 }
+%inline strictly_poly(X):
 | poly(X)
     { let bound_vars, inner_type = $1 in
       mktyp ~loc:$sloc (Ptyp_poly (bound_vars, inner_type)) }
+;
+
+possibly_poly(X):
+  X
+    { $1 }
+| strictly_poly(X)
+    { $1 }
 ;
 %inline poly_type:
   possibly_poly(core_type)
     { $1 }
 ;
+
+%inline strictly_poly_type:
+  strictly_poly(core_type)
+    { $1 }
+;
+
+%inline poly_tuple_type:
+  | tuple_type { $1 }
+  | LPAREN strictly_poly_type RPAREN { $2 }
+;
+
+%inline poly_type_with_modes:
+  | poly_tuple_type at_mode_expr { $1, $2 }
+;
+
+%inline poly_type_with_optional_modes:
+  | poly_type_with_modes { $1 }
+  | poly_type { $1, [] }
+;
+
+%inline strictly_poly_type_with_optional_modes:
+  | strictly_poly_type { $1, [] }
+  | LPAREN strictly_poly_type RPAREN at_mode_expr { $2, $4 }
+;
+
 %inline poly_type_no_attr:
   possibly_poly(core_type_no_attr)
     { $1 }
@@ -4333,6 +4333,10 @@ core_type:
   | core_type attribute
       { Typ.attr $1 $2 }
 ;
+
+%inline core_type_with_optional_modes:
+    core_type { $1, [] }
+  | tuple_type at_mode_expr { $1, $2 }
 
 (* A core type without attributes is currently defined as an alias type, but
    this could change in the future if new forms of types are introduced. From
@@ -4511,15 +4515,6 @@ at_mode_expr:
   }
 ;
 
-atat_mode_expr:
-  | ATAT mode_expr {$2}
-  | ATAT error { expecting $loc($2) "mode expression" }
-;
-
-%inline optional_atat_mode_expr:
-  | { [] }
-  | atat_mode_expr {$1}
-;
 
 /* Modalities */
 
@@ -4529,22 +4524,16 @@ atat_mode_expr:
 %inline modalities:
   | modality+ { $1 }
 
-at_modalities_expr:
-  | AT modalities {$2}
-  | AT error { expecting $loc($2) "modality expression" }
+atat_modalities_expr:
+  | ATAT modalities {$2}
+  | ATAT error { expecting $loc($2) "modality expression" }
 ;
 
 optional_atat_modalities_expr:
   | %prec below_HASH
     { [] }
-  | ATAT modalities { $2 }
-  | ATAT error { expecting $loc($2) "modality expression" }
-;
-
-optional_at_modalities_expr:
-  | { [] }
-  | AT modalities { $2 }
-  | AT error { expecting $loc($2) "modality expression" }
+  | atat_modalities_expr
+    { $1 }
 ;
 
 %inline stack(expr):

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -3175,8 +3175,8 @@ let_binding_body_no_punning:
         (v, $5, Some (Pvc_constraint { locally_abstract_univars = []; typ }),
          modes)
       }
-  | let_ident_with_modes COLON        TYPE ntys = newtypes DOT cty = core_type        modes1 = empty_list EQUAL e = seq_expr
-  | let_ident_with_modes COLON LPAREN TYPE ntys = newtypes DOT cty = core_type RPAREN modes1=at_mode_expr EQUAL e = seq_expr
+  | let_ident_with_modes COLON TYPE ntys = newtypes DOT cty = core_type  modes1 = empty_list EQUAL e = seq_expr
+  | let_ident_with_modes COLON TYPE ntys = newtypes DOT cty = tuple_type modes1=at_mode_expr EQUAL e = seq_expr
       (* The code upstream looks like:
          {[
            let constraint' =
@@ -4301,9 +4301,13 @@ possibly_poly(X):
     { $1 }
 ;
 
+%inline strictly_poly_tuple_type:
+  strictly_poly(tuple_type)
+    { $1 }
+
 %inline poly_tuple_type:
   | tuple_type { $1 }
-  | LPAREN strictly_poly_type RPAREN { $2 }
+  | strictly_poly_tuple_type { $1 }
 ;
 
 %inline poly_type_with_modes:
@@ -4317,7 +4321,7 @@ possibly_poly(X):
 
 %inline strictly_poly_type_with_optional_modes:
   | strictly_poly_type { $1, [] }
-  | LPAREN strictly_poly_type RPAREN at_mode_expr { $2, $4 }
+  | strictly_poly_tuple_type at_mode_expr { $1, $2 }
 ;
 
 %inline poly_type_no_attr:

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -792,6 +792,7 @@ and labeled_tuple_pattern ctxt f ~unboxed l closed =
     (list ~sep:",@;" (labeled_pattern1 ctxt)) l
     closed_flag closed
 
+(** for special treatment of modes in labeled expressions *)
 and pattern2 ctxt f p =
   match p.ppat_desc with
   | Ppat_constraint(p, ct, m) ->
@@ -816,6 +817,7 @@ and pattern2 ctxt f p =
     end
   | _ -> pattern1 ctxt f p
 
+(** for special treatment of modes in labeled expressions *)
 and simple_pattern1 ctxt f p =
   match p.ppat_desc with
   | Ppat_constraint _ ->

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -594,7 +594,7 @@ end
     similar in most regards.)
 
    *)
-module (Memprof @ nonportable) :
+module (Memprof @@ nonportable) :
   sig @@ portable
     type t
     (** the type of a profile *)
@@ -748,7 +748,7 @@ end
 
         OCAMLRUNPARAM='Xfoo=42'
     *)
-module (Tweak @ nonportable) : sig
+module (Tweak @@ nonportable) : sig
   (** Change a parameter.
       Raises Invalid_argument if no such parameter exists *)
   val set : string -> int -> unit

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -375,7 +375,7 @@ let bits32 = apply0 State.bits32
 let bits64 = apply0 State.bits64
 let nativebits = apply0 State.nativebits
 
-let full_init (seed : int array @@ uncontended) =
+let full_init (seed : int array @ uncontended) =
   DLS.access (fun access ->
     State.reinit
       (DLS.get access random_key)

--- a/stdlib/scanf.mli
+++ b/stdlib/scanf.mli
@@ -103,7 +103,7 @@ open! Stdlib
 
 (** {1 Formatted input channel} *)
 
-module (Scanning @ nonportable) : sig @@ portable
+module (Scanning @@ nonportable) : sig @@ portable
 
 type in_channel
 (** The notion of input channel for the {!Scanf} module:

--- a/testsuite/tests/capsule-api/basics.ml
+++ b/testsuite/tests/capsule-api/basics.ml
@@ -34,7 +34,7 @@ module Cell = struct
   let read (type a : value mod portable contended) (t : a t) : a =
     let (Mk (m, p)) = t in
     Capsule.Mutex.with_lock m (fun k ->
-      let read' : a myref -> a @ portable contended @@ portable = (fun r -> r.v) in
+      let read' : (a myref -> a @ portable contended) @ portable = (fun r -> r.v) in
       Capsule.Data.extract k read' p)
 
   let write (type a : value mod portable contended) (t : a t) (x : a) =

--- a/testsuite/tests/capsule-api/data.ml
+++ b/testsuite/tests/capsule-api/data.ml
@@ -11,13 +11,13 @@ external reraise : exn -> 'a @ portable @@ portable = "%reraise"
 
 type 'a myref = { mutable v : 'a}
 
-let mk_ref : ('a -> 'a myref) @@ portable = fun v -> {v}
+let mk_ref : ('a -> 'a myref) @ portable = fun v -> {v}
 
 (* We need ['a] to be [portable] to return a [portable] value from the read.
    The return value is marked as [contended] because our callsites require that,
    but the typechecker does not implicitly downcast the result. *)
-let read_ref : ('a : value mod portable) .
-  ('a myref -> 'a @ portable contended) @@ portable = fun r -> r.v
+let read_ref : (('a : value mod portable) .
+  ('a myref -> 'a @ portable contended)) @ portable = fun r -> r.v
 
 (* We need ['a] to be [portable] and [contended] to capture it in
    a [portable] closure like this.*)

--- a/testsuite/tests/capsule-api/data.ml
+++ b/testsuite/tests/capsule-api/data.ml
@@ -16,8 +16,8 @@ let mk_ref : ('a -> 'a myref) @ portable = fun v -> {v}
 (* We need ['a] to be [portable] to return a [portable] value from the read.
    The return value is marked as [contended] because our callsites require that,
    but the typechecker does not implicitly downcast the result. *)
-let read_ref : (('a : value mod portable) .
-  ('a myref -> 'a @ portable contended)) @ portable = fun r -> r.v
+let read_ref : ('a : value mod portable) .
+  ('a myref -> 'a @ portable contended) @ portable = fun r -> r.v
 
 (* We need ['a] to be [portable] and [contended] to capture it in
    a [portable] closure like this.*)
@@ -177,4 +177,3 @@ let ptr' : (int, lost_capsule) Capsule.Data.t =
 let () =
   assert (Capsule.Data.project ptr' = 111)
 ;;
-

--- a/testsuite/tests/capsule-api/key.ml
+++ b/testsuite/tests/capsule-api/key.ml
@@ -21,7 +21,7 @@ type 'a aliased = Aliased of 'a @@ aliased [@@unboxed]
 
 let () =
   (* [Capsule.create] creates a new capsule with an unique key. *)
-  let packed : Capsule.Key.packed @@ unique = Capsule.create () in
+  let packed : Capsule.Key.packed @ unique = Capsule.create () in
   let (P k) = packed in
   (* [Capsule.Key.access] *)
   let Aliased x, k =
@@ -84,7 +84,7 @@ let () =
   (* We can still access the data through the password. *)
   let s =
     Capsule.Data.Local.extract p
-      (fun x -> (x.contents : string @@ portable)) x
+      (fun x -> (x.contents : string @ portable)) x
   in
   assert (s = "Local value")
 ;;

--- a/testsuite/tests/capsule-api/rwlock_capsule.ml
+++ b/testsuite/tests/capsule-api/rwlock_capsule.ml
@@ -83,8 +83,8 @@ let with_read_guarded x (f : 'k . 'k Capsule.Password.Shared.t @ local -> ('a, '
 ;;
 
 (* reading from myref with the expected modes *)
-let read_ref : ('a : value mod portable) .
-  ('a myref @ shared -> 'a @ portable contended) @@ portable = fun r -> r.v
+let read_ref : (('a : value mod portable) .
+  ('a myref @ shared -> 'a @ portable contended)) @ portable = fun r -> r.v
 
 (* writing to myref with the expected modes *)
  let write_ref : ('a : value mod portable contended) .

--- a/testsuite/tests/capsule-api/rwlock_capsule.ml
+++ b/testsuite/tests/capsule-api/rwlock_capsule.ml
@@ -83,8 +83,8 @@ let with_read_guarded x (f : 'k . 'k Capsule.Password.Shared.t @ local -> ('a, '
 ;;
 
 (* reading from myref with the expected modes *)
-let read_ref : (('a : value mod portable) .
-  ('a myref @ shared -> 'a @ portable contended)) @ portable = fun r -> r.v
+let read_ref : ('a : value mod portable) .
+  ('a myref @ shared -> 'a @ portable contended) @ portable = fun r -> r.v
 
 (* writing to myref with the expected modes *)
  let write_ref : ('a : value mod portable contended) .

--- a/testsuite/tests/capsule-api/shared.ml
+++ b/testsuite/tests/capsule-api/shared.ml
@@ -17,9 +17,9 @@ external reraise : exn -> 'a @ portable = "%reraise"
 
 type 'a myref = { mutable v : 'a }
 
-let mk_ref : ('a -> 'a myref) @@ portable = fun v -> {v}
-let read_ref : ('a : value mod portable) .
-  ('a myref -> 'a @ portable contended) @@ portable = fun r -> r.v
+let mk_ref : ('a -> 'a myref) @ portable = fun v -> {v}
+let read_ref : (('a : value mod portable) .
+  ('a myref -> 'a @ portable contended)) @ portable = fun r -> r.v
 let write_ref : ('a : value mod portable contended) .
   'a -> ('a myref -> unit) @ portable = fun v r -> r.v <- v
 

--- a/testsuite/tests/capsule-api/shared.ml
+++ b/testsuite/tests/capsule-api/shared.ml
@@ -18,8 +18,8 @@ external reraise : exn -> 'a @ portable = "%reraise"
 type 'a myref = { mutable v : 'a }
 
 let mk_ref : ('a -> 'a myref) @ portable = fun v -> {v}
-let read_ref : (('a : value mod portable) .
-  ('a myref -> 'a @ portable contended)) @ portable = fun r -> r.v
+let read_ref : ('a : value mod portable) .
+  ('a myref -> 'a @ portable contended) @ portable = fun r -> r.v
 let write_ref : ('a : value mod portable contended) .
   'a -> ('a myref -> unit) @ portable = fun v r -> r.v <- v
 

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -79,14 +79,14 @@ run {| let foo : type a . a -> a = fun x -> x in foo |}
 
 (* CR: untypeast/pprintast are totally busted on programs with modes in value
    bindings. Fix this. *)
-run {| let foo : 'a -> 'a @@ portable = fun x -> x in foo |}
+run {| let foo : ('a -> 'a) @ portable = fun x -> x in foo |}
 
 [%%expect{|
->> Fatal error: Unrecognized mode portable - should not parse
-Exception: Misc.Fatal_error.
+- : string =
+"let (foo : 'a -> 'a) = ((fun x -> x : 'a -> 'a) : _ @ portable) in foo"
 |}];;
 
-run {| let foo : 'a . 'a -> 'a @@ portable = fun x -> x in foo |}
+run {| let foo : ('a . 'a -> 'a) @ portable = fun x -> x in foo |}
 
 [%%expect{|
 - : string = "let foo : ('a : value) . 'a -> 'a = fun x -> x in foo"

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -86,7 +86,7 @@ run {| let foo : ('a -> 'a) @ portable = fun x -> x in foo |}
 "let (foo : 'a -> 'a) = ((fun x -> x : 'a -> 'a) : _ @ portable) in foo"
 |}];;
 
-run {| let foo : ('a . 'a -> 'a) @ portable = fun x -> x in foo |}
+run {| let foo : 'a . ('a -> 'a) @ portable = fun x -> x in foo |}
 
 [%%expect{|
 - : string = "let foo : ('a : value) . 'a -> 'a = fun x -> x in foo"

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -335,44 +335,49 @@ let f ?(local_ x = 42)
       ?(local_ x @ once portable = 42)
       ?(local_ x : int @ once portable = 42)
       ?(local_ x : ('a -> 'a) @ once portable = fun x -> x)
-      ?(local_ x : (('a : any) 'b . 'a) @ once portable = assert false)
-      ?(local_ x : (('a : any) 'b . 'a -> 'b) @ once portable = assert false)
+      ?(local_ x : ('a : any) 'b . 'a @ once portable = assert false)
+      ?(local_ x : ('a : any) 'b . 'a -> 'b @ once portable = assert false)
+      ?(local_ x : ('a : any) 'b . ('a -> 'b) @ once portable = assert false)
 
       ?x:(local_ (y, z) = 42)
       ?x:(local_ (y, z) @ once portable = 42)
       ?x:(local_ (y, z) : int @ once portable = 42)
       ?x:(local_ (y, z) : ('a -> 'a) @ once portable = 42)
-      ?x:(local_ (y, z) : (('a : any) 'b . 'a) @ once portable = 42)
-      ?x:(local_ (y, z) : (('a : any) 'b . 'a -> 'b) @ once portable = 42)
+      ?x:(local_ (y, z) : ('a : any) 'b . 'a @ once portable = 42)
+      ?x:(local_ (y, z) : ('a : any) 'b . 'a -> 'b @ once portable = 42)
+      ?x:(local_ (y, z) : ('a : any) 'b . ('a -> 'b) @ once portable = 42)
 
       ~(local_ x)
       ~(local_ x @ once portable)
       ~(local_ x : int @ once portable)
       ~(local_ x : ('a -> 'a) @ once portable)
-      ~(local_ x : (('a : any) 'b . 'a) @ once portable)
-      ~(local_ x : (('a : any) 'b . 'a -> 'b) @ once portable)
+      ~(local_ x : ('a : any) 'b . 'a @ once portable)
+      ~(local_ x : ('a : any) 'b . 'a -> 'b @ once portable)
+      ~(local_ x : ('a : any) 'b . ('a -> 'b) @ once portable)
 
       ~x:(local_ (y, z))
       ~x:(local_ (y, z) @ once portable)
       ~x:(local_ (y, z) : int @ once portable)
       ~x:(local_ (y, z) : ('a -> 'a) @ once portable)
-      ~x:(local_ (y, z) : (('a : any) 'b . 'a) @ once portable)
-      ~x:(local_ (y, z) : (('a : any) 'b . 'a -> 'b) @ once portable)
+      ~x:(local_ (y, z) : ('a : any) 'b . 'a @ once portable)
+      ~x:(local_ (y, z) : ('a : any) 'b . ('a -> 'b) @ once portable)
+      ~x:(local_ (y, z) : ('a : any) 'b . 'a -> 'b @ once portable)
 
       (local_ (y, z))
       (local_ (y, z) @ once portable)
       (local_ (y, z) : int @ once portable)
       (local_ (y, z) : ('a -> 'a) @ once portable)
-      (local_ (y, z) : (('a : any) 'b . 'a) @ once portable)
-      (local_ (y, z) : (('a : any) 'b . 'a -> 'b) @ once portable)
+      (local_ (y, z) : ('a : any) 'b . 'a @ once portable)
+      (local_ (y, z) : ('a : any) 'b . ('a -> 'b) @ once portable)
+      (local_ (y, z) : ('a : any) 'b . 'a -> 'b @ once portable)
 
       = ();;
 
 (* This file is only about syntax - type error is fine *)
 [%%expect{|
-Line 5, characters 8-55:
-5 |       ?(local_ x : (('a : any) 'b . 'a) @ once portable = assert false)
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 5, characters 8-53:
+5 |       ?(local_ x : ('a : any) 'b . 'a @ once portable = assert false)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Optional parameters cannot be polymorphic
 |}]
 
@@ -392,11 +397,13 @@ let g () =
   let local_ a : int @ once portable = 42 in
   let local_ a : (int -> int) @ once portable = 42 in
 
-  let local_ a : (('a : any) 'b. 'a) @ once portable = 42 in
-  let local_ a : (('a : any) 'b. 'a -> 'a) @ once portable = 42 in
+  let local_ a : ('a : any) 'b. 'a @ once portable = 42 in
+  let local_ a : ('a : any) 'b. 'a -> 'a @ once portable = 42 in
+  let local_ a : ('a : any) 'b. ('a -> 'a) @ once portable = 42 in
 
-  let a : (type (a : any) b. int) @ once portable = 42 in
-  let a : (type (a : any) b. a -> b) @ once portable = 42 in
+  let a : type (a : any) b. int @ once portable = 42 in
+  let a : type (a : any) b. a -> b @ once portable = 42 in
+  let a : type (a : any) b. (a -> b) @ once portable = 42 in
 
   let (a, b) @ once portable = 42 in
   let (a, b) : int @ once portable = 42 in
@@ -503,8 +510,8 @@ type typvar_fn = a:('a. 'a) @ local unique portable contended -> unit
 let f ~(x1 @ many)
       ~(x2 : string @ local)
       ~(x3 : (string -> string) @ local)
-      ~(x4 : ('a. 'a -> 'a) @ local)
-      ~(x9 : ('a. 'a) @ local)
+      ~(x4 : 'a. ('a -> 'a) @ local)
+      ~(x9 : 'a. 'a @ local)
       ~(local_ x5)
       ~x6:(local_ true | false @ many)
       ~x7:(local_ true | false : bool @ many)

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -761,6 +761,23 @@ Line 1, characters 12-20:
 Error: Mode annotations on modules are not supported yet.
 |}]
 
+module (G @ portable) () = F
+
+[%%expect{|
+Line 1, characters 12-20:
+1 | module (G @ portable) () = F
+                ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
+module (G' @ portable) = F
+[%%expect{|
+Line 1, characters 13-21:
+1 | module (G' @ portable) = F
+                 ^^^^^^^^
+Error: Mode annotations on modules are not supported yet.
+|}]
+
 module rec (F @ portable) () = struct end
 and (G @ portable) () = struct end
 [%%expect{|

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1157,7 +1157,7 @@ Error: The kind of type "t" is value
 type 'a t : value mod global portable contended many aliased unyielding =
   { x : 'a @@ global portable contended many aliased } [@@unboxed]
 [%%expect {|
-type 'a t = { global_ x : 'a @@ many portable aliased contended; } [@@unboxed]
+type 'a t = { x : 'a @@ global many portable aliased contended; } [@@unboxed]
 |}]
 (* CR layouts v2.8: this could be accepted, if we infer ('a : value mod
    unyielding). We do not currently do this, because we finish inference of the
@@ -1335,7 +1335,7 @@ type _ t =
   | K : (_ : value mod global) t
 
 let f (type a : value) (x : a t) =
-  let y : a @@ local = assert false in
+  let y : a @ local = assert false in
   match x with
   | K -> y
 

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -55,16 +55,16 @@ Error: This type "t" should be an instance of type "('a : value mod global)"
          because of the definition of require_global at line 7, characters 0-43.
 |}]
 
-let foo (t : t @@ contended) = use_uncontended t
+let foo (t : t @ contended) = use_uncontended t
 [%%expect {|
 val foo : t @ contended -> unit = <fun>
 |}]
 
-let foo (t : t @@ local) = use_global t [@nontail]
+let foo (t : t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 38-39:
-1 | let foo (t : t @@ local) = use_global t [@nontail]
-                                          ^
+Line 1, characters 37-38:
+1 | let foo (t : t @ local) = use_global t [@nontail]
+                                         ^
 Error: This value escapes its region.
 |}]
 
@@ -93,16 +93,16 @@ Error: This type "t" should be an instance of type "('a : value mod aliased)"
          because of the definition of require_aliased at line 8, characters 0-45.
 |}]
 
-let foo (t : t @@ once) = use_many t
+let foo (t : t @ once) = use_many t
 [%%expect {|
 val foo : t @ once -> unit = <fun>
 |}]
 
-let foo (t : t @@ aliased) = use_unique t
+let foo (t : t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : t @@ aliased) = use_unique t
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : t @ aliased) = use_unique t
+                                           ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -114,16 +114,16 @@ type u = Foo of int | Bar of string
 type t = Baz of u * int
 |}]
 
-let foo (t : t @@ contended) = use_uncontended t
+let foo (t : t @ contended) = use_uncontended t
 [%%expect {|
 val foo : t @ contended -> unit = <fun>
 |}]
 
-let foo (t : t @@ local) = use_global t [@nontail]
+let foo (t : t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 38-39:
-1 | let foo (t : t @@ local) = use_global t [@nontail]
-                                          ^
+Line 1, characters 37-38:
+1 | let foo (t : t @ local) = use_global t [@nontail]
+                                         ^
 Error: This value escapes its region.
 |}]
 
@@ -135,16 +135,16 @@ type u = Foo of int
 type t = { z : u; }
 |}]
 
-let foo (t : t @@ contended) = use_uncontended t
+let foo (t : t @ contended) = use_uncontended t
 [%%expect {|
 val foo : t @ contended -> unit = <fun>
 |}]
 
-let foo (t : t @@ local) = use_global t [@nontail]
+let foo (t : t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 38-39:
-1 | let foo (t : t @@ local) = use_global t [@nontail]
-                                          ^
+Line 1, characters 37-38:
+1 | let foo (t : t @ local) = use_global t [@nontail]
+                                         ^
 Error: This value escapes its region.
 |}]
 
@@ -159,26 +159,26 @@ type ('a : immutable_data) t = { x : 'a list }
 type ('a : immutable_data) t = { x : 'a list; }
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 (* CR layouts v2.8: fix principal case *)
 [%%expect {|
 val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}, Principal{|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
 val foo : int t @ contended -> unit = <fun>
 |}]
 
-let foo (t : int ref t @@ contended) = use_uncontended t
+let foo (t : int ref t @ contended) = use_uncontended t
 [%%expect {|
 Line 1, characters 13-20:
-1 | let foo (t : int ref t @@ contended) = use_uncontended t
+1 | let foo (t : int ref t @ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
        The kind of int ref is mutable_data.
@@ -186,7 +186,7 @@ Error: This type "int ref" should be an instance of type "('a : immutable_data)"
          because of the definition of t at line 1, characters 0-46.
 |}, Principal{|
 Line 1, characters 13-20:
-1 | let foo (t : int ref t @@ contended) = use_uncontended t
+1 | let foo (t : int ref t @ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
        The kind of int ref is mutable_data with int @@ many unyielding.
@@ -198,11 +198,11 @@ Error: This type "int ref" should be an instance of type "('a : immutable_data)"
          portability: mod portable with int ≰ mod portable
 |}]
 
-let foo (t : int t @@ local) = use_global t [@nontail]
+let foo (t : int t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : int t @@ local) = use_global t [@nontail]
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : int t @ local) = use_global t [@nontail]
+                                             ^
 Error: This value escapes its region.
 |}]
 
@@ -229,24 +229,24 @@ type 'a t = {
 }
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect{|
 val foo : int t @ contended -> unit = <fun>
 |}]
 
-let foo (t : int t @@ nonportable) = use_portable t
+let foo (t : int t @ nonportable) = use_portable t
 [%%expect{|
-Line 1, characters 50-51:
-1 | let foo (t : int t @@ nonportable) = use_portable t
-                                                      ^
+Line 1, characters 49-50:
+1 | let foo (t : int t @ nonportable) = use_portable t
+                                                     ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : int ref t @@ contended) = use_uncontended t
+let foo (t : int ref t @ contended) = use_uncontended t
 [%%expect{|
-Line 1, characters 55-56:
-1 | let foo (t : int ref t @@ contended) = use_uncontended t
-                                                           ^
+Line 1, characters 54-55:
+1 | let foo (t : int ref t @ contended) = use_uncontended t
+                                                          ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
@@ -258,32 +258,32 @@ type 'a u = 'a list
 type 'a t = { x : 'a u; }
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
 val foo : int t @ contended -> unit = <fun>
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int ref t @@ contended) = use_uncontended t
+let foo (t : int ref t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 55-56:
-1 | let foo (t : int ref t @@ contended) = use_uncontended t
-                                                           ^
+Line 1, characters 54-55:
+1 | let foo (t : int ref t @ contended) = use_uncontended t
+                                                          ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int t @@ local) = use_global t [@nontail]
+let foo (t : int t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : int t @@ local) = use_global t [@nontail]
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : int t @ local) = use_global t [@nontail]
+                                             ^
 Error: This value escapes its region.
 |}]
 
@@ -293,24 +293,24 @@ type 'a t = Empty | Cons of 'a * 'a t
 type 'a t = Empty | Cons of 'a * 'a t
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
 val foo : int t @ contended -> unit = <fun>
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int t @@ local) = use_global t [@nontail]
+let foo (t : int t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : int t @@ local) = use_global t [@nontail]
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : int t @ local) = use_global t [@nontail]
+                                             ^
 Error: This value escapes its region.
 |}]
 
@@ -320,15 +320,15 @@ type ('a : immutable_data) t : immutable_data = Empty | Cons of 'a * 'a t
 type ('a : immutable_data) t = Empty | Cons of 'a * 'a t
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
 val foo : int t @ contended -> unit = <fun>
 |}]
 
-let foo (t : int ref t @@ contended) = use_uncontended t
+let foo (t : int ref t @ contended) = use_uncontended t
 [%%expect {|
 Line 1, characters 13-20:
-1 | let foo (t : int ref t @@ contended) = use_uncontended t
+1 | let foo (t : int ref t @ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
        The kind of int ref is mutable_data.
@@ -336,7 +336,7 @@ Error: This type "int ref" should be an instance of type "('a : immutable_data)"
          because of the definition of t at line 1, characters 0-73.
 |}, Principal{|
 Line 1, characters 13-20:
-1 | let foo (t : int ref t @@ contended) = use_uncontended t
+1 | let foo (t : int ref t @ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
        The kind of int ref is mutable_data with int @@ many unyielding.
@@ -348,11 +348,11 @@ Error: This type "int ref" should be an instance of type "('a : immutable_data)"
          portability: mod portable with int ≰ mod portable
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -360,29 +360,29 @@ Error: This value is "aliased" but expected to be "unique".
 type 'a t = { x : 'a; y : int }
 type nonrec ('a : immutable_data) t : immutable_data = 'a t
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
 type 'a t = { x : 'a; y : int; }
 type nonrec ('a : immutable_data) t = 'a t
 val foo : int t @ contended -> unit = <fun>
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 (* CR layouts v2.8: fix principal case *)
 [%%expect {|
 val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}, Principal{|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -397,24 +397,24 @@ type 'a t = { head : 'a; tail : 'a t option }
 type 'a t = { head : 'a; tail : 'a t option; }
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
 val foo : int t @ contended -> unit = <fun>
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -426,16 +426,16 @@ type t = None | Some of u
 and u = None | Some of t
 |}]
 
-let foo (t : t @@ contended) = use_uncontended t
+let foo (t : t @ contended) = use_uncontended t
 [%%expect {|
 val foo : t @ contended -> unit = <fun>
 |}]
 
-let foo (t : t @@ aliased) = use_unique t
+let foo (t : t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : t @@ aliased) = use_unique t
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : t @ aliased) = use_unique t
+                                           ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -447,16 +447,16 @@ type 'a t = None | Some of 'a u
 and 'a u = None | Some of 'a t
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
 val foo : 'a t @ contended -> unit = <fun>
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -468,24 +468,24 @@ type 'a t = Value of 'a | Some of 'a u
 and 'a u = None | Some of 'a t
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
 val foo : int t @ contended -> unit = <fun>
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -495,16 +495,16 @@ type t : immutable_data = int list list
 type t = int list list
 |}]
 
-let foo (t : t @@ contended) = use_uncontended t
+let foo (t : t @ contended) = use_uncontended t
 [%%expect {|
 val foo : t @ contended -> unit = <fun>
 |}]
 
-let foo (t : t @@ aliased) = use_unique t
+let foo (t : t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : t @@ aliased) = use_unique t
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : t @ aliased) = use_unique t
+                                           ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -543,20 +543,20 @@ type t =
     list list list list list list list list list list
 |}]
 
-let foo (t : t @@ contended) = use_uncontended t
+let foo (t : t @ contended) = use_uncontended t
 (* CR layouts v2.8: fix this *)
 [%%expect {|
-Line 1, characters 47-48:
-1 | let foo (t : t @@ contended) = use_uncontended t
-                                                   ^
+Line 1, characters 46-47:
+1 | let foo (t : t @ contended) = use_uncontended t
+                                                  ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : t @@ aliased) = use_unique t
+let foo (t : t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : t @@ aliased) = use_unique t
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : t @ aliased) = use_unique t
+                                           ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -567,24 +567,24 @@ type 'a t = Empty | Cons of { mutable head : 'a; tail : 'a t; }
 |}]
 
 
-let foo (t : int t @@ nonportable) = use_portable t
+let foo (t : int t @ nonportable) = use_portable t
 [%%expect {|
 val foo : int t -> unit = <fun>
 |}]
 
-let foo (t : _ t @@ nonportable) = use_portable t
+let foo (t : _ t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 48-49:
-1 | let foo (t : _ t @@ nonportable) = use_portable t
-                                                    ^
+Line 1, characters 47-48:
+1 | let foo (t : _ t @ nonportable) = use_portable t
+                                                   ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 51-52:
-1 | let foo (t : int t @@ contended) = use_uncontended t
-                                                       ^
+Line 1, characters 50-51:
+1 | let foo (t : int t @ contended) = use_uncontended t
+                                                      ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
@@ -603,20 +603,20 @@ Error: The kind of type "t" is immutable_data with 'a t t t t t t t t t t t
        as it is very large or deeply recursive.
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 (* CR layouts v2.8: fix this *)
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : _ t @@ aliased) = use_unique t
+let foo (t : _ t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : _ t @@ aliased) = use_unique t
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : _ t @ aliased) = use_unique t
+                                             ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -651,29 +651,29 @@ Error: The kind of type "t" is immutable_data
        as it is very large or deeply recursive.
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 (* CR layouts v2.8: fix this *)
 [%%expect {|
-Line 1, characters 51-52:
-1 | let foo (t : int t @@ contended) = use_uncontended t
-                                                       ^
+Line 1, characters 50-51:
+1 | let foo (t : int t @ contended) = use_uncontended t
+                                                      ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 (* CR layouts v2.8: fix this *)
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : _ t @@ aliased) = use_unique t
+let foo (t : _ t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : _ t @@ aliased) = use_unique t
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : _ t @ aliased) = use_unique t
+                                             ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -685,16 +685,16 @@ type 'a u : immutable_data with 'a
 type t = { x : int u; y : string u; }
 |}]
 
-let foo (t : t @@ contended) = use_uncontended t
+let foo (t : t @ contended) = use_uncontended t
 [%%expect {|
 val foo : t @ contended -> unit = <fun>
 |}]
 
-let foo (t : t @@ aliased) = use_unique t
+let foo (t : t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : t @@ aliased) = use_unique t
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : t @ aliased) = use_unique t
+                                           ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -708,11 +708,11 @@ type 'a u
 type 'a t = None | Some of ('a * 'a) t u
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 51-52:
-1 | let foo (t : int t @@ contended) = use_uncontended t
-                                                       ^
+Line 1, characters 50-51:
+1 | let foo (t : int t @ contended) = use_uncontended t
+                                                      ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
@@ -726,28 +726,28 @@ type 'a u : immutable_data with 'a
 type 'a t = None | Some of ('a * 'a) t u
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 (* CR layouts v2.8: this should work when we get tuples working *)
 [%%expect {|
-Line 1, characters 51-52:
-1 | let foo (t : int t @@ contended) = use_uncontended t
-                                                       ^
+Line 1, characters 50-51:
+1 | let foo (t : int t @ contended) = use_uncontended t
+                                                      ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -759,29 +759,29 @@ type 'a t =
 type 'a t = None | Some of ('a * 'a) t
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 (* CR layouts v2.8: this should work, but the recursive expansion
    of with-bounds presumably runs out of fuel and gives up. *)
 [%%expect {|
-Line 1, characters 51-52:
-1 | let foo (t : int t @@ contended) = use_uncontended t
-                                                       ^
+Line 1, characters 50-51:
+1 | let foo (t : int t @ contended) = use_uncontended t
+                                                      ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -793,20 +793,20 @@ type 'a t =
 type 'a t = Leaf of 'a | Some of ('a * 'a) t
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 (* CR layouts v2.8: fix this *)
 [%%expect {|
-Line 1, characters 51-52:
-1 | let foo (t : int t @@ contended) = use_uncontended t
-                                                       ^
+Line 1, characters 50-51:
+1 | let foo (t : int t @ contended) = use_uncontended t
+                                                      ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
@@ -818,46 +818,46 @@ type 'a t =
 type 'a t = None | Some of 'a t * 'a t
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
 val foo : 'a t @ contended -> unit = <fun>
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (***********************************************************************)
 type 'a rose_tree = Node of 'a * 'a rose_tree list
 
-let f (x : int rose_tree @@ contended) = use_uncontended x
+let f (x : int rose_tree @ contended) = use_uncontended x
 [%%expect{|
 type 'a rose_tree = Node of 'a * 'a rose_tree list
 val f : int rose_tree @ contended -> unit = <fun>
 |}]
 
-let f (x : int ref rose_tree @@ contended) = use_uncontended x
+let f (x : int ref rose_tree @ contended) = use_uncontended x
 [%%expect{|
-Line 1, characters 61-62:
-1 | let f (x : int ref rose_tree @@ contended) = use_uncontended x
-                                                                 ^
+Line 1, characters 60-61:
+1 | let f (x : int ref rose_tree @ contended) = use_uncontended x
+                                                                ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let f (x : int rose_tree @@ nonportable) = use_portable x
+let f (x : int rose_tree @ nonportable) = use_portable x
 [%%expect{|
 val f : int rose_tree -> unit = <fun>
 |}]
 
-let f (x : (int -> int) rose_tree @@ nonportable) = use_portable x
+let f (x : (int -> int) rose_tree @ nonportable) = use_portable x
 [%%expect{|
-Line 1, characters 65-66:
-1 | let f (x : (int -> int) rose_tree @@ nonportable) = use_portable x
-                                                                     ^
+Line 1, characters 64-65:
+1 | let f (x : (int -> int) rose_tree @ nonportable) = use_portable x
+                                                                    ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
@@ -866,29 +866,29 @@ type 'a rose_tree2 =
   | Leaf of 'a
   | Branch of 'a rose_tree2 list
 
-let f (x : int rose_tree2 @@ contended) = use_uncontended x
+let f (x : int rose_tree2 @ contended) = use_uncontended x
 [%%expect{|
 type 'a rose_tree2 = Empty | Leaf of 'a | Branch of 'a rose_tree2 list
 val f : int rose_tree2 @ contended -> unit = <fun>
 |}]
 
-let f (x : int ref rose_tree2 @@ contended) = use_uncontended x
+let f (x : int ref rose_tree2 @ contended) = use_uncontended x
 [%%expect{|
-Line 1, characters 62-63:
-1 | let f (x : int ref rose_tree2 @@ contended) = use_uncontended x
-                                                                  ^
+Line 1, characters 61-62:
+1 | let f (x : int ref rose_tree2 @ contended) = use_uncontended x
+                                                                 ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let f (x : int rose_tree2 @@ nonportable) = use_portable x
+let f (x : int rose_tree2 @ nonportable) = use_portable x
 [%%expect{|
 val f : int rose_tree2 -> unit = <fun>
 |}]
 
-let f (x : (int -> int) rose_tree2 @@ nonportable) = use_portable x
+let f (x : (int -> int) rose_tree2 @ nonportable) = use_portable x
 [%%expect{|
-Line 1, characters 66-67:
-1 | let f (x : (int -> int) rose_tree2 @@ nonportable) = use_portable x
-                                                                      ^
+Line 1, characters 65-66:
+1 | let f (x : (int -> int) rose_tree2 @ nonportable) = use_portable x
+                                                                     ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -37,19 +37,19 @@ type t =
 type t = Foo : 'a -> t
 |}]
 
-let foo (t : t @@ nonportable) = use_portable t
+let foo (t : t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 46-47:
-1 | let foo (t : t @@ nonportable) = use_portable t
-                                                  ^
+Line 1, characters 45-46:
+1 | let foo (t : t @ nonportable) = use_portable t
+                                                 ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : t @@ aliased) = use_unique t
+let foo (t : t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : t @@ aliased) = use_unique t
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : t @ aliased) = use_unique t
+                                           ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -60,20 +60,20 @@ type t =
 type t = Foo : ('a : immutable_data). 'a -> t
 |}]
 
-let foo (t : t @@ contended) = use_uncontended t
+let foo (t : t @ contended) = use_uncontended t
 (* CR layouts v2.8: fix this *)
 [%%expect {|
-Line 1, characters 47-48:
-1 | let foo (t : t @@ contended) = use_uncontended t
-                                                   ^
+Line 1, characters 46-47:
+1 | let foo (t : t @ contended) = use_uncontended t
+                                                  ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : t @@ local) = use_global t [@nontail]
+let foo (t : t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 38-39:
-1 | let foo (t : t @@ local) = use_global t [@nontail]
-                                          ^
+Line 1, characters 37-38:
+1 | let foo (t : t @ local) = use_global t [@nontail]
+                                         ^
 Error: This value escapes its region.
 |}]
 
@@ -84,19 +84,19 @@ type 'a t =
 type 'a t = Foo : 'a -> 'a t
 |}]
 
-let foo (t : int t @@ once) = use_many t
+let foo (t : int t @ once) = use_many t
 (* CR layouts v2.8: fix this *)
 [%%expect {|
-Line 1, characters 39-40:
-1 | let foo (t : int t @@ once) = use_many t
-                                           ^
+Line 1, characters 38-39:
+1 | let foo (t : int t @ once) = use_many t
+                                          ^
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : t @@ aliased) = use_unique t
+let foo (t : t @ aliased) = use_unique t
 [%%expect {|
 Line 1, characters 13-14:
-1 | let foo (t : t @@ aliased) = use_unique t
+1 | let foo (t : t @ aliased) = use_unique t
                  ^
 Error: The type constructor "t" expects 1 argument(s),
        but is here applied to 0 argument(s)
@@ -116,7 +116,7 @@ end
 type (_ : any, _ : any) eq =
   Refl : ('a : any). ('a, 'a) eq
 
-let use_portable (_ : _ @@ portable) = ()
+let use_portable (_ : _ @ portable) = ()
 
 module F (X : S) = struct
   type t3 : value mod portable with X.t1
@@ -131,7 +131,7 @@ end
 module M1 = F(Arg1)
 
 let f (witness : (M1.t3, M1.t4) eq)
-      (t3 : M1.t3 @@ nonportable) (t4 : M1.t4 @@ nonportable) =
+      (t3 : M1.t3 @ nonportable) (t4 : M1.t4 @ nonportable) =
   match witness with
   | Refl ->
     use_portable t3;

--- a/testsuite/tests/typing-jkind-bounds/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/modalities.ml
@@ -27,34 +27,34 @@ type t_test = int t require_contended
 type t_test = int ref t require_contended
 |}]
 
-let foo (t : int ref t @@ contended) = use_uncontended t
+let foo (t : int ref t @ contended) = use_uncontended t
 [%%expect{|
 val foo : int ref t @ contended -> unit = <fun>
 |}]
 
-let foo (t : int ref t @@ contended) = use_uncontended t.contended
+let foo (t : int ref t @ contended) = use_uncontended t.contended
 [%%expect{|
-Line 1, characters 55-66:
-1 | let foo (t : int ref t @@ contended) = use_uncontended t.contended
-                                                           ^^^^^^^^^^^
+Line 1, characters 54-65:
+1 | let foo (t : int ref t @ contended) = use_uncontended t.contended
+                                                          ^^^^^^^^^^^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int ref t @@ contended) = cross_contended t
+let foo (t : int ref t @ contended) = cross_contended t
 [%%expect{|
 val foo : int ref t @ contended -> unit = <fun>
 |}]
 
-let foo (t : int t @@ nonportable) = use_portable t
+let foo (t : int t @ nonportable) = use_portable t
 [%%expect{|
 val foo : int t -> unit = <fun>
 |}]
 
-let foo (t : _ t @@ nonportable) = use_portable t
+let foo (t : _ t @ nonportable) = use_portable t
 [%%expect{|
-Line 1, characters 48-49:
-1 | let foo (t : _ t @@ nonportable) = use_portable t
-                                                    ^
+Line 1, characters 47-48:
+1 | let foo (t : _ t @ nonportable) = use_portable t
+                                                   ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
@@ -74,7 +74,7 @@ type 'a portable : value mod portable = { portable : 'a @@ portable }
 type 'a portable = { portable : 'a @@ portable; }
 |}]
 
-let foo (x : (int -> int) ref portable @@ nonportable) = use_portable x
+let foo (x : (int -> int) ref portable @ nonportable) = use_portable x
 [%%expect{|
 val foo : (int -> int) ref portable -> unit = <fun>
 |}]
@@ -83,7 +83,7 @@ val foo : (int -> int) ref portable -> unit = <fun>
 
 type t : value mod portable = { f : int -> int @@ portable }
 type _foo = t require_portable
-let foo (t : t @@ nonportable) = use_portable t
+let foo (t : t @ nonportable) = use_portable t
 [%%expect{|
 type t = { f : int -> int @@ portable; }
 type _foo = t require_portable
@@ -105,35 +105,35 @@ val use_portable : ('a : value & value). 'a @ portable -> unit = <fun>
 type 'a t = #{ global_ x : 'a; global_ y : 'a; }
 |}]
 
-let foo (t : string t @@ local) = use_global t
+let foo (t : string t @ local) = use_global t
 
 [%%expect{|
 val foo : local_ string t -> unit = <fun>
 |}]
 
-let foo (t : string t @@ local) = cross_global t
+let foo (t : string t @ local) = cross_global t
 
 [%%expect{|
 val foo : local_ string t -> unit = <fun>
 |}]
 
-let foo (t : string t @@ nonportable) = use_portable t
+let foo (t : string t @ nonportable) = use_portable t
 
 [%%expect{|
 val foo : string t -> unit = <fun>
 |}]
 
-let foo (t : (string -> string) t @@ nonportable) = use_portable t
+let foo (t : (string -> string) t @ nonportable) = use_portable t
 
 [%%expect{|
-Line 1, characters 65-66:
-1 | let foo (t : (string -> string) t @@ nonportable) = use_portable t
-                                                                     ^
+Line 1, characters 64-65:
+1 | let foo (t : (string -> string) t @ nonportable) = use_portable t
+                                                                    ^
 Error: This value is "nonportable" but expected to be "portable".
 |}, Principal{|
-Line 1, characters 65-66:
-1 | let foo (t : (string -> string) t @@ nonportable) = use_portable t
-                                                                     ^
+Line 1, characters 64-65:
+1 | let foo (t : (string -> string) t @ nonportable) = use_portable t
+                                                                    ^
 Error: This expression has type "(string -> string) t"
        but an expression was expected of type "('a : value & value)"
        The kind of (string -> string) t is

--- a/testsuite/tests/typing-jkind-bounds/no_infer_with_bounds.ml
+++ b/testsuite/tests/typing-jkind-bounds/no_infer_with_bounds.ml
@@ -5,15 +5,15 @@
 (****************************)
 (* Test 1: unboxed products *)
 
-let use_portable (_ : (_ : value & value) @@ portable) = ()
-let use_uncontended (_ : (_ : value & value) @@ uncontended) = ()
+let use_portable (_ : (_ : value & value) @ portable) = ()
+let use_uncontended (_ : (_ : value & value) @ uncontended) = ()
 
 [%%expect{|
 val use_portable : ('a : value & value). 'a @ portable -> unit = <fun>
 val use_uncontended : ('a : value & value). 'a -> unit = <fun>
 |}]
 
-let f (x : #( (int -> int) list * int ref list ) @@ nonportable contended) =
+let f (x : #( (int -> int) list * int ref list ) @ nonportable contended) =
   use_portable x
 
 [%%expect{|
@@ -23,7 +23,7 @@ Line 2, characters 15-16:
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let f (x : #( (int -> int) list * int ref list ) @@ nonportable contended) =
+let f (x : #( (int -> int) list * int ref list ) @ nonportable contended) =
   use_uncontended x
 
 [%%expect{|
@@ -33,7 +33,7 @@ Line 2, characters 18-19:
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let f (x : #( unit list * string list ) @@ nonportable contended) =
+let f (x : #( unit list * string list ) @ nonportable contended) =
   use_portable x;
   use_uncontended x
 

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -135,7 +135,7 @@ Error: This type "int option" should be an instance of type
          because of the definition of require_global at line 7, characters 0-43.
 |}]
 
-let foo (t : int option @@ contended portable once) =
+let foo (t : int option @ contended portable once) =
   use_many t;
   use_uncontended t;
   use_portable t
@@ -143,11 +143,11 @@ let foo (t : int option @@ contended portable once) =
 val foo : int option @ once portable contended -> unit = <fun>
 |}]
 
-let foo (t : int option @@ local) = use_global t [@nontail]
+let foo (t : int option @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 47-48:
-1 | let foo (t : int option @@ local) = use_global t [@nontail]
-                                                   ^
+Line 1, characters 46-47:
+1 | let foo (t : int option @ local) = use_global t [@nontail]
+                                                  ^
 Error: This value escapes its region.
 |}]
 
@@ -230,18 +230,18 @@ Error: This type "int ref" should be an instance of type
          contention: mod uncontended ≰ mod contended
 |}]
 
-let foo (t : int ref @@ portable once) =
+let foo (t : int ref @ portable once) =
   use_many t;
   use_portable t
 [%%expect {|
 val foo : int ref @ once portable -> unit = <fun>
 |}]
 
-let foo (t : int ref @@ contended) = use_uncontended t
+let foo (t : int ref @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 53-54:
-1 | let foo (t : int ref @@ contended) = use_uncontended t
-                                                         ^
+Line 1, characters 52-53:
+1 | let foo (t : int ref @ contended) = use_uncontended t
+                                                        ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
@@ -352,7 +352,7 @@ Error: This type "int list" should be an instance of type
          because of the definition of require_global at line 7, characters 0-43.
 |}]
 
-let foo (t : int list @@ contended portable once) =
+let foo (t : int list @ contended portable once) =
   use_many t;
   use_uncontended t;
   use_portable t
@@ -360,11 +360,11 @@ let foo (t : int list @@ contended portable once) =
 val foo : int list @ once portable contended -> unit = <fun>
 |}]
 
-let foo (t : int list @@ local) = use_global t [@nontail]
+let foo (t : int list @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 45-46:
-1 | let foo (t : int list @@ local) = use_global t [@nontail]
-                                                 ^
+Line 1, characters 44-45:
+1 | let foo (t : int list @ local) = use_global t [@nontail]
+                                                ^
 Error: This value escapes its region.
 |}]
 
@@ -443,18 +443,18 @@ Error: This type "int array" should be an instance of type
          because of the definition of require_contended at line 9, characters 0-49.
 |}]
 
-let foo (t : int array @@ portable once) =
+let foo (t : int array @ portable once) =
   use_many t;
   use_portable t
 [%%expect {|
 val foo : int array @ once portable -> unit = <fun>
 |}]
 
-let foo (t : int array @@ contended) = use_uncontended t
+let foo (t : int array @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 55-56:
-1 | let foo (t : int array @@ contended) = use_uncontended t
-                                                           ^
+Line 1, characters 54-55:
+1 | let foo (t : int array @ contended) = use_uncontended t
+                                                          ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
@@ -563,7 +563,7 @@ Error: This type "int iarray" should be an instance of type
          because of the definition of require_global at line 7, characters 0-43.
 |}]
 
-let foo (t : int iarray @@ contended portable once) =
+let foo (t : int iarray @ contended portable once) =
   use_many t;
   use_uncontended t;
   use_portable t
@@ -571,10 +571,10 @@ let foo (t : int iarray @@ contended portable once) =
 val foo : int iarray @ once portable contended -> unit = <fun>
 |}]
 
-let foo (t : int iarray @@ local) = use_global t [@nontail]
+let foo (t : int iarray @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 47-48:
-1 | let foo (t : int iarray @@ local) = use_global t [@nontail]
-                                                   ^
+Line 1, characters 46-47:
+1 | let foo (t : int iarray @ local) = use_global t [@nontail]
+                                                  ^
 Error: This value escapes its region.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -325,7 +325,7 @@ Error: The kind of type "t" is immutable_data with 'a
 (**** Test 3: Record values cross when appropriate ****)
 
 type t = { x : int }
-let foo (t : t @@ nonportable contended once) =
+let foo (t : t @ nonportable contended once) =
   use_portable t;
   use_uncontended t;
   use_many t
@@ -334,24 +334,24 @@ type t = { x : int; }
 val foo : t @ once contended -> unit = <fun>
 |}]
 
-let foo (t : t @@ local) = use_global t [@nontail]
+let foo (t : t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 38-39:
-1 | let foo (t : t @@ local) = use_global t [@nontail]
-                                          ^
+Line 1, characters 37-38:
+1 | let foo (t : t @ local) = use_global t [@nontail]
+                                         ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : t @@ aliased) = use_unique t
+let foo (t : t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : t @@ aliased) = use_unique t
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : t @ aliased) = use_unique t
+                                           ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
 type t = { mutable x : int }
-let foo (t : t @@ nonportable once) =
+let foo (t : t @ nonportable once) =
   use_portable t;
   use_many t
 [%%expect {|
@@ -359,32 +359,32 @@ type t = { mutable x : int; }
 val foo : t @ once -> unit = <fun>
 |}]
 
-let foo (t : t @@ local) = use_global t [@nontail]
+let foo (t : t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 38-39:
-1 | let foo (t : t @@ local) = use_global t [@nontail]
-                                          ^
+Line 1, characters 37-38:
+1 | let foo (t : t @ local) = use_global t [@nontail]
+                                         ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : t @@ aliased) = use_unique t
+let foo (t : t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : t @@ aliased) = use_unique t
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : t @ aliased) = use_unique t
+                                           ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
-let foo (t : t @@ contended) = use_uncontended t
+let foo (t : t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 47-48:
-1 | let foo (t : t @@ contended) = use_uncontended t
-                                                   ^
+Line 1, characters 46-47:
+1 | let foo (t : t @ contended) = use_uncontended t
+                                                  ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 type 'a t = { x : 'a }
-let foo (t : int t @@ nonportable contended once) =
+let foo (t : int t @ nonportable contended once) =
   use_portable t;
   use_uncontended t;
   use_many t
@@ -393,67 +393,67 @@ type 'a t = { x : 'a; }
 val foo : int t @ once contended -> unit = <fun>
 |}]
 
-let foo (t : int t @@ local) = use_global t [@nontail]
+let foo (t : int t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : int t @@ local) = use_global t [@nontail]
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : int t @ local) = use_global t [@nontail]
+                                             ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
 type 'a t = { x : 'a }
 
-let foo (t : _ t @@ nonportable) = use_portable t
+let foo (t : _ t @ nonportable) = use_portable t
 [%%expect {|
 type 'a t = { x : 'a; }
-Line 3, characters 48-49:
-3 | let foo (t : _ t @@ nonportable) = use_portable t
-                                                    ^
+Line 3, characters 47-48:
+3 | let foo (t : _ t @ nonportable) = use_portable t
+                                                   ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : _ t @@ once) = use_many t
+let foo (t : _ t @ once) = use_many t
 [%%expect {|
-Line 1, characters 37-38:
-1 | let foo (t : _ t @@ once) = use_many t
-                                         ^
+Line 1, characters 36-37:
+1 | let foo (t : _ t @ once) = use_many t
+                                        ^
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : _ t @@ local) = use_global t [@nontail]
+let foo (t : _ t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : _ t @@ local) = use_global t [@nontail]
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : _ t @ local) = use_global t [@nontail]
+                                           ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : _ t @@ aliased) = use_unique t
+let foo (t : _ t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : _ t @@ aliased) = use_unique t
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : _ t @ aliased) = use_unique t
+                                             ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
 type 'a t = { x : 'a }
-let foo (t : ('a : immutable_data) t @@ nonportable contended once) =
+let foo (t : ('a : immutable_data) t @ nonportable contended once) =
   use_portable t;
   use_uncontended t;
   use_many t
@@ -469,24 +469,24 @@ Line 3, characters 15-16:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : ('a : immutable_data) t @@ local) = use_global t [@nontail]
+let foo (t : ('a : immutable_data) t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 60-61:
-1 | let foo (t : ('a : immutable_data) t @@ local) = use_global t [@nontail]
-                                                                ^
+Line 1, characters 59-60:
+1 | let foo (t : ('a : immutable_data) t @ local) = use_global t [@nontail]
+                                                               ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : ('a : immutable_data) t @@ aliased) = use_unique t
+let foo (t : ('a : immutable_data) t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 62-63:
-1 | let foo (t : ('a : immutable_data) t @@ aliased) = use_unique t
-                                                                  ^
+Line 1, characters 61-62:
+1 | let foo (t : ('a : immutable_data) t @ aliased) = use_unique t
+                                                                 ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
 type ('a : immutable_data) t = { x : 'a }
-let foo (t : _ t @@ nonportable contended once) =
+let foo (t : _ t @ nonportable contended once) =
   use_portable t;
   use_uncontended t;
   use_many t
@@ -502,34 +502,34 @@ Line 3, characters 15-16:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : _ t @@ local) = use_global t [@nontail]
+let foo (t : _ t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : _ t @@ local) = use_global t [@nontail]
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : _ t @ local) = use_global t [@nontail]
+                                           ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : _ t @@ aliased) = use_unique t
+let foo (t : _ t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : _ t @@ aliased) = use_unique t
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : _ t @ aliased) = use_unique t
+                                             ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
 type 'a t = { x : 'a }
-let foo (t : (unit -> unit) t @@ contended) = use_uncontended t
+let foo (t : (unit -> unit) t @ contended) = use_uncontended t
 [%%expect {|
 type 'a t = { x : 'a; }
 val foo : (unit -> unit) t @ contended -> unit = <fun>
 |}]
 
-let foo (t : (unit -> unit) t @@ nonportable) = use_portable t
+let foo (t : (unit -> unit) t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 61-62:
-1 | let foo (t : (unit -> unit) t @@ nonportable) = use_portable t
-                                                                 ^
+Line 1, characters 60-61:
+1 | let foo (t : (unit -> unit) t @ nonportable) = use_portable t
+                                                                ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -74,7 +74,7 @@ end = struct
   let a_is_int : (a, int) eq = Eq
 end
 
-let f (x : M.t @@ nonportable) : M.t @@ portable =
+let f (x : M.t @ nonportable) : M.t @ portable =
   match M.a_is_int with
   | Eq -> x
 [%%expect {|

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -329,7 +329,7 @@ Error: The kind of type "t" is immutable_data with 'a
 (**** Test 3: Variant values cross when appropriate ****)
 
 type t = Foo of int
-let foo (t : t @@ nonportable contended once) =
+let foo (t : t @ nonportable contended once) =
   use_portable t;
   use_uncontended t;
   use_many t
@@ -338,24 +338,24 @@ type t = Foo of int
 val foo : t @ once contended -> unit = <fun>
 |}]
 
-let foo (t : t @@ local) = use_global t [@nontail]
+let foo (t : t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 38-39:
-1 | let foo (t : t @@ local) = use_global t [@nontail]
-                                          ^
+Line 1, characters 37-38:
+1 | let foo (t : t @ local) = use_global t [@nontail]
+                                         ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : t @@ aliased) = use_unique t
+let foo (t : t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : t @@ aliased) = use_unique t
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : t @ aliased) = use_unique t
+                                           ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
 type t = Foo of { mutable x : int }
-let foo (t : t @@ nonportable once) =
+let foo (t : t @ nonportable once) =
   use_portable t;
   use_many t
 [%%expect {|
@@ -363,32 +363,32 @@ type t = Foo of { mutable x : int; }
 val foo : t @ once -> unit = <fun>
 |}]
 
-let foo (t : t @@ local) = use_global t [@nontail]
+let foo (t : t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 38-39:
-1 | let foo (t : t @@ local) = use_global t [@nontail]
-                                          ^
+Line 1, characters 37-38:
+1 | let foo (t : t @ local) = use_global t [@nontail]
+                                         ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : t @@ aliased) = use_unique t
+let foo (t : t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : t @@ aliased) = use_unique t
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : t @ aliased) = use_unique t
+                                           ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
-let foo (t : t @@ contended) = use_uncontended t
+let foo (t : t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 47-48:
-1 | let foo (t : t @@ contended) = use_uncontended t
-                                                   ^
+Line 1, characters 46-47:
+1 | let foo (t : t @ contended) = use_uncontended t
+                                                  ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 type 'a t = Foo of { x : 'a } | Bar
-let foo (t : int t @@ nonportable contended once) =
+let foo (t : int t @ nonportable contended once) =
   use_portable t;
   use_uncontended t;
   use_many t
@@ -397,67 +397,67 @@ type 'a t = Foo of { x : 'a; } | Bar
 val foo : int t @ once contended -> unit = <fun>
 |}]
 
-let foo (t : int t @@ local) = use_global t [@nontail]
+let foo (t : int t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : int t @@ local) = use_global t [@nontail]
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : int t @ local) = use_global t [@nontail]
+                                             ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
 type 'a t = { x : 'a }
 
-let foo (t : _ t @@ nonportable) = use_portable t
+let foo (t : _ t @ nonportable) = use_portable t
 [%%expect {|
 type 'a t = { x : 'a; }
-Line 3, characters 48-49:
-3 | let foo (t : _ t @@ nonportable) = use_portable t
-                                                    ^
+Line 3, characters 47-48:
+3 | let foo (t : _ t @ nonportable) = use_portable t
+                                                   ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : _ t @@ once) = use_many t
+let foo (t : _ t @ once) = use_many t
 [%%expect {|
-Line 1, characters 37-38:
-1 | let foo (t : _ t @@ once) = use_many t
-                                         ^
+Line 1, characters 36-37:
+1 | let foo (t : _ t @ once) = use_many t
+                                        ^
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : _ t @@ local) = use_global t [@nontail]
+let foo (t : _ t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : _ t @@ local) = use_global t [@nontail]
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : _ t @ local) = use_global t [@nontail]
+                                           ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : _ t @@ aliased) = use_unique t
+let foo (t : _ t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : _ t @@ aliased) = use_unique t
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : _ t @ aliased) = use_unique t
+                                             ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
 type 'a t = Foo of { x : 'a }
-let foo (t : ('a : immutable_data) t @@ nonportable contended once) =
+let foo (t : ('a : immutable_data) t @ nonportable contended once) =
   use_portable t;
   use_uncontended t;
   use_many t
@@ -473,24 +473,24 @@ Line 3, characters 15-16:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : ('a : immutable_data) t @@ local) = use_global t [@nontail]
+let foo (t : ('a : immutable_data) t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 60-61:
-1 | let foo (t : ('a : immutable_data) t @@ local) = use_global t [@nontail]
-                                                                ^
+Line 1, characters 59-60:
+1 | let foo (t : ('a : immutable_data) t @ local) = use_global t [@nontail]
+                                                               ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : ('a : immutable_data) t @@ aliased) = use_unique t
+let foo (t : ('a : immutable_data) t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 62-63:
-1 | let foo (t : ('a : immutable_data) t @@ aliased) = use_unique t
-                                                                  ^
+Line 1, characters 61-62:
+1 | let foo (t : ('a : immutable_data) t @ aliased) = use_unique t
+                                                                 ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
 type ('a : immutable_data) t = Foo of { x : 'a } | Bar of 'a
-let foo (t : _ t @@ nonportable contended once) =
+let foo (t : _ t @ nonportable contended once) =
   use_portable t;
   use_uncontended t;
   use_many t
@@ -506,34 +506,34 @@ Line 3, characters 15-16:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : _ t @@ local) = use_global t [@nontail]
+let foo (t : _ t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 40-41:
-1 | let foo (t : _ t @@ local) = use_global t [@nontail]
-                                            ^
+Line 1, characters 39-40:
+1 | let foo (t : _ t @ local) = use_global t [@nontail]
+                                           ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : _ t @@ aliased) = use_unique t
+let foo (t : _ t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : _ t @@ aliased) = use_unique t
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : _ t @ aliased) = use_unique t
+                                             ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
 type 'a t = Foo of { x : 'a }
-let foo (t : (unit -> unit) t @@ contended) = use_uncontended t
+let foo (t : (unit -> unit) t @ contended) = use_uncontended t
 [%%expect {|
 type 'a t = Foo of { x : 'a; }
 val foo : (unit -> unit) t @ contended -> unit = <fun>
 |}]
 
-let foo (t : (unit -> unit) t @@ nonportable) = use_portable t
+let foo (t : (unit -> unit) t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 61-62:
-1 | let foo (t : (unit -> unit) t @@ nonportable) = use_portable t
-                                                                 ^
+Line 1, characters 60-61:
+1 | let foo (t : (unit -> unit) t @ nonportable) = use_portable t
+                                                                ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -22,7 +22,7 @@ type ('a : value mod portable) require_portable
 (**********************************************)
 (* TEST: Mode crossing looks through [option] *)
 
-let foo (t : int option @@ contended nonportable once) =
+let foo (t : int option @ contended nonportable once) =
     use_uncontended t;
     use_portable t;
     use_many t
@@ -30,7 +30,7 @@ let foo (t : int option @@ contended nonportable once) =
 val foo : int option @ once contended -> unit = <fun>
 |}]
 
-let foo (t : int option @@ local) =
+let foo (t : int option @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -40,7 +40,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (t : int option @@ aliased) =
+let foo (t : int option @ aliased) =
   use_unique t;
 
 [%%expect{|
@@ -51,13 +51,13 @@ Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (* crosses contention but not portability or linearity *)
-let foo (t : ('a -> 'a) option @@ contended) =
+let foo (t : ('a -> 'a) option @ contended) =
   use_uncontended t
 [%%expect{|
 val foo : ('a : any). ('a -> 'a) option @ contended -> unit = <fun>
 |}]
 
-let foo (t : ('a -> 'a) option @@ nonportable) =
+let foo (t : ('a -> 'a) option @ nonportable) =
   use_portable t
 [%%expect{|
 Line 2, characters 15-16:
@@ -66,7 +66,7 @@ Line 2, characters 15-16:
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : ('a -> 'a) option @@ once) =
+let foo (t : ('a -> 'a) option @ once) =
   use_many t
 
 [%%expect{|
@@ -76,7 +76,7 @@ Line 2, characters 11-12:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : ('a -> 'a) option @@ local) =
+let foo (t : ('a -> 'a) option @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -86,7 +86,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (t : ('a -> 'a) option @@ aliased) =
+let foo (t : ('a -> 'a) option @ aliased) =
   use_unique t
 
 [%%expect{|
@@ -97,7 +97,7 @@ Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (* references crosses portability but not contention *)
-let foo (t : int ref option @@ contended) =
+let foo (t : int ref option @ contended) =
     use_uncontended t
 [%%expect{|
 Line 2, characters 20-21:
@@ -106,14 +106,14 @@ Line 2, characters 20-21:
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int ref option @@ nonportable once) =
+let foo (t : int ref option @ nonportable once) =
     use_portable t;
     use_many t
 [%%expect{|
 val foo : int ref option @ once -> unit = <fun>
 |}]
 
-let foo (t : int ref option @@ local) =
+let foo (t : int ref option @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -123,7 +123,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (t : int ref option @@ aliased) =
+let foo (t : int ref option @ aliased) =
   use_unique t
 
 [%%expect{|
@@ -134,7 +134,7 @@ Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (* shouldn't cross anything *)
-let foo (t : ('a -> 'a) ref option @@ contended) =
+let foo (t : ('a -> 'a) ref option @ contended) =
   use_uncontended t
 
 [%%expect{|
@@ -144,7 +144,7 @@ Line 2, characters 18-19:
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : ('a -> 'a) ref option @@ nonportable) =
+let foo (t : ('a -> 'a) ref option @ nonportable) =
   use_portable t
 
 [%%expect{|
@@ -154,7 +154,7 @@ Line 2, characters 15-16:
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : ('a -> 'a ref) option @@ once) =
+let foo (t : ('a -> 'a ref) option @ once) =
   use_many t
 
 [%%expect{|
@@ -164,7 +164,7 @@ Line 2, characters 11-12:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : ('a -> 'a) ref option @@ local) =
+let foo (t : ('a -> 'a) ref option @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -174,7 +174,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (t : ('a -> 'a) ref option @@ aliased) =
+let foo (t : ('a -> 'a) ref option @ aliased) =
   use_unique t
 
 [%%expect{|
@@ -185,7 +185,7 @@ Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (* crosses nothing *)
-let foo (t : 'a option @@ contended) =
+let foo (t : 'a option @ contended) =
     use_uncontended t
 [%%expect{|
 Line 2, characters 20-21:
@@ -194,7 +194,7 @@ Line 2, characters 20-21:
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : 'a option @@ nonportable) =
+let foo (t : 'a option @ nonportable) =
     use_portable t
 [%%expect{|
 Line 2, characters 17-18:
@@ -203,7 +203,7 @@ Line 2, characters 17-18:
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : 'a option @@ once) =
+let foo (t : 'a option @ once) =
   use_many t
 
 [%%expect{|
@@ -213,7 +213,7 @@ Line 2, characters 11-12:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : 'a option @@ local) =
+let foo (t : 'a option @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -223,7 +223,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (t : 'a option @@ aliased) =
+let foo (t : 'a option @ aliased) =
   use_unique t
 
 [%%expect{|
@@ -235,7 +235,7 @@ Error: This value is "aliased" but expected to be "unique".
 
 (* looks at kinds *)
 let foo (type a : value mod contended portable)
-      (t : a option @@ contended nonportable) =
+      (t : a option @ contended nonportable) =
   use_uncontended t;
   use_portable t
 
@@ -245,7 +245,7 @@ val foo : ('a : value mod contended portable). 'a option @ contended -> unit =
 |}]
 
 (* CR layouts v2.8: This should be accepted *)
-let foo (t : ('a : value mod contended portable) option @@ contended nonportable) =
+let foo (t : ('a : value mod contended portable) option @ contended nonportable) =
   use_uncontended t;
   use_portable t
 
@@ -259,7 +259,7 @@ Line 2, characters 18-19:
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (type a : value mod contended portable) (t : a option @@ once) =
+let foo (type a : value mod contended portable) (t : a option @ once) =
   use_many t
 
 [%%expect{|
@@ -269,7 +269,7 @@ Line 2, characters 11-12:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : ('a : value mod contended portable) option @@ local) =
+let foo (t : ('a : value mod contended portable) option @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -279,7 +279,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (type a : value mod aliased) (t : a option @@ aliased) =
+let foo (type a : value mod aliased) (t : a option @ aliased) =
   use_unique t
 
 [%%expect{|
@@ -292,7 +292,7 @@ Error: This value is "aliased" but expected to be "unique".
 (********************************************)
 (* TEST: Mode crossing looks through [list] *)
 
-let foo (t : int list @@ contended nonportable once) =
+let foo (t : int list @ contended nonportable once) =
     use_uncontended t;
     use_portable t;
     use_many t
@@ -300,7 +300,7 @@ let foo (t : int list @@ contended nonportable once) =
 val foo : int list @ once contended -> unit = <fun>
 |}]
 
-let foo (t : int list @@ local) =
+let foo (t : int list @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -310,7 +310,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (t : int list @@ aliased) =
+let foo (t : int list @ aliased) =
   use_unique t;
 
 [%%expect{|
@@ -321,13 +321,13 @@ Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (* crosses contention but not portability or linearity *)
-let foo (t : ('a -> 'a) list @@ contended) =
+let foo (t : ('a -> 'a) list @ contended) =
   use_uncontended t
 [%%expect{|
 val foo : ('a : any). ('a -> 'a) list @ contended -> unit = <fun>
 |}]
 
-let foo (t : ('a -> 'a) list @@ nonportable) =
+let foo (t : ('a -> 'a) list @ nonportable) =
   use_portable t
 [%%expect{|
 Line 2, characters 15-16:
@@ -336,7 +336,7 @@ Line 2, characters 15-16:
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : ('a -> 'a) list @@ once) =
+let foo (t : ('a -> 'a) list @ once) =
   use_many t
 
 [%%expect{|
@@ -346,7 +346,7 @@ Line 2, characters 11-12:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : ('a -> 'a) list @@ local) =
+let foo (t : ('a -> 'a) list @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -356,7 +356,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (t : ('a -> 'a) list @@ aliased) =
+let foo (t : ('a -> 'a) list @ aliased) =
   use_unique t
 
 [%%expect{|
@@ -367,7 +367,7 @@ Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (* references crosses portability but not contention *)
-let foo (t : int ref list @@ contended) =
+let foo (t : int ref list @ contended) =
     use_uncontended t
 [%%expect{|
 Line 2, characters 20-21:
@@ -376,14 +376,14 @@ Line 2, characters 20-21:
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int ref list @@ nonportable once) =
+let foo (t : int ref list @ nonportable once) =
     use_portable t;
     use_many t
 [%%expect{|
 val foo : int ref list @ once -> unit = <fun>
 |}]
 
-let foo (t : int ref list @@ local) =
+let foo (t : int ref list @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -393,7 +393,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (t : int ref list @@ aliased) =
+let foo (t : int ref list @ aliased) =
   use_unique t
 
 [%%expect{|
@@ -404,7 +404,7 @@ Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (* shouldn't cross anything *)
-let foo (t : ('a -> 'a) ref list @@ contended) =
+let foo (t : ('a -> 'a) ref list @ contended) =
   use_uncontended t
 
 [%%expect{|
@@ -414,7 +414,7 @@ Line 2, characters 18-19:
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : ('a -> 'a) ref list @@ nonportable) =
+let foo (t : ('a -> 'a) ref list @ nonportable) =
   use_portable t
 
 [%%expect{|
@@ -424,7 +424,7 @@ Line 2, characters 15-16:
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : ('a -> 'a ref) list @@ once) =
+let foo (t : ('a -> 'a ref) list @ once) =
   use_many t
 
 [%%expect{|
@@ -434,7 +434,7 @@ Line 2, characters 11-12:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : ('a -> 'a) ref list @@ local) =
+let foo (t : ('a -> 'a) ref list @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -444,7 +444,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (t : ('a -> 'a) ref list @@ aliased) =
+let foo (t : ('a -> 'a) ref list @ aliased) =
   use_unique t
 
 [%%expect{|
@@ -455,7 +455,7 @@ Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (* crosses nothing *)
-let foo (t : 'a list @@ contended) =
+let foo (t : 'a list @ contended) =
     use_uncontended t
 [%%expect{|
 Line 2, characters 20-21:
@@ -464,7 +464,7 @@ Line 2, characters 20-21:
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : 'a list @@ nonportable) =
+let foo (t : 'a list @ nonportable) =
     use_portable t
 [%%expect{|
 Line 2, characters 17-18:
@@ -473,7 +473,7 @@ Line 2, characters 17-18:
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : 'a list @@ once) =
+let foo (t : 'a list @ once) =
   use_many t
 
 [%%expect{|
@@ -483,7 +483,7 @@ Line 2, characters 11-12:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (t : 'a list @@ local) =
+let foo (t : 'a list @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -493,7 +493,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (t : 'a list @@ aliased) =
+let foo (t : 'a list @ aliased) =
   use_unique t
 
 [%%expect{|
@@ -505,7 +505,7 @@ Error: This value is "aliased" but expected to be "unique".
 
 (* looks at kinds *)
 let foo (type a : value mod contended portable)
-      (t : a list @@ contended nonportable) =
+      (t : a list @ contended nonportable) =
   use_uncontended t;
   use_portable t
 
@@ -514,7 +514,7 @@ val foo : ('a : value mod contended portable). 'a list @ contended -> unit =
   <fun>
 |}]
 
-let foo (type a : value mod contended portable) (t : a list @@ once) =
+let foo (type a : value mod contended portable) (t : a list @ once) =
   use_many t
 
 [%%expect{|
@@ -524,7 +524,7 @@ Line 2, characters 11-12:
 Error: This value is "once" but expected to be "many".
 |}]
 
-let foo (type a : value mod contended portable) (t : a list @@ local) =
+let foo (type a : value mod contended portable) (t : a list @ local) =
   use_global t [@nontail]
 
 [%%expect{|
@@ -534,7 +534,7 @@ Line 2, characters 13-14:
 Error: This value escapes its region.
 |}]
 
-let foo (type a : value mod contended portable) (t : a list @@ aliased) =
+let foo (type a : value mod contended portable) (t : a list @ aliased) =
   use_unique t
 
 [%%expect{|
@@ -619,7 +619,7 @@ type 'a contended_with : value mod contended with 'a
 type _ t = Foo : ('a : value mod contended). 'a t
 |}]
 
-let f (type a) (t : a t) (x : a contended_with @@ contended) : _ @@ uncontended =
+let f (type a) (t : a t) (x : a contended_with @ contended) : _ @ uncontended =
   match t with
   | _ -> x
 [%%expect {|
@@ -630,7 +630,7 @@ Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 
-let f (type a) (t : a t) (x : a contended_with @@ contended) : _ @@ uncontended =
+let f (type a) (t : a t) (x : a contended_with @ contended) : _ @ uncontended =
   match t with
   | Foo -> x
 [%%expect {|
@@ -696,16 +696,16 @@ Error: This type "t" should be an instance of type "('a : value mod portable)"
          because of the definition of require_portable at line 7, characters 0-47.
 |}]
 
-let foo (t : t @@ contended) = use_uncontended t
+let foo (t : t @ contended) = use_uncontended t
 [%%expect {|
 val foo : t @ contended -> unit = <fun>
 |}]
 
-let foo (t : t @@ nonportable) = use_portable t
+let foo (t : t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 46-47:
-1 | let foo (t : t @@ nonportable) = use_portable t
-                                                  ^
+Line 1, characters 45-46:
+1 | let foo (t : t @ nonportable) = use_portable t
+                                                 ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
@@ -715,16 +715,16 @@ type 'a t : value mod contended with int
 type 'a t : value mod contended
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
 val foo : 'a t @ contended -> unit = <fun>
 |}]
 
-let foo (t : int t @@ nonportable) = use_portable t
+let foo (t : int t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 50-51:
-1 | let foo (t : int t @@ nonportable) = use_portable t
-                                                      ^
+Line 1, characters 49-50:
+1 | let foo (t : int t @ nonportable) = use_portable t
+                                                     ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
@@ -734,24 +734,24 @@ type 'a t : value mod contended with 'a
 type 'a t : value mod contended with 'a
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
 val foo : int t @ contended -> unit = <fun>
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int t @@ nonportable) = use_portable t
+let foo (t : int t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 50-51:
-1 | let foo (t : int t @@ nonportable) = use_portable t
-                                                      ^
+Line 1, characters 49-50:
+1 | let foo (t : int t @ nonportable) = use_portable t
+                                                     ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
@@ -777,27 +777,27 @@ Error: This type "'a t" should be an instance of type
          because of the definition of require_contended at line 6, characters 0-49.
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
 val foo : int t @ contended -> unit = <fun>
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 (* CR layouts v2.8: fix principal case *)
 [%%expect {|
 val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}, Principal{|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int t @@ nonportable) = use_portable t
+let foo (t : int t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 50-51:
-1 | let foo (t : int t @@ nonportable) = use_portable t
-                                                      ^
+Line 1, characters 49-50:
+1 | let foo (t : int t @ nonportable) = use_portable t
+                                                     ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
@@ -836,24 +836,24 @@ Error: This type "('a, 'b) t" should be an instance of type
          because of the definition of require_contended at line 6, characters 0-49.
 |}]
 
-let foo (t : (int, int) t @@ contended) = use_uncontended t
+let foo (t : (int, int) t @ contended) = use_uncontended t
 [%%expect {|
 val foo : (int, int) t @ contended -> unit = <fun>
 |}]
 
-let foo (t : (_, _) t @@ contended) = use_uncontended t
+let foo (t : (_, _) t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 54-55:
-1 | let foo (t : (_, _) t @@ contended) = use_uncontended t
-                                                          ^
+Line 1, characters 53-54:
+1 | let foo (t : (_, _) t @ contended) = use_uncontended t
+                                                         ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : (_, int) t @@ contended) = use_uncontended t
+let foo (t : (_, int) t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 56-57:
-1 | let foo (t : (_, int) t @@ contended) = use_uncontended t
-                                                            ^
+Line 1, characters 55-56:
+1 | let foo (t : (_, int) t @ contended) = use_uncontended t
+                                                           ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
@@ -869,16 +869,16 @@ end
 module T : sig type t : value mod contended end
 |}]
 
-let foo (t : T.t @@ contended) = use_uncontended t
+let foo (t : T.t @ contended) = use_uncontended t
 [%%expect {|
 val foo : T.t @ contended -> unit = <fun>
 |}]
 
-let foo (t : T.t @@ nonportable) = use_portable t
+let foo (t : T.t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 48-49:
-1 | let foo (t : T.t @@ nonportable) = use_portable t
-                                                    ^
+Line 1, characters 47-48:
+1 | let foo (t : T.t @ nonportable) = use_portable t
+                                                   ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
@@ -892,24 +892,24 @@ end
 module T : sig type 'a t : value mod contended with 'a end
 |}]
 
-let foo (t : int T.t @@ contended) = use_uncontended t
+let foo (t : int T.t @ contended) = use_uncontended t
 [%%expect {|
 val foo : int T.t @ contended -> unit = <fun>
 |}]
 
-let foo (t : _ T.t @@ contended) = use_uncontended t
+let foo (t : _ T.t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 51-52:
-1 | let foo (t : _ T.t @@ contended) = use_uncontended t
-                                                       ^
+Line 1, characters 50-51:
+1 | let foo (t : _ T.t @ contended) = use_uncontended t
+                                                      ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : int T.t @@ nonportable) = use_portable t
+let foo (t : int T.t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 52-53:
-1 | let foo (t : int T.t @@ nonportable) = use_portable t
-                                                        ^
+Line 1, characters 51-52:
+1 | let foo (t : int T.t @ nonportable) = use_portable t
+                                                       ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
@@ -923,24 +923,24 @@ type 'a u = { x : 'a; }
 type 'a t = 'a u
 |}]
 
-let foo (t : int t @@ nonportable) = use_portable t
+let foo (t : int t @ nonportable) = use_portable t
 [%%expect {|
 val foo : int t -> unit = <fun>
 |}]
 
-let foo (t : _ t @@ nonportable) = use_portable t
+let foo (t : _ t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 48-49:
-1 | let foo (t : _ t @@ nonportable) = use_portable t
-                                                    ^
+Line 1, characters 47-48:
+1 | let foo (t : _ t @ nonportable) = use_portable t
+                                                   ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -953,27 +953,27 @@ type ('a : immutable_data) u = Foo of 'a | Bar
 type ('a : immutable_data) t = 'a u
 |}]
 
-let foo (t : int t @@ nonportable) = use_portable t
+let foo (t : int t @ nonportable) = use_portable t
 [%%expect {|
 val foo : int t -> unit = <fun>
 |}]
 
-let foo (t : _ t @@ nonportable) = use_portable t
+let foo (t : _ t @ nonportable) = use_portable t
 (* CR layouts v2.8: fix principal case *)
 [%%expect {|
 val foo : ('a : immutable_data). 'a t -> unit = <fun>
 |}, Principal{|
-Line 1, characters 48-49:
-1 | let foo (t : _ t @@ nonportable) = use_portable t
-                                                    ^
+Line 1, characters 47-48:
+1 | let foo (t : _ t @ nonportable) = use_portable t
+                                                   ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
@@ -982,7 +982,7 @@ Error: This value is "aliased" but expected to be "unique".
 
 type u = { x : int }
 type t : immutable_data = u = { x : int }
-let foo (t : t @@ nonportable) = use_portable t
+let foo (t : t @ nonportable) = use_portable t
 [%%expect {|
 type u = { x : int; }
 type t = u = { x : int; }
@@ -993,7 +993,7 @@ val foo : t -> unit = <fun>
 
 type 'a u = Foo of 'a
 type 'a t = 'a u = Foo of 'a
-let foo (t : int t @@ once) = use_many t
+let foo (t : int t @ once) = use_many t
 [%%expect {|
 type 'a u = Foo of 'a
 type 'a t = 'a u = Foo of 'a
@@ -1004,7 +1004,7 @@ val foo : int t @ once -> unit = <fun>
 
 type ('a, 'b) u = Foo of 'a | Bar of 'b
 type ('b, 'a) t = ('b, 'a) u = Foo of 'b | Bar of 'a
-let foo (t : (int, string) t @@ contended) = use_uncontended t
+let foo (t : (int, string) t @ contended) = use_uncontended t
 [%%expect {|
 type ('a, 'b) u = Foo of 'a | Bar of 'b
 type ('b, 'a) t = ('b, 'a) u = Foo of 'b | Bar of 'a
@@ -1081,7 +1081,7 @@ type 'a u = { x : 'a; }
 type 'a t = private 'a u
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
 val foo : int t @ contended -> unit = <fun>
 |}]
@@ -1091,7 +1091,7 @@ type 'a t : value = private Foo of 'a
 type 'a t = private Foo of 'a
 |}]
 
-let foo (t : int t @@ contended) = use_uncontended t
+let foo (t : int t @ contended) = use_uncontended t
 [%%expect {|
 val foo : int t @ contended -> unit = <fun>
 |}]
@@ -1118,7 +1118,7 @@ type 'a t = int * 'a
 type 'a t = int * 'a
 |}]
 
-let foo (t : int t @@ contended nonportable once) =
+let foo (t : int t @ contended nonportable once) =
   use_uncontended t;
   use_portable t;
   use_many t
@@ -1126,43 +1126,43 @@ let foo (t : int t @@ contended nonportable once) =
 val foo : int t @ once contended -> unit = <fun>
 |}]
 
-let foo (t : int t @@ local) = use_global t [@nontail]
+let foo (t : int t @ local) = use_global t [@nontail]
 [%%expect {|
-Line 1, characters 42-43:
-1 | let foo (t : int t @@ local) = use_global t [@nontail]
-                                              ^
+Line 1, characters 41-42:
+1 | let foo (t : int t @ local) = use_global t [@nontail]
+                                             ^
 Error: This value escapes its region.
 |}]
 
-let foo (t : int t @@ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 44-45:
-1 | let foo (t : int t @@ aliased) = use_unique t
-                                                ^
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
-let foo (t : _ t @@ contended) = use_uncontended t
+let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-Line 1, characters 49-50:
-1 | let foo (t : _ t @@ contended) = use_uncontended t
-                                                     ^
+Line 1, characters 48-49:
+1 | let foo (t : _ t @ contended) = use_uncontended t
+                                                    ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : _ t @@ nonportable) = use_portable t
+let foo (t : _ t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 48-49:
-1 | let foo (t : _ t @@ nonportable) = use_portable t
-                                                    ^
+Line 1, characters 47-48:
+1 | let foo (t : _ t @ nonportable) = use_portable t
+                                                   ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let foo (t : _ t @@ once) = use_many t
+let foo (t : _ t @ once) = use_many t
 [%%expect {|
-Line 1, characters 37-38:
-1 | let foo (t : _ t @@ once) = use_many t
-                                         ^
+Line 1, characters 36-37:
+1 | let foo (t : _ t @ once) = use_many t
+                                        ^
 Error: This value is "once" but expected to be "many".
 |}]
 
@@ -1172,16 +1172,16 @@ type ('a, 'b, 'c, 'd) t = 'a * ('b * 'c) * 'd
 type ('a, 'b, 'c, 'd) t = 'a * ('b * 'c) * 'd
 |}]
 
-let foo (t : (int, int, int, int) t @@ nonportable) = use_portable t
+let foo (t : (int, int, int, int) t @ nonportable) = use_portable t
 [%%expect {|
 val foo : (int, int, int, int) t -> unit = <fun>
 |}]
 
-let foo (t : (int, int, _, int) t @@ nonportable) = use_portable t
+let foo (t : (int, int, _, int) t @ nonportable) = use_portable t
 [%%expect {|
-Line 1, characters 65-66:
-1 | let foo (t : (int, int, _, int) t @@ nonportable) = use_portable t
-                                                                     ^
+Line 1, characters 64-65:
+1 | let foo (t : (int, int, _, int) t @ nonportable) = use_portable t
+                                                                    ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -23,7 +23,7 @@ Error: The kind of type "t" is mutable_data
 (* On the other hand, if we set the attribute, we shouldn't get an error. *)
 type t : value mod contended = { mutable contents : string }
 [@@unsafe_allow_any_mode_crossing]
-let f (x : t @@ contended) = use_uncontended x
+let f (x : t @ contended) = use_uncontended x
 [%%expect{|
 type t : value mod contended = { mutable contents : string; }
 [@@unsafe_allow_any_mode_crossing]
@@ -69,7 +69,7 @@ end = struct
   type t : value mod contended = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
-  let f (x : t @@ contended) = use_uncontended x
+  let f (x : t @ contended) = use_uncontended x
 end
 [%%expect{|
 module M : sig type t : value mod contended end
@@ -104,7 +104,7 @@ end = struct
   type t : value mod contended = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
-  let f (x : t @@ contended) = use_uncontended x
+  let f (x : t @ contended) = use_uncontended x
 end
 module M2 : sig
   type t : value mod contended = M1.t = { mutable contents : string }
@@ -113,7 +113,7 @@ end = struct
   type t : value mod contended = M1.t = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
-  let f (x : t @@ contended) = use_uncontended x
+  let f (x : t @ contended) = use_uncontended x
 end
 [%%expect{|
 module M1 :
@@ -136,7 +136,7 @@ end = struct
   type t  : value mod contended = { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
-  let f (x : t @@ contended) = use_uncontended x
+  let f (x : t @ contended) = use_uncontended x
 end
 [%%expect{|
 module Private :
@@ -170,9 +170,9 @@ end = struct
     | Mut of { mutable contents : string }
   [@@unsafe_allow_any_mode_crossing]
 
-  let f1 (x : t1 @@ contended) = use_uncontended x
-  let f2 (x : t2 @@ contended) = use_uncontended x
-  let f3 (x : t3 @@ contended) = use_uncontended x
+  let f1 (x : t1 @ contended) = use_uncontended x
+  let f2 (x : t2 @ contended) = use_uncontended x
+  let f3 (x : t3 @ contended) = use_uncontended x
 end
 [%%expect{|
 module M :
@@ -333,16 +333,16 @@ type 'a t : immutable_data with 'a = P : ('a, 'k) imm -> 'a t
 [@@unsafe_allow_any_mode_crossing]
 |}]
 
-let f (x : int t @@ contended) = use_uncontended x
+let f (x : int t @ contended) = use_uncontended x
 [%%expect{|
 val f : int t @ contended -> int t = <fun>
 |}]
 
-let bad (x : int ref t @@ contended) = use_uncontended x
+let bad (x : int ref t @ contended) = use_uncontended x
 [%%expect{|
-Line 1, characters 55-56:
-1 | let bad (x : int ref t @@ contended) = use_uncontended x
-                                                           ^
+Line 1, characters 54-55:
+1 | let bad (x : int ref t @ contended) = use_uncontended x
+                                                          ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
@@ -363,16 +363,16 @@ module B :
   end
 |}]
 
-let f (x : int B.t_reexported @@ contended) = use_uncontended x
+let f (x : int B.t_reexported @ contended) = use_uncontended x
 [%%expect{|
 val f : int B.t_reexported @ contended -> int B.t_reexported = <fun>
 |}]
 
-let bad (x : int ref B.t_reexported @@ contended) = use_uncontended x
+let bad (x : int ref B.t_reexported @ contended) = use_uncontended x
 [%%expect{|
-Line 1, characters 68-69:
-1 | let bad (x : int ref B.t_reexported @@ contended) = use_uncontended x
-                                                                        ^
+Line 1, characters 67-68:
+1 | let bad (x : int ref B.t_reexported @ contended) = use_uncontended x
+                                                                       ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -217,7 +217,7 @@ type r = { i : int ; mutable s : string }
 type u = r# = #{ i : int ; s : string @@ global many aliased unyielding }
 [%%expect{|
 type r = { i : int; mutable s : string; }
-type u = r# = #{ i : int; global_ s : string @@ many aliased; }
+type u = r# = #{ i : int; s : string @@ global many aliased; }
 |}]
 
 (*******************)

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1404,7 +1404,7 @@ Error: Signature mismatch:
          "foo : string;"
        is not the same as:
          "global_ foo : string;"
-       The second is global_ and the first is not.
+       The second is global and the first is not.
 |}]
 
 module M : sig
@@ -1430,7 +1430,7 @@ Error: Signature mismatch:
          "global_ foo : string;"
        is not the same as:
          "foo : string;"
-       The first is global_ and the second is not.
+       The first is global and the second is not.
 |}]
 
 (* Unboxed records version of the same test *)
@@ -1458,7 +1458,7 @@ Error: Signature mismatch:
          "foo : string;"
        is not the same as:
          "global_ foo : string;"
-       The second is global_ and the first is not.
+       The second is global and the first is not.
 |}]
 
 module M : sig
@@ -1484,7 +1484,7 @@ Error: Signature mismatch:
          "global_ foo : string;"
        is not the same as:
          "foo : string;"
-       The first is global_ and the second is not.
+       The first is global and the second is not.
 |}]
 
 (* Special handling of tuples in matches and let bindings *)
@@ -2310,7 +2310,7 @@ Error: Signature mismatch:
        is not the same as:
          "Bar of int * global_ string"
        Modality mismatch at argument position 2:
-       The second is global_ and the first is not.
+       The second is global and the first is not.
 |}]
 
 
@@ -2338,7 +2338,7 @@ Error: Signature mismatch:
        is not the same as:
          "Bar of int * string"
        Modality mismatch at argument position 2:
-       The first is global_ and the second is not.
+       The first is global and the second is not.
 |}]
 
 (* global_ binds closer than star *)

--- a/testsuite/tests/typing-modal-kinds/unboxed.ml
+++ b/testsuite/tests/typing-modal-kinds/unboxed.ml
@@ -41,14 +41,14 @@ type ('a : value & value) portended_vv = {
 |}]
 
 (* Unboxed records with modalities should cross regardless of what we put in them *)
-let foo (x : (int -> int) portable @@ nonportable) = use_portable x
-let foo (x : (int -> int) ref portable @@ nonportable) = use_portable x
-let foo (x : int ref contended @@ contended) = use_uncontended x
-let foo (x : (int -> int) ref contended @@ contended) = use_uncontended x
-let foo (x : (int -> int) ref portended @@ nonportable) =
+let foo (x : (int -> int) portable @ nonportable) = use_portable x
+let foo (x : (int -> int) ref portable @ nonportable) = use_portable x
+let foo (x : int ref contended @ contended) = use_uncontended x
+let foo (x : (int -> int) ref contended @ contended) = use_uncontended x
+let foo (x : (int -> int) ref portended @ nonportable) =
   use_uncontended x;
   use_portable x
-let foo (x : (int -> int) ref ref portended @@ nonportable) =
+let foo (x : (int -> int) ref ref portended @ nonportable) =
   use_uncontended x;
   use_portable x
 type test = (int -> int) portable require_portable
@@ -77,9 +77,9 @@ type test = (int -> int) ref ref portended require_portable
 |}]
 
 (* Modalities should propagate through arbitrary levels of nesting *)
-let foo (x : ((int -> int) portable portable portable) @@ nonportable) = use_portable x
-let foo (x : ((int -> int) portable ref portable ref portable) @@ nonportable) = use_portable x
-let foo (x : (((int -> int) ref) portable contended portable contended) @@ nonportable contended) =
+let foo (x : ((int -> int) portable portable portable) @ nonportable) = use_portable x
+let foo (x : ((int -> int) portable ref portable ref portable) @ nonportable) = use_portable x
+let foo (x : (((int -> int) ref) portable contended portable contended) @ nonportable contended) =
   use_uncontended x;
   use_portable x
 
@@ -102,13 +102,13 @@ type test =
 |}]
 
 (* Modalities should work in unboxed tuples and products too *)
-let foo (x : #(int ref contended * int ref contended) @@ contended) = use_uncontended_vv x
-let foo (x : #(int ref * int ref) contended_vv @@ contended) = use_uncontended_vv x
-let foo (x : #(int ref contended * int ref contended) contended_vv @@ contended) = use_uncontended_vv x
-let foo (x : #((int -> int) ref portended * (int -> int) ref portended) @@ nonportable contended) =
+let foo (x : #(int ref contended * int ref contended) @ contended) = use_uncontended_vv x
+let foo (x : #(int ref * int ref) contended_vv @ contended) = use_uncontended_vv x
+let foo (x : #(int ref contended * int ref contended) contended_vv @ contended) = use_uncontended_vv x
+let foo (x : #((int -> int) ref portended * (int -> int) ref portended) @ nonportable contended) =
   use_portable_vv x;
   use_uncontended_vv x
-let foo (x : #((int -> int) portable * int ref contended) portended_vv @@ contended) =
+let foo (x : #((int -> int) portable * int ref contended) portended_vv @ contended) =
   use_portable_vv x;
   use_uncontended_vv x
 [%%expect{|
@@ -128,62 +128,62 @@ val foo :
 
 (* [@@unboxed] variants, of all sorts *)
 type 'a portable = Portable of 'a @@ portable [@@unboxed]
-let foo (x : (int -> int) portable @@ nonportable) = use_portable x
+let foo (x : (int -> int) portable @ nonportable) = use_portable x
 [%%expect{|
 type 'a portable = Portable of 'a @@ portable [@@unboxed]
 val foo : (int -> int) portable -> unit = <fun>
 |}]
 
-let foo (x : int ref portable @@ contended) = use_uncontended x
+let foo (x : int ref portable @ contended) = use_uncontended x
 [%%expect{|
-Line 1, characters 62-63:
-1 | let foo (x : int ref portable @@ contended) = use_uncontended x
-                                                                  ^
+Line 1, characters 61-62:
+1 | let foo (x : int ref portable @ contended) = use_uncontended x
+                                                                 ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 type 'a portable = Portable of { portable : 'a @@ portable } [@@unboxed]
-let foo (x : (int -> int) portable @@ nonportable) = use_portable x
+let foo (x : (int -> int) portable @ nonportable) = use_portable x
 [%%expect{|
 type 'a portable = Portable of { portable : 'a @@ portable; } [@@unboxed]
 val foo : (int -> int) portable -> unit = <fun>
 |}]
 
-let foo (x : int ref portable @@ contended) = use_uncontended x
+let foo (x : int ref portable @ contended) = use_uncontended x
 [%%expect{|
-Line 1, characters 62-63:
-1 | let foo (x : int ref portable @@ contended) = use_uncontended x
-                                                                  ^
+Line 1, characters 61-62:
+1 | let foo (x : int ref portable @ contended) = use_uncontended x
+                                                                 ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 type 'a portable = Portable : 'a @@ portable -> 'a portable [@@unboxed]
-let foo (x : (int -> int) portable @@ nonportable) = use_portable x
+let foo (x : (int -> int) portable @ nonportable) = use_portable x
 [%%expect{|
 type 'a portable = Portable : 'a @@ portable -> 'a portable [@@unboxed]
 val foo : (int -> int) portable -> unit = <fun>
 |}]
 
-let foo (x : int ref portable @@ contended) = use_uncontended x
+let foo (x : int ref portable @ contended) = use_uncontended x
 [%%expect{|
-Line 1, characters 62-63:
-1 | let foo (x : int ref portable @@ contended) = use_uncontended x
-                                                                  ^
+Line 1, characters 61-62:
+1 | let foo (x : int ref portable @ contended) = use_uncontended x
+                                                                 ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 type 'a portable = Portable : { portable : 'a @@ portable } -> 'a portable [@@unboxed]
-let foo (x : (int -> int) portable @@ nonportable) = use_portable x
+let foo (x : (int -> int) portable @ nonportable) = use_portable x
 [%%expect{|
 type 'a portable = Portable : { portable : 'a @@ portable; } -> 'a portable [@@unboxed]
 val foo : (int -> int) portable -> unit = <fun>
 |}]
 
-let foo (x : int ref portable @@ contended) = use_uncontended x
+let foo (x : int ref portable @ contended) = use_uncontended x
 [%%expect{|
-Line 1, characters 62-63:
-1 | let foo (x : int ref portable @@ contended) = use_uncontended x
-                                                                  ^
+Line 1, characters 61-62:
+1 | let foo (x : int ref portable @ contended) = use_uncontended x
+                                                                 ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
@@ -195,14 +195,14 @@ type 'a t : value & value mod portable =
 type 'a t = #{ x : 'a @@ portable; y : 'a @@ portable; }
 |}]
 
-let f (x : (int -> int) t @@ nonportable) = use_portable_vv x
+let f (x : (int -> int) t @ nonportable) = use_portable_vv x
 
 [%%expect{|
 val f : (int -> int) t -> unit = <fun>
 |}, Principal{|
-Line 1, characters 60-61:
-1 | let f (x : (int -> int) t @@ nonportable) = use_portable_vv x
-                                                                ^
+Line 1, characters 59-60:
+1 | let f (x : (int -> int) t @ nonportable) = use_portable_vv x
+                                                               ^
 Error: This expression has type "(int -> int) t"
        but an expression was expected of type "('a : value & value)"
        The kind of (int -> int) t is

--- a/testsuite/tests/typing-modes/class.ml
+++ b/testsuite/tests/typing-modes/class.ml
@@ -49,18 +49,18 @@ Error: This value is "aliased" but expected to be "unique".
 
 (* instance variables need to be defined as legacy *)
 class cla = object
-    val x = ("world" : _ @@ local)
+    val x = ("world" : _ @ local)
 end
 [%%expect{|
-Line 2, characters 12-34:
-2 |     val x = ("world" : _ @@ local)
-                ^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 12-33:
+2 |     val x = ("world" : _ @ local)
+                ^^^^^^^^^^^^^^^^^^^^^
 Error: This value escapes its region.
 |}]
 
 (* instance variables are available as legacy to methods *)
 class cla = object
-    val x = (fun y -> y : _ @@ portable)
+    val x = (fun y -> y : _ @ portable)
 
     method foo = portable_use x
 end
@@ -75,12 +75,12 @@ Error: This value is "nonportable" but expected to be "portable".
 class cla = object
     val mutable x = "hello"
 
-    method foo = x <- ("world" : _ @@ local)
+    method foo = x <- ("world" : _ @ local)
 end
 [%%expect{|
-Line 4, characters 22-44:
-4 |     method foo = x <- ("world" : _ @@ local)
-                          ^^^^^^^^^^^^^^^^^^^^^^
+Line 4, characters 22-43:
+4 |     method foo = x <- ("world" : _ @ local)
+                          ^^^^^^^^^^^^^^^^^^^^^
 Error: This value escapes its region.
 |}]
 
@@ -114,7 +114,7 @@ val foo : local_ cla -> cla ref = <fun>
 |}]
 
 (* crosses at binding site. This allows the closure to be global. *)
-let foo (obj : cla @@ local) =
+let foo (obj : cla @ local) =
     ref (fun () -> let _ = obj in ())
 [%%expect{|
 val foo : local_ cla -> (unit -> unit) ref = <fun>
@@ -122,7 +122,7 @@ val foo : local_ cla -> (unit -> unit) ref = <fun>
 
 (* Objects don't cross monadic axes. Objects are defined at [uncontended]
     always, but that doesn't mean they cross contention. *)
-let foo (obj : cla @@ contended) =
+let foo (obj : cla @ contended) =
     let _ @ uncontended = obj in
     ()
 [%%expect{|

--- a/testsuite/tests/typing-modes/crossing.ml
+++ b/testsuite/tests/typing-modes/crossing.ml
@@ -10,7 +10,7 @@ written type does. *)
 module M : sig
     val f : int @ nonportable -> int @ portable
 end = struct
-    let f (x @ portable) = (x : _ @@ nonportable)
+    let f (x @ portable) = (x : _ @ nonportable)
 end
 [%%expect{|
 module M : sig val f : int -> int @ portable end
@@ -21,12 +21,12 @@ written type does not. *)
 module M : sig
     val f : unit -> [`A | `B of 'a -> 'a] @ portable
 end = struct
-    let f () = (`A : _ @@ nonportable)
+    let f () = (`A : _ @ nonportable)
 end
 [%%expect{|
 Lines 3-5, characters 6-3:
 3 | ......struct
-4 |     let f () = (`A : _ @@ nonportable)
+4 |     let f () = (`A : _ @ nonportable)
 5 | end
 Error: Signature mismatch:
        Modules do not match:
@@ -47,7 +47,7 @@ the written type does. *)
 module M : sig
     val f : [`A] @ nonportable -> unit
 end = struct
-    let f (x : [< `A | `B of string -> string] @@ portable) =
+    let f (x : [< `A | `B of string -> string] @ portable) =
         match x with
         | `A -> ()
         | `B f -> ()
@@ -119,109 +119,109 @@ type cross_shared : value mod shared
 type cross_uncontended
 |}]
 
-let cross_global (x : cross_global @@ local) : _ @@ global = x
+let cross_global (x : cross_global @ local) : _ @ global = x
 [%%expect{|
 val cross_global : local_ cross_global -> cross_global = <fun>
 |}]
 
-let cross_local (x : cross_local @@ local) : _ @@ global = x
+let cross_local (x : cross_local @ local) : _ @ global = x
 [%%expect{|
-Line 1, characters 59-60:
-1 | let cross_local (x : cross_local @@ local) : _ @@ global = x
-                                                               ^
+Line 1, characters 57-58:
+1 | let cross_local (x : cross_local @ local) : _ @ global = x
+                                                             ^
 Error: This value escapes its region.
 |}]
 
-let cross_many (x : cross_many @@ once) : _ @@ many = x
+let cross_many (x : cross_many @ once) : _ @ many = x
 [%%expect{|
 val cross_many : cross_many @ once -> cross_many = <fun>
 |}]
 
-let cross_once (x : cross_once @@ once) : _ @@ many = x
+let cross_once (x : cross_once @ once) : _ @ many = x
 [%%expect{|
-Line 1, characters 54-55:
-1 | let cross_once (x : cross_once @@ once) : _ @@ many = x
-                                                          ^
+Line 1, characters 52-53:
+1 | let cross_once (x : cross_once @ once) : _ @ many = x
+                                                        ^
 Error: This value is "once" but expected to be "many".
 |}]
 
-let cross_portable (x : cross_portable @@ nonportable) : _ @@ portable = x
+let cross_portable (x : cross_portable @ nonportable) : _ @ portable = x
 [%%expect{|
 val cross_portable : cross_portable -> cross_portable @ portable = <fun>
 |}]
 
-let cross_nonportable (x : cross_nonportable @@ nonportable) : _ @@ portable = x
+let cross_nonportable (x : cross_nonportable @ nonportable) : _ @ portable = x
 [%%expect{|
-Line 1, characters 79-80:
-1 | let cross_nonportable (x : cross_nonportable @@ nonportable) : _ @@ portable = x
-                                                                                   ^
+Line 1, characters 77-78:
+1 | let cross_nonportable (x : cross_nonportable @ nonportable) : _ @ portable = x
+                                                                                 ^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-let cross_unyielding (x : cross_unyielding @@ yielding) : _ @@ unyielding = x
+let cross_unyielding (x : cross_unyielding @ yielding) : _ @ unyielding = x
 [%%expect{|
 val cross_unyielding : cross_unyielding @ yielding -> cross_unyielding =
   <fun>
 |}]
 
-let cross_yielding (x : cross_yielding @@ yielding) : _ @@ unyielding = x
+let cross_yielding (x : cross_yielding @ yielding) : _ @ unyielding = x
 [%%expect{|
-Line 1, characters 72-73:
-1 | let cross_yielding (x : cross_yielding @@ yielding) : _ @@ unyielding = x
-                                                                            ^
+Line 1, characters 70-71:
+1 | let cross_yielding (x : cross_yielding @ yielding) : _ @ unyielding = x
+                                                                          ^
 Error: This value is "yielding" but expected to be "unyielding".
 |}]
 
-let cross_aliased (x : cross_aliased @@ aliased) : _ @@ unique = x
+let cross_aliased (x : cross_aliased @ aliased) : _ @ unique = x
 [%%expect{|
 val cross_aliased : cross_aliased -> cross_aliased @ unique = <fun>
 |}]
 
-let cross_unique (x : cross_unique @@ aliased) : _ @@ unique = x
+let cross_unique (x : cross_unique @ aliased) : _ @ unique = x
 [%%expect{|
-Line 1, characters 63-64:
-1 | let cross_unique (x : cross_unique @@ aliased) : _ @@ unique = x
-                                                                   ^
+Line 1, characters 61-62:
+1 | let cross_unique (x : cross_unique @ aliased) : _ @ unique = x
+                                                                 ^
 Error: This value is "aliased" but expected to be "unique".
 |}]
 
-let cross_contended1 (x : cross_contended @@ shared) : _ @@ uncontended = x
+let cross_contended1 (x : cross_contended @ shared) : _ @ uncontended = x
 [%%expect{|
 val cross_contended1 : cross_contended @ shared -> cross_contended = <fun>
 |}]
 
-let cross_contended2 (x : cross_contended @@ contended) : _ @@ shared = x
+let cross_contended2 (x : cross_contended @ contended) : _ @ shared = x
 [%%expect{|
 val cross_contended2 :
   cross_contended @ contended -> cross_contended @ shared = <fun>
 |}]
 
-let cross_shared1 (x : cross_shared @@ shared) : _ @@ uncontended = x
+let cross_shared1 (x : cross_shared @ shared) : _ @ uncontended = x
 [%%expect{|
 val cross_shared1 : cross_shared @ shared -> cross_shared = <fun>
 |}]
 
-let cross_shared2 (x : cross_shared @@ contended) : _ @@ shared = x
+let cross_shared2 (x : cross_shared @ contended) : _ @ shared = x
 [%%expect{|
-Line 1, characters 66-67:
-1 | let cross_shared2 (x : cross_shared @@ contended) : _ @@ shared = x
-                                                                      ^
+Line 1, characters 64-65:
+1 | let cross_shared2 (x : cross_shared @ contended) : _ @ shared = x
+                                                                    ^
 Error: This value is "contended" but expected to be "shared".
 |}]
 
-let cross_uncontended1 (x : cross_uncontended @@ shared) : _ @@ uncontended = x
+let cross_uncontended1 (x : cross_uncontended @ shared) : _ @ uncontended = x
 [%%expect{|
-Line 1, characters 78-79:
-1 | let cross_uncontended1 (x : cross_uncontended @@ shared) : _ @@ uncontended = x
-                                                                                  ^
+Line 1, characters 76-77:
+1 | let cross_uncontended1 (x : cross_uncontended @ shared) : _ @ uncontended = x
+                                                                                ^
 Error: This value is "shared" but expected to be "uncontended".
 |}]
 
-let cross_uncontended2 (x : cross_uncontended @@ contended) : _ @@ shared = x
+let cross_uncontended2 (x : cross_uncontended @ contended) : _ @ shared = x
 [%%expect{|
-Line 1, characters 76-77:
-1 | let cross_uncontended2 (x : cross_uncontended @@ contended) : _ @@ shared = x
-                                                                                ^
+Line 1, characters 74-75:
+1 | let cross_uncontended2 (x : cross_uncontended @ contended) : _ @ shared = x
+                                                                              ^
 Error: This value is "contended" but expected to be "shared".
 |}]
 

--- a/testsuite/tests/typing-modes/currying.ml
+++ b/testsuite/tests/typing-modes/currying.ml
@@ -390,7 +390,7 @@ Error: This application is complete, but surplus arguments were provided afterwa
 |}]
 
 let _ =
-  let f : _ -> (_ -> _) @@ once = fun _ -> fun x -> x in
+  let f : (_ -> (_ -> _)) @ once = fun _ -> fun x -> x in
   f "hello" "world"
 [%%expect{|
 Line 3, characters 2-11:
@@ -402,7 +402,7 @@ Error: This application is complete, but surplus arguments were provided afterwa
 |}]
 
 let _ =
-  let f : _ -> (_ -> _) @@ unique = fun _ -> fun x -> x in
+  let f : (_ -> (_ -> _)) @ unique = fun _ -> fun x -> x in
   f "hello" "world"
 [%%expect{|
 - : string = "world"
@@ -425,14 +425,14 @@ let _ =
 |}]
 
 let _ =
-  let f : _ -> (_ -> _) @@ nonportable = fun _ -> fun x -> x in
+  let f : (_ -> (_ -> _)) @ nonportable = fun _ -> fun x -> x in
   f "hello" "world"
 [%%expect{|
 - : string = "world"
 |}]
 
 let _ =
-  let f : _ -> (_ -> _) @@ uncontended = fun _ -> fun x -> x in
+  let f : (_ -> (_ -> _)) @ uncontended = fun _ -> fun x -> x in
   f "hello" "world"
 [%%expect{|
 - : string = "world"
@@ -442,13 +442,13 @@ let _ =
    the inferred type of [g] doesn't contain extra parenthesis, as they would
    if pushed to legacy; this is prevented by [check_curried_application_complete]. *)
 let f g x =
-  g (x: _ @@ once) x [@nontail]
+  g (x: _ @ once) x [@nontail]
 [%%expect{|
 val f : ('a @ once -> 'a -> 'b) -> 'a -> 'b = <fun>
 |}]
 
 let f g x y =
-  g (x: _ @@ unique) y [@nontail]
+  g (x: _ @ unique) y [@nontail]
 [%%expect{|
 val f : ('a -> 'b -> 'c) -> 'a @ unique -> 'b -> 'c = <fun>
 |}]
@@ -469,13 +469,13 @@ val f : ('a -> 'a -> 'b) @ once -> 'a -> 'b = <fun>
 
 (* portability and contention is not affected due to the choice of legacy modes. *)
 let f g x =
-  g (x: _ @@ nonportable) x [@nontail]
+  g (x: _ @ nonportable) x [@nontail]
 [%%expect{|
 val f : ('a -> 'a -> 'b) -> 'a -> 'b = <fun>
 |}]
 
 let f g x y =
-  g (x: _ @@ uncontended) y [@nontail]
+  g (x: _ @ uncontended) y [@nontail]
 [%%expect{|
 val f : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c = <fun>
 |}]

--- a/testsuite/tests/typing-modes/modes.ml
+++ b/testsuite/tests/typing-modes/modes.ml
@@ -3,11 +3,11 @@
 *)
 
 (* Let bindings *)
-let local_ foo : string @@ unique = "hello"
+let local_ foo : string @ unique = "hello"
 [%%expect{|
-Line 1, characters 4-43:
-1 | let local_ foo : string @@ unique = "hello"
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 4-42:
+1 | let local_ foo : string @ unique = "hello"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value escapes its region.
 |}]
 
@@ -19,15 +19,15 @@ Line 1, characters 4-33:
 Error: This value escapes its region.
 |}]
 
-let local_ foo : 'a. 'a -> 'a @@ unique = fun x -> x
+let local_ foo : ('a. 'a -> 'a) @ unique = fun x -> x
 [%%expect{|
-Line 1, characters 4-52:
-1 | let local_ foo : 'a. 'a -> 'a @@ unique = fun x -> x
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 4-53:
+1 | let local_ foo : ('a. 'a -> 'a) @ unique = fun x -> x
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value escapes its region.
 |}]
 
-let foo : type a. a -> a @@ unique = fun x -> x
+let foo : (type a. a -> a) @ unique = fun x -> x
 [%%expect{|
 val foo : 'a -> 'a = <fun>
 |}]
@@ -40,11 +40,11 @@ Line 1, characters 4-44:
 Error: This value escapes its region.
 |}]
 
-let (x, y) : _ @@ local unique = "hello", "world"
+let (x, y) : _ @ local unique = "hello", "world"
 [%%expect{|
-Line 1, characters 4-49:
-1 | let (x, y) : _ @@ local unique = "hello", "world"
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 4-48:
+1 | let (x, y) : _ @ local unique = "hello", "world"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value escapes its region.
 |}]
 
@@ -113,30 +113,30 @@ Error: This value escapes its region.
   Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
-let foo a b : int @@ local = local_ 42
+let foo a b : int @ local = local_ 42
 [%%expect{|
 val foo : 'a -> 'b -> local_ int = <fun>
 |}]
 
-let foo = fun a b : int @@ local -> local_ 42
+let foo = fun a b @ local -> exclave_ 42
 [%%expect{|
 val foo : 'a -> 'b -> local_ int = <fun>
 |}]
 
-let foo a b : _ @@ local = local_ 42
+let foo a b @ local = local_ 42
 [%%expect{|
-Line 1, characters 27-36:
-1 | let foo a b : _ @@ local = local_ 42
-                               ^^^^^^^^^
+Line 1, characters 22-31:
+1 | let foo a b @ local = local_ 42
+                          ^^^^^^^^^
 Error: This value escapes its region.
   Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
 
-let foo = fun a b : _ @@ local -> local_ 42
+let foo = fun a b @ local -> local_ 42
 [%%expect{|
-Line 1, characters 34-43:
-1 | let foo = fun a b : _ @@ local -> local_ 42
-                                      ^^^^^^^^^
+Line 1, characters 29-38:
+1 | let foo = fun a b @ local -> local_ 42
+                                 ^^^^^^^^^
 Error: This value escapes its region.
   Hint: Cannot return a local value without an "exclave_" annotation.
 |}]
@@ -144,7 +144,7 @@ Error: This value escapes its region.
 
 (* the return mode annotation is used to interpret the return type annotation, giving the
     expected currying behavior *)
-let foo a : string -> string -> unit @@ local = fun b c -> ()
+let foo a : (string -> string -> unit) @ local = fun b c -> ()
 [%%expect{|
 val foo : 'a -> local_ (string -> string -> unit) = <fun>
 |}]
@@ -153,18 +153,18 @@ val foo : 'a -> local_ (string -> string -> unit) = <fun>
     describe different axes. *)
 (* CR zqian: this should probably be improved somehow. *)
 let bar () = exclave_
-  let (foo @ local) a : string -> string -> unit @@ nonportable = fun b c -> () in
+  let (foo @ local) a : (string -> string -> unit) @ nonportable = fun b c -> () in
   foo
 [%%expect{|
 val bar : unit -> local_ ('a -> (string -> string -> unit)) = <fun>
 |}]
 
 (* Expressions *)
-let foo = ("hello" : _ @@ local)
+let foo = ("hello" : _ @ local)
 [%%expect{|
-Line 1, characters 10-32:
-1 | let foo = ("hello" : _ @@ local)
-              ^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 10-31:
+1 | let foo = ("hello" : _ @ local)
+              ^^^^^^^^^^^^^^^^^^^^^
 Error: This value escapes its region.
 |}]
 
@@ -251,20 +251,19 @@ Error: Found a aliased value where a unique value was expected
 (* arrow types *)
 type r = local_ string @ unique once -> unique_ string @ local once
 [%%expect{|
-type r = local_ string @ once unique -> local_ string @ once unique
+type r = string @ local unique once -> string @ local unique once
 |}]
 
 type r = local_ string * y:string @ unique once -> local_ string * w:string @ once
 [%%expect{|
 type r =
-    local_ string * y:string @ once unique -> local_ string * w:string @ once
+    string * y:string @ local unique once -> string * w:string @ local once
 |}]
 
 type r = x:local_ string * y:string @ unique once -> local_ string * w:string @ once
 [%%expect{|
 type r =
-    x:local_ string * y:string @ once unique -> local_
-    string * w:string @ once
+    x:string * y:string @ local unique once -> string * w:string @ local once
 |}]
 
 
@@ -287,22 +286,22 @@ Error: The locality axis has already been specified.
 (* Mixing legacy and new modes *)
 type r = local_ unique_ once_ string -> string
 [%%expect{|
-type r = local_ string @ once unique -> string
+type r = string @ local unique once -> string
 |}]
 
 type r = local_ unique_ once_ string @ portable contended -> string
 [%%expect{|
-type r = local_ string @ once unique portable contended -> string
+type r = string @ local unique once portable contended -> string
 |}]
 
 type r = string @ local unique once portable contended -> string
 [%%expect{|
-type r = local_ string @ once unique portable contended -> string
+type r = string @ local unique once portable contended -> string
 |}]
 
 type r = string @ local unique once nonportable uncontended -> string
 [%%expect{|
-type r = local_ string @ once unique -> string
+type r = string @ local unique once -> string
 |}]
 
 
@@ -357,14 +356,14 @@ type r = {
   global_ x : string @@ aliased
 }
 [%%expect{|
-type r = { global_ x : string @@ aliased; }
+type r = { x : string @@ global aliased; }
 |}]
 
 type r = {
   x : string @@ aliased global many
 }
 [%%expect{|
-type r = { global_ x : string @@ many aliased; }
+type r = { x : string @@ global many aliased; }
 |}]
 
 type r = {
@@ -372,12 +371,12 @@ type r = {
 }
 (* CR reduced-modality: this should warn. *)
 [%%expect{|
-type r = { global_ x : string @@ many aliased; }
+type r = { x : string @@ global many aliased; }
 |}]
 
 type r = Foo of string @@ global aliased many
 [%%expect{|
-type r = Foo of global_ string @@ many aliased
+type r = Foo of string @@ global many aliased
 |}]
 
 (* mutable implies global aliased many. No warnings are given since we imagine
@@ -394,37 +393,37 @@ type r = { mutable x : string; }
 
 let foo ?(local_ x @ unique once = 42) () = ()
 [%%expect{|
-val foo : ?x:local_ int @ once unique -> unit -> unit = <fun>
+val foo : ?x:int @ local unique once -> unit -> unit = <fun>
 |}]
 
-let foo ?(local_ x : _ @@ unique once = 42) () = ()
+let foo ?(local_ x : _ @ unique once = 42) () = ()
 [%%expect{|
-val foo : ?x:local_ int @ once unique -> unit -> unit = <fun>
+val foo : ?x:int @ local unique once -> unit -> unit = <fun>
 |}]
 
-let foo ?(local_ x : 'a. 'a -> 'a @@ unique once) = ()
+let foo ?(local_ x : ('a. 'a -> 'a) @ unique once) = ()
 [%%expect{|
-Line 1, characters 10-48:
-1 | let foo ?(local_ x : 'a. 'a -> 'a @@ unique once) = ()
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 10-49:
+1 | let foo ?(local_ x : ('a. 'a -> 'a) @ unique once) = ()
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Optional parameters cannot be polymorphic
 |}]
 
 let foo ?x:(local_ (x,y) @ unique once = (42, 42)) () = ()
 [%%expect{|
-val foo : ?x:local_ int * int @ once unique -> unit -> unit = <fun>
+val foo : ?x:int * int @ local unique once -> unit -> unit = <fun>
 |}]
 
-let foo ?x:(local_ (x,y) : _ @@ unique once = (42, 42)) () = ()
+let foo ?x:(local_ (x,y) : _ @ unique once = (42, 42)) () = ()
 [%%expect{|
-val foo : ?x:local_ int * int @ once unique -> unit -> unit = <fun>
+val foo : ?x:int * int @ local unique once -> unit -> unit = <fun>
 |}]
 
-let foo ?x:(local_ (x,y) : 'a.'a->'a @@ unique once) () = ()
+let foo ?x:(local_ (x,y) : ('a.'a->'a) @ unique once) () = ()
 [%%expect{|
-Line 1, characters 12-51:
-1 | let foo ?x:(local_ (x,y) : 'a.'a->'a @@ unique once) () = ()
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 12-52:
+1 | let foo ?x:(local_ (x,y) : ('a.'a->'a) @ unique once) () = ()
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Optional parameters cannot be polymorphic
 |}]
 
@@ -459,7 +458,7 @@ val foo : unit -> unit = <fun>
  * Modification of return modes in argument position
  *)
 
-let use_local (f : _ -> _ -> _ @@ local) x y =
+let use_local (f : (_ -> _ -> _) @ local) x y =
   f x y
 let result = use_local (^) "hello" " world"
 [%%expect{|

--- a/testsuite/tests/typing-modes/modes.ml
+++ b/testsuite/tests/typing-modes/modes.ml
@@ -19,15 +19,15 @@ Line 1, characters 4-33:
 Error: This value escapes its region.
 |}]
 
-let local_ foo : ('a. 'a -> 'a) @ unique = fun x -> x
+let local_ foo : 'a. ('a -> 'a) @ unique = fun x -> x
 [%%expect{|
 Line 1, characters 4-53:
-1 | let local_ foo : ('a. 'a -> 'a) @ unique = fun x -> x
+1 | let local_ foo : 'a. ('a -> 'a) @ unique = fun x -> x
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value escapes its region.
 |}]
 
-let foo : (type a. a -> a) @ unique = fun x -> x
+let foo : type a. (a -> a) @ unique = fun x -> x
 [%%expect{|
 val foo : 'a -> 'a = <fun>
 |}]
@@ -401,10 +401,10 @@ let foo ?(local_ x : _ @ unique once = 42) () = ()
 val foo : ?x:int @ local unique once -> unit -> unit = <fun>
 |}]
 
-let foo ?(local_ x : ('a. 'a -> 'a) @ unique once) = ()
+let foo ?(local_ x : 'a. ('a -> 'a) @ unique once) = ()
 [%%expect{|
 Line 1, characters 10-49:
-1 | let foo ?(local_ x : ('a. 'a -> 'a) @ unique once) = ()
+1 | let foo ?(local_ x : 'a. ('a -> 'a) @ unique once) = ()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Optional parameters cannot be polymorphic
 |}]
@@ -419,10 +419,10 @@ let foo ?x:(local_ (x,y) : _ @ unique once = (42, 42)) () = ()
 val foo : ?x:int * int @ local unique once -> unit -> unit = <fun>
 |}]
 
-let foo ?x:(local_ (x,y) : ('a.'a->'a) @ unique once) () = ()
+let foo ?x:(local_ (x,y) : 'a.('a->'a) @ unique once) () = ()
 [%%expect{|
 Line 1, characters 12-52:
-1 | let foo ?x:(local_ (x,y) : ('a.'a->'a) @ unique once) () = ()
+1 | let foo ?x:(local_ (x,y) : 'a.('a->'a) @ unique once) () = ()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Optional parameters cannot be polymorphic
 |}]

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -58,10 +58,10 @@ val u : unit = ()
 |}]
 
 (* first class modules are produced at legacy *)
-let x = ((module M : SL) : _ @@ portable)
+let x = ((module M : SL) : _ @ portable)
 [%%expect{|
 Line 1, characters 9-24:
-1 | let x = ((module M : SL) : _ @@ portable)
+1 | let x = ((module M : SL) : _ @ portable)
              ^^^^^^^^^^^^^^^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
@@ -83,7 +83,7 @@ let foo () =
         let _ : F(M).t = 42 in
         ()
     in
-    let _ = (bar : _ @@ portable) in
+    let _ = (bar : _ @ portable) in
     ()
 [%%expect{|
 val foo : unit -> unit = <fun>
@@ -97,7 +97,7 @@ let foo () =
         in
         ()
     in
-    let _ = (bar : _ @@ portable) in
+    let _ = (bar : _ @ portable) in
     ()
 [%%expect{|
 val foo : unit -> unit = <fun>
@@ -112,7 +112,7 @@ let foo () =
         in
         ()
     in
-    let _ = (bar : _ @@ portable) in
+    let _ = (bar : _ @ portable) in
     ()
 [%%expect{|
 val foo : unit -> unit = <fun>
@@ -130,7 +130,7 @@ let foo () =
         in
         ()
     in
-    let _ = (bar : _ @@ portable) in
+    let _ = (bar : _ @ portable) in
     ()
 [%%expect{|
 val foo : unit -> unit = <fun>
@@ -145,7 +145,7 @@ let foo () =
         in
         ()
     in
-    let _ = (bar : _ @@ portable) in
+    let _ = (bar : _ @ portable) in
     ()
 [%%expect{|
 val foo : unit -> unit = <fun>

--- a/testsuite/tests/typing-modes/mutable.ml
+++ b/testsuite/tests/typing-modes/mutable.ml
@@ -73,10 +73,10 @@ Error: This value escapes its region.
 
 (* mutable defaults to mutable(legacy = nonportable), so currently we can't construct a
    portable record (ignoring mode-crossing). *)
-let foo (s @ portable) = ({s} : _ @@ portable)
+let foo (s @ portable) = ({s} : _ @ portable)
 [%%expect{|
 Line 1, characters 26-29:
-1 | let foo (s @ portable) = ({s} : _ @@ portable)
+1 | let foo (s @ portable) = ({s} : _ @ portable)
                               ^^^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
@@ -90,15 +90,15 @@ let foo r (s @ aliased) = r.s <- s
 val foo : 'a r -> 'a -> unit = <fun>
 |}]
 
-let foo (s @ aliased) = ({s} : _ @@ unique)
+let foo (s @ aliased) = ({s} : _ @ unique)
 [%%expect{|
 val foo : 'a -> 'a r = <fun>
 |}]
 
-let foo (r @ unique) = (r.s : _ @@ unique)
+let foo (r @ unique) = (r.s : _ @ unique)
 [%%expect{|
 Line 1, characters 24-27:
-1 | let foo (r @ unique) = (r.s : _ @@ unique)
+1 | let foo (r @ unique) = (r.s : _ @ unique)
                             ^^^
 Error: This value is "aliased" but expected to be "unique".
 |}]
@@ -126,7 +126,7 @@ Error: Signature mismatch:
          "mutable s : string;"
        is not the same as:
          "mutable s : string;"
-       The first is global_ and the second is not.
+       The first is global and the second is not.
 |}]
 
 module M : sig
@@ -152,7 +152,7 @@ Error: Signature mismatch:
          "mutable s : string;"
        is not the same as:
          "mutable s : string;"
-       The second is global_ and the first is not.
+       The second is global and the first is not.
 |}]
 
 type r =
@@ -195,7 +195,7 @@ let r @ portable =
 val r : r = {f = <fun>; g = <fun>}
 |}]
 
-let r : int array @@ portable = [| 42; 24 |]
+let r : int array @ portable = [| 42; 24 |]
 [%%expect{|
 val r : int array = [|42; 24|]
 |}]
@@ -206,7 +206,7 @@ type 'a r =
   { f : string -> string;
     mutable a : 'a
   }
-let r : int r @@ portable =
+let r : int r @ portable =
   { f = (fun x -> x);
     a = 42 }
 [%%expect{|

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -321,25 +321,25 @@ Error: This function when partially applied returns a value which is "nonportabl
 (* CR modes: These three tests are in principle fine to allow (they don't cause a data
    race), since a is never used *)
 
-let foo : 'a @ contended portable -> (string -> string) @ portable @@ nonportable contended = fun a b -> best_bytes ()
+let foo : ('a @ contended portable -> (string -> string) @ portable) @ nonportable contended = fun a b -> best_bytes ()
 (* CR layouts v2.8: arrows should cross contention. *)
 [%%expect{|
-Line 1, characters 4-118:
-1 | let foo : 'a @ contended portable -> (string -> string) @ portable @@ nonportable contended = fun a b -> best_bytes ()
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 4-119:
+1 | let foo : ('a @ contended portable -> (string -> string) @ portable) @ nonportable contended = fun a b -> best_bytes ()
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo : 'a @ contended portable -> (string -> string) @ portable @@ uncontended portable = fun a b -> best_bytes ()
+let foo : ('a @ contended portable -> (string -> string) @ portable) @ uncontended portable = fun a b -> best_bytes ()
 [%%expect{|
-Line 1, characters 104-114:
-1 | let foo : 'a @ contended portable -> (string -> string) @ portable @@ uncontended portable = fun a b -> best_bytes ()
-                                                                                                            ^^^^^^^^^^
+Line 1, characters 105-115:
+1 | let foo : ('a @ contended portable -> (string -> string) @ portable) @ uncontended portable = fun a b -> best_bytes ()
+                                                                                                             ^^^^^^^^^^
 Error: The value "best_bytes" is nonportable, so cannot be used inside a function that is portable.
 |}]
 
 (* immediates crosses portability and contention *)
-let foo (x : int @@ nonportable) (y : int @@ contended) =
+let foo (x : int @ nonportable) (y : int @ contended) =
     let _ @ portable = x in
     let _ @ uncontended = y in
     let _ @ shared = y in
@@ -348,7 +348,7 @@ let foo (x : int @@ nonportable) (y : int @@ contended) =
 val foo : int -> int @ contended -> unit = <fun>
 |}]
 
-let foo (x : int @@ shared) =
+let foo (x : int @ shared) =
     let _ @ uncontended = x in
     ()
 [%%expect{|
@@ -358,7 +358,7 @@ val foo : int @ shared -> unit = <fun>
 (* TESTING immutable array *)
 module Iarray = Stdlib_stable.Iarray
 
-let foo (r : int iarray @@ contended) = Iarray.get r 42
+let foo (r : int iarray @ contended) = Iarray.get r 42
 [%%expect{|
 module Iarray = Stdlib_stable.Iarray
 val foo : int iarray @ contended -> int = <fun>

--- a/testsuite/tests/typing-modes/probe.ml
+++ b/testsuite/tests/typing-modes/probe.ml
@@ -7,5 +7,5 @@
 let f (x @ local nonportable once) =
     [%probe "a" (let _ = x in ())]
 [%%expect{|
-val f : local_ 'a @ once -> unit = <fun>
+val f : 'a @ local once -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-modes/rec.ml
+++ b/testsuite/tests/typing-modes/rec.ml
@@ -17,7 +17,7 @@ let te (local_ x) =
     use_portable foo;
     ()
 [%%expect{|
-val te : local_ 'a @ portable -> unit = <fun>
+val te : 'a @ local portable -> unit = <fun>
 |}]
 
 (* for mixed definitions, they will still share the same mode, but the locality

--- a/testsuite/tests/typing-modes/stack.ml
+++ b/testsuite/tests/typing-modes/stack.ml
@@ -26,22 +26,22 @@ Error: This value escapes its region.
 |}]
 
 let f () =
-  let g = stack_ ((42, 42) : _ @@ global ) in
+  let g = stack_ ((42, 42) : _ @ global ) in
   ()
 [%%expect{|
-Line 2, characters 17-42:
-2 |   let g = stack_ ((42, 42) : _ @@ global ) in
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 17-41:
+2 |   let g = stack_ ((42, 42) : _ @ global ) in
+                     ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This allocation cannot be on the stack.
 |}]
 
 let f () =
-  let g = ref (stack_ ((42, 42) : _ @@ global )) in
+  let g = ref (stack_ ((42, 42) : _ @ global )) in
   ()
 [%%expect{|
-Line 2, characters 14-48:
-2 |   let g = ref (stack_ ((42, 42) : _ @@ global )) in
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 14-47:
+2 |   let g = ref (stack_ ((42, 42) : _ @ global )) in
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value escapes its region.
 |}]
 

--- a/testsuite/tests/typing-modes/syntax-error.compilers.reference
+++ b/testsuite/tests/typing-modes/syntax-error.compilers.reference
@@ -152,8 +152,8 @@ Line 2, characters 16-19:
 2 | module type S = sig
                     ^^^
   This "sig" might be unmatched
-Line 2, characters 31-32:
+Line 2, characters 10-32:
 2 | let foo = ("bar" :> int @ local);;
-                                   ^
-Error: Syntax error
+              ^^^^^^^^^^^^^^^^^^^^^^
+Error: Syntax error: "mode annotations" not expected.
 

--- a/testsuite/tests/typing-modes/syntax-error.compilers.reference
+++ b/testsuite/tests/typing-modes/syntax-error.compilers.reference
@@ -11,7 +11,7 @@ Line 2, characters 35-36:
                                        ^
 Error: Syntax error: "mode expression" expected.
 Line 2, characters 30-31:
-2 | let foo : (type a. a -> a) @  = fun x -> x;;
+2 | let foo : type a. (a -> a) @  = fun x -> x;;
                                   ^
 Error: Syntax error: "mode expression" expected.
 Line 2, characters 13-14:

--- a/testsuite/tests/typing-modes/syntax-error.compilers.reference
+++ b/testsuite/tests/typing-modes/syntax-error.compilers.reference
@@ -1,57 +1,53 @@
-Line 5, characters 27-28:
-5 | let local_ foo : string @@ = "hello";;
-                               ^
+Line 5, characters 26-27:
+5 | let local_ foo : string @ = "hello";;
+                              ^
 Error: Syntax error: "mode expression" expected.
 Line 2, characters 17-18:
 2 | let local_ foo @ = "hello";;
                      ^
 Error: Syntax error: "mode expression" expected.
-Line 2, characters 34-35:
-2 | let local_ foo : 'a. 'a -> 'a @@  = fun x -> x;;
-                                      ^
+Line 2, characters 35-36:
+2 | let local_ foo : ('a. 'a -> 'a) @  = fun x -> x;;
+                                       ^
 Error: Syntax error: "mode expression" expected.
-Line 2, characters 29-30:
-2 | let foo : type a. a -> a @@  = fun x -> x;;
-                                 ^
+Line 2, characters 30-31:
+2 | let foo : (type a. a -> a) @  = fun x -> x;;
+                                  ^
 Error: Syntax error: "mode expression" expected.
 Line 2, characters 13-14:
 2 | let (x, y) @ = "hello", "world";;
                  ^
 Error: Syntax error: "mode expression" expected.
-Line 2, characters 18-19:
-2 | let (x, y) : _ @@ = "hello", "world";;
-                      ^
+Line 2, characters 17-18:
+2 | let (x, y) : _ @ = "hello", "world";;
+                     ^
 Error: Syntax error: "mode expression" expected.
 Line 2, characters 10-11:
 2 | let foo @ = "hello";;
               ^
 Error: Syntax error: "mode expression" expected.
-Line 2, characters 26-27:
-2 | let foo = ("hello" : _ @@ );;
-                              ^
+Line 2, characters 25-26:
+2 | let foo = ("hello" : _ @ );;
+                             ^
 Error: Syntax error: "mode expression" expected.
 Line 2, characters 21-22:
 2 | let foo = ("hello" @ );;
                          ^
 Error: Syntax error
 val foo : bar:string -> string = <fun>
-Line 4, characters 16-18:
-4 |   foo ~(bar : _ @@ )
-                    ^^
-Error: Syntax error
+Line 4, characters 18-19:
+4 |   foo ~(bar : _ @ )
+                      ^
+Error: Syntax error: "mode expression" expected.
 Line 4, characters 12-13:
 4 |   foo ~(bar @ )
                 ^
 Error: Syntax error
 type r = { a : string; b : string; }
-Line 2, characters 15-17:
-2 | let r = {a : _ @@ = "hello";
-                   ^^
-Error: Syntax error: "}" expected
-Line 2, characters 8-9:
-2 | let r = {a : _ @@ = "hello";
-            ^
-  This "{" might be unmatched
+Line 2, characters 17-18:
+2 | let r = {a : _ @ = "hello";
+                     ^
+Error: Syntax error: "mode expression" expected.
 Line 3, characters 5-6:
 3 |   {a @  = "hello";
          ^
@@ -60,10 +56,10 @@ Line 3, characters 2-3:
 3 |   {a @  = "hello";
       ^
   This "{" might be unmatched
-Line 5, characters 9-11:
-5 |   ~(bar:_@@), ~(biz:_@@)
-             ^^
-Error: Syntax error
+Line 5, characters 10-11:
+5 |   ~(bar:_@), ~(biz:_@)
+              ^
+Error: Syntax error: "mode expression" expected.
 Line 5, characters 8-9:
 5 |   ~(bar @ ), ~(biz @ )
             ^
@@ -96,45 +92,53 @@ Line 2, characters 21-22:
 2 | let foo ?(local_ x @ = 42) () = () ;;
                          ^
 Error: Syntax error: "mode expression" expected.
-Line 2, characters 26-27:
-2 | let foo ?(local_ x : _ @@ = 42) () = ();;
-                              ^
+Line 2, characters 25-26:
+2 | let foo ?(local_ x : _ @ = 42) () = ();;
+                             ^
 Error: Syntax error: "mode expression" expected.
-Line 2, characters 37-38:
-2 | let foo ?(local_ x : 'a. 'a -> 'a @@ ) = ();;
-                                         ^
+Line 2, characters 38-39:
+2 | let foo ?(local_ x : ('a. 'a -> 'a) @ ) = ();;
+                                          ^
 Error: Syntax error: "mode expression" expected.
 Line 2, characters 27-28:
 2 | let foo ?x:(local_ (x,y) @ = (42, 42)) () = ();;
                                ^
 Error: Syntax error: "mode expression" expected.
-Line 2, characters 32-33:
-2 | let foo ?x:(local_ (x,y) : _ @@ = (42, 42)) () = ();;
-                                    ^
+Line 2, characters 31-32:
+2 | let foo ?x:(local_ (x,y) : _ @ = (42, 42)) () = ();;
+                                   ^
 Error: Syntax error: "mode expression" expected.
-Line 2, characters 40-41:
-2 | let foo ?x:(local_ (x,y) : 'a.'a->'a @@ ) () = ();;
-                                            ^
+Line 2, characters 41-42:
+2 | let foo ?x:(local_ (x,y) : ('a.'a->'a) @ ) () = ();;
+                                             ^
 Error: Syntax error: "mode expression" expected.
-Line 2, characters 14-15:
+Line 2, characters 12-13:
 2 | let foo ((x @ ), (y@)) = x + y ;;
-                  ^
-Error: Syntax error: "mode expression" expected.
-Line 2, characters 19-20:
-2 | let foo ((x : _ @@ ), (y : _ @@ )) = x + y;;
-                       ^
+                ^
+Error: Syntax error: ")" expected
+Line 2, characters 9-10:
+2 | let foo ((x @ ), (y@)) = x + y ;;
+             ^
+  This "(" might be unmatched
+Line 2, characters 18-19:
+2 | let foo ((x : _ @ ), (y : _ @ )) = x + y;;
+                      ^
 Error: Syntax error: "mode expression" expected.
 Line 3, characters 13-14:
 3 |   let (bar @ ) a b = () in
                  ^
 Error: Syntax error: "mode expression" expected.
-Line 2, characters 26-27:
+Line 2, characters 12-13:
 2 | let foo ((x @ unique once), (y@local unique)) = x + y;;
-                              ^
-Error: Syntax error
-Line 2, characters 31-32:
-2 | let foo ((x : _ @@ unique once), (y : _ @@ local unique)) = x + y;;
-                                   ^
+                ^
+Error: Syntax error: ")" expected
+Line 2, characters 9-10:
+2 | let foo ((x @ unique once), (y@local unique)) = x + y;;
+             ^
+  This "(" might be unmatched
+Line 2, characters 29-30:
+2 | let foo ((x : _ @ unique once), (y : _ @ local unique)) = x + y;;
+                                 ^
 Error: Syntax error
 Line 4, characters 0-3:
 4 | end;;
@@ -148,8 +152,8 @@ Line 2, characters 16-19:
 2 | module type S = sig
                     ^^^
   This "sig" might be unmatched
-Line 2, characters 10-33:
-2 | let foo = ("bar" :> int @@ local);;
-              ^^^^^^^^^^^^^^^^^^^^^^^
-Error: Syntax error: "mode annotations" not expected.
+Line 2, characters 31-32:
+2 | let foo = ("bar" :> int @ local);;
+                                   ^
+Error: Syntax error
 

--- a/testsuite/tests/typing-modes/syntax-error.ml
+++ b/testsuite/tests/typing-modes/syntax-error.ml
@@ -2,21 +2,21 @@
  toplevel;
 *)
 
-let local_ foo : string @@ = "hello";;
+let local_ foo : string @ = "hello";;
 
 let local_ foo @ = "hello";;
 
-let local_ foo : 'a. 'a -> 'a @@  = fun x -> x;;
+let local_ foo : ('a. 'a -> 'a) @  = fun x -> x;;
 
-let foo : type a. a -> a @@  = fun x -> x;;
+let foo : (type a. a -> a) @  = fun x -> x;;
 
 let (x, y) @ = "hello", "world";;
 
-let (x, y) : _ @@ = "hello", "world";;
+let (x, y) : _ @ = "hello", "world";;
 
 let foo @ = "hello";;
 
-let foo = ("hello" : _ @@ );;
+let foo = ("hello" : _ @ );;
 
 let foo = ("hello" @ );;
 
@@ -24,7 +24,7 @@ let foo ~bar = bar ^ "hello";;
 
 let x =
   let bar = "world" in
-  foo ~(bar : _ @@ )
+  foo ~(bar : _ @ )
 ;;
 
 let x =
@@ -34,8 +34,8 @@ let x =
 
 type r = {a : string; b : string};;
 
-let r = {a : _ @@ = "hello";
-          b : _ @@ = "world"}
+let r = {a : _ @ = "hello";
+          b : _ @ = "world"}
 ;;
 
 let r =
@@ -46,7 +46,7 @@ let r =
 let foo () =
   let bar = "hello" in
   let biz = "world" in
-  ~(bar:_@@), ~(biz:_@@)
+  ~(bar:_@), ~(biz:_@)
 ;;
 
 let foo () =
@@ -72,19 +72,19 @@ type r = {
 
 let foo ?(local_ x @ = 42) () = () ;;
 
-let foo ?(local_ x : _ @@ = 42) () = ();;
+let foo ?(local_ x : _ @ = 42) () = ();;
 
-let foo ?(local_ x : 'a. 'a -> 'a @@ ) = ();;
+let foo ?(local_ x : ('a. 'a -> 'a) @ ) = ();;
 
 let foo ?x:(local_ (x,y) @ = (42, 42)) () = ();;
 
-let foo ?x:(local_ (x,y) : _ @@ = (42, 42)) () = ();;
+let foo ?x:(local_ (x,y) : _ @ = (42, 42)) () = ();;
 
-let foo ?x:(local_ (x,y) : 'a.'a->'a @@ ) () = ();;
+let foo ?x:(local_ (x,y) : ('a.'a->'a) @ ) () = ();;
 
 let foo ((x @ ), (y@)) = x + y ;;
 
-let foo ((x : _ @@ ), (y : _ @@ )) = x + y;;
+let foo ((x : _ @ ), (y : _ @ )) = x + y;;
 
 let foo () =
   let (bar @ ) a b = () in
@@ -94,7 +94,7 @@ let foo () =
 
 let foo ((x @ unique once), (y@local unique)) = x + y;;
 
-let foo ((x : _ @@ unique once), (y : _ @@ local unique)) = x + y;;
+let foo ((x : _ @ unique once), (y : _ @ local unique)) = x + y;;
 
 module type S = sig
   module M : S @ portable
@@ -104,4 +104,4 @@ module type S = sig
   module F : S @@ portable -> S @@ portable
 end;;
 
-let foo = ("bar" :> int @@ local);;
+let foo = ("bar" :> int @ local);;

--- a/testsuite/tests/typing-modes/syntax-error.ml
+++ b/testsuite/tests/typing-modes/syntax-error.ml
@@ -8,7 +8,7 @@ let local_ foo @ = "hello";;
 
 let local_ foo : ('a. 'a -> 'a) @  = fun x -> x;;
 
-let foo : (type a. a -> a) @  = fun x -> x;;
+let foo : type a. (a -> a) @  = fun x -> x;;
 
 let (x, y) @ = "hello", "world";;
 

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -17,7 +17,7 @@ type r = { mutable x : string; }
 val uncontended_use : 'a -> unit = <fun>
 |}]
 
-let share_use : 'a -> unit @@ portable = fun _ -> ()
+let share_use : ('a -> unit) @ portable = fun _ -> ()
 [%%expect{|
 val share_use : 'a -> unit = <fun>
 |}]
@@ -713,7 +713,7 @@ Error: Signature mismatch:
          val foo : 'a
        is not included in
          val foo : 'a @@ global many
-       The second is global_ and the first is not.
+       The second is global and the first is not.
 |}]
 
 (* Module declaration inclusion check inside a module type declaration inclusion
@@ -765,7 +765,7 @@ Error: Signature mismatch:
          val foo : 'a -> 'a
        is not included in
          val foo : 'a -> 'a @@ global many
-       The second is global_ and the first is not.
+       The second is global and the first is not.
 |}]
 
 (* functor type inclusion: the following two functor types are equivalent,

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -322,7 +322,7 @@ type moded_record = { a : (int -> int) option; b : int -> int @@ portable; }
 
 let update : moded_record @ unique once -> moded_record @ many =
   function mr ->
-    let many_fun : int -> int @@ many = function x -> x in
+    let many_fun : (int -> int) @ many = function x -> x in
     overwrite_ mr with { a = None; b = many_fun }
 [%%expect{|
 Line 4, characters 4-49:
@@ -335,7 +335,7 @@ Uncaught exception: File "parsing/location.ml", line 1107, characters 2-8: Asser
 
 let update : moded_record @ unique once -> moded_record @ many =
   function mr ->
-    let once_fun : int -> int @@ once = function x -> x in
+    let once_fun : (int -> int) @ once = function x -> x in
     overwrite_ mr with { a = None; b = once_fun }
 [%%expect{|
 Line 4, characters 39-47:
@@ -367,7 +367,7 @@ Error: This value is "once" but expected to be "many".
 
 let update : moded_record @ unique nonportable -> moded_record @ portable =
   function mr ->
-    let portable_fun : int -> int @@ portable = function x -> x in
+    let portable_fun : (int -> int) @ portable = function x -> x in
     overwrite_ mr with { a = None; b = portable_fun }
 [%%expect{|
 Line 4, characters 4-53:
@@ -380,7 +380,7 @@ Uncaught exception: File "parsing/location.ml", line 1107, characters 2-8: Asser
 
 let update : moded_record @ unique nonportable -> moded_record @ portable =
   function mr ->
-    let nonportable_fun : int -> int @@ nonportable = function x -> x in
+    let nonportable_fun : (int -> int) @ nonportable = function x -> x in
     overwrite_ mr with { a = None; b = nonportable_fun }
 [%%expect{|
 Line 4, characters 39-54:
@@ -391,8 +391,8 @@ Error: This value is "nonportable" but expected to be "portable".
 
 let update : moded_record @ unique nonportable -> moded_record @ portable =
   function mr ->
-    let portable_fun : int -> int @@ portable = function x -> x in
-    let nonportable_fun : int -> int @@ nonportable = function x -> x in
+    let portable_fun : (int -> int) @ portable = function x -> x in
+    let nonportable_fun : (int -> int) @ nonportable = function x -> x in
     overwrite_ mr with { a = Some nonportable_fun; b = portable_fun }
 [%%expect{|
 Line 5, characters 34-49:

--- a/testsuite/tests/typing-unique/unique.ml
+++ b/testsuite/tests/typing-unique/unique.ml
@@ -362,7 +362,7 @@ val unique_default_args : ?x:float @ unique -> unit -> float = <fun>
 
 let ul (unique_ local_ x) = x
 [%%expect{|
-val ul : local_ 'a @ unique -> local_ 'a = <fun>
+val ul : 'a @ local unique -> local_ 'a = <fun>
 |}]
 
 let ul_ret x = exclave_ unique_ x
@@ -376,7 +376,7 @@ let rec foo =
   | Some () -> foo None
   | None -> ()
 [%%expect{|
-val foo : local_ unit option @ unique -> unit = <fun>
+val foo : unit option @ local unique -> unit = <fun>
 |}]
 
 let rec bar =
@@ -385,17 +385,17 @@ let rec bar =
   | Some () -> ()
   | None -> bar (local_ Some ()) [@nontail]
 [%%expect{|
-val bar : local_ unit option @ unique -> unit = <fun>
+val bar : unit option @ local unique -> unit = <fun>
 |}]
 
 let foo : local_ unique_ string -> unit = fun (local_ s) -> ()
 [%%expect{|
-val foo : local_ string @ unique -> unit = <fun>
+val foo : string @ local unique -> unit = <fun>
 |}]
 
 let bar : local_ unique_ string -> unit = fun (unique_ s) -> ()
 [%%expect{|
-val bar : local_ string @ unique -> unit = <fun>
+val bar : string @ local unique -> unit = <fun>
 |}]
 
 (* Currying *)

--- a/testsuite/tests/typing-unique/unique_typedecl.ml
+++ b/testsuite/tests/typing-unique/unique_typedecl.ml
@@ -37,9 +37,9 @@ Lines 3-4, characters 0-68:
 4 | = 'a -> unique_ 'b -> unique_ once_ ('c -> unique_ once_ ('d -> 'e))
 Error: The type constraints are not consistent.
        Type "'a -> 'b @ unique -> 'c -> 'd -> 'e" is not compatible with type
-         "'a -> 'b @ unique -> ('c -> ('d -> 'e) @ once unique) @ once unique"
+         "'a -> 'b @ unique -> ('c -> ('d -> 'e) @ unique once) @ unique once"
        Type "'b @ unique -> 'c -> 'd -> 'e" is not compatible with type
-         "'b @ unique -> ('c -> ('d -> 'e) @ once unique) @ once unique"
+         "'b @ unique -> ('c -> ('d -> 'e) @ unique once) @ unique once"
 |}]
 
 type distinct_sarg = unit constraint unique_ int -> int = int -> int

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1401,47 +1401,57 @@ let outcome_label : Types.arg_label -> Outcometree.arg_label = function
   | Optional l -> Optional l
   | Position l -> Position l
 
-let tree_of_modality_new (t: Parsetree.modality loc) =
-  let Modality s = t.txt in s
+let rec all_or_none f = function
+  | [] -> Some []
+  | x :: xs ->
+    Option.bind (f x) (fun y ->
+      Option.bind (all_or_none f xs) (fun ys ->
+        Some (y :: ys)
+        )
+      )
 
-let tree_of_modality (t: Parsetree.modality loc) =
+let tree_of_modality_new (t: Parsetree.modality loc) =
+  let Modality s = t.txt in Ogf_new s
+
+let tree_of_modality_old (t: Parsetree.modality loc) =
   match t.txt with
-  | Modality "global" -> Ogf_legacy Ogf_global
-  | _ -> Ogf_new (tree_of_modality_new t)
+  | Modality "global" -> Some (Ogf_legacy Ogf_global)
+  | _ -> None
 
 let tree_of_modalities mut attrs t =
   let t = Typemode.untransl_modalities mut attrs t in
-  List.map tree_of_modality t
+  match all_or_none tree_of_modality_old t with
+  | Some l -> l
+  | None -> List.map tree_of_modality_new t
 
 let tree_of_modalities_new mut attrs t =
   let l = Typemode.untransl_modalities mut attrs t in
-  List.map tree_of_modality_new l
+  List.map (fun ({txt = Parsetree.Modality s; _}) -> s) l
 
 (** [tree_of_mode m l] finds the outcome node in [l] that corresponds to [m].
 Raise if not found. *)
-let tree_of_mode (mode : 'm option) (l : ('m * out_mode) list) : out_mode option =
-  Option.map (fun x -> List.assoc x l) mode
+let tree_of_mode_old (t : Parsetree.mode loc) =
+  match t.txt with
+  | Mode "local" -> Some (Omd_legacy Omd_local)
+  | _ -> None
+
+let tree_of_mode_new (t: Parsetree.mode loc) =
+  let Mode s = t.txt in Omd_new s
 
 let tree_of_modes (modes : Mode.Alloc.Const.t) =
   let diff = Mode.Alloc.Const.diff modes Mode.Alloc.Const.legacy in
   (* [yielding] has custom defaults depending on [areality]: *)
-  let diff_yielding =
+  let yielding =
     match modes.areality, modes.yielding with
     | Local, Yielding | Global, Unyielding -> None
     | _, _ -> Some modes.yielding
   in
+  let diff = {diff with yielding} in
   (* The mapping passed to [tree_of_mode] must cover all non-legacy modes *)
-  let l = [
-    tree_of_mode diff.areality [Mode.Locality.Const.Local, Omd_legacy Omd_local];
-    tree_of_mode diff.linearity [Mode.Linearity.Const.Once, Omd_new "once"];
-    tree_of_mode diff.uniqueness [Mode.Uniqueness.Const.Unique, Omd_new "unique"];
-    tree_of_mode diff.portability [Mode.Portability.Const.Portable, Omd_new "portable"];
-    tree_of_mode diff.contention [Mode.Contention.Const.Contended, Omd_new "contended";
-                                  Mode.Contention.Const.Shared, Omd_new "shared"];
-    tree_of_mode diff_yielding [Mode.Yielding.Const.Yielding, Omd_new "yielding";
-                                Mode.Yielding.Const.Unyielding, Omd_new "unyielding"]]
-  in
-  List.filter_map Fun.id l
+  let l = Typemode.untransl_mode_annots diff in
+  match all_or_none tree_of_mode_old l with
+  | Some l -> l
+  | None -> List.map tree_of_mode_new l
 
 (* [alloc_mode] is the mode that our printing has expressed on [ty]. For the
   example [A -> local_ (B -> C)], we will call [tree_of_typexp] on (B -> C) with
@@ -1694,12 +1704,13 @@ let tree_of_typexp mode ty = tree_of_typexp mode Alloc.Const.legacy ty
 let typexp mode ppf ty =
   !Oprint.out_type ppf (tree_of_typexp mode ty)
 
+(* Only used for printing a single modality in error message *)
 let modality ?(id = fun _ppf -> ()) ppf modality =
   if Mode.Modality.is_id modality then id ppf
   else
     modality
     |> Typemode.untransl_modality
-    |> tree_of_modality
+    |> tree_of_modality_new
     |> !Oprint.out_modality ppf
 
 let prepared_type_expr ppf ty = typexp Type ppf ty

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -218,7 +218,7 @@ let transl_mode_annots annots : Alloc.Const.Option.t =
       yielding = Option.map get_txt modes.yielding
     }
 
-let untransl_mode_annots ~loc (modes : Mode.Alloc.Const.Option.t) =
+let untransl_mode_annots (modes : Mode.Alloc.Const.Option.t) =
   let print_to_string_opt print a = Option.map (Format.asprintf "%a" print) a in
   let areality = print_to_string_opt Mode.Locality.Const.print modes.areality in
   let uniqueness =
@@ -243,7 +243,8 @@ let untransl_mode_annots ~loc (modes : Mode.Alloc.Const.Option.t) =
     | _, _ -> print_to_string_opt Mode.Yielding.Const.print modes.yielding
   in
   List.filter_map
-    (fun x -> Option.map (fun s -> { txt = Parsetree.Mode s; loc }) x)
+    (fun x ->
+      Option.map (fun s -> { txt = Parsetree.Mode s; loc = Location.none }) x)
     [areality; uniqueness; linearity; portability; contention; yielding]
 
 let transl_modality ~maturity { txt = Parsetree.Modality modality; loc } =

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -1,8 +1,7 @@
 (** Interpret mode syntax as mode annotation, where axes can be left unspecified *)
 val transl_mode_annots : Parsetree.modes -> Mode.Alloc.Const.Option.t
 
-val untransl_mode_annots :
-  loc:Location.t -> Mode.Alloc.Const.Option.t -> Parsetree.modes
+val untransl_mode_annots : Mode.Alloc.Const.Option.t -> Parsetree.modes
 
 (** Interpret mode syntax as alloc mode (on arrow types), where axes are set to
     legacy if unspecified *)

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -423,7 +423,7 @@ let exp_extra sub (extra, loc, attrs) sexp =
         Pexp_newtype (label_loc, jkind, sexp)
     | Texp_stack -> Pexp_stack sexp
     | Texp_mode modes ->
-        Pexp_constraint (sexp, None, Typemode.untransl_mode_annots ~loc modes)
+        Pexp_constraint (sexp, None, Typemode.untransl_mode_annots modes)
   in
   Exp.mk ~loc ~attrs desc
 


### PR DESCRIPTION
This PR refactors the new mode syntax (`@` and `@@`).

- With this PR, `@` always means modes, and `@@` always mean modalities. Previously, `@@` can mean modes in some position for disambiguition. For example, `x : a -> a @@ local` says `x` is local, and `x : b -> a @ local` says `a` is local). After this PR, the first example will write `x : (a -> a) @ local`. The second example doesn't change. You can also write `x : a @ local`.
- To ensure certain parsing-printing roundtrip, we print modes in legacy position only if the whole mode annotation contains old modes only. That means `local_ a @ portable -> b` will print back `a @ local portable -> b`, while `local_ a -> b` prints back the same. The idea is that "if the user already knows about and uses the new mode syntax, then we should print back new mode syntax". This is done in both `pprintast.ml` and `printtyp.ml`.
- `fun a b : ty @@ modes -> ..` was introduced by #3327 , and would be changed to `fun a b : ty @ modes -> ..`. Note the ambiguity:  the arrow could be arrow type. We decide to remove this for simplicity.
- Refactoring and fixes in `parser.mly` and `pprintast.ml`, so that some missing corner cases are covered, and diff to the upstream is minimized. For example, `labeled_simple_pattern` is now almost identical to upstream. This allows systematic enumeration of all possible syntax, which helps with user documentation, and test coverage.
- The mode section in `source_jane_street.ml` is rewritten to cover all possible syntax.

# Suggestions to reviewers

- First look at the mode section of `source_jane_street.ml`, to get a sense of the new syntax (don't look at the type errors - they are fine).
- Then look at `parser.mly`. 
- Then look at `pprintast.ml` and `printtyp.ml`. The former should be functionally "most fine" as tested by `source_jane_street.ml`, but other aspects such as coding style should be inspected.
- Changes in tests, except `source_jane_street.ml`, are all mechanical and can be skipped.