### PR TITLE
jkind subsumption

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1116,10 +1116,12 @@ type 'a contended : immutable_data with 'a @@ contended
 type 'a contended_with_int : immutable_data with 'a @@ contended with int
 
 [%%expect{|
-type 'a list : immutable_data with 'a
-type ('a, 'b) either : immutable_data with 'a * 'b
-type 'a contended : immutable_data with 'a @@ contended
-type 'a contended_with_int : immutable_data with 'a @@ contended
+type 'a list : immutable_data with 'a @@ global aliased
+type ('a, 'b) either : immutable_data with 'a * 'b @@ global aliased
+type 'a contended : immutable_data with 'a @@ global aliased contended
+type 'a contended_with_int
+  : immutable_data
+  with 'a @@ global aliased contended
 |}]
 
 (* not yet supported *)

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1667,3 +1667,58 @@ end
 [%%expect{|
 module M : sig type t end
 |}]
+
+(*********************************)
+(* Test 16: principality *)
+
+let id x = x
+let require_portable (_ : ('a : value mod portable)) = ()
+type 'a t = Box of 'a
+
+let f x =
+  match true with
+  | true ->
+    let _ : int = x in
+    ()
+  | false ->
+    (Box x)
+     |> id
+     |> require_portable
+[%%expect {|
+val id : 'a -> 'a = <fun>
+val require_portable : ('a : value mod portable). 'a -> unit = <fun>
+type 'a t = Box of 'a
+val f : int -> unit = <fun>
+|}, Principal{|
+val id : 'a -> 'a = <fun>
+val require_portable : ('a : value mod portable). 'a -> unit = <fun>
+type 'a t = Box of 'a
+Lines 11-12, characters 4-10:
+11 | ....(Box x)
+12 |      |> id
+Error: This expression has type "int t" but an expression was expected of type
+         "('a : value mod portable)"
+       The kind of int t is immutable_data
+         because of the definition of t at line 3, characters 0-21.
+       But the kind of int t must be a subkind of value mod portable
+         because of the definition of require_portable at line 2, characters 21-57.
+|}]
+
+(*********************************)
+(* Test 17: extensible variants *)
+
+(* The best kind an extensible variant can get is [value] *)
+type extensible : value = ..
+[%%expect{|
+type extensible = ..
+|}]
+
+(* Since the kind is [best], it should normalize away *)
+module M : sig
+  type t : immediate with extensible
+end = struct
+  type t
+end
+[%%expect{|
+module M : sig type t end
+|}]

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -568,7 +568,7 @@ type 'a t : immutable_data = Flat | Nested of 'a t t
 Line 1, characters 0-52:
 1 | type 'a t : immutable_data = Flat | Nested of 'a t t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
+Error: The kind of type "t" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -611,7 +611,7 @@ type ('a : immutable_data) t : immutable_data = Flat | Nested of 'a t t
 Line 1, characters 0-71:
 1 | type ('a : immutable_data) t : immutable_data = Flat | Nested of 'a t t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
+Error: The kind of type "t" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -133,7 +133,7 @@ Error: This value escapes its region.
 
 (* ref *)
 type t : mutable_data = int ref
-type 'a t : mutable_data with 'a @@ global many = 'a ref
+type 'a t : mutable_data with 'a = 'a ref
 type ('a : mutable_data) t : mutable_data = 'a list
 [%%expect {|
 type t = int ref

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -236,7 +236,7 @@ Error: Signature mismatch:
 module M : sig
   type 'a t : immutable_data with 'a ref
 end = struct
-  type 'a t : mutable_data with 'a @@ many
+  type 'a t : mutable_data with 'a @@ many unyielding
 end
 [%%expect {|
 module M :

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -79,8 +79,19 @@ end
 
 module type T = S with type ('a, 'b) t = ('a, 'b) t
 [%%expect {|
-type ('a, 'b) t : immutable_data with 'a with 'b
-module type S = sig type ('a, 'b) t : immutable_data with 'a with 'b end
+type ('a, 'b) t
+  : immutable_data
+  with 'a @@ global aliased
+
+  with 'b @@ global aliased
+module type S =
+  sig
+    type ('a, 'b) t
+      : immutable_data
+      with 'a @@ global aliased
+
+      with 'b @@ global aliased
+  end
 module type T = sig type ('a, 'b) t = ('a, 'b) t end
 |}]
 
@@ -90,7 +101,14 @@ end = struct
   type ('a, 'b) t : immutable_data with 'b
 end
 [%%expect {|
-module M : sig type ('a, 'b) t : immutable_data with 'a with 'b end
+module M :
+  sig
+    type ('a, 'b) t
+      : immutable_data
+      with 'a @@ global aliased
+
+      with 'b @@ global aliased
+  end
 |}]
 
 module M : sig
@@ -105,30 +123,47 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type ('a, 'b) t : immutable_data with 'a with 'b end
+         sig
+           type ('a, 'b) t
+             : immutable_data
+             with 'a @@ global aliased
+
+             with 'b @@ global aliased
+         end
        is not included in
-         sig type ('a, 'b) t : immutable_data with 'a end
+         sig type ('a, 'b) t : immutable_data with 'a @@ global aliased end
        Type declarations do not match:
-         type ('a, 'b) t : immutable_data with 'a with 'b
+         type ('a, 'b) t
+           : immutable_data
+           with 'a @@ global aliased
+
+           with 'b @@ global aliased
        is not included in
-         type ('a, 'b) t : immutable_data with 'a
-       The kind of the first is immutable_data with 'a with 'b
+         type ('a, 'b) t : immutable_data with 'a @@ global aliased
+       The kind of the first is immutable_data with 'a @@ global aliased
+         with 'b @@ global aliased
          because of the definition of t at line 4, characters 2-50.
-       But the kind of the first must be a subkind of immutable_data with 'a
+       But the kind of the first must be a subkind of immutable_data
+         with 'a @@ global aliased
          because of the definition of t at line 2, characters 2-42.
 |}]
 
 type ('a, 'b) u : immutable_data with 'b with 'a
 type ('a, 'b) t : immutable_data with 'a = ('a, 'b) u
 [%%expect {|
-type ('a, 'b) u : immutable_data with 'a with 'b
+type ('a, 'b) u
+  : immutable_data
+  with 'a @@ global aliased
+
+  with 'b @@ global aliased
 Line 2, characters 0-53:
 2 | type ('a, 'b) t : immutable_data with 'a = ('a, 'b) u
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "('a, 'b) u" is immutable_data with 'a with 'b
+Error: The kind of type "('a, 'b) u" is immutable_data
+         with 'a @@ global aliased with 'b @@ global aliased
          because of the definition of u at line 1, characters 0-48.
        But the kind of type "('a, 'b) u" must be a subkind of immutable_data
-         with 'a
+         with 'a @@ global aliased
          because of the definition of t at line 2, characters 0-53.
 |}]
 
@@ -140,15 +175,21 @@ end
 
 module type T = S with type ('a, 'b) t = ('a, 'b) t
 [%%expect {|
-type ('a, 'b) t : immutable_data with 'a with 'b
-module type S = sig type ('a, 'b) t : immutable_data with 'a end
+type ('a, 'b) t
+  : immutable_data
+  with 'a @@ global aliased
+
+  with 'b @@ global aliased
+module type S =
+  sig type ('a, 'b) t : immutable_data with 'a @@ global aliased end
 Line 7, characters 23-51:
 7 | module type T = S with type ('a, 'b) t = ('a, 'b) t
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "('a, 'b) t" is immutable_data with 'a with 'b
+Error: The kind of type "('a, 'b) t" is immutable_data
+         with 'a @@ global aliased with 'b @@ global aliased
          because of the definition of t at line 1, characters 0-48.
        But the kind of type "('a, 'b) t" must be a subkind of immutable_data
-         with 'a
+         with 'a @@ global aliased
          because of the definition of t at line 4, characters 2-42.
 |}]
 
@@ -158,7 +199,8 @@ end = struct
   type 'a t : immutable_data with 'a ref
 end
 [%%expect {|
-module M : sig type 'a t : mutable_data with 'a end
+module M :
+  sig type 'a t : mutable_data with 'a @@ global aliased contended end
 |}]
 
 module M : sig
@@ -174,16 +216,20 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type 'a t : mutable_data with 'a end
+         sig type 'a t : mutable_data with 'a @@ global aliased contended end
        is not included in
-         sig type 'a t : mutable_data with 'a end
+         sig
+           type 'a t : mutable_data with 'a @@ global many aliased contended
+         end
        Type declarations do not match:
-         type 'a t : mutable_data with 'a
+         type 'a t : mutable_data with 'a @@ global aliased contended
        is not included in
-         type 'a t : mutable_data with 'a
-       The kind of the first is mutable_data with 'a
+         type 'a t : mutable_data with 'a @@ global many aliased contended
+       The kind of the first is mutable_data
+         with 'a @@ global aliased contended
          because of the definition of t at line 4, characters 2-34.
-       But the kind of the first must be a subkind of mutable_data with 'a
+       But the kind of the first must be a subkind of mutable_data
+         with 'a @@ global many aliased contended
          because of the definition of t at line 2, characters 2-40.
 |}]
 
@@ -193,7 +239,8 @@ end = struct
   type 'a t : mutable_data with 'a @@ many
 end
 [%%expect {|
-module M : sig type 'a t : mutable_data with 'a end
+module M :
+  sig type 'a t : mutable_data with 'a @@ global many aliased contended end
 |}]
 
 (* CR layouts v2.8: 'a u's kind should get normalized to just immutable_data *)
@@ -204,7 +251,7 @@ end
 [%%expect {|
 module M :
   sig
-    type ('a : immutable_data) u : immutable_data with 'a
+    type ('a : immutable_data) u : immutable_data with 'a @@ global aliased
     type ('a : immutable_data) t = 'a u
   end
 |}]
@@ -227,7 +274,7 @@ type t : value mod portable with u
 type q : value mod portable with t = { x : t }
 [%%expect {|
 type u
-type t : value mod portable with u
+type t : value mod portable with u @@ global many aliased contended
 type q = { x : t; }
 |}]
 
@@ -237,8 +284,8 @@ type v : value mod portable with t
 type q : value mod portable with t = { x : v }
 [%%expect {|
 type u
-type t : value mod portable with u
-type v : value mod portable with t
+type t : value mod portable with u @@ global many aliased contended
+type v : value mod portable with t @@ global many aliased contended
 type q = { x : v; }
 |}]
 
@@ -252,7 +299,7 @@ type t = private u
 Line 3, characters 0-46:
 3 | type v : immutable_data with u = { value : t }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "v" is immutable_data with t
+Error: The kind of type "v" is immutable_data with t @@ global aliased
          because it's a boxed record type.
        But the kind of type "v" must be a subkind of immutable_data with u
          because of the annotation on the declaration of the type v.
@@ -274,7 +321,7 @@ Line 2, characters 0-44:
 Error: The kind of type "[ `foo of t ]" is value
          because it's a polymorphic variant type.
        But the kind of type "[ `foo of t ]" must be a subkind of immutable_data
-         with t
+         with t @@ global aliased
          because of the definition of u at line 2, characters 0-44.
 |}]
 
@@ -310,12 +357,12 @@ type t1
 type t2
 module M :
   sig
-    type a : immutable_data with t2
-    type b : immutable_data with t1
+    type a : immutable_data with t2 @@ global aliased
+    type b : immutable_data with t1 @@ global aliased
     val eq : (a, b) eq
   end
 >> Fatal error: Abstract kind with [with]: immutable_data
-with t1
+with t1 @@ global aliased
 Uncaught exception: Misc.Fatal_error
 
 |}]
@@ -335,13 +382,14 @@ Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a end
        is not included in
-         sig type 'a t : immutable_data with 'a end
+         sig type 'a t : immutable_data with 'a @@ global aliased end
        Type declarations do not match:
          type 'a t = 'a
        is not included in
-         type 'a t : immutable_data with 'a
+         type 'a t : immutable_data with 'a @@ global aliased
        The kind of the first is value
          because of the definition of t at line 2, characters 2-36.
-       But the kind of the first must be a subkind of immutable_data with 'a
+       But the kind of the first must be a subkind of immutable_data
+         with 'a @@ global aliased
          because of the definition of t at line 2, characters 2-36.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -1,0 +1,347 @@
+(* TEST
+    flags = "-extension layouts_alpha";
+    expect;
+*)
+
+module M : sig
+  type t
+end = struct
+  type t : value with int
+end
+[%%expect {|
+module M : sig type t end
+|}]
+
+module M : sig
+  type _ t
+end = struct
+  type 'a t : value with 'a
+end
+[%%expect {|
+module M : sig type _ t end
+|}]
+
+module M : sig
+  type t : immediate
+end = struct
+  type t : immediate with int
+end
+[%%expect {|
+module M : sig type t : immediate end
+|}]
+
+module M : sig
+  type t : immediate
+end = struct
+  type t : immediate with string
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t : immediate with string
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t : immutable_data end
+       is not included in
+         sig type t : immediate end
+       Type declarations do not match:
+         type t : immutable_data
+       is not included in
+         type t : immediate
+       The kind of the first is immutable_data
+         because of the definition of t at line 4, characters 2-32.
+       But the kind of the first must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-20.
+|}]
+
+module M : sig
+  type t : float64
+end = struct
+  type t : float64 with int
+end
+[%%expect {|
+module M : sig type t : float64 end
+|}]
+
+type u : immutable_data
+type t : immutable_data with int = u
+[%%expect {|
+type u : immutable_data
+type t = u
+|}]
+
+type ('a, 'b) t : immutable_data with 'b with 'a
+
+module type S = sig
+  type ('a, 'b) t : immutable_data with 'a with 'b
+end
+
+module type T = S with type ('a, 'b) t = ('a, 'b) t
+[%%expect {|
+type ('a, 'b) t : immutable_data with 'a with 'b
+module type S = sig type ('a, 'b) t : immutable_data with 'a with 'b end
+module type T = sig type ('a, 'b) t = ('a, 'b) t end
+|}]
+
+module M : sig
+  type ('a, 'b) t : immutable_data with 'a with 'b
+end = struct
+  type ('a, 'b) t : immutable_data with 'b
+end
+[%%expect {|
+module M : sig type ('a, 'b) t : immutable_data with 'a with 'b end
+|}]
+
+module M : sig
+  type ('a, 'b) t : immutable_data with 'a
+end = struct
+  type ('a, 'b) t : immutable_data with 'b with 'a
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a, 'b) t : immutable_data with 'b with 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a, 'b) t : immutable_data with 'a with 'b end
+       is not included in
+         sig type ('a, 'b) t : immutable_data with 'a end
+       Type declarations do not match:
+         type ('a, 'b) t : immutable_data with 'a with 'b
+       is not included in
+         type ('a, 'b) t : immutable_data with 'a
+       The kind of the first is immutable_data with 'a with 'b
+         because of the definition of t at line 4, characters 2-50.
+       But the kind of the first must be a subkind of immutable_data with 'a
+         because of the definition of t at line 2, characters 2-42.
+|}]
+
+type ('a, 'b) u : immutable_data with 'b with 'a
+type ('a, 'b) t : immutable_data with 'a = ('a, 'b) u
+[%%expect {|
+type ('a, 'b) u : immutable_data with 'a with 'b
+Line 2, characters 0-53:
+2 | type ('a, 'b) t : immutable_data with 'a = ('a, 'b) u
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "('a, 'b) u" is immutable_data with 'a with 'b
+         because of the definition of u at line 1, characters 0-48.
+       But the kind of type "('a, 'b) u" must be a subkind of immutable_data
+         with 'a
+         because of the definition of t at line 2, characters 0-53.
+|}]
+
+type ('a, 'b) t : immutable_data with 'a with 'b
+
+module type S = sig
+  type ('a, 'b) t : immutable_data with 'a
+end
+
+module type T = S with type ('a, 'b) t = ('a, 'b) t
+[%%expect {|
+type ('a, 'b) t : immutable_data with 'a with 'b
+module type S = sig type ('a, 'b) t : immutable_data with 'a end
+Line 7, characters 23-51:
+7 | module type T = S with type ('a, 'b) t = ('a, 'b) t
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "('a, 'b) t" is immutable_data with 'a with 'b
+         because of the definition of t at line 1, characters 0-48.
+       But the kind of type "('a, 'b) t" must be a subkind of immutable_data
+         with 'a
+         because of the definition of t at line 4, characters 2-42.
+|}]
+
+module M : sig
+  type 'a t : mutable_data with 'a
+end = struct
+  type 'a t : immutable_data with 'a ref
+end
+[%%expect {|
+module M : sig type 'a t : mutable_data with 'a end
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a ref
+end = struct
+  type 'a t : mutable_data with 'a
+end
+(* This isn't accepted because ['a ref] is always [many] *)
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t : mutable_data with 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t : mutable_data with 'a end
+       is not included in
+         sig type 'a t : mutable_data with 'a end
+       Type declarations do not match:
+         type 'a t : mutable_data with 'a
+       is not included in
+         type 'a t : mutable_data with 'a
+       The kind of the first is mutable_data with 'a
+         because of the definition of t at line 4, characters 2-34.
+       But the kind of the first must be a subkind of mutable_data with 'a
+         because of the definition of t at line 2, characters 2-40.
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a ref
+end = struct
+  type 'a t : mutable_data with 'a @@ many
+end
+[%%expect {|
+module M : sig type 'a t : mutable_data with 'a end
+|}]
+
+(* CR layouts v2.8: 'a u's kind should get normalized to just immutable_data *)
+module M = struct
+  type ('a : immutable_data) u : immutable_data with 'a
+  type 'a t : immutable_data = 'a u
+end
+[%%expect {|
+module M :
+  sig
+    type ('a : immutable_data) u : immutable_data with 'a
+    type ('a : immutable_data) t = 'a u
+  end
+|}]
+
+module M : sig
+  type t : mutable_data
+end = struct
+  type a : immediate
+  type b : immutable_data with a with int with string with a ref
+  type c : mutable_data with b with a with b with a
+  type d : immediate with a
+  type t : immutable_data mod aliased with d with d with b with d with c with a
+end
+[%%expect {|
+module M : sig type t : mutable_data end
+|}]
+
+type u
+type t : value mod portable with u
+type q : value mod portable with t = { x : t }
+[%%expect {|
+type u
+type t : value mod portable with u
+type q = { x : t; }
+|}]
+
+type u
+type t : value mod portable with u
+type v : value mod portable with t
+type q : value mod portable with t = { x : v }
+[%%expect {|
+type u
+type t : value mod portable with u
+type v : value mod portable with t
+type q = { x : v; }
+|}]
+
+type u
+type t = private u
+type v : immutable_data with u = { value : t }
+(* CR layouts v2.8: this should be accepted *)
+[%%expect {|
+type u
+type t = private u
+Line 3, characters 0-46:
+3 | type v : immutable_data with u = { value : t }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "v" is immutable_data with t
+         because it's a boxed record type.
+       But the kind of type "v" must be a subkind of immutable_data with u
+         because of the annotation on the declaration of the type v.
+|}]
+
+type t : immediate with t = [`foo | `bar]
+[%%expect {|
+type t = [ `bar | `foo ]
+|}]
+
+type t
+type u : immutable_data with t = [`foo of t]
+(* CR layouts v2.8: we can do better for polymorphic variants *)
+[%%expect {|
+type t
+Line 2, characters 0-44:
+2 | type u : immutable_data with t = [`foo of t]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "[ `foo of t ]" is value
+         because it's a polymorphic variant type.
+       But the kind of type "[ `foo of t ]" must be a subkind of immutable_data
+         with t
+         because of the definition of u at line 2, characters 0-44.
+|}]
+
+type (_, _) eq = Eq : ('a, 'a) eq
+
+type t1
+type t2
+
+module M : sig
+  type a : immutable_data with t2
+  type b : immutable_data with t1
+  val eq : (a, b) eq
+end = struct
+  type a = int
+  type b = int
+  let eq = Eq
+end
+
+let _ =
+  match M.eq with
+  | Eq ->
+    (* M.a = M.b *)
+    let module _ : sig
+      type t : immutable_data with t1
+    end = struct
+      type t : immutable_data with M.a
+    end in
+    ()
+(* CR layouts v2.8: Ideally this would be accepted *)
+[%%expect {|
+type (_, _) eq = Eq : ('a, 'a) eq
+type t1
+type t2
+module M :
+  sig
+    type a : immutable_data with t2
+    type b : immutable_data with t1
+    val eq : (a, b) eq
+  end
+>> Fatal error: Abstract kind with [with]: immutable_data
+with t1
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a
+end = struct
+  type 'a t = 'a
+end
+(* CR layouts v2.8: This should get accepted. But we should wait until we have kind_of *)
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t = 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a end
+       is not included in
+         sig type 'a t : immutable_data with 'a end
+       Type declarations do not match:
+         type 'a t = 'a
+       is not included in
+         type 'a t : immutable_data with 'a
+       The kind of the first is value
+         because of the definition of t at line 2, characters 2-36.
+       But the kind of the first must be a subkind of immutable_data with 'a
+         because of the definition of t at line 2, characters 2-36.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha";
+    flags = "-extension layouts_alpha -infer-with-bounds";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
@@ -54,7 +54,8 @@ end
 [%%expect{|
 module M :
   sig
-    type ('a, 'b) t : immutable_data with 'b * 'b constraint 'a = 'b * 'b
+    type ('a, 'b) t : immutable_data with 'b * 'b @@ global aliased
+      constraint 'a = 'b * 'b
   end
 |}]
 
@@ -66,7 +67,8 @@ end
 [%%expect{|
 module M :
   sig
-    type ('a, 'b) t : immutable_data with 'b * 'b constraint 'a = 'b * 'b
+    type ('a, 'b) t : immutable_data with 'b * 'b @@ global aliased
+      constraint 'a = 'b * 'b
   end
 |}]
 
@@ -123,7 +125,10 @@ end = struct
 end
 [%%expect {|
 module M :
-  sig type 'a t : immutable_data with 'b constraint 'a = 'b option end
+  sig
+    type 'a t : immutable_data with 'b @@ global aliased
+      constraint 'a = 'b option
+  end
 |}]
 
 module M : sig
@@ -140,14 +145,20 @@ Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = Foo of 'a constraint 'a = 'b ref end
        is not included in
-         sig type 'a t : immutable_data with 'b constraint 'a = 'b ref end
+         sig
+           type 'a t : immutable_data with 'b @@ global aliased
+             constraint 'a = 'b ref
+         end
        Type declarations do not match:
          type 'a t = Foo of 'a constraint 'a = 'b ref
        is not included in
-         type 'a t : immutable_data with 'b constraint 'a = 'b ref
-       The kind of the first is mutable_data with 'b
+         type 'a t : immutable_data with 'b @@ global aliased
+           constraint 'a = 'b ref
+       The kind of the first is mutable_data
+         with 'b @@ global many aliased contended
          because of the definition of t at line 4, characters 2-46.
-       But the kind of the first must be a subkind of immutable_data with 'b
+       But the kind of the first must be a subkind of immutable_data
+         with 'b @@ global aliased
          because of the definition of t at line 2, characters 2-59.
 |}]
 
@@ -157,7 +168,11 @@ end = struct
   type 'a t = Foo of 'a constraint 'a = 'b ref
 end
 [%%expect {|
-module M : sig type 'a t : mutable_data with 'b constraint 'a = 'b ref end
+module M :
+  sig
+    type 'a t : mutable_data with 'b @@ global aliased contended
+      constraint 'a = 'b ref
+  end
 |}]
 
 module M : sig
@@ -176,7 +191,10 @@ end = struct
 end
 [%%expect {|
 module M :
-  sig type 'a t : immutable_data with 'b constraint 'a = 'b option end
+  sig
+    type 'a t : immutable_data with 'b @@ global aliased
+      constraint 'a = 'b option
+  end
 |}]
 
 module M : sig
@@ -198,7 +216,7 @@ Error: Signature mismatch:
          type 'a t = Foo of 'a constraint 'a = 'b list
        is not included in
          type 'a t : immutable_data constraint 'a = 'b list
-       The kind of the first is immutable_data with 'b
+       The kind of the first is immutable_data with 'b @@ global aliased
          because of the definition of t at line 4, characters 2-64.
        But the kind of the first must be a subkind of immutable_data
          because of the definition of t at line 2, characters 2-69.

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
@@ -1,0 +1,205 @@
+(* TEST
+    flags = "-extension layouts_alpha";
+    expect;
+*)
+
+module M : sig
+  type 'a t : immediate constraint 'a = int
+end = struct
+  type 'a t = 'a constraint 'a = int
+end
+[%%expect {|
+module M : sig type 'a t : immediate constraint 'a = int end
+|}]
+
+module M : sig
+  type 'a t : immutable_data constraint 'a = int
+end = struct
+  type 'a t = Foo of 'a constraint 'a = int
+end
+[%%expect{|
+module M : sig type 'a t : immutable_data constraint 'a = int end
+|}]
+
+module M : sig
+  type 'a t : immediate constraint 'a = int
+end = struct
+  type 'a t = Foo of 'a constraint 'a = int
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t = Foo of 'a constraint 'a = int
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = Foo of 'a constraint 'a = int end
+       is not included in
+         sig type 'a t : immediate constraint 'a = int end
+       Type declarations do not match:
+         type 'a t = Foo of 'a constraint 'a = int
+       is not included in
+         type 'a t : immediate constraint 'a = int
+       The kind of the first is immutable_data
+         because of the definition of t at line 4, characters 2-43.
+       But the kind of the first must be a subkind of immediate
+         because of the definition of t at line 2, characters 2-43.
+|}]
+
+module M : sig
+  type ('a, 'b) t : immutable_data with 'b * 'b constraint 'a = 'b * 'b
+end = struct
+  type ('a, 'b) t = Foo of 'a constraint 'a = 'b * 'b
+end
+[%%expect{|
+module M :
+  sig
+    type ('a, 'b) t : immutable_data with 'b * 'b constraint 'a = 'b * 'b
+  end
+|}]
+
+module M : sig
+  type ('a, 'b) t : immutable_data with 'a constraint 'a = 'b * 'b
+end = struct
+  type ('a, 'b) t = Foo of 'a constraint 'a = 'b * 'b
+end
+[%%expect{|
+module M :
+  sig
+    type ('a, 'b) t : immutable_data with 'b * 'b constraint 'a = 'b * 'b
+  end
+|}]
+
+module M : sig
+  type ('a : value mod portable, 'b : value mod uncontended) t : value mod portable uncontended constraint 'a = 'b
+end = struct
+  type ('a : value mod portable, 'b : value mod uncontended) t = 'a constraint 'a = 'b
+end
+[%%expect{|
+module M :
+  sig
+    type ('b : value mod uncontended portable, 'a) t
+      : value mod uncontended portable constraint 'a = 'b
+  end
+|}]
+
+module M : sig
+  type ('a : value mod portable, 'b : value mod uncontended) t : value mod many constraint 'a = 'b
+end = struct
+  type ('a : value mod portable, 'b : value mod uncontended) t = 'a constraint 'a = 'b
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a : value mod portable, 'b : value mod uncontended) t = 'a constraint 'a = 'b
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type ('b : value mod uncontended portable, 'a) t = 'b
+             constraint 'a = 'b
+         end
+       is not included in
+         sig
+           type ('b : value mod uncontended portable, 'a) t : value mod many
+             constraint 'a = 'b
+         end
+       Type declarations do not match:
+         type ('b : value mod uncontended portable, 'a) t = 'b
+           constraint 'a = 'b
+       is not included in
+         type ('b : value mod uncontended portable, 'a) t : value mod many
+           constraint 'a = 'b
+       The kind of the first is value mod uncontended portable
+         because of the definition of t at line 2, characters 2-98.
+       But the kind of the first must be a subkind of value mod many
+         because of the definition of t at line 2, characters 2-98.
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'b constraint 'a = 'b option
+end = struct
+  type 'a t = Foo of 'a constraint 'a = 'b option
+end
+[%%expect {|
+module M :
+  sig type 'a t : immutable_data with 'b constraint 'a = 'b option end
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'b constraint 'a = 'b ref
+end = struct
+  type 'a t = Foo of 'a constraint 'a = 'b ref
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t = Foo of 'a constraint 'a = 'b ref
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = Foo of 'a constraint 'a = 'b ref end
+       is not included in
+         sig type 'a t : immutable_data with 'b constraint 'a = 'b ref end
+       Type declarations do not match:
+         type 'a t = Foo of 'a constraint 'a = 'b ref
+       is not included in
+         type 'a t : immutable_data with 'b constraint 'a = 'b ref
+       The kind of the first is mutable_data with 'b
+         because of the definition of t at line 4, characters 2-46.
+       But the kind of the first must be a subkind of immutable_data with 'b
+         because of the definition of t at line 2, characters 2-59.
+|}]
+
+module M : sig
+  type 'a t : mutable_data with 'b constraint 'a = 'b ref
+end = struct
+  type 'a t = Foo of 'a constraint 'a = 'b ref
+end
+[%%expect {|
+module M : sig type 'a t : mutable_data with 'b constraint 'a = 'b ref end
+|}]
+
+module M : sig
+  type 'a t : immutable_data constraint 'a = ('b : immutable_data) list
+end = struct
+  type 'a t = Foo of 'a constraint 'a = ('b : immutable_data) list
+end
+[%%expect {|
+module M : sig type 'a t : immutable_data constraint 'a = 'b list end
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a constraint 'a = 'b option
+end = struct
+  type 'a t = Foo of 'a constraint 'a = 'b option
+end
+[%%expect {|
+module M :
+  sig type 'a t : immutable_data with 'b constraint 'a = 'b option end
+|}]
+
+module M : sig
+  type 'a t : immutable_data constraint 'a = ('b : mutable_data) list
+end = struct
+  type 'a t = Foo of 'a constraint 'a = ('b : mutable_data) list
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t = Foo of 'a constraint 'a = ('b : mutable_data) list
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = Foo of 'a constraint 'a = 'b list end
+       is not included in
+         sig type 'a t : immutable_data constraint 'a = 'b list end
+       Type declarations do not match:
+         type 'a t = Foo of 'a constraint 'a = 'b list
+       is not included in
+         type 'a t : immutable_data constraint 'a = 'b list
+       The kind of the first is immutable_data with 'b
+         because of the definition of t at line 4, characters 2-64.
+       But the kind of the first must be a subkind of immutable_data
+         because of the definition of t at line 2, characters 2-69.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha";
+    flags = "-extension layouts_alpha -infer-with-bounds";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/fuel.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/fuel.ml
@@ -1,0 +1,121 @@
+(* TEST
+    flags = "-extension layouts_alpha";
+    expect;
+*)
+
+type 'a my_list = 'a list = [] | ( :: ) of 'a * 'a my_list
+
+(* At the time this test is written, "fuel" is used to deal with recursive types. Two
+   types that are equal can get different jkinds due to fuel running out at different
+   places. The below types are chosen so that they are equal, but fuel runs out in
+   different places. If fuel is changed, they should be modified so that this continues
+   to be true, and all instances of them in this file should also be updated. *)
+type t : immutable_data = int list my_list list my_list list
+[%%expect {|
+type 'a my_list = 'a list = [] | (::) of 'a * 'a my_list
+type t = int list my_list list my_list list
+|}]
+type t : immutable_data = int list list list list list
+(* CR layouts v2.8: The "because of the definition of t at line 1" part of the message
+   is not great. It should say something about the kind annotation on t. *)
+[%%expect {|
+Line 1, characters 0-54:
+1 | type t : immutable_data = int list list list list list
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int list list list list list" is immutable_data
+         with int list list list list
+         because it's a boxed variant type.
+       But the kind of type "int list list list list list" must be a subkind of
+         immutable_data
+         because of the definition of t at line 1, characters 0-54.
+|}]
+
+(* Differences in fuel consumption do not cause errors for module inclusion check
+   when both types have manifests *)
+module M : sig
+  type t = int list my_list list my_list list
+end = struct
+  type t = int list list list list list
+end
+[%%expect{|
+module M : sig type t = int list my_list list my_list list end
+|}]
+
+(* Differences in fuel consumption do not cause errors for module inclusion check
+   when both types have kinds *)
+module M : sig
+  type t = Foo of int list my_list list my_list list
+end = struct
+  type t = Foo of int list list list list list
+end
+[%%expect{|
+module M : sig type t = Foo of int list my_list list my_list list end
+|}]
+
+(* Differences in fuel consumption do not cause errors for module inclusion check
+   when both types have kinds and manifests *)
+type foo = Foo of int list my_list list my_list list
+module M : sig
+  type t = foo = Foo of int list my_list list my_list list
+end = struct
+  type t = foo = Foo of int list list list list list
+end
+[%%expect{|
+type foo = Foo of int list my_list list my_list list
+module M : sig type t = foo = Foo of int list my_list list my_list list end
+|}]
+
+type foo = Foo of int list list list list list
+module M : sig
+  type t = foo = Foo of int list my_list list my_list list
+end = struct
+  type t = foo = Foo of int list list list list list
+end
+[%%expect{|
+type foo = Foo of int list list list list list
+module M : sig type t = foo = Foo of int list my_list list my_list list end
+|}]
+
+(* Differences in fuel consumption do not cause errors when both a type has both kind and
+   manifest *)
+type foo1 = Foo of int list my_list list my_list list
+type foo2 = foo1 = Foo of int list list list list list
+[%%expect{|
+type foo1 = Foo of int list my_list list my_list list
+type foo2 = foo1 = Foo of int list list list list list
+|}]
+
+type foo1 = Foo of int list list list list list
+type foo2 = foo1 = Foo of int list my_list list my_list list
+[%%expect{|
+type foo1 = Foo of int list list list list list
+type foo2 = foo1 = Foo of int list my_list list my_list list
+|}]
+
+(* Differences in fuel consumption do not cause errors when satisfying a functor
+   constraint *)
+module F (M : sig
+  type t = Foo of int list my_list list my_list list
+end) = struct end
+module M = F (struct
+  type t = Foo of int list list list list list
+end)
+[%%expect {|
+module F :
+  functor (M : sig type t = Foo of int list my_list list my_list list end) ->
+    sig end
+module M : sig end
+|}]
+
+module F (M : sig
+  type t = int list my_list list my_list list
+end) = struct end
+module M = F (struct
+  type t = int list list list list list
+end)
+[%%expect {|
+module F :
+  functor (M : sig type t = int list my_list list my_list list end) ->
+    sig end
+module M : sig end
+|}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/fuel.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/fuel.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha";
+    flags = "-extension layouts_alpha -infer-with-bounds";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
@@ -1,0 +1,126 @@
+(* TEST
+    flags = "-extension layouts_alpha";
+    expect;
+*)
+
+module F (M : sig type t end) = struct
+  type t : immutable_data with M.t
+end
+
+module Int = struct
+  type t = int
+end
+type t : immutable_data = F(Int).t
+[%%expect {|
+module F :
+  functor (M : sig type t end) -> sig type t : immutable_data with M.t end
+module Int : sig type t = int end
+type t = F(Int).t
+|}]
+
+module T = struct
+  type t
+end
+type t : immutable_data = F(T).t
+[%%expect {|
+module T : sig type t end
+Line 4, characters 0-32:
+4 | type t : immutable_data = F(T).t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "F(T).t" is immutable_data with T.t
+         because of the definition of t at line 2, characters 2-34.
+       But the kind of type "F(T).t" must be a subkind of immutable_data
+         because of the definition of t at line 4, characters 0-32.
+|}]
+
+module F (M : sig type 'a t end) = struct
+  type 'a t : immutable_data with 'a M.t
+end
+
+module Ref = struct
+  type 'a t = 'a ref
+end
+type 'a t : mutable_data with 'a = 'a F(Ref).t
+[%%expect {|
+module F :
+  functor (M : sig type 'a t end) ->
+    sig type 'a t : immutable_data with 'a M.t end
+module Ref : sig type 'a t = 'a ref end
+type 'a t = 'a F(Ref).t
+|}]
+
+module Ref = struct
+  type 'a t = 'a ref
+end
+type 'a t : immutable_data with 'a = 'a F(Ref).t
+[%%expect {|
+module Ref : sig type 'a t = 'a ref end
+Line 4, characters 0-48:
+4 | type 'a t : immutable_data with 'a = 'a F(Ref).t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "'a F(Ref).t" is mutable_data with 'a
+         because of the definition of t at line 2, characters 2-40.
+       But the kind of type "'a F(Ref).t" must be a subkind of immutable_data
+         with 'a
+         because of the definition of t at line 4, characters 0-48.
+|}]
+
+module Ref = struct
+  type 'a t = 'a ref
+end
+type 'a t : mutable_data = 'a F(Ref).t
+[%%expect {|
+module Ref : sig type 'a t = 'a ref end
+Line 4, characters 0-38:
+4 | type 'a t : mutable_data = 'a F(Ref).t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "'a F(Ref).t" is immutable_data with 'a Ref.t
+         because of the definition of t at line 2, characters 2-40.
+       But the kind of type "'a F(Ref).t" must be a subkind of mutable_data
+         because of the definition of t at line 4, characters 0-38.
+|}]
+
+module F (M : sig
+  type t
+  type u
+end) = struct
+  type t : immediate with M.u with M.t
+end
+
+module Int_int = struct
+  type t = int
+  type u = int
+end
+type t : immutable_data = F(Int_int).t
+[%%expect {|
+module F :
+  functor (M : sig type t type u end) ->
+    sig type t : immediate with M.t with M.u end
+module Int_int : sig type t = int type u = int end
+type t = F(Int_int).t
+|}]
+
+module Int_abstract = struct
+  type t = int
+  type u : value mod global
+end
+type t : value mod global = F(Int_abstract).t
+type t : value mod portable with Int_abstract.u = F(Int_abstract).t
+[%%expect {|
+module Int_abstract : sig type t = int type u : value mod global end
+type t = F(Int_abstract).t
+type t = F(Int_abstract).t
+|}]
+
+type t : value mod portable = F(Int_abstract).t
+[%%expect {|
+Line 1, characters 0-47:
+1 | type t : value mod portable = F(Int_abstract).t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "F(Int_abstract).t" is immediate with Int_abstract.t
+         with Int_abstract.u
+         because of the definition of t at line 5, characters 2-38.
+       But the kind of type "F(Int_abstract).t" must be a subkind of
+         value mod portable
+         because of the definition of t at line 1, characters 0-47.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
@@ -13,7 +13,8 @@ end
 type t : immutable_data = F(Int).t
 [%%expect {|
 module F :
-  functor (M : sig type t end) -> sig type t : immutable_data with M.t end
+  functor (M : sig type t end) ->
+    sig type t : immutable_data with M.t @@ global aliased end
 module Int : sig type t = int end
 type t = F(Int).t
 |}]
@@ -27,7 +28,7 @@ module T : sig type t end
 Line 4, characters 0-32:
 4 | type t : immutable_data = F(T).t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "F(T).t" is immutable_data with T.t
+Error: The kind of type "F(T).t" is immutable_data with T.t @@ global aliased
          because of the definition of t at line 2, characters 2-34.
        But the kind of type "F(T).t" must be a subkind of immutable_data
          because of the definition of t at line 4, characters 0-32.
@@ -44,7 +45,7 @@ type 'a t : mutable_data with 'a = 'a F(Ref).t
 [%%expect {|
 module F :
   functor (M : sig type 'a t end) ->
-    sig type 'a t : immutable_data with 'a M.t end
+    sig type 'a t : immutable_data with 'a M.t @@ global aliased end
 module Ref : sig type 'a t = 'a ref end
 type 'a t = 'a F(Ref).t
 |}]
@@ -58,10 +59,11 @@ module Ref : sig type 'a t = 'a ref end
 Line 4, characters 0-48:
 4 | type 'a t : immutable_data with 'a = 'a F(Ref).t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a F(Ref).t" is mutable_data with 'a
+Error: The kind of type "'a F(Ref).t" is mutable_data
+         with 'a @@ global many aliased contended
          because of the definition of t at line 2, characters 2-40.
        But the kind of type "'a F(Ref).t" must be a subkind of immutable_data
-         with 'a
+         with 'a @@ global aliased
          because of the definition of t at line 4, characters 0-48.
 |}]
 
@@ -74,7 +76,8 @@ module Ref : sig type 'a t = 'a ref end
 Line 4, characters 0-38:
 4 | type 'a t : mutable_data = 'a F(Ref).t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a F(Ref).t" is immutable_data with 'a Ref.t
+Error: The kind of type "'a F(Ref).t" is immutable_data
+         with 'a Ref.t @@ global aliased
          because of the definition of t at line 2, characters 2-40.
        But the kind of type "'a F(Ref).t" must be a subkind of mutable_data
          because of the definition of t at line 4, characters 0-38.

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha";
+    flags = "-extension layouts_alpha -infer-with-bounds";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha";
+    flags = "-extension layouts_alpha -infer-with-bounds";
     expect;
 *)
 
@@ -126,7 +126,8 @@ end = struct
   type 'a t : immediate with 'a @@ aliased many contended global portable
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data mod global unique end
+module M :
+  sig type 'a t : value mod global unique many uncontended portable end
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -1,0 +1,338 @@
+(* TEST
+    flags = "-extension layouts_alpha";
+    expect;
+*)
+
+module M : sig
+  type ('a, 'b) t : immutable_data with 'a
+end = struct
+  type ('a, 'b) t : immutable_data with 'a @@ portable
+end
+[%%expect {|
+module M : sig type ('a, 'b) t : immutable_data with 'a end
+|}]
+
+module M : sig
+  type ('a, 'b) t : immutable_data with 'a @@ portable
+end = struct
+  type ('a, 'b) t : immutable_data with 'a
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a, 'b) t : immutable_data with 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a, 'b) t : immutable_data with 'a end
+       is not included in
+         sig type ('a, 'b) t : immutable_data with 'a end
+       Type declarations do not match:
+         type ('a, 'b) t : immutable_data with 'a
+       is not included in
+         type ('a, 'b) t : immutable_data with 'a
+       The kind of the first is immutable_data with 'a
+         because of the definition of t at line 4, characters 2-42.
+       But the kind of the first must be a subkind of immutable_data with 'a
+         because of the definition of t at line 2, characters 2-54.
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a
+end = struct
+  type 'a t : immutable_data with 'a @@ portable
+end
+[%%expect {|
+module M : sig type 'a t : immutable_data with 'a end
+|}]
+
+module M : sig
+  type 'a t : value mod portable
+end = struct
+  type 'a t : immutable_data with 'a @@ portable
+end
+[%%expect {|
+module M : sig type 'a t : value mod portable end
+|}]
+
+module M : sig
+  type 'a t : mutable_data with 'a @@ portable
+end = struct
+  type 'a t : mutable_data with 'a @@ portable
+end
+[%%expect {|
+module M : sig type 'a t : mutable_data with 'a end
+|}]
+
+type 'a u : immutable_data with 'a @@ contended
+type 'a t : value mod portable = 'a u
+[%%expect {|
+type 'a u : immutable_data with 'a
+Line 2, characters 0-37:
+2 | type 'a t : value mod portable = 'a u
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "'a u" is immutable_data with 'a
+         because of the definition of u at line 1, characters 0-47.
+       But the kind of type "'a u" must be a subkind of value mod portable
+         because of the definition of t at line 2, characters 0-37.
+|}]
+
+module M : sig
+  type 'a t : value mod global
+end = struct
+  type 'a t : immediate with 'a @@ global
+end
+[%%expect {|
+module M : sig type 'a t : value mod global end
+|}]
+
+module M : sig
+  type 'a t : value mod uncontended
+end = struct
+  type 'a t : immutable_data with 'a @@ contended
+end
+[%%expect {|
+module M : sig type 'a t : value mod uncontended end
+|}]
+
+type 'a u : immutable_data with 'a @@ many
+type 'a t : value mod many = 'a u
+[%%expect {|
+type 'a u : immutable_data with 'a
+type 'a t = 'a u
+|}]
+
+module M : sig
+  type 'a t : value mod unique
+end = struct
+  type 'a t : immediate with 'a @@ aliased
+end
+[%%expect {|
+module M : sig type 'a t : value mod unique end
+|}]
+
+module M : sig
+  type 'a t : value mod global unique many portable uncontended
+end = struct
+  type 'a t : immediate with 'a @@ aliased many contended global portable
+end
+[%%expect {|
+module M : sig type 'a t : immutable_data mod global unique end
+|}]
+
+module M : sig
+  type ('a, 'b) t : value mod portable
+end = struct
+  type ('a, 'b) t : value mod portable with 'a @@ portable with 'b @@ portable
+end
+[%%expect {|
+module M : sig type ('a, 'b) t : value mod portable end
+|}]
+
+type ('a, 'b) t : value mod portable with 'a @@ portable with 'b @@ contended
+
+module type S = sig
+  type ('a, 'b) t : value mod portable
+end
+
+module type T = S with type ('a, 'b) t = ('a, 'b) t
+[%%expect {|
+type ('a, 'b) t : value mod portable with 'b
+module type S = sig type ('a, 'b) t : value mod portable end
+Line 7, characters 23-51:
+7 | module type T = S with type ('a, 'b) t = ('a, 'b) t
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "('a, 'b) t" is value mod portable with 'b
+         because of the definition of t at line 1, characters 0-77.
+       But the kind of type "('a, 'b) t" must be a subkind of
+         value mod portable
+         because of the definition of t at line 4, characters 2-38.
+|}]
+
+module M : sig
+  type ('a, 'b) t : value mod portable with 'b
+end = struct
+  type ('a, 'b) t : value mod portable with 'a @@ portable with 'b @@ contended
+end
+[%%expect {|
+module M : sig type ('a, 'b) t : value mod portable with 'b end
+|}]
+
+module M : sig
+  type ('a, 'b) t : value mod portable with 'a @@ portable with 'b @@ contended
+end = struct
+  type ('a, 'b) t : value mod portable with 'b
+end
+[%%expect {|
+module M : sig type ('a, 'b) t : value mod portable with 'b end
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a @@ portable
+end = struct
+  type 'a t : immutable_data with 'a @@ portable with 'a
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t : immutable_data with 'a @@ portable with 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t : immutable_data with 'a end
+       is not included in
+         sig type 'a t : immutable_data with 'a end
+       Type declarations do not match:
+         type 'a t : immutable_data with 'a
+       is not included in
+         type 'a t : immutable_data with 'a
+       The kind of the first is immutable_data with 'a
+         because of the definition of t at line 4, characters 2-56.
+       But the kind of the first must be a subkind of immutable_data with 'a
+         because of the definition of t at line 2, characters 2-48.
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a @@ portable
+end = struct
+  type 'a t : immutable_data with 'a with 'a @@ portable
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t : immutable_data with 'a with 'a @@ portable
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t : immutable_data with 'a end
+       is not included in
+         sig type 'a t : immutable_data with 'a end
+       Type declarations do not match:
+         type 'a t : immutable_data with 'a
+       is not included in
+         type 'a t : immutable_data with 'a
+       The kind of the first is immutable_data with 'a
+         because of the definition of t at line 4, characters 2-56.
+       But the kind of the first must be a subkind of immutable_data with 'a
+         because of the definition of t at line 2, characters 2-48.
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a
+end = struct
+  type 'a t : immutable_data with 'a @@ portable with 'a
+end
+[%%expect {|
+module M : sig type 'a t : immutable_data with 'a end
+|}]
+
+type 'a u : value mod uncontended with 'a @@ global
+type 'a t : value mod global = 'a u
+[%%expect {|
+type 'a u : value mod uncontended with 'a
+Line 2, characters 0-35:
+2 | type 'a t : value mod global = 'a u
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "'a u" is value mod uncontended with 'a
+         because of the definition of u at line 1, characters 0-51.
+       But the kind of type "'a u" must be a subkind of value mod global
+         because of the definition of t at line 2, characters 0-35.
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a @@ contended portable
+end = struct
+  type 'a t : immutable_data with 'a @@ contended with 'a @@ portable
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t : immutable_data with 'a @@ contended with 'a @@ portable
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t : immutable_data with 'a end
+       is not included in
+         sig type 'a t : immutable_data with 'a end
+       Type declarations do not match:
+         type 'a t : immutable_data with 'a
+       is not included in
+         type 'a t : immutable_data with 'a
+       The kind of the first is immutable_data with 'a
+         because of the definition of t at line 4, characters 2-69.
+       But the kind of the first must be a subkind of immutable_data with 'a
+         because of the definition of t at line 2, characters 2-58.
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a @@ contended with 'a @@ portable
+end = struct
+  type 'a t : immutable_data with 'a @@ contended portable
+end
+[%%expect {|
+module M : sig type 'a t : immutable_data with 'a end
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a @@ portable
+end = struct
+  type 'a t : immutable_data with 'a @@ contended portable with 'a @@ portable many
+end
+[%%expect {|
+module M : sig type 'a t : immutable_data with 'a end
+|}]
+
+type ('a, 'b) u : immutable_data with 'a @@ portable with 'b @@ contended
+type ('a, 'b) t : immutable_data with 'a @@ portable with 'b @@ contended = ('a, 'b) u
+[%%expect {|
+type ('a, 'b) u : immutable_data with 'a with 'b
+type ('a, 'b) t = ('a, 'b) u
+|}]
+
+module M : sig
+  type ('a, 'b) t : immutable_data with 'a @@ portable with 'b @@ contended
+end = struct
+  type ('a, 'b) t : immutable_data with 'a @@ contended with 'b @@ portable
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type ('a, 'b) t : immutable_data with 'a @@ contended with 'b @@ portable
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type ('a, 'b) t : immutable_data with 'a with 'b end
+       is not included in
+         sig type ('a, 'b) t : immutable_data with 'a with 'b end
+       Type declarations do not match:
+         type ('a, 'b) t : immutable_data with 'a with 'b
+       is not included in
+         type ('a, 'b) t : immutable_data with 'a with 'b
+       The kind of the first is immutable_data with 'a with 'b
+         because of the definition of t at line 4, characters 2-75.
+       But the kind of the first must be a subkind of immutable_data
+         with 'a with 'b
+         because of the definition of t at line 2, characters 2-75.
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a @@ portable
+end = struct
+  type 'a t : immutable_data with 'a @@ portable contended portable
+end
+[%%expect {|
+module M : sig type 'a t : immutable_data with 'a end
+|}]
+
+type t : immutable_data with int ref @@ contended
+
+module type S = sig
+  type t : immutable_data
+end
+
+module type T = S with type t = t
+[%%expect {|
+type t : immutable_data
+module type S = sig type t : immutable_data end
+module type T = sig type t = t end
+|}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -9,7 +9,7 @@ end = struct
   type ('a, 'b) t : immutable_data with 'a @@ portable
 end
 [%%expect {|
-module M : sig type ('a, 'b) t : immutable_data with 'a end
+module M : sig type ('a, 'b) t : immutable_data with 'a @@ global aliased end
 |}]
 
 module M : sig
@@ -24,16 +24,21 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type ('a, 'b) t : immutable_data with 'a end
+         sig type ('a, 'b) t : immutable_data with 'a @@ global aliased end
        is not included in
-         sig type ('a, 'b) t : immutable_data with 'a end
+         sig
+           type ('a, 'b) t
+             : immutable_data
+             with 'a @@ global portable aliased
+         end
        Type declarations do not match:
-         type ('a, 'b) t : immutable_data with 'a
+         type ('a, 'b) t : immutable_data with 'a @@ global aliased
        is not included in
-         type ('a, 'b) t : immutable_data with 'a
-       The kind of the first is immutable_data with 'a
+         type ('a, 'b) t : immutable_data with 'a @@ global portable aliased
+       The kind of the first is immutable_data with 'a @@ global aliased
          because of the definition of t at line 4, characters 2-42.
-       But the kind of the first must be a subkind of immutable_data with 'a
+       But the kind of the first must be a subkind of immutable_data
+         with 'a @@ global portable aliased
          because of the definition of t at line 2, characters 2-54.
 |}]
 
@@ -43,7 +48,7 @@ end = struct
   type 'a t : immutable_data with 'a @@ portable
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data with 'a end
+module M : sig type 'a t : immutable_data with 'a @@ global aliased end
 |}]
 
 module M : sig
@@ -61,17 +66,21 @@ end = struct
   type 'a t : mutable_data with 'a @@ portable
 end
 [%%expect {|
-module M : sig type 'a t : mutable_data with 'a end
+module M :
+  sig
+    type 'a t : mutable_data with 'a @@ global portable aliased contended
+  end
 |}]
 
 type 'a u : immutable_data with 'a @@ contended
 type 'a t : value mod portable = 'a u
 [%%expect {|
-type 'a u : immutable_data with 'a
+type 'a u : immutable_data with 'a @@ global aliased contended
 Line 2, characters 0-37:
 2 | type 'a t : value mod portable = 'a u
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a u" is immutable_data with 'a
+Error: The kind of type "'a u" is immutable_data
+         with 'a @@ global aliased contended
          because of the definition of u at line 1, characters 0-47.
        But the kind of type "'a u" must be a subkind of value mod portable
          because of the definition of t at line 2, characters 0-37.
@@ -98,7 +107,7 @@ module M : sig type 'a t : value mod uncontended end
 type 'a u : immutable_data with 'a @@ many
 type 'a t : value mod many = 'a u
 [%%expect {|
-type 'a u : immutable_data with 'a
+type 'a u : immutable_data with 'a @@ global many aliased
 type 'a t = 'a u
 |}]
 
@@ -137,12 +146,13 @@ end
 
 module type T = S with type ('a, 'b) t = ('a, 'b) t
 [%%expect {|
-type ('a, 'b) t : value mod portable with 'b
+type ('a, 'b) t : value mod portable with 'b @@ global many aliased contended
 module type S = sig type ('a, 'b) t : value mod portable end
 Line 7, characters 23-51:
 7 | module type T = S with type ('a, 'b) t = ('a, 'b) t
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "('a, 'b) t" is value mod portable with 'b
+Error: The kind of type "('a, 'b) t" is value mod portable
+         with 'b @@ global many aliased contended
          because of the definition of t at line 1, characters 0-77.
        But the kind of type "('a, 'b) t" must be a subkind of
          value mod portable
@@ -155,7 +165,12 @@ end = struct
   type ('a, 'b) t : value mod portable with 'a @@ portable with 'b @@ contended
 end
 [%%expect {|
-module M : sig type ('a, 'b) t : value mod portable with 'b end
+module M :
+  sig
+    type ('a, 'b) t
+      : value mod portable
+      with 'b @@ global many aliased contended
+  end
 |}]
 
 module M : sig
@@ -164,7 +179,12 @@ end = struct
   type ('a, 'b) t : value mod portable with 'b
 end
 [%%expect {|
-module M : sig type ('a, 'b) t : value mod portable with 'b end
+module M :
+  sig
+    type ('a, 'b) t
+      : value mod portable
+      with 'b @@ global many aliased contended
+  end
 |}]
 
 module M : sig
@@ -179,16 +199,19 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type 'a t : immutable_data with 'a end
+         sig type 'a t : immutable_data with 'a @@ global aliased end
        is not included in
-         sig type 'a t : immutable_data with 'a end
+         sig
+           type 'a t : immutable_data with 'a @@ global portable aliased
+         end
        Type declarations do not match:
-         type 'a t : immutable_data with 'a
+         type 'a t : immutable_data with 'a @@ global aliased
        is not included in
-         type 'a t : immutable_data with 'a
-       The kind of the first is immutable_data with 'a
+         type 'a t : immutable_data with 'a @@ global portable aliased
+       The kind of the first is immutable_data with 'a @@ global aliased
          because of the definition of t at line 4, characters 2-56.
-       But the kind of the first must be a subkind of immutable_data with 'a
+       But the kind of the first must be a subkind of immutable_data
+         with 'a @@ global portable aliased
          because of the definition of t at line 2, characters 2-48.
 |}]
 
@@ -204,16 +227,19 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type 'a t : immutable_data with 'a end
+         sig type 'a t : immutable_data with 'a @@ global aliased end
        is not included in
-         sig type 'a t : immutable_data with 'a end
+         sig
+           type 'a t : immutable_data with 'a @@ global portable aliased
+         end
        Type declarations do not match:
-         type 'a t : immutable_data with 'a
+         type 'a t : immutable_data with 'a @@ global aliased
        is not included in
-         type 'a t : immutable_data with 'a
-       The kind of the first is immutable_data with 'a
+         type 'a t : immutable_data with 'a @@ global portable aliased
+       The kind of the first is immutable_data with 'a @@ global aliased
          because of the definition of t at line 4, characters 2-56.
-       But the kind of the first must be a subkind of immutable_data with 'a
+       But the kind of the first must be a subkind of immutable_data
+         with 'a @@ global portable aliased
          because of the definition of t at line 2, characters 2-48.
 |}]
 
@@ -223,17 +249,18 @@ end = struct
   type 'a t : immutable_data with 'a @@ portable with 'a
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data with 'a end
+module M : sig type 'a t : immutable_data with 'a @@ global aliased end
 |}]
 
 type 'a u : value mod uncontended with 'a @@ global
 type 'a t : value mod global = 'a u
 [%%expect {|
-type 'a u : value mod uncontended with 'a
+type 'a u : value mod uncontended with 'a @@ global many portable aliased
 Line 2, characters 0-35:
 2 | type 'a t : value mod global = 'a u
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a u" is value mod uncontended with 'a
+Error: The kind of type "'a u" is value mod uncontended
+         with 'a @@ global many portable aliased
          because of the definition of u at line 1, characters 0-51.
        But the kind of type "'a u" must be a subkind of value mod global
          because of the definition of t at line 2, characters 0-35.
@@ -251,16 +278,23 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type 'a t : immutable_data with 'a end
+         sig type 'a t : immutable_data with 'a @@ global aliased end
        is not included in
-         sig type 'a t : immutable_data with 'a end
+         sig
+           type 'a t
+             : immutable_data
+             with 'a @@ global portable aliased contended
+         end
        Type declarations do not match:
-         type 'a t : immutable_data with 'a
+         type 'a t : immutable_data with 'a @@ global aliased
        is not included in
-         type 'a t : immutable_data with 'a
-       The kind of the first is immutable_data with 'a
+         type 'a t
+           : immutable_data
+           with 'a @@ global portable aliased contended
+       The kind of the first is immutable_data with 'a @@ global aliased
          because of the definition of t at line 4, characters 2-69.
-       But the kind of the first must be a subkind of immutable_data with 'a
+       But the kind of the first must be a subkind of immutable_data
+         with 'a @@ global portable aliased contended
          because of the definition of t at line 2, characters 2-58.
 |}]
 
@@ -270,7 +304,7 @@ end = struct
   type 'a t : immutable_data with 'a @@ contended portable
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data with 'a end
+module M : sig type 'a t : immutable_data with 'a @@ global aliased end
 |}]
 
 module M : sig
@@ -279,13 +313,18 @@ end = struct
   type 'a t : immutable_data with 'a @@ contended portable with 'a @@ portable many
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data with 'a end
+module M :
+  sig type 'a t : immutable_data with 'a @@ global portable aliased end
 |}]
 
 type ('a, 'b) u : immutable_data with 'a @@ portable with 'b @@ contended
 type ('a, 'b) t : immutable_data with 'a @@ portable with 'b @@ contended = ('a, 'b) u
 [%%expect {|
-type ('a, 'b) u : immutable_data with 'a with 'b
+type ('a, 'b) u
+  : immutable_data
+  with 'a @@ global portable aliased
+
+  with 'b @@ global aliased contended
 type ('a, 'b) t = ('a, 'b) u
 |}]
 
@@ -301,17 +340,40 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type ('a, 'b) t : immutable_data with 'a with 'b end
+         sig
+           type ('a, 'b) t
+             : immutable_data
+             with 'a @@ global aliased contended
+
+             with 'b @@ global portable aliased
+         end
        is not included in
-         sig type ('a, 'b) t : immutable_data with 'a with 'b end
+         sig
+           type ('a, 'b) t
+             : immutable_data
+             with 'a @@ global portable aliased
+
+             with 'b @@ global aliased contended
+         end
        Type declarations do not match:
-         type ('a, 'b) t : immutable_data with 'a with 'b
+         type ('a, 'b) t
+           : immutable_data
+           with 'a @@ global aliased contended
+
+           with 'b @@ global portable aliased
        is not included in
-         type ('a, 'b) t : immutable_data with 'a with 'b
-       The kind of the first is immutable_data with 'a with 'b
+         type ('a, 'b) t
+           : immutable_data
+           with 'a @@ global portable aliased
+
+           with 'b @@ global aliased contended
+       The kind of the first is immutable_data
+         with 'a @@ global aliased contended
+         with 'b @@ global portable aliased
          because of the definition of t at line 4, characters 2-75.
        But the kind of the first must be a subkind of immutable_data
-         with 'a with 'b
+         with 'a @@ global portable aliased
+         with 'b @@ global aliased contended
          because of the definition of t at line 2, characters 2-75.
 |}]
 
@@ -321,7 +383,8 @@ end = struct
   type 'a t : immutable_data with 'a @@ portable contended portable
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data with 'a end
+module M :
+  sig type 'a t : immutable_data with 'a @@ global portable aliased end
 |}]
 
 type t : immutable_data with int ref @@ contended

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha";
+    flags = "-extension layouts_alpha -infer-with-bounds";
     expect;
 *)
 
@@ -532,7 +532,7 @@ Error: Signature mismatch:
          because of the definition of t at line 3, characters 2-39.
 |}]
 
-module type S = sig 
+module type S = sig
   val nonportable_f : int -> int
 end
 type s = (module S)
@@ -613,14 +613,14 @@ Error: Signature mismatch:
        Modules do not match:
          sig type t : value mod many end
        is not included in
-         sig type t : mutable_data end
+         sig type t : value mod many portable end
        Type declarations do not match:
          type t : value mod many
        is not included in
-         type t : mutable_data
+         type t : value mod many portable
        The kind of the first is value mod many
          because of the definition of t at line 5, characters 2-25.
-       But the kind of the first must be a subkind of mutable_data
+       But the kind of the first must be a subkind of value mod many portable
          because of the definition of t at line 3, characters 2-41.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -19,14 +19,15 @@ Error: Signature mismatch:
        Modules do not match:
          sig type 'a t end
        is not included in
-         sig type 'a t : immutable_data with 'a end
+         sig type 'a t : immutable_data with 'a @@ global aliased end
        Type declarations do not match:
          type 'a t
        is not included in
-         type 'a t : immutable_data with 'a
+         type 'a t : immutable_data with 'a @@ global aliased
        The kind of the first is value
          because of the definition of t at line 4, characters 2-11.
-       But the kind of the first must be a subkind of immutable_data with 'a
+       But the kind of the first must be a subkind of immutable_data
+         with 'a @@ global aliased
          because of the definition of t at line 2, characters 2-36.
 |}]
 
@@ -48,15 +49,20 @@ Error: Signature mismatch:
        Modules do not match:
          sig type a type t end
        is not included in
-         sig type a type t : value mod portable with a end
+         sig
+           type a
+           type t
+             : value mod portable
+             with a @@ global many aliased contended
+         end
        Type declarations do not match:
          type t
        is not included in
-         type t : value mod portable with a
+         type t : value mod portable with a @@ global many aliased contended
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
        But the kind of the first must be a subkind of value mod portable
-         with a
+         with a @@ global many aliased contended
          because of the definition of t at line 3, characters 2-36.
 |}]
 
@@ -82,7 +88,7 @@ type ('a, 'b) eq = Eq : ('a, 'a) eq
 module M :
   sig
     type a
-    type t : value mod portable with a
+    type t : value mod portable with a @@ global many aliased contended
     val a_is_int : (a, int) eq
   end
 val f : M.t -> M.t @ portable = <fun>
@@ -101,7 +107,8 @@ Line 4, characters 0-36:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "u" is value
          because of the definition of u at line 3, characters 0-6.
-       But the kind of type "u" must be a subkind of value mod global with a
+       But the kind of type "u" must be a subkind of value mod global
+         with a @@ many portable aliased contended
          because of the definition of t at line 4, characters 0-36.
 |}]
 
@@ -118,7 +125,8 @@ Line 6, characters 25-35:
                              ^^^^^^^^^^
 Error: The kind of type "t" is value
          because of the definition of t at line 5, characters 2-8.
-       But the kind of type "t" must be a subkind of value mod global with M.t
+       But the kind of type "t" must be a subkind of value mod global
+         with M.t @@ many portable aliased contended
          because of the definition of t at line 3, characters 4-38.
 |}]
 
@@ -148,15 +156,21 @@ Error: Signature mismatch:
        Modules do not match:
          sig type t : value mod portable end
        is not included in
-         sig type t : value mod uncontended portable with M.t end
+         sig
+           type t
+             : value mod uncontended portable
+             with M.t @@ global many aliased
+         end
        Type declarations do not match:
          type t : value mod portable
        is not included in
-         type t : value mod uncontended portable with M.t
+         type t
+           : value mod uncontended portable
+           with M.t @@ global many aliased
        The kind of the first is value mod portable
          because of the definition of t at line 13, characters 2-29.
        But the kind of the first must be a subkind of
-         value mod uncontended portable with M.t
+         value mod uncontended portable with M.t @@ global many aliased
          because of the definition of t at line 11, characters 2-50.
 |}]
 
@@ -188,15 +202,21 @@ Error: Signature mismatch:
        Modules do not match:
          sig type t : value mod portable end
        is not included in
-         sig type t : value mod uncontended portable with M.u end
+         sig
+           type t
+             : value mod uncontended portable
+             with M.u @@ global many aliased
+         end
        Type declarations do not match:
          type t : value mod portable
        is not included in
-         type t : value mod uncontended portable with M.u
+         type t
+           : value mod uncontended portable
+           with M.u @@ global many aliased
        The kind of the first is value mod portable
          because of the definition of t at line 15, characters 2-29.
        But the kind of the first must be a subkind of
-         value mod uncontended portable with M.u
+         value mod uncontended portable with M.u @@ global many aliased
          because of the definition of t at line 13, characters 2-50.
 |}]
 
@@ -220,15 +240,18 @@ Error: Signature mismatch:
        is not included in
          sig
            type a = [ `a of string | `b ]
-           type t : value mod global with a
+           type t
+             : value mod global
+             with a @@ many portable aliased contended
          end
        Type declarations do not match:
          type t
        is not included in
-         type t : value mod global with a
+         type t : value mod global with a @@ many portable aliased contended
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
-       But the kind of the first must be a subkind of value mod global with a
+       But the kind of the first must be a subkind of value mod global
+         with a @@ many portable aliased contended
          because of the definition of t at line 3, characters 2-34.
 |}]
 
@@ -254,18 +277,22 @@ Error: Signature mismatch:
        is not included in
          sig
            type 'a u = 'a constraint 'a = [< `a of string | `b ]
-           type 'a t : value mod global with [< `a of string | `b ] u
+           type 'a t
+             : value mod global
+             with [< `a of string | `b ] u @@ many portable aliased contended
              constraint 'a = [< `a of string | `b ]
          end
        Type declarations do not match:
          type 'a t constraint 'a = [< `a of string | `b ]
        is not included in
-         type 'a t : value mod global with [< `a of string | `b ] u
+         type 'a t
+           : value mod global
+           with [< `a of string | `b ] u @@ many portable aliased contended
            constraint 'a = [< `a of string | `b ]
        The kind of the first is value
          because of the definition of t at line 6, characters 2-49.
        But the kind of the first must be a subkind of value mod global
-         with [< `a of string | `b ] u
+         with [< `a of string | `b ] u @@ many portable aliased contended
          because of the definition of t at line 3, characters 2-40.
 |}]
 
@@ -291,18 +318,22 @@ Error: Signature mismatch:
        is not included in
          sig
            type 'a u = 'a constraint 'a = [> `a of string | `b ]
-           type 'a t : value mod portable with [> `a of string | `b ] u
+           type 'a t
+             : value mod portable
+             with [> `a of string | `b ] u @@ global many aliased contended
              constraint 'a = [> `a of string | `b ]
          end
        Type declarations do not match:
          type 'a t constraint 'a = [> `a of string | `b ]
        is not included in
-         type 'a t : value mod portable with [> `a of string | `b ] u
+         type 'a t
+           : value mod portable
+           with [> `a of string | `b ] u @@ global many aliased contended
            constraint 'a = [> `a of string | `b ]
        The kind of the first is value
          because of the definition of t at line 6, characters 2-49.
        But the kind of the first must be a subkind of value mod portable
-         with [> `a of string | `b ] u
+         with [> `a of string | `b ] u @@ global many aliased contended
          because of the definition of t at line 3, characters 2-42.
 |}]
 
@@ -324,14 +355,20 @@ Error: Signature mismatch:
        Modules do not match:
          sig type a = < value : string > type t end
        is not included in
-         sig type a = < value : string > type t : value mod global with a end
+         sig
+           type a = < value : string >
+           type t
+             : value mod global
+             with a @@ many portable aliased contended
+         end
        Type declarations do not match:
          type t
        is not included in
-         type t : value mod global with a
+         type t : value mod global with a @@ many portable aliased contended
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
-       But the kind of the first must be a subkind of value mod global with a
+       But the kind of the first must be a subkind of value mod global
+         with a @@ many portable aliased contended
          because of the definition of t at line 3, characters 2-34.
 |}]
 
@@ -406,15 +443,22 @@ Error: Signature mismatch:
        Modules do not match:
          sig type a = int ref * int type t end
        is not included in
-         sig type a = int ref * int type t : value mod uncontended with a end
+         sig
+           type a = int ref * int
+           type t
+             : value mod uncontended
+             with a @@ global many portable aliased
+         end
        Type declarations do not match:
          type t
        is not included in
-         type t : value mod uncontended with a
+         type t
+           : value mod uncontended
+           with a @@ global many portable aliased
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
        But the kind of the first must be a subkind of value mod uncontended
-         with a
+         with a @@ global many portable aliased
          because of the definition of t at line 3, characters 2-39.
 |}]
 
@@ -471,16 +515,20 @@ Error: Signature mismatch:
        is not included in
          sig
            type a = { foo : 'a. 'a; } [@@unboxed]
-           type t : value mod uncontended with a
+           type t
+             : value mod uncontended
+             with a @@ global many portable aliased
          end
        Type declarations do not match:
          type t
        is not included in
-         type t : value mod uncontended with a
+         type t
+           : value mod uncontended
+           with a @@ global many portable aliased
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
        But the kind of the first must be a subkind of value mod uncontended
-         with a
+         with a @@ global many portable aliased
          because of the definition of t at line 3, characters 2-39.
 |}]
 
@@ -506,15 +554,19 @@ Error: Signature mismatch:
        Modules do not match:
          sig type t end
        is not included in
-         sig type t : value mod portable with s end
+         sig
+           type t
+             : value mod portable
+             with s @@ global many aliased contended
+         end
        Type declarations do not match:
          type t
        is not included in
-         type t : value mod portable with s
+         type t : value mod portable with s @@ global many aliased contended
        The kind of the first is value
          because of the definition of t at line 8, characters 2-8.
        But the kind of the first must be a subkind of value mod portable
-         with s
+         with s @@ global many aliased contended
          because of the definition of t at line 6, characters 2-36.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -1,0 +1,606 @@
+(* TEST
+    flags = "-extension layouts_alpha";
+    expect;
+*)
+
+(* Test that not-best kinds are respected *)
+
+module M : sig
+  type 'a t : immutable_data with 'a
+end = struct
+  type 'a t
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t end
+       is not included in
+         sig type 'a t : immutable_data with 'a end
+       Type declarations do not match:
+         type 'a t
+       is not included in
+         type 'a t : immutable_data with 'a
+       The kind of the first is value
+         because of the definition of t at line 4, characters 2-11.
+       But the kind of the first must be a subkind of immutable_data with 'a
+         because of the definition of t at line 2, characters 2-36.
+|}]
+
+(* This appears sound to accept. But it isn't. See the following test. *)
+module M : sig
+  type a
+  type t : value mod portable with a
+end = struct
+  type a
+  type t
+end
+[%%expect {|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type a
+6 |   type t
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type a type t end
+       is not included in
+         sig type a type t : value mod portable with a end
+       Type declarations do not match:
+         type t
+       is not included in
+         type t : value mod portable with a
+       The kind of the first is value
+         because of the definition of t at line 6, characters 2-8.
+       But the kind of the first must be a subkind of value mod portable
+         with a
+         because of the definition of t at line 3, characters 2-36.
+|}]
+
+(* This test demonstrates why the above shouldn't be accepted. We can learn more about
+   a via gadt refinement *)
+type ('a, 'b) eq = Eq : ('a, 'a) eq
+
+module M : sig
+  type a
+  type t : value mod portable with a
+  val a_is_int : (a, int) eq
+end = struct
+  type a = int
+  type t : value mod portable with a
+  let a_is_int : (a, int) eq = Eq
+end
+
+let f (x : M.t @@ nonportable) : M.t @@ portable =
+  match M.a_is_int with
+  | Eq -> x
+[%%expect {|
+type ('a, 'b) eq = Eq : ('a, 'a) eq
+module M :
+  sig
+    type a
+    type t : value mod portable with a
+    val a_is_int : (a, int) eq
+  end
+val f : M.t -> M.t @ portable = <fun>
+|}]
+
+type a
+type b = a
+type u
+type t : value mod global with a = u
+[%%expect {|
+type a
+type b = a
+type u
+Line 4, characters 0-36:
+4 | type t : value mod global with a = u
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "u" is value
+         because of the definition of u at line 3, characters 0-6.
+       But the kind of type "u" must be a subkind of value mod global with a
+         because of the definition of t at line 4, characters 0-36.
+|}]
+
+module F (M : sig type t end) = struct
+  module type S = sig
+    type t : value mod global with M.t
+  end
+  type t
+  module type T = S with type t = t
+end
+[%%expect {|
+Line 6, characters 25-35:
+6 |   module type T = S with type t = t
+                             ^^^^^^^^^^
+Error: The kind of type "t" is value
+         because of the definition of t at line 5, characters 2-8.
+       But the kind of type "t" must be a subkind of value mod global with M.t
+         because of the definition of t at line 3, characters 4-38.
+|}]
+
+module type S = sig
+  type t
+end
+
+type a
+module M : S with type t = a = struct
+  type t = a
+end
+
+module _ : sig
+  type t : value mod portable uncontended with M.t
+end = struct
+  type t : value mod portable
+end
+[%%expect {|
+module type S = sig type t end
+type a
+module M : sig type t = a end
+Lines 12-14, characters 6-3:
+12 | ......struct
+13 |   type t : value mod portable
+14 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t : value mod portable end
+       is not included in
+         sig type t : value mod uncontended portable with M.t end
+       Type declarations do not match:
+         type t : value mod portable
+       is not included in
+         type t : value mod uncontended portable with M.t
+       The kind of the first is value mod portable
+         because of the definition of t at line 13, characters 2-29.
+       But the kind of the first must be a subkind of
+         value mod uncontended portable with M.t
+         because of the definition of t at line 11, characters 2-50.
+|}]
+
+module type S = sig
+  type t
+  type u = t
+end
+
+type a
+module M : S with type t := a = struct
+  type t = a
+  type u = a
+end
+
+module M : sig
+  type t : value mod portable uncontended with M.u
+end = struct
+  type t : value mod portable
+end
+[%%expect {|
+module type S = sig type t type u = t end
+type a
+module M : sig type u = a end
+Lines 14-16, characters 6-3:
+14 | ......struct
+15 |   type t : value mod portable
+16 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t : value mod portable end
+       is not included in
+         sig type t : value mod uncontended portable with M.u end
+       Type declarations do not match:
+         type t : value mod portable
+       is not included in
+         type t : value mod uncontended portable with M.u
+       The kind of the first is value mod portable
+         because of the definition of t at line 15, characters 2-29.
+       But the kind of the first must be a subkind of
+         value mod uncontended portable with M.u
+         because of the definition of t at line 13, characters 2-50.
+|}]
+
+module M : sig
+  type a = [`a of string | `b]
+  type t : value mod global with a
+end = struct
+  type a = [`a of string | `b]
+  type t
+end
+(* CR layouts v2.8: this is fine to accept *)
+[%%expect {|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type a = [`a of string | `b]
+6 |   type t
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type a = [ `a of string | `b ] type t end
+       is not included in
+         sig
+           type a = [ `a of string | `b ]
+           type t : value mod global with a
+         end
+       Type declarations do not match:
+         type t
+       is not included in
+         type t : value mod global with a
+       The kind of the first is value
+         because of the definition of t at line 6, characters 2-8.
+       But the kind of the first must be a subkind of value mod global with a
+         because of the definition of t at line 3, characters 2-34.
+|}]
+
+module M : sig
+  type 'a u = [< `a of string | `b] as 'a
+  type 'a t : value mod global with 'a u
+end = struct
+  type 'a u = [< `a of string | `b] as 'a
+  type 'a t constraint 'a = [< `a of string | `b]
+end
+[%%expect {|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type 'a u = [< `a of string | `b] as 'a
+6 |   type 'a t constraint 'a = [< `a of string | `b]
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type 'a u = 'a constraint 'a = [< `a of string | `b ]
+           type 'a t constraint 'a = [< `a of string | `b ]
+         end
+       is not included in
+         sig
+           type 'a u = 'a constraint 'a = [< `a of string | `b ]
+           type 'a t : value mod global with [< `a of string | `b ] u
+             constraint 'a = [< `a of string | `b ]
+         end
+       Type declarations do not match:
+         type 'a t constraint 'a = [< `a of string | `b ]
+       is not included in
+         type 'a t : value mod global with [< `a of string | `b ] u
+           constraint 'a = [< `a of string | `b ]
+       The kind of the first is value
+         because of the definition of t at line 6, characters 2-49.
+       But the kind of the first must be a subkind of value mod global
+         with [< `a of string | `b ] u
+         because of the definition of t at line 3, characters 2-40.
+|}]
+
+module M : sig
+  type 'a u = [> `a of string | `b] as 'a
+  type 'a t : value mod portable with 'a u
+end = struct
+  type 'a u = [> `a of string | `b] as 'a
+  type 'a t constraint 'a = [> `a of string | `b]
+end
+[%%expect {|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type 'a u = [> `a of string | `b] as 'a
+6 |   type 'a t constraint 'a = [> `a of string | `b]
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type 'a u = 'a constraint 'a = [> `a of string | `b ]
+           type 'a t constraint 'a = [> `a of string | `b ]
+         end
+       is not included in
+         sig
+           type 'a u = 'a constraint 'a = [> `a of string | `b ]
+           type 'a t : value mod portable with [> `a of string | `b ] u
+             constraint 'a = [> `a of string | `b ]
+         end
+       Type declarations do not match:
+         type 'a t constraint 'a = [> `a of string | `b ]
+       is not included in
+         type 'a t : value mod portable with [> `a of string | `b ] u
+           constraint 'a = [> `a of string | `b ]
+       The kind of the first is value
+         because of the definition of t at line 6, characters 2-49.
+       But the kind of the first must be a subkind of value mod portable
+         with [> `a of string | `b ] u
+         because of the definition of t at line 3, characters 2-42.
+|}]
+
+module M : sig
+  type a = < value : string >
+  type t : value mod global with a
+end = struct
+  type a = < value : string >
+  type t
+end
+(* CR layouts v2.8: this is fine to accept *)
+[%%expect {|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type a = < value : string >
+6 |   type t
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type a = < value : string > type t end
+       is not included in
+         sig type a = < value : string > type t : value mod global with a end
+       Type declarations do not match:
+         type t
+       is not included in
+         type t : value mod global with a
+       The kind of the first is value
+         because of the definition of t at line 6, characters 2-8.
+       But the kind of the first must be a subkind of value mod global with a
+         because of the definition of t at line 3, characters 2-34.
+|}]
+
+(* CR layouts v2.8: gadts shouldn't be "best" because we intend to give them more refined
+   jkinds in the future. So this program will error in the future. *)
+type gadt = Foo : int -> gadt
+module M : sig
+  type t : value mod portable with gadt
+end = struct
+  type t
+end
+[%%expect {|
+type gadt = Foo : int -> gadt
+module M : sig type t end
+|}]
+
+(* CR layouts v2.8: gadts shouldn't be "best". But maybe they should track quality along
+   individual axes, and so this should be accepted anyways? *)
+type gadt = Foo : int -> gadt
+module M : sig
+  type t : value mod global with gadt
+end = struct
+  type t
+end
+[%%expect {|
+type gadt = Foo : int -> gadt
+module M : sig type t end
+|}]
+
+type gadt = Foo : int -> gadt [@@unboxed]
+module M : sig
+  type t : value mod portable with gadt
+end = struct
+  type t
+end
+[%%expect {|
+type gadt = Foo : int -> gadt [@@unboxed]
+Lines 4-6, characters 6-3:
+4 | ......struct
+5 |   type t
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t end
+       is not included in
+         sig type t : value mod portable end
+       Type declarations do not match:
+         type t
+       is not included in
+         type t : value mod portable
+       The kind of the first is value
+         because of the definition of t at line 5, characters 2-8.
+       But the kind of the first must be a subkind of value mod portable
+         because of the definition of t at line 3, characters 2-39.
+|}]
+
+module M : sig
+  type a = int ref * int
+  type t : value mod uncontended with a
+end = struct
+  type a = int ref * int
+  type t
+end
+(* CR layouts v2.8: this should be accepted *)
+[%%expect {|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type a = int ref * int
+6 |   type t
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type a = int ref * int type t end
+       is not included in
+         sig type a = int ref * int type t : value mod uncontended with a end
+       Type declarations do not match:
+         type t
+       is not included in
+         type t : value mod uncontended with a
+       The kind of the first is value
+         because of the definition of t at line 6, characters 2-8.
+       But the kind of the first must be a subkind of value mod uncontended
+         with a
+         because of the definition of t at line 3, characters 2-39.
+|}]
+
+module M : sig
+  type a = #(int ref * int)
+  type t : value mod uncontended with a
+end = struct
+  type a = #(int ref * int)
+  type t
+end
+[%%expect {|
+module M : sig type a = #(int ref * int) type t end
+|}]
+
+module M : sig
+  type a = int -> int
+  type t : value mod portable with a
+end = struct
+  type a = int -> int
+  type t
+end
+[%%expect {|
+module M : sig type a = int -> int type t end
+|}]
+
+module M : sig
+  type a = { foo : 'a. 'a ref } [@@unboxed]
+  type t : value mod uncontended with a
+end = struct
+  type a = { foo : 'a. 'a ref } [@@unboxed]
+  type t
+end
+[%%expect {|
+module M : sig type a = { foo : 'a. 'a ref; } [@@unboxed] type t end
+|}]
+
+module M : sig
+  type a = { foo : ('a : value). 'a } [@@unboxed]
+  type t : value mod uncontended with a
+end = struct
+  type a = { foo : ('a : value). 'a } [@@unboxed]
+  type t
+end
+(* CR layouts v2.8: maybe this should be accepted? *)
+[%%expect {|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type a = { foo : ('a : value). 'a } [@@unboxed]
+6 |   type t
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type a = { foo : 'a. 'a; } [@@unboxed] type t end
+       is not included in
+         sig
+           type a = { foo : 'a. 'a; } [@@unboxed]
+           type t : value mod uncontended with a
+         end
+       Type declarations do not match:
+         type t
+       is not included in
+         type t : value mod uncontended with a
+       The kind of the first is value
+         because of the definition of t at line 6, characters 2-8.
+       But the kind of the first must be a subkind of value mod uncontended
+         with a
+         because of the definition of t at line 3, characters 2-39.
+|}]
+
+module type S = sig 
+  val nonportable_f : int -> int
+end
+type s = (module S)
+module M : sig
+  type t : value mod portable with s
+end = struct
+  type t
+end
+(* CR layouts v2.8: this should be accepted because module types should be best
+   (once we start giving them proper kinds) *)
+[%%expect {|
+module type S = sig val nonportable_f : int -> int end
+type s = (module S)
+Lines 7-9, characters 6-3:
+7 | ......struct
+8 |   type t
+9 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t end
+       is not included in
+         sig type t : value mod portable with s end
+       Type declarations do not match:
+         type t
+       is not included in
+         type t : value mod portable with s
+       The kind of the first is value
+         because of the definition of t at line 8, characters 2-8.
+       But the kind of the first must be a subkind of value mod portable
+         with s
+         because of the definition of t at line 6, characters 2-36.
+|}]
+
+type a : value = private int
+module M : sig
+  type t : value mod portable with a
+end = struct
+  type t
+end
+[%%expect {|
+type a = private int
+Lines 4-6, characters 6-3:
+4 | ......struct
+5 |   type t
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t end
+       is not included in
+         sig type t : value mod portable end
+       Type declarations do not match:
+         type t
+       is not included in
+         type t : value mod portable
+       The kind of the first is value
+         because of the definition of t at line 5, characters 2-8.
+       But the kind of the first must be a subkind of value mod portable
+         because of the definition of t at line 3, characters 2-36.
+|}]
+
+type a : value mod many = private string
+module M : sig
+  type t : value mod many portable with a
+end = struct
+  type t : value mod many
+end
+[%%expect {|
+type a = private string
+Lines 4-6, characters 6-3:
+4 | ......struct
+5 |   type t : value mod many
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t : value mod many end
+       is not included in
+         sig type t : mutable_data end
+       Type declarations do not match:
+         type t : value mod many
+       is not included in
+         type t : mutable_data
+       The kind of the first is value mod many
+         because of the definition of t at line 5, characters 2-25.
+       But the kind of the first must be a subkind of mutable_data
+         because of the definition of t at line 3, characters 2-41.
+|}]
+
+type a = { foo : int -> int }
+module M : sig
+  type t : value mod portable with a
+end = struct
+  type t
+end
+[%%expect {|
+type a = { foo : int -> int; }
+module M : sig type t end
+|}]
+
+type a = Foo of (int -> int)
+module M : sig
+  type t : value mod portable with a
+end = struct
+  type t
+end
+[%%expect {|
+type a = Foo of (int -> int)
+module M : sig type t end
+|}]
+
+type a = ..
+module M : sig
+  type t : value mod portable with a
+end = struct
+  type t
+end
+[%%expect {|
+type a = ..
+module M : sig type t end
+|}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
@@ -1,0 +1,256 @@
+(* TEST
+    flags = "-extension layouts_alpha";
+    expect;
+*)
+
+type 'a my_list : immutable_data with 'a = Nil | Cons of 'a * 'a my_list
+[%%expect {|
+type 'a my_list = Nil | Cons of 'a * 'a my_list
+|}]
+
+type 'a my_list : immutable_data with 'a = 'a list = [] | ( :: ) of 'a * 'a my_list
+[%%expect {|
+type 'a my_list = 'a list = [] | (::) of 'a * 'a my_list
+|}]
+
+type 'a my_list : immutable_data with 'a = Nil | Cons of 'a * 'a foo
+and 'a foo = 'a my_list
+[%%expect {|
+type 'a my_list = Nil | Cons of 'a * 'a foo
+and 'a foo = 'a my_list
+|}]
+
+(* CR layouts v2.8: this should be accepted *)
+type 'a my_list : immutable_data with 'a =
+  | Nil
+  | Cons of 'a * 'a my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list
+(* CR layouts v2.8: consider making the error message say something about running out of fuel *)
+[%%expect {|
+Line 3, characters 17-115:
+3 |   | Cons of 'a * 'a my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Layout mismatch in final type declaration consistency check.
+       This is most often caused by the fact that type inference is not
+       clever enough to propagate layouts through variables in different
+       declarations. It is also not clever enough to produce a good error
+       message, so we'll say this instead:
+         The layout of 'a my_list my_list my_list my_list my_list my_list
+                       my_list my_list my_list my_list my_list is any
+           because the .cmi file for my_list is missing.
+         But the layout of 'a my_list my_list my_list my_list my_list my_list
+                           my_list my_list my_list my_list my_list must be a sublayout of value
+           because it instantiates an unannotated type parameter of my_list,
+           chosen to have layout value.
+         No .cmi file found containing my_list.
+       A good next step is to add a layout annotation on a parameter to
+       the declaration where this error is reported.
+|}]
+
+type 'a mutable_list : mutable_data with 'a = Nil | Cons of 'a ref * 'a mutable_list
+[%%expect {|
+type 'a mutable_list = Nil | Cons of 'a ref * 'a mutable_list
+|}]
+
+type 'a mutable_list : mutable_data with 'a = Nil | Cons of { mutable hd : 'a; tl : 'a mutable_list }
+[%%expect {|
+type 'a mutable_list =
+    Nil
+  | Cons of { mutable hd : 'a; tl : 'a mutable_list; }
+|}]
+
+type ('a : immutable_data) immutable_list : immutable_data = Nil | Cons of 'a * 'a immutable_list
+[%%expect {|
+type ('a : immutable_data) immutable_list =
+    Nil
+  | Cons of 'a * 'a immutable_list
+|}]
+
+(* CR layouts v2.8: this should be accepted *)
+(* CR layouts v2.8: this error message is bad *)
+type 'a degenerate : immutable_data with 'a = Leaf of 'a | Branch of ('a * 'a) degenerate
+[%%expect {|
+Line 1, characters 0-89:
+1 | type 'a degenerate : immutable_data with 'a = Leaf of 'a | Branch of ('a * 'a) degenerate
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "degenerate" is immutable_data with 'a with 'a * 'a
+         with ('a * 'a) * ('a * 'a)
+         with (('a * 'a) * ('a * 'a)) * (('a * 'a) * ('a * 'a))
+         with (((('a * 'a) * ('a * 'a)) * (('a * 'a) * ('a * 'a))) *
+ ((('a * 'a) * ('a * 'a)) * (('a * 'a) * ('a * 'a))))
+degenerate
+         because it's a boxed variant type.
+       But the kind of type "degenerate" must be a subkind of immutable_data
+         with 'a
+         because of the annotation on the declaration of the type degenerate.
+|}]
+
+type ('a, 'b) zipped_list : immutable_data with 'a with 'b = Nil | Cons of 'a * 'b * ('a, 'b) zipped_list
+[%%expect {|
+type ('a, 'b) zipped_list = Nil | Cons of 'a * 'b * ('a, 'b) zipped_list
+|}]
+
+module rec My_list : sig
+  type 'a t : immutable_data with 'a = Nil | Cons of 'a * 'a My_list.t
+end = My_list
+(* CR layouts v2.8: fix this *)
+[%%expect {|
+>> Fatal error: I do not yet know how to deal with [with]-types (such as
+                'a)
+                in recursive modules. Please contact the Jane Street OCaml Language
+                team for help if you see this.
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+module rec My_list : sig
+  type 'a t = Nil | Cons of 'a * 'a My_list.t
+end = My_list
+module My_list = struct
+  type 'a t : immutable_data with 'a = 'a My_list.t
+end
+[%%expect {|
+module rec My_list : sig type 'a t = Nil | Cons of 'a * 'a My_list.t end
+module My_list : sig type 'a t = 'a My_list.t end
+|}]
+
+module rec My_int_list : sig
+  type t : immutable_data = Nil | Cons of int * My_int_list.t
+end = My_int_list
+[%%expect {|
+module rec My_int_list : sig type t = Nil | Cons of int * My_int_list.t end
+|}]
+
+module rec My_list : sig
+  type 'a t = Nil | Cons of 'a * 'a Foo.t
+end = My_list
+
+and Foo : sig
+  type 'a t = 'a My_list.t
+end = Foo
+
+module My_list = struct
+  type 'a t : immutable_data with 'a = 'a My_list.t
+end
+
+module Foo = struct
+  type 'a t : immutable_data with 'a = 'a Foo.t
+end
+[%%expect {|
+module rec My_list : sig type 'a t = Nil | Cons of 'a * 'a Foo.t end
+and Foo : sig type 'a t = 'a My_list.t end
+module My_list : sig type 'a t = 'a My_list.t end
+module Foo : sig type 'a t = 'a Foo.t end
+|}]
+
+type 'a my_list : immutable_data with 'a = Nil | Cons of 'a * 'a foo
+and 'a foo = 'a my_list
+[%%expect {|
+type 'a my_list = Nil | Cons of 'a * 'a foo
+and 'a foo = 'a my_list
+|}]
+
+(* This test was failing at one point due to insufficient fuel and an unnecessary
+   subsumption check when there is both a manifest and a kind. *)
+type info
+
+module Types = struct
+   module rec Ivar : sig
+     type 'a t
+   end =
+     Ivar
+
+   and Forwarding : sig
+     type t =
+       | Parent of Monitor.t
+   end =
+     Forwarding
+
+   and Monitor : sig
+     type t =
+       { name : info
+       ; mutable next_error : exn Ivar.t
+       ; mutable tails_for_all_errors : exn Tail.t
+       ; mutable forwarding : Forwarding.t
+       }
+   end =
+     Monitor
+
+   and Tail : sig
+     type 'a t = {  next : 'a Ivar.t }
+   end =
+     Tail
+
+   type 'a ivar
+   and forwarding = | Parent of monitor
+   and 'a tail = { next : 'a ivar }
+   and monitor = { name : info
+   ; mutable next_error : exn ivar
+   ; mutable tails_for_all_errors : exn tail
+   ; mutable forwarding : forwarding
+   }
+end
+
+type t =
+  { name : info
+  ; mutable next_error : exn Types.Ivar.t
+  ; mutable tails_for_all_errors : exn Types.Tail.t
+  ; mutable forwarding : Types.Forwarding.t
+  }
+[%%expect {|
+type info
+module Types :
+  sig
+    module rec Ivar : sig type 'a t end
+    and Forwarding : sig type t = Parent of Monitor.t end
+    and Monitor :
+      sig
+        type t = {
+          name : info;
+          mutable next_error : exn Ivar.t;
+          mutable tails_for_all_errors : exn Tail.t;
+          mutable forwarding : Forwarding.t;
+        }
+      end
+    and Tail : sig type 'a t = { next : 'a Ivar.t; } end
+    type 'a ivar
+    and forwarding = Parent of monitor
+    and 'a tail = { next : 'a ivar; }
+    and monitor = {
+      name : info;
+      mutable next_error : exn ivar;
+      mutable tails_for_all_errors : exn tail;
+      mutable forwarding : forwarding;
+    }
+  end
+type t = {
+  name : info;
+  mutable next_error : exn Types.Ivar.t;
+  mutable tails_for_all_errors : exn Types.Tail.t;
+  mutable forwarding : Types.Forwarding.t;
+}
+|}]
+
+type 'a t : immutable_data = Leaf | Node of int * 'a t
+[%%expect {|
+type 'a t = Leaf | Node of int * 'a t
+|}]
+
+type 'a mutable_list : mutable_data  = Nil | Cons of int ref * 'a mutable_list
+[%%expect {|
+type 'a mutable_list = Nil | Cons of int ref * 'a mutable_list
+|}]
+
+type t1
+type 'a t2 : immutable_data with 'a with t1 = Leaf of 'a | Node of 'a * t1 t2
+(* CR layouts v2.8: this should be accepted *)
+[%%expect {|
+type t1
+Line 2, characters 0-77:
+2 | type 'a t2 : immutable_data with 'a with t1 = Leaf of 'a | Node of 'a * t1 t2
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t2" is immutable_data with 'a with t1 with t1 t2
+         because it's a boxed variant type.
+       But the kind of type "t2" must be a subkind of immutable_data with 'a
+         with t1
+         because of the annotation on the declaration of the type t2.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
@@ -72,12 +72,14 @@ type 'a degenerate : immutable_data with 'a = Leaf of 'a | Branch of ('a * 'a) d
 Line 1, characters 0-89:
 1 | type 'a degenerate : immutable_data with 'a = Leaf of 'a | Branch of ('a * 'a) degenerate
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "degenerate" is immutable_data with 'a with 'a * 'a
-         with ('a * 'a) * ('a * 'a)
-         with (('a * 'a) * ('a * 'a)) * (('a * 'a) * ('a * 'a))
+Error: The kind of type "degenerate" is immutable_data
+         with 'a @@ global aliased with 'a * 'a @@ global aliased
+         with ('a * 'a) * ('a * 'a) @@ global aliased
+         with (('a * 'a) * ('a * 'a)) * (('a * 'a) * ('a * 'a)) @@ global aliased
+
          with (((('a * 'a) * ('a * 'a)) * (('a * 'a) * ('a * 'a))) *
  ((('a * 'a) * ('a * 'a)) * (('a * 'a) * ('a * 'a))))
-degenerate
+degenerate @@ global aliased
          because it's a boxed variant type.
        But the kind of type "degenerate" must be a subkind of immutable_data
          with 'a
@@ -248,7 +250,8 @@ type t1
 Line 2, characters 0-77:
 2 | type 'a t2 : immutable_data with 'a with t1 = Leaf of 'a | Node of 'a * t1 t2
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t2" is immutable_data with 'a with t1 with t1 t2
+Error: The kind of type "t2" is immutable_data with 'a @@ global aliased
+         with t1 @@ global aliased with t1 t2 @@ global aliased
          because it's a boxed variant type.
        But the kind of type "t2" must be a subkind of immutable_data with 'a
          with t1

--- a/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha";
+    flags = "-extension layouts_alpha -infer-with-bounds";
     expect;
 *)
 

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -10,7 +10,6 @@ module Or_null = struct
     | Null
     | This of 'a
 end
-
 [%%expect{|
 Lines 2-4, characters 2-16:
 2 | ..type ('a : value) t : value_or_null = 'a or_null =
@@ -21,13 +20,10 @@ Error: This variant or record definition does not match that of type
        Their internal representations differ:
        the original definition has a null constructor.
 |}]
-(* CR aspsmith: this should be rejected; don't merge this PR unless it is (I believe this
-   will happen once we rebase on main) *)
 
 module Or_null = struct
   type ('a : value) t : value_or_null = 'a or_null
 end
-
 [%%expect{|
 module Or_null : sig type 'a t = 'a or_null end
 |}]
@@ -59,7 +55,6 @@ module Or_null = struct
 end
 let n = Or_null.Null
 let t v = Or_null.This v
-
 [%%expect{|
 module Or_null :
   sig type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport] end

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -7031,7 +7031,7 @@ let check_decl_jkind env decl jkind =
   let type_equal = type_equal env in
   let jkind_of_type ty = Some (type_jkind_purely env ty) in
   match Jkind.sub_jkind_l ~type_equal ~jkind_of_type decl.type_jkind jkind with
-  | Ok _ -> Ok ()
+  | Ok () -> Ok ()
   | Error _ as err ->
     match decl.type_manifest with
     | None -> err
@@ -7040,7 +7040,7 @@ let check_decl_jkind env decl jkind =
          think not. *)
       let ty_jkind = type_jkind env ty in
       match Jkind.sub_jkind_l ~type_equal ~jkind_of_type ty_jkind jkind with
-      | Ok _ -> Ok ()
+      | Ok () -> Ok ()
       | Error _ as err -> err
 
 let constrain_decl_jkind env decl jkind =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1341,8 +1341,18 @@ module Jkind_desc = struct
   let equate_or_equal ~allow_mutation t1 t2 =
     Layout_and_axes.equal (Layout.equate_or_equal ~allow_mutation) t1 t2
 
-  let normalize (type l r) ~jkind_of_type ~require_best (t : (l * r) jkind_desc)
-      : (l * disallowed) jkind_desc =
+  type 'd normalize_side =
+    | (** Normalize a left jkind, dropping not-best types in with-bounds and leaving
+          bounds at their conservative maximum *)
+      L : ('l * disallowed) normalize_side
+    | LR : ('l * 'r) normalize_side
+
+  let normalize
+        (type l1 r1 l2 r2)
+        ~jkind_of_type
+        (side : (l2 * r2) normalize_side)
+        (t : (l1 * r1) jkind_desc)
+      : (l2 * r2) jkind_desc =
     (* Sadly, it seems hard (impossible?) to be sure to expand all types
        here without using a fuel parameter to stop infinite regress. Here
        is a nasty case:

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -352,15 +352,13 @@ module With_bounds = struct
       let open Format in
       fprintf ppf "@[{ relevant_axes = %a }]" Axis_set.print relevant_axes
 
-    let is_on_axis (type a) ~(axis : a Axis.t) { relevant_axes } =
-      Axis_set.mem relevant_axes axis
-
     let join { relevant_axes = axes1 } { relevant_axes = axes2 } =
       { relevant_axes = Axis_set.union axes1 axes2 }
   end
 
-  let of_with_bounds_types tys =
-    if With_bounds_types.is_empty tys then No_with_bounds else With_bounds tys
+  let to_best_eff_map = function
+    | No_with_bounds -> With_bounds_types.empty
+    | With_bounds bounds -> bounds
 
   let to_list : type d. d with_bounds -> _ = function
     | No_with_bounds -> []
@@ -403,15 +401,6 @@ module With_bounds = struct
         |> Seq.map (fun (ty, ti) -> f ty, ti)
         |> With_bounds_types.of_seq)
 
-  let types_on_axis (type l r a) ~(axis : a Jkind_axis.Axis.t) : (l * r) t -> _
-      = function
-    | No_with_bounds -> []
-    | With_bounds tys ->
-      tys |> With_bounds_types.to_seq
-      |> Seq.filter_map (fun (te, ti) ->
-             if Type_info.is_on_axis ~axis ti then Some te else None)
-      |> List.of_seq
-
   let debug_print (type l r) ~print_type_expr ppf : (l * r) t -> _ =
     let open Format in
     function
@@ -425,14 +414,6 @@ module With_bounds = struct
         (With_bounds_types.to_seq tys)
 
   let join_bounds =
-    With_bounds_types.merge (fun _ ti1 ti2 ->
-        match ti1, ti2 with
-        | None, None -> None
-        | Some ti, None -> Some ti
-        | None, Some ti -> Some ti
-        | Some ti1, Some ti2 -> Some (Type_info.join ti1 ti2))
-
-  let join_bounds_maybe_empty =
     With_bounds_types.merge (fun _ ti1 ti2 ->
         match ti1, ti2 with
         | None, None -> None
@@ -463,8 +444,14 @@ module With_bounds = struct
         | None -> Some type_info | Some ti -> Some (Type_info.join ti type_info))
       tys
 
-  let add ~relevant_for_nullability ~modality ~type_expr (t : (allowed * 'r) t)
-      : (allowed * 'r) t =
+  let add type_expr type_info bounds =
+    match bounds with
+    | No_with_bounds ->
+      With_bounds (With_bounds_types.singleton type_expr type_info)
+    | With_bounds bounds -> With_bounds (add_bound type_expr type_info bounds)
+
+  let add_modality ~relevant_for_nullability ~modality ~type_expr
+      (t : (allowed * 'r) t) : (allowed * 'r) t =
     let relevant_axes =
       Jkind_axis.Axis_set.create ~f:(fun ~axis:(Pack axis) ->
           match axis with
@@ -491,7 +478,9 @@ module With_bounds = struct
     in
     match t with
     | No_with_bounds ->
-      With_bounds (With_bounds_types.singleton type_expr { relevant_axes })
+      With_bounds
+        (With_bounds_types.singleton type_expr
+           ({ relevant_axes } : With_bounds_type_info.t))
     | With_bounds tys -> With_bounds (add_bound type_expr { relevant_axes } tys)
 end
 
@@ -562,15 +551,6 @@ module Mod_bounds = struct
             Bound_ops.meet)
       }
 
-  let le =
-    Fold2.f
-      { f =
-          (fun (type axis) ~(axis : axis Axis.t) ->
-            let (module Bound_ops) = Axis.get axis in
-            Bound_ops.le)
-      }
-      ~combine:( && )
-
   let less_or_equal =
     Fold2.f
       { f =
@@ -588,6 +568,13 @@ module Mod_bounds = struct
             Bound_ops.equal)
       }
       ~combine:( && )
+
+  (** Get all axes that are set to max *)
+  let get_max_axes t =
+    Axis_set.create ~f:(fun ~axis:(Pack axis) ->
+        let (module Axis_ops) = Axis.get axis in
+        let bound = get ~axis t in
+        Axis_ops.le Axis_ops.max bound)
 
   let for_arrow =
     simple ~linearity:Linearity.Const.max ~locality:Locality.Const.max
@@ -693,10 +680,6 @@ module Quality = struct
     function
     | Not_best -> Some Not_best
     | Best -> None
-
-  let is_best : type l r. (l * r) jkind_quality -> bool = function
-    | Best -> true
-    | Not_best -> false
 end
 
 include Allowance.Magic_allow_disallow (struct
@@ -1250,8 +1233,9 @@ module Const = struct
         { layout = base.layout;
           mod_bounds = base.mod_bounds;
           with_bounds =
-            With_bounds.add ~modality ~relevant_for_nullability:`Irrelevant
-              ~type_expr:type_ base.with_bounds
+            With_bounds.add_modality ~modality
+              ~relevant_for_nullability:`Irrelevant ~type_expr:type_
+              base.with_bounds
         })
     | Default | Kind_of _ -> raise ~loc:jkind.pjkind_loc Unimplemented_syntax
 
@@ -1332,8 +1316,8 @@ module Jkind_desc = struct
     | _ ->
       { t with
         with_bounds =
-          With_bounds.add ~relevant_for_nullability ~type_expr ~modality
-            t.with_bounds
+          With_bounds.add_modality ~relevant_for_nullability ~type_expr
+            ~modality t.with_bounds
       }
 
   let max = of_const Const.max
@@ -1341,18 +1325,34 @@ module Jkind_desc = struct
   let equate_or_equal ~allow_mutation t1 t2 =
     Layout_and_axes.equal (Layout.equate_or_equal ~allow_mutation) t1 t2
 
-  type 'd normalize_side =
-    | (** Normalize a left jkind, dropping not-best types in with-bounds and leaving
-          bounds at their conservative maximum *)
-      L : ('l * disallowed) normalize_side
-    | LR : ('l * 'r) normalize_side
+  type 'd normalize_mode =
+    | Require_best : ('l * disallowed) normalize_mode
+    | Ignore_best : ('l * 'r) normalize_mode
 
-  let normalize
-        (type l1 r1 l2 r2)
-        ~jkind_of_type
-        (side : (l2 * r2) normalize_side)
-        (t : (l1 * r1) jkind_desc)
-      : (l2 * r2) jkind_desc =
+  module Fuel_status = struct
+    type t =
+      | Ran_out_of_fuel
+      | Sufficient_fuel
+
+    let both a b =
+      match a, b with
+      | Ran_out_of_fuel, _ | _, Ran_out_of_fuel -> Ran_out_of_fuel
+      | Sufficient_fuel, Sufficient_fuel -> Sufficient_fuel
+  end
+
+  (* Normalize the jkind. If mode is Require_best, only jkinds that are best will be used.
+     If mode is Ignore_best, then Not_best will be used. Since Ignore_best can use
+     Not_best, the result is guaranteed to have no with-bounds.
+
+     At each step during normalization, before expanding a type, [map_type_info] is used
+     to map the type-info for the type being expanded. The type can be prevented from
+     being expanded by mapping the relevant axes to an empty set. [map_type_info] is used
+     by sub_jkind_l to remove irrelevant axes. *)
+  let map_normalize (type l1 r1 l2 r2) ~jkind_of_type
+      ~(mode : (l2 * r2) normalize_mode)
+      ~(map_type_info :
+         type_expr -> With_bounds_type_info.t -> With_bounds_type_info.t)
+      (t : (l1 * r1) jkind_desc) : (l2 * r2) jkind_desc * Fuel_status.t =
     (* Sadly, it seems hard (impossible?) to be sure to expand all types
        here without using a fuel parameter to stop infinite regress. Here
        is a nasty case:
@@ -1394,26 +1394,30 @@ module Jkind_desc = struct
     let module Loop_control = struct
       type t =
         { tuple_fuel : int;
-          constr : (int * type_expr list) Path.Map.t
+          constr : (int * type_expr list) Path.Map.t;
+          fuel_status : Fuel_status.t
         }
 
       type result =
-        | Stop (* give up, returning [max] *)
+        | Stop of t (* give up, returning [max] *)
         | Skip (* skip reducing this type, but otherwise continue *)
         | Continue of t (* continue, with a new [t] *)
 
       let initial_fuel_per_ty = 2
 
       let starting =
-        { tuple_fuel = initial_fuel_per_ty; constr = Path.Map.empty }
+        { tuple_fuel = initial_fuel_per_ty;
+          constr = Path.Map.empty;
+          fuel_status = Sufficient_fuel
+        }
 
-      let rec check ({ tuple_fuel; constr } as t) ty =
+      let rec check ({ tuple_fuel; constr; fuel_status = _ } as t) ty =
         match Types.get_desc ty with
         | Tpoly (ty, _) -> check t ty
         | Ttuple _ ->
           if tuple_fuel > 0
           then Continue { t with tuple_fuel = tuple_fuel - 1 }
-          else Stop
+          else Stop { t with fuel_status = Ran_out_of_fuel }
         | Tconstr (p, args, _) -> (
           match Path.Map.find_opt p constr with
           | None ->
@@ -1432,7 +1436,7 @@ module Jkind_desc = struct
             then
               Continue
                 { t with constr = Path.Map.add p (fuel - 1, args) constr }
-            else Stop)
+            else Stop { t with fuel_status = Ran_out_of_fuel })
         | Tvar _ | Tarrow _ | Tunboxed_tuple _ | Tobject _ | Tfield _ | Tnil
         | Tvariant _ | Tunivar _ | Tpackage _ ->
           (* these cases either cannot be infinitely recursive or their jkinds
@@ -1442,103 +1446,114 @@ module Jkind_desc = struct
           Continue t
         | Tlink _ | Tsubst _ -> Misc.fatal_error "Tlink or Tsubst in normalize"
     end in
-    let rec loop ctl bounds_so_far :
+    let rec loop (ctl : Loop_control.t) bounds_so_far :
         (type_expr * With_bounds_type_info.t) list ->
-        Mod_bounds.t * with_bounds_types = function
+        Mod_bounds.t * (l2 * r2) with_bounds * Fuel_status.t = function
       (* early cutoff *)
-      | _ when Mod_bounds.le Mod_bounds.max bounds_so_far ->
-        bounds_so_far, With_bounds_types.empty
-      | [] -> bounds_so_far, With_bounds_types.empty
+      | _
+        when Misc.Le_result.is_le
+               (Mod_bounds.less_or_equal Mod_bounds.max bounds_so_far) ->
+        (* CR layouts v2.8: we can do better by early-terminating on a per-axis basis *)
+        bounds_so_far, No_with_bounds, Sufficient_fuel
+      | [] -> bounds_so_far, No_with_bounds, ctl.fuel_status
       | (ty, ti) :: bs -> (
-        let omit (type a) (axis : a Axis.t) =
-          not (Axis_set.mem ti.relevant_axes axis)
+        (* Map the type's info before expanding the type *)
+        let ti = map_type_info ty ti in
+        (* We don't care about axes that are already max because they can't get any
+           better or worse. By ignoring them, we may be able to terminate early *)
+        let ti : With_bounds_type_info.t =
+          { relevant_axes =
+              Axis_set.diff ti.relevant_axes
+                (Mod_bounds.get_max_axes bounds_so_far)
+          }
         in
-        let join_respecting_omit bound =
-          Mod_bounds.Map2.f
-            { f =
-                (fun (type a) ~(axis : a Axis.t) b1 b2 ->
-                  if omit axis
-                  then b1
-                  else
-                    let (module Bound_ops) = Axis.get axis in
-                    Bound_ops.join b1 b2)
-            }
-            bounds_so_far bound
-        in
-        match Loop_control.check ctl ty with
-        | Stop ->
-          (* out of fuel *)
-          join_respecting_omit Mod_bounds.max, With_bounds_types.of_list bs
-        | Skip -> loop ctl bounds_so_far bs (* skip [ty] *)
-        | Continue ctl_after_unpacking_b -> (
-          match jkind_of_type ty with
-          | Some b_jkind ->
-            if Quality.is_best b_jkind.quality || not require_best
-            then
+        match Axis_set.is_empty ti.relevant_axes with
+        | true ->
+          (* If [ty] is not relevant to any axes, then we can safely drop it and thereby
+             avoid doing the work of expanding it. *)
+          loop ctl bounds_so_far bs
+        | false -> (
+          let join_bounds b1 b2 ~relevant_axes =
+            Mod_bounds.Map2.f
+              { f =
+                  (fun (type a) ~(axis : a Axis.t) b1 b2 ->
+                    if Axis_set.mem relevant_axes axis
+                    then
+                      let (module Bound_ops) = Axis.get axis in
+                      Bound_ops.join b1 b2
+                    else b1)
+              }
+              b1 b2
+          in
+          let found_jkind_for_ty new_ctl b_upper_bounds b_with_bounds quality :
+              Mod_bounds.t * (l2 * r2) with_bounds * Fuel_status.t =
+            match quality, mode with
+            | Best, _ | Not_best, Ignore_best ->
               let bounds_so_far =
-                join_respecting_omit b_jkind.jkind.mod_bounds
+                join_bounds bounds_so_far b_upper_bounds
+                  ~relevant_axes:ti.relevant_axes
               in
               (* Descend into the with-bounds of each of our with-bounds types'
                   with-bounds *)
-              let bounds_so_far, nested_with_bounds =
-                loop ctl_after_unpacking_b bounds_so_far
-                  (With_bounds.to_list b_jkind.jkind.with_bounds)
+              let bounds_so_far, nested_with_bounds, fuel_result1 =
+                loop new_ctl bounds_so_far (With_bounds.to_list b_with_bounds)
               in
-              (* CR layouts v2.8: we use [ctl_after_unpacking_b] here, not [ctl], to avoid
-                 big quadratic stack growth for very widely recursive types. This is sad,
-                 since it prevents us from mode crossing a record with 20 lists with
-                 different payloads, but less sad than a stack overflow of the compiler
-                 during type declaration checking.
+              (* CR layouts v2.8: we use [new_ctl] here, not [ctl], to avoid big quadratic
+                 stack growth for very widely recursive types. This is sad, since it
+                 prevents us from mode crossing a record with 20 lists with different
+                 payloads, but less sad than a stack overflow of the compiler during type
+                 declaration checking.
 
                  Ideally, this whole problem goes away once we rethink fuel.
               *)
-              let bounds, bs' = loop ctl_after_unpacking_b bounds_so_far bs in
-              bounds, With_bounds.join_bounds_maybe_empty nested_with_bounds bs'
-            else
-              (* Don't know the best kind for this type! We want to either:
-
-                 - skip it, leaving it in the with_bounds, in the case of best normalization
-                 - round up along its relevant axes, in the case of not-best normalization
-              *)
-              let bounds_so_far =
-                if require_best
-                then bounds_so_far
-                else join_respecting_omit Mod_bounds.max
+              let bounds, bs', fuel_result2 = loop new_ctl bounds_so_far bs in
+              ( bounds,
+                With_bounds.join nested_with_bounds bs',
+                Fuel_status.both fuel_result1 fuel_result2 )
+            | Not_best, Require_best ->
+              let bounds_so_far, bs', fuel_result =
+                loop new_ctl bounds_so_far bs
               in
-              let bounds_so_far, bs' =
-                loop ctl_after_unpacking_b bounds_so_far bs
-              in
-              ( bounds_so_far,
-                if require_best then With_bounds.add_bound ty ti bs' else bs' )
-          | None ->
-            (* kind of b is not principally known, so we treat it as having the max
-               bound (only along the axes we care about for this type!) *)
-            let bounds_so_far = join_respecting_omit Mod_bounds.max in
-            let bounds_so_far, bs' =
-              loop ctl_after_unpacking_b bounds_so_far bs
-            in
-            bounds_so_far, With_bounds.add_bound ty ti bs'))
+              bounds_so_far, With_bounds.add ty ti bs', fuel_result
+          in
+          match Loop_control.check ctl ty with
+          | Stop ctl_after_stop ->
+            (* out of fuel, so assume [ty] has the worst possible bounds. *)
+            found_jkind_for_ty ctl_after_stop Mod_bounds.max No_with_bounds
+              Not_best
+          | Skip -> loop ctl bounds_so_far bs (* skip [b] *)
+          | Continue ctl_after_unpacking_b -> (
+            match jkind_of_type ty with
+            | Some b_jkind ->
+              found_jkind_for_ty ctl_after_unpacking_b b_jkind.jkind.mod_bounds
+                b_jkind.jkind.with_bounds b_jkind.quality
+            | None ->
+              (* kind of b is not principally known, so we treat it as having the max
+                 bound (only along the axes we care about for this type!) *)
+              found_jkind_for_ty ctl_after_unpacking_b Mod_bounds.max
+                No_with_bounds Not_best)))
     in
-    let mod_bounds, with_bounds =
+    let mod_bounds, with_bounds, fuel_status =
       loop Loop_control.starting t.mod_bounds
         (With_bounds.to_list t.with_bounds)
     in
-    { t with
-      mod_bounds;
-      with_bounds = With_bounds.of_with_bounds_types with_bounds
-    }
+    { t with mod_bounds; with_bounds }, fuel_status
+
+  let normalize ~jkind_of_type ~mode t =
+    map_normalize ~jkind_of_type ~mode ~map_type_info:(fun _ ti -> ti) t
 
   let sub (type l r) ~type_equal:_ ~jkind_of_type
       (sub : (allowed * r) jkind_desc)
       ({ layout = lay2; mod_bounds = bounds2; with_bounds = No_with_bounds } :
         (l * allowed) jkind_desc) =
-    let { layout = lay1; mod_bounds = bounds1; with_bounds = _ } =
-      normalize ~require_best:false ~jkind_of_type sub
+    let ( ({ layout = lay1; mod_bounds = bounds1; with_bounds = No_with_bounds } :
+            Allowance.right_only jkind_desc),
+          _ ) =
+      normalize ~mode:Ignore_best ~jkind_of_type sub
     in
     let layout = Layout.sub lay1 lay2 in
     let bounds = Mod_bounds.less_or_equal bounds1 bounds2 in
-    let result = Misc.Le_result.combine layout bounds in
-    result
+    Misc.Le_result.combine layout bounds
 
   let intersection
       { layout = lay1; mod_bounds = mod_bounds1; with_bounds = with_bounds1 }
@@ -1594,8 +1609,8 @@ module Jkind_desc = struct
         let with_bounds =
           List.fold_right
             (fun (type_expr, modality) bounds ->
-              With_bounds.add ~relevant_for_nullability:`Relevant ~type_expr
-                ~modality bounds)
+              With_bounds.add_modality ~relevant_for_nullability:`Relevant
+                ~type_expr ~modality bounds)
             tys_modalities No_with_bounds
         in
         { layout; mod_bounds; with_bounds }
@@ -1967,13 +1982,21 @@ let for_object =
 (******************************)
 (* elimination and defaulting *)
 
-let[@inline] normalize ~require_best ~jkind_of_type t =
-  { (disallow_right t) with
-    jkind = Jkind_desc.normalize ~require_best ~jkind_of_type t.jkind;
+type normalize_mode =
+  | Require_best
+  | Ignore_best
+
+let[@inline] normalize ~mode ~jkind_of_type t =
+  let mode : _ Jkind_desc.normalize_mode =
+    match mode with Require_best -> Require_best | Ignore_best -> Ignore_best
+  in
+  let jkind, fuel_result = Jkind_desc.normalize ~jkind_of_type ~mode t.jkind in
+  { t with
+    jkind;
     quality =
-      (match require_best with
-      | true -> Quality.disallow_right t.quality
-      | false -> Not_best)
+      (match t.quality, fuel_result with
+      | Not_best, _ | _, Ran_out_of_fuel -> Not_best
+      | Best, Sufficient_fuel -> Best)
   }
 
 let get_layout_defaulting_to_value { jkind = { layout; _ }; _ } =
@@ -2002,8 +2025,12 @@ let extract_layout jk = jk.jkind.layout
 
 let get_modal_upper_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) :
     Alloc.Const.t =
-  let jk = normalize ~require_best:false ~jkind_of_type jk in
-  let get axis = Mod_bounds.get jk.jkind.mod_bounds ~axis in
+  let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
+          Allowance.right_only jkind_desc),
+        _ ) =
+    Jkind_desc.normalize ~mode:Ignore_best ~jkind_of_type jk.jkind
+  in
+  let get axis = Mod_bounds.get mod_bounds ~axis in
   { areality = get (Modal (Comonadic Areality));
     linearity = get (Modal (Comonadic Linearity));
     uniqueness = get (Modal (Monadic Uniqueness));
@@ -2013,8 +2040,12 @@ let get_modal_upper_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) :
   }
 
 let get_externality_upper_bound ~jkind_of_type jk =
-  let jk = normalize ~require_best:false ~jkind_of_type jk in
-  Mod_bounds.get jk.jkind.mod_bounds ~axis:(Nonmodal Externality)
+  let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
+          Allowance.right_only jkind_desc),
+        _ ) =
+    Jkind_desc.normalize ~mode:Ignore_best ~jkind_of_type jk.jkind
+  in
+  Mod_bounds.get mod_bounds ~axis:(Nonmodal Externality)
 
 let set_externality_upper_bound jk externality_upper_bound =
   { jk with
@@ -2614,7 +2645,7 @@ let intersection_or_error ~type_equal ~jkind_of_type ~reason t1 t2 =
 let round_up (type l r) ~jkind_of_type (t : (allowed * r) jkind) :
     (l * allowed) jkind =
   let normalized =
-    normalize ~require_best:false ~jkind_of_type (t |> disallow_right)
+    normalize ~mode:Ignore_best ~jkind_of_type (t |> disallow_right)
   in
   { t with
     jkind = { normalized.jkind with with_bounds = No_with_bounds };
@@ -2647,74 +2678,93 @@ let sub_or_error ~type_equal ~jkind_of_type t1 t2 =
   | Sub -> Ok ()
   | _ -> Error (Violation.of_ (Not_a_subjkind (t1, t2)))
 
-(* CR layouts v2.8: Rewrite this to do the hard subjkind check from the
-   kind polymorphism design. *)
 let sub_jkind_l ~type_equal ~jkind_of_type ?(allow_any_crossing = false) sub
     super =
-  (* CR layouts v2.8: Do something better than just comparing for equality. *)
-  (* We can't use other functions, because they insist that we only compare
-     lr-jkinds for equality, not just l-jkinds. *)
-  let layouts =
-    Misc.Le_result.is_le (Layout.sub sub.jkind.layout super.jkind.layout)
+  ignore allow_any_crossing;
+  (* XXX FIXME XXX FIXME *)
+  (* This function implements the "SUB" judgement from kind-inference.md. *)
+  let open Misc.Stdlib.Monad.Result.Syntax in
+  let require_le le_result =
+    match Misc.Le_result.is_le le_result with
+    | true -> Ok ()
+    | false ->
+      (* When we report an error, we want to show the best-normalized version of sub, but
+         the original super. When this check fails, it is usually the case that the super
+         was written by the user and the sub was inferred. Thus, we should display the
+         user-written jkind, but simplify the inferred one, since the inferred one is
+         probably overly complex. *)
+      (* CR layouts v2.8: It would be useful report to the user why this
+         violation occurred, specifically which axes the violation is along. *)
+      let best_sub = normalize ~mode:Require_best ~jkind_of_type sub in
+      Error (Violation.of_ (Not_a_subjkind (best_sub, super)))
   in
-  let sub = normalize ~require_best:true ~jkind_of_type sub in
-  (* CR aspsmith: this weird double-normalization is poorly explained because it will go
-     away (soon) once we get better subsumption *)
-  let sub_not_best = lazy (normalize ~require_best:false ~jkind_of_type sub) in
-  let super =
-    normalize ~require_best:true ~jkind_of_type (super |> disallow_right)
+  let* () =
+    (* Validate layouts *)
+    require_le (Layout.sub sub.jkind.layout super.jkind.layout)
   in
-  let bounds =
-    allow_any_crossing
-    || List.for_all
-         (fun (Axis.Pack axis) ->
-           let (module Bound_ops) = Axis.get axis in
-           let bound1 = Mod_bounds.get ~axis sub.jkind.mod_bounds in
-           let bound2 = Mod_bounds.get ~axis super.jkind.mod_bounds in
-           let with_bounds1 =
-             With_bounds.types_on_axis ~axis sub.jkind.with_bounds
-           in
-           (* If bound1 is min and has no with-bounds, we're good. *)
-           (Bound_ops.le bound1 Bound_ops.min && List.length with_bounds1 = 0)
-           (* If bound2 is max, we're good. *)
-           || Bound_ops.le Bound_ops.max bound2
-           (* Otherwise, try harder. *)
-           ||
-           (* Maybe an individual axis has the right shape on the right;
-              try this again before doing the stupid equality check. *)
-           match With_bounds.types_on_axis ~axis super.jkind.with_bounds with
-           | [] -> (
-             let sub_not_best = Lazy.force sub_not_best in
-             match
-               With_bounds.types_on_axis ~axis sub_not_best.jkind.with_bounds
-             with
-             | [] ->
-               let bound1 =
-                 Mod_bounds.get ~axis sub_not_best.jkind.mod_bounds
-               in
-               Bound_ops.less_or_equal bound1 bound2 |> Misc.Le_result.is_le
-             | _ :: _ -> false)
-           | with_bounds2 ->
-             let with_bounds1 =
-               With_bounds.types_on_axis ~axis sub.jkind.with_bounds
-             in
-             let modifiers = Bound_ops.equal bound1 bound2 in
-             let with_bounds =
-               List.compare_lengths with_bounds1 with_bounds2 = 0
-               && List.for_all2 type_equal with_bounds1 with_bounds2
-             in
-             modifiers && with_bounds)
-         Axis.all
+  let best_super =
+    (* MB_EXPAND_R *)
+    normalize ~mode:Require_best ~jkind_of_type super
   in
-  if layouts && bounds
-  then
-    Ok
-      { sub with
-        history =
-          combine_histories ~type_equal ~jkind_of_type Subjkind (Pack_jkind sub)
-            (Pack_jkind super)
-      }
-  else Error (Violation.of_ (Not_a_subjkind (sub, super)))
+  let right_bounds = With_bounds.to_best_eff_map best_super.jkind.with_bounds in
+  let axes_max_on_right =
+    (* If the upper_bound is max on the right, then that axis is irrelevant - the
+       left will always satisfy the right along that axis. This is an optimization,
+       not necessary for correctness *)
+    Mod_bounds.get_max_axes best_super.jkind.mod_bounds
+  in
+  let ( ({ layout = _;
+           mod_bounds = sub_upper_bounds;
+           with_bounds = No_with_bounds
+         } :
+          Allowance.right_only jkind_desc),
+        _ ) =
+    (* MB_EXPAND_L *)
+    (* Here we progressively expand types on the left.
+
+       Every time we see a type [ty] on the left, we first look to see if [ty] occurs on the
+       right. If it does, then we can skip* [ty]. There is an * on skip because we can
+       actually only skip on a per-axis basis - if [ty] is relevant only along the
+       portability axis on the right, then [ty] is no longer relevant to portability on
+       the left, but it is still relevant to all other axes. So really, we subtract the
+       axes that are relevant to the right from the axes that are relevant to the left.
+       We can also skip [ty] on any axes that are max on the right since anything is
+       <= max. Hence, we can also subtract [axes_max_on_right].
+
+       After finding which axes [ty] is relevant along, we lookup [ty]'s jkind and join it
+       with the [mod_bounds] along the relevant axes. *)
+    (* [Jkind_desc.map_normalize] handles the stepping, jkind lookups, and joining.
+       [map_type_info] handles looking for [ty] on the right and removing irrelevant axes. *)
+    Jkind_desc.map_normalize sub.jkind ~jkind_of_type ~mode:Ignore_best
+      ~map_type_info:(fun ty { relevant_axes = left_relevant_axes } ->
+        let right_relevant_axes =
+          (* Look for [ty] on the right. There may be multiple occurrences of it on the
+             right; if so, we union together the relevant axes. *)
+          right_bounds |> With_bounds_types.to_seq
+          (* CR layouts v2.8: maybe it's worth memoizing using a best-effort type map? *)
+          |> Seq.fold_left
+               (fun acc (ty2, data) ->
+                 match type_equal ty ty2 with
+                 | true -> data :: acc
+                 | false -> acc)
+               []
+          |> List.fold_left
+               (fun acc (ti : With_bounds_type_info.t) ->
+                 Axis_set.union acc ti.relevant_axes)
+               Axis_set.empty
+        in
+        let axes_to_drop =
+          Axis_set.union right_relevant_axes axes_max_on_right
+        in
+        (* MB_WITH : drop types from the left that appear on the right *)
+        { relevant_axes = Axis_set.diff left_relevant_axes axes_to_drop })
+  in
+  let* () =
+    (* MB_MODE : verify that the remaining upper_bounds from sub are <= super's bounds *)
+    let super_lower_bounds = best_super.jkind.mod_bounds in
+    require_le (Mod_bounds.less_or_equal sub_upper_bounds super_lower_bounds)
+  in
+  Ok ()
 
 let is_void_defaulting = function
   | { jkind = { layout = Sort s; _ }; _ } -> Sort.is_void_defaulting s

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -537,8 +537,17 @@ val get_annotation : 'd Types.jkind -> Parsetree.jkind_annotation option
 (*********************************)
 (* normalization *)
 
+type normalize_mode =
+  | Require_best
+      (** Normalize a jkind without losing any precision. That is, keep any with-bounds
+          if the kind of the type is not best (a stronger kind may be found). *)
+  | Ignore_best
+      (** Normalize a left jkind, conservatively rounding up. That is, if the kind of a
+          type is not best, use the not-best kind. The resulting jkind will have no
+          with-bounds. *)
+
 val normalize :
-  require_best:bool ->
+  mode:normalize_mode ->
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
   Types.jkind_l ->
   Types.jkind_l
@@ -639,13 +648,9 @@ val sub_or_error :
   ('l * allowed) Types.jkind ->
   (unit, Violation.t) result
 
-(** Like [sub], but returns the subjkind with an updated history.
+(** Like [sub], but compares a left jkind against another left jkind.
     Pre-condition: the super jkind must be fully settled; no variables which
-    might be filled in later. Right now, if the super jkind has any
-    [with]-types, the sub jkind must have exactly the same [with]-types, in the
-    same order.
-
-    CR layouts v2.8: Implement this properly.
+    might be filled in later.
 *)
 val sub_jkind_l :
   type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
@@ -653,7 +658,7 @@ val sub_jkind_l :
   ?allow_any_crossing:bool ->
   Types.jkind_l ->
   Types.jkind_l ->
-  (Types.jkind_l, Violation.t) result
+  (unit, Violation.t) result
 
 (** "round up" a [jkind_l] to a [jkind_r] such that the input is less than the
     output. *)

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Liam Stevenson, Jane Street, New York                 *)
 (*                                                                        *)
-(*   Copyright 2021 Jane Street Group LLC                                 *)
+(*   Copyright 2024 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -172,136 +172,49 @@ module Axis = struct
     | Nonmodal Nullability -> false
 end
 
-module type Axed = sig
-  type 'axis t
-end
-
 module Axis_collection = struct
-  type 'a t =
-    { locality : 'a;
-      linearity : 'a;
-      uniqueness : 'a;
-      portability : 'a;
-      contention : 'a;
-      yielding : 'a;
-      externality : 'a;
-      nullability : 'a
-    }
-
-  let create ~(f : axis:Axis.packed -> _) =
-    { locality = f ~axis:(Pack (Modal (Comonadic Areality)));
-      linearity = f ~axis:(Pack (Modal (Comonadic Linearity)));
-      uniqueness = f ~axis:(Pack (Modal (Monadic Uniqueness)));
-      portability = f ~axis:(Pack (Modal (Comonadic Portability)));
-      contention = f ~axis:(Pack (Modal (Monadic Contention)));
-      yielding = f ~axis:(Pack (Modal (Comonadic Yielding)));
-      externality = f ~axis:(Pack (Nonmodal Externality));
-      nullability = f ~axis:(Pack (Nonmodal Nullability))
-    }
-
-  let get (type a) ~(axis : a Axis.t) t =
-    match axis with
-    | Modal (Comonadic Areality) -> t.locality
-    | Modal (Comonadic Linearity) -> t.linearity
-    | Modal (Monadic Uniqueness) -> t.uniqueness
-    | Modal (Comonadic Portability) -> t.portability
-    | Modal (Monadic Contention) -> t.contention
-    | Modal (Comonadic Yielding) -> t.yielding
-    | Nonmodal Externality -> t.externality
-    | Nonmodal Nullability -> t.nullability
-
-  let set (type a) ~(axis : a Axis.t) t value =
-    match axis with
-    | Modal (Comonadic Areality) -> { t with locality = value }
-    | Modal (Comonadic Linearity) -> { t with linearity = value }
-    | Modal (Monadic Uniqueness) -> { t with uniqueness = value }
-    | Modal (Comonadic Portability) -> { t with portability = value }
-    | Modal (Monadic Contention) -> { t with contention = value }
-    | Modal (Comonadic Yielding) -> { t with yielding = value }
-    | Nonmodal Externality -> { t with externality = value }
-    | Nonmodal Nullability -> { t with nullability = value }
-
-  let mapi ~(f : axis:Axis.packed -> _ -> _)
-      { locality;
-        linearity;
-        uniqueness;
-        portability;
-        contention;
-        yielding;
-        externality;
-        nullability
-      } =
-    { locality = f ~axis:(Pack (Modal (Comonadic Areality))) locality;
-      linearity = f ~axis:(Pack (Modal (Comonadic Linearity))) linearity;
-      uniqueness = f ~axis:(Pack (Modal (Monadic Uniqueness))) uniqueness;
-      portability = f ~axis:(Pack (Modal (Comonadic Portability))) portability;
-      contention = f ~axis:(Pack (Modal (Monadic Contention))) contention;
-      yielding = f ~axis:(Pack (Modal (Comonadic Yielding))) yielding;
-      externality = f ~axis:(Pack (Nonmodal Externality)) externality;
-      nullability = f ~axis:(Pack (Nonmodal Nullability)) nullability
-    }
-
-  let map ~f = mapi ~f:(fun ~axis:_ x -> f x)
-
-  let fold ~(f : axis:Axis.packed -> _ -> _) ~combine
-      { locality;
-        linearity;
-        uniqueness;
-        portability;
-        contention;
-        yielding;
-        externality;
-        nullability
-      } =
-    combine (f ~axis:(Pack (Modal (Comonadic Areality))) locality)
-    @@ combine (f ~axis:(Pack (Modal (Comonadic Linearity))) linearity)
-    @@ combine (f ~axis:(Pack (Modal (Monadic Uniqueness))) uniqueness)
-    @@ combine (f ~axis:(Pack (Modal (Comonadic Portability))) portability)
-    @@ combine (f ~axis:(Pack (Modal (Monadic Contention))) contention)
-    @@ combine (f ~axis:(Pack (Modal (Comonadic Yielding))) yielding)
-    @@ combine (f ~axis:(Pack (Nonmodal Externality)) externality)
-    @@ f ~axis:(Pack (Nonmodal Nullability)) nullability
-
-  (* Sadly this needs to be functorized since we don't have higher-kinded types *)
-  module Indexed (T : Axed) = struct
-    type t =
-      { locality : Mode.Locality.Const.t T.t;
-        linearity : Mode.Linearity.Const.t T.t;
-        uniqueness : Mode.Uniqueness.Const.t T.t;
-        portability : Mode.Portability.Const.t T.t;
-        contention : Mode.Contention.Const.t T.t;
-        yielding : Mode.Yielding.Const.t T.t;
-        externality : Externality.t T.t;
-        nullability : Nullability.t T.t
+  module Indexed_gen (T : Misc.T2) = struct
+    type 'a t_poly =
+      { locality : (Mode.Locality.Const.t, 'a) T.t;
+        linearity : (Mode.Linearity.Const.t, 'a) T.t;
+        uniqueness : (Mode.Uniqueness.Const.t, 'a) T.t;
+        portability : (Mode.Portability.Const.t, 'a) T.t;
+        contention : (Mode.Contention.Const.t, 'a) T.t;
+        yielding : (Mode.Yielding.Const.t, 'a) T.t;
+        externality : (Externality.t, 'a) T.t;
+        nullability : (Nullability.t, 'a) T.t
       }
 
-    let get (type a) ~(axis : a Axis.t) values : a T.t =
-      match axis with
-      | Modal (Comonadic Areality) -> values.locality
-      | Modal (Comonadic Linearity) -> values.linearity
-      | Modal (Monadic Uniqueness) -> values.uniqueness
-      | Modal (Comonadic Portability) -> values.portability
-      | Modal (Monadic Contention) -> values.contention
-      | Modal (Comonadic Yielding) -> values.yielding
-      | Nonmodal Externality -> values.externality
-      | Nonmodal Nullability -> values.nullability
+    type 'a t = 'a t_poly
 
-    let set (type a) ~(axis : a Axis.t) values (value : a T.t) =
+    let get (type a) ~(axis : a Axis.t) (t : 'b t) : (a, 'b) T.t =
       match axis with
-      | Modal (Comonadic Areality) -> { values with locality = value }
-      | Modal (Comonadic Linearity) -> { values with linearity = value }
-      | Modal (Monadic Uniqueness) -> { values with uniqueness = value }
-      | Modal (Comonadic Portability) -> { values with portability = value }
-      | Modal (Monadic Contention) -> { values with contention = value }
-      | Modal (Comonadic Yielding) -> { values with yielding = value }
-      | Nonmodal Externality -> { values with externality = value }
-      | Nonmodal Nullability -> { values with nullability = value }
+      | Modal (Comonadic Areality) -> t.locality
+      | Modal (Comonadic Linearity) -> t.linearity
+      | Modal (Monadic Uniqueness) -> t.uniqueness
+      | Modal (Comonadic Portability) -> t.portability
+      | Modal (Monadic Contention) -> t.contention
+      | Modal (Comonadic Yielding) -> t.yielding
+      | Nonmodal Externality -> t.externality
+      | Nonmodal Nullability -> t.nullability
+
+    let set (type a) ~(axis : a Axis.t) (t : 'b t) (value : (a, 'b) T.t) =
+      match axis with
+      | Modal (Comonadic Areality) -> { t with locality = value }
+      | Modal (Comonadic Linearity) -> { t with linearity = value }
+      | Modal (Monadic Uniqueness) -> { t with uniqueness = value }
+      | Modal (Comonadic Portability) -> { t with portability = value }
+      | Modal (Monadic Contention) -> { t with contention = value }
+      | Modal (Comonadic Yielding) -> { t with yielding = value }
+      | Nonmodal Externality -> { t with externality = value }
+      | Nonmodal Nullability -> { t with nullability = value }
 
     (* Since we don't have polymorphic parameters, use a record to pass the
        polymorphic function *)
     module Create = struct
       module Monadic (M : Misc.Stdlib.Monad.S) = struct
-        type f = { f : 'axis. axis:'axis Axis.t -> 'axis T.t M.t } [@@unboxed]
+        type 'a f = { f : 'axis. axis:'axis Axis.t -> ('axis, 'a) T.t M.t }
+        [@@unboxed]
 
         let[@inline] f { f } =
           let open M.Syntax in
@@ -328,14 +241,17 @@ module Axis_collection = struct
 
       module Monadic_identity = Monadic (Misc.Stdlib.Monad.Identity)
 
-      type f = Monadic_identity.f
+      type 'a f = 'a Monadic_identity.f
 
       let[@inline] f f = Monadic_identity.f f
     end
 
     module Map = struct
       module Monadic (M : Misc.Stdlib.Monad.S) = struct
-        type f = { f : 'axis. axis:'axis Axis.t -> 'axis T.t -> 'axis T.t M.t }
+        type ('a, 'b) f =
+          { f :
+              'axis. axis:'axis Axis.t -> ('axis, 'a) T.t -> ('axis, 'b) T.t M.t
+          }
         [@@unboxed]
 
         module Create = Create.Monadic (M)
@@ -347,13 +263,14 @@ module Axis_collection = struct
 
       module Monadic_identity = Monadic (Misc.Stdlib.Monad.Identity)
 
-      type f = Monadic_identity.f
+      type ('a, 'b) f = ('a, 'b) Monadic_identity.f
 
       let[@inline] f f bounds = Monadic_identity.f f bounds
     end
 
     module Iter = struct
-      type f = { f : 'axis. axis:'axis Axis.t -> 'axis T.t -> unit }
+      type 'a f = { f : 'axis. axis:'axis Axis.t -> ('axis, 'a) T.t -> unit }
+      [@@unboxed]
 
       let[@inline] f { f }
           { locality;
@@ -377,10 +294,13 @@ module Axis_collection = struct
 
     module Map2 = struct
       module Monadic (M : Misc.Stdlib.Monad.S) = struct
-        type f =
+        type ('a, 'b, 'c) f =
           { f :
               'axis.
-              axis:'axis Axis.t -> 'axis T.t -> 'axis T.t -> 'axis T.t M.t
+              axis:'axis Axis.t ->
+              ('axis, 'a) T.t ->
+              ('axis, 'b) T.t ->
+              ('axis, 'c) T.t M.t
           }
         [@@unboxed]
 
@@ -395,13 +315,14 @@ module Axis_collection = struct
 
       module Monadic_identity = Monadic (Misc.Stdlib.Monad.Identity)
 
-      type f = Monadic_identity.f
+      type ('a, 'b, 'c) f = ('a, 'b, 'c) Monadic_identity.f
 
       let[@inline] f f bounds1 bounds2 = Monadic_identity.f f bounds1 bounds2
     end
 
     module Fold = struct
-      type 'r f = { f : 'axis. axis:'axis Axis.t -> 'axis T.t -> 'r }
+      type ('a, 'r) f =
+        { f : 'axis. axis:'axis Axis.t -> ('axis, 'a) T.t -> 'r }
       [@@unboxed]
 
       let[@inline] f { f }
@@ -425,8 +346,10 @@ module Axis_collection = struct
     end
 
     module Fold2 = struct
-      type 'r f =
-        { f : 'axis. axis:'axis Axis.t -> 'axis T.t -> 'axis T.t -> 'r }
+      type ('a, 'b, 'r) f =
+        { f :
+            'axis. axis:'axis Axis.t -> ('axis, 'a) T.t -> ('axis, 'b) T.t -> 'r
+        }
       [@@unboxed]
 
       let[@inline] f { f }
@@ -458,6 +381,29 @@ module Axis_collection = struct
         @@ f ~axis:Axis.(Nonmodal Nullability) nul1 nul2
     end
   end
+
+  module Indexed (T : Misc.T1) = struct
+    include Indexed_gen (struct
+      type ('a, 'b) t = 'a T.t
+    end)
+
+    type nonrec t = unit t
+  end
+
+  module Identity = Indexed (Misc.Stdlib.Monad.Identity)
+
+  include Indexed_gen (struct
+    type ('a, 'b) t = 'b
+  end)
+
+  let create ~f = Create.f { f = (fun ~axis -> f ~axis:(Axis.Pack axis)) }
+
+  let map ~f t = Map.f { f = (fun ~axis:_ x -> f x) } t
+
+  let mapi ~f t = Map.f { f = (fun ~axis x -> f ~axis:(Axis.Pack axis) x) } t
+
+  let fold ~f ~combine t =
+    Fold.f { f = (fun ~axis acc -> f ~axis:(Axis.Pack axis) acc) } t ~combine
 end
 
 module Axis_set = struct
@@ -467,8 +413,6 @@ module Axis_set = struct
   (* TODO: this could be represented with a uint8 since there's only 7 possible members *)
 
   let empty = Axis_collection.create ~f:(fun ~axis:_ -> false)
-
-  let create ~f = Axis_collection.create ~f
 
   let add t axis = Axis_collection.set ~axis t true
 
@@ -484,12 +428,18 @@ module Axis_set = struct
     Axis_collection.create ~f:(fun ~axis:(Pack axis) ->
         Axis_collection.get ~axis t1 && Axis_collection.get ~axis t2)
 
+  let diff t1 t2 =
+    Axis_collection.create ~f:(fun ~axis:(Pack axis) ->
+        Axis_collection.get ~axis t1 && not (Axis_collection.get ~axis t2))
+
   let is_subset t1 t2 =
     Axis_collection.fold
       ~f:(fun ~axis:(Pack axis) t1_on_axis ->
         let t2_on_axis = Axis_collection.get ~axis t2 in
         (not t1_on_axis) || t2_on_axis)
       ~combine:( && ) t1
+
+  let is_empty t = is_subset t empty
 
   let complement t = Axis_collection.map ~f:not t
 
@@ -498,6 +448,8 @@ module Axis_set = struct
       ~f:(fun ~axis t_on_axis ->
         match t_on_axis with true -> [axis] | false -> [])
       ~combine:( @ ) t
+
+  let create = Axis_collection.create
 
   let print ppf t =
     Format.pp_print_list

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                  Liam Stevenson, Jane Street, New York                 *)
 (*                                                                        *)
-(*   Copyright 2021 Jane Street Group LLC                                 *)
+(*   Copyright 2024 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -70,16 +70,131 @@ end
 
 (** A collection with one item for each jkind axis *)
 module Axis_collection : sig
-  type 'a t =
-    { locality : 'a;
-      linearity : 'a;
-      uniqueness : 'a;
-      portability : 'a;
-      contention : 'a;
-      yielding : 'a;
-      externality : 'a;
-      nullability : 'a
-    }
+  module type S_gen := sig
+    type ('a, 'b) u
+
+    (* This is t_poly instead of t because in some instantiations of this signature, u
+       ignores its second parameter. In order to avoid needed to apply a useless type
+       parameter for those instantiations, we define [type t = unit t_poly] in them. In
+       instantiations where the polymorphism is actually used, we define
+       [type 'a t = 'a t_poly] *)
+    type 'a t_poly =
+      { locality : (Mode.Locality.Const.t, 'a) u;
+        linearity : (Mode.Linearity.Const.t, 'a) u;
+        uniqueness : (Mode.Uniqueness.Const.t, 'a) u;
+        portability : (Mode.Portability.Const.t, 'a) u;
+        contention : (Mode.Contention.Const.t, 'a) u;
+        yielding : (Mode.Yielding.Const.t, 'a) u;
+        externality : (Externality.t, 'a) u;
+        nullability : (Nullability.t, 'a) u
+      }
+
+    val get : axis:'a Axis.t -> 'b t_poly -> ('a, 'b) u
+
+    val set : axis:'a Axis.t -> 'b t_poly -> ('a, 'b) u -> 'b t_poly
+
+    (** Create an axis collection by applying the function on each axis *)
+    module Create : sig
+      module Monadic (M : Misc.Stdlib.Monad.S) : sig
+        type 'a f = { f : 'axis. axis:'axis Axis.t -> ('axis, 'a) u M.t }
+        [@@unboxed]
+
+        val f : 'a f -> 'a t_poly M.t
+      end
+
+      (** This record type is used to pass a polymorphic function to [create] *)
+      type 'a f = 'a Monadic(Misc.Stdlib.Monad.Identity).f
+
+      val f : 'a f -> 'a t_poly
+    end
+
+    (** Map an operation over all the bounds *)
+    module Map : sig
+      module Monadic (M : Misc.Stdlib.Monad.S) : sig
+        type ('a, 'b) f =
+          { f : 'axis. axis:'axis Axis.t -> ('axis, 'a) u -> ('axis, 'b) u M.t }
+        [@@unboxed]
+
+        val f : ('a, 'b) f -> 'a t_poly -> 'b t_poly M.t
+      end
+
+      type ('a, 'b) f = ('a, 'b) Monadic(Misc.Stdlib.Monad.Identity).f
+
+      val f : ('a, 'b) f -> 'a t_poly -> 'b t_poly
+    end
+
+    module Iter : sig
+      type 'a f = { f : 'axis. axis:'axis Axis.t -> ('axis, 'a) u -> unit }
+      [@@unboxed]
+
+      val f : 'a f -> 'a t_poly -> unit
+    end
+
+    (** Map an operation over two sets of bounds *)
+    module Map2 : sig
+      module Monadic (M : Misc.Stdlib.Monad.S) : sig
+        type ('a, 'b, 'c) f =
+          { f :
+              'axis.
+              axis:'axis Axis.t ->
+              ('axis, 'a) u ->
+              ('axis, 'b) u ->
+              ('axis, 'c) u M.t
+          }
+        [@@unboxed]
+
+        val f : ('a, 'b, 'c) f -> 'a t_poly -> 'b t_poly -> 'c t_poly M.t
+      end
+
+      type ('a, 'b, 'c) f = ('a, 'b, 'c) Monadic(Misc.Stdlib.Monad.Identity).f
+
+      val f : ('a, 'b, 'c) f -> 'a t_poly -> 'b t_poly -> 'c t_poly
+    end
+
+    (** Fold an operation over the bounds to a summary value *)
+    module Fold : sig
+      type ('a, 'r) f = { f : 'axis. axis:'axis Axis.t -> ('axis, 'a) u -> 'r }
+      [@@unboxed]
+
+      (** [combine] should be commutative and associative. *)
+      val f : ('a, 'r) f -> 'a t_poly -> combine:('r -> 'r -> 'r) -> 'r
+    end
+
+    (** Fold an operation over two sets of bounds to a summary value *)
+    module Fold2 : sig
+      type ('a, 'b, 'r) f =
+        { f : 'axis. axis:'axis Axis.t -> ('axis, 'a) u -> ('axis, 'b) u -> 'r }
+      [@@unboxed]
+
+      (** [combine] should be commutative and associative. *)
+      val f :
+        ('a, 'b, 'r) f ->
+        'a t_poly ->
+        'b t_poly ->
+        combine:('r -> 'r -> 'r) ->
+        'r
+    end
+  end
+
+  module type S_poly := sig
+    include S_gen
+
+    type 'a t = 'a t_poly
+  end
+
+  module type S_mono := sig
+    include S_gen
+
+    type t = unit t_poly
+  end
+
+  module Indexed_gen (T : Misc.T2) : S_poly with type ('a, 'b) u := ('a, 'b) T.t
+
+  module Indexed (T : Misc.T1) : S_mono with type ('a, 'b) u := 'a T.t
+
+  module Identity : S_mono with type ('a, 'b) u := 'a
+
+  include S_poly with type ('a, 'b) u := 'b
 
   val create : f:(axis:Axis.packed -> 'a) -> 'a t
 
@@ -93,96 +208,6 @@ module Axis_collection : sig
 
   val fold :
     f:(axis:Axis.packed -> 'a -> 'r) -> combine:('r -> 'r -> 'r) -> 'a t -> 'r
-
-  (** A collection with one item for each jkind axis, where the value type is indexed by the
-      particular axis. *)
-  module Indexed (T : Misc.T1) : sig
-    type t =
-      { locality : Mode.Locality.Const.t T.t;
-        linearity : Mode.Linearity.Const.t T.t;
-        uniqueness : Mode.Uniqueness.Const.t T.t;
-        portability : Mode.Portability.Const.t T.t;
-        contention : Mode.Contention.Const.t T.t;
-        yielding : Mode.Yielding.Const.t T.t;
-        externality : Externality.t T.t;
-        nullability : Nullability.t T.t
-      }
-
-    val get : axis:'a Axis.t -> t -> 'a T.t
-
-    val set : axis:'a Axis.t -> t -> 'a T.t -> t
-
-    (** Create an axis collection by applying the function on each axis *)
-    module Create : sig
-      module Monadic (M : Misc.Stdlib.Monad.S) : sig
-        type f = { f : 'axis. axis:'axis Axis.t -> 'axis T.t M.t } [@@unboxed]
-
-        val f : f -> t M.t
-      end
-
-      (** This record type is used to pass a polymorphic function to [create] *)
-      type f = Monadic(Misc.Stdlib.Monad.Identity).f
-
-      val f : f -> t
-    end
-
-    (** Map an operation over all the bounds *)
-    module Map : sig
-      module Monadic (M : Misc.Stdlib.Monad.S) : sig
-        type f = { f : 'axis. axis:'axis Axis.t -> 'axis T.t -> 'axis T.t M.t }
-        [@@unboxed]
-
-        val f : f -> t -> t M.t
-      end
-
-      type f = Monadic(Misc.Stdlib.Monad.Identity).f
-
-      val f : f -> t -> t
-    end
-
-    module Iter : sig
-      type f = { f : 'axis. axis:'axis Axis.t -> 'axis T.t -> unit }
-
-      val f : f -> t -> unit
-    end
-
-    (** Map an operation over two sets of bounds *)
-    module Map2 : sig
-      module Monadic (M : Misc.Stdlib.Monad.S) : sig
-        type f =
-          { f :
-              'axis.
-              axis:'axis Axis.t -> 'axis T.t -> 'axis T.t -> 'axis T.t M.t
-          }
-        [@@unboxed]
-
-        val f : f -> t -> t -> t M.t
-      end
-
-      type f = Monadic(Misc.Stdlib.Monad.Identity).f
-
-      val f : f -> t -> t -> t
-    end
-
-    (** Fold an operation over the bounds to a summary value *)
-    module Fold : sig
-      type 'r f = { f : 'axis. axis:'axis Axis.t -> 'axis T.t -> 'r }
-      [@@unboxed]
-
-      (** [combine] should be commutative and associative. *)
-      val f : 'r f -> t -> combine:('r -> 'r -> 'r) -> 'r
-    end
-
-    (** Fold an operation over two sets of bounds to a summary value *)
-    module Fold2 : sig
-      type 'r f =
-        { f : 'axis. axis:'axis Axis.t -> 'axis T.t -> 'axis T.t -> 'r }
-      [@@unboxed]
-
-      (** [combine] should be commutative and associative. *)
-      val f : 'r f -> t -> t -> combine:('r -> 'r -> 'r) -> 'r
-    end
-  end
 end
 
 module Axis_set : sig
@@ -190,7 +215,7 @@ module Axis_set : sig
 
   val empty : t
 
-  val create : f:(axis:Axis.packed -> bool) -> t
+  val is_empty : t -> bool
 
   val add : t -> _ Axis.t -> t
 
@@ -202,11 +227,16 @@ module Axis_set : sig
 
   val intersection : t -> t -> t
 
+  val diff : t -> t -> t
+
   val is_subset : t -> t -> bool
 
   val complement : t -> t
 
   val to_list : t -> Axis.packed list
+
+  (** Create a [t], specify for each axis whether it should be included *)
+  val create : f:(axis:Axis.packed -> bool) -> t
 
   val print : Format.formatter -> t -> unit
 end

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1276,7 +1276,7 @@ let narrow_to_manifest_jkind env loc decl =
           Jkind.sub_jkind_l ~type_equal ~jkind_of_type
             manifest_jkind decl.type_jkind
         with
-        | Ok _ -> ()
+        | Ok () -> ()
         | Error v -> raise (Error (loc, Jkind_mismatch_of_type (ty,v)))
       end
     | Some type_jkind -> begin
@@ -1834,6 +1834,8 @@ let update_decl_jkind env id decl =
       { decl with type_jkind }
     | Type_record (lbls, rep, umc) ->
       let lbls, rep, type_jkind = update_record_kind decl.type_loc lbls rep in
+      (* See Note [Quality of jkinds during inference] for more information about when we
+         mark jkinds as best *)
       let type_jkind = Jkind.mark_best type_jkind in
       { decl with type_kind = Type_record (lbls, rep, umc); type_jkind }
     (* CR layouts v3.0: handle this case in [update_variant_jkind] when
@@ -2474,7 +2476,7 @@ let normalize_decl_jkinds env shapes decls =
     (fun env (id, original_jkind, allow_any_crossing, decl) shape ->
        let normalized_jkind =
          Jkind.normalize
-           ~require_best:true
+           ~mode:Require_best
            ~jkind_of_type:(fun ty -> Some (Ctype.type_jkind env ty))
            decl.type_jkind
        in


### PR DESCRIPTION
Improve the implementation of `Jkind.sub_jkind_l` to give a proper subsumption check. The implementation is based on the rules in `jane/doc/proposals/kind-inference.md`. At the moment, this check is quadratic because we don't have a proper comparison function on types. But based on my anecdotal experience building and running tests, this doesn't seem to hurt performance too bad.