### PR TITLE
fix build on arm64 linux

### DIFF
--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -568,7 +568,7 @@ L(caml_call_local_realloc):
         ldp     x29, x30, [sp], 16
         ret
         CFI_ENDPROC
-        END_FUNCTION(caml_call_gc)
+END_FUNCTION(caml_call_local_realloc)
 
 /* Call a C function from OCaml */
 /* Function to call is in ADDITIONAL_ARG */


### PR DESCRIPTION
arm64 linux builds were previously failing due to a mismatching END_FUNCTION call. This patch trivially fixes this.

Example of a previous build failure:

```
# /tmp/build_65ff2e_dune/cc9ksxcR.s: Assembler messages:
# /tmp/build_65ff2e_dune/cc9ksxcR.s: Error: .size expression for caml_call_gc does not evaluate to a constant
```