### PR TITLE
flambda2-types: Recover aliases after meet

### DIFF
--- a/middle_end/flambda2/term_basics/simple.ml
+++ b/middle_end/flambda2/term_basics/simple.ml
@@ -107,6 +107,11 @@ let[@inline always] must_be_name t =
     ~name:(fun name ~coercion -> Some (name, coercion))
     ~const:(fun _ -> None)
 
+let[@inline always] must_be_const t =
+  pattern_match t
+    ~const:(fun const -> Some const)
+    ~name:(fun _ ~coercion:_ -> None)
+
 let free_names_with_mode t mode =
   pattern_match t
     ~name:(fun name ~coercion ->

--- a/middle_end/flambda2/term_basics/simple.mli
+++ b/middle_end/flambda2/term_basics/simple.mli
@@ -37,6 +37,8 @@ val must_be_symbol : t -> (Symbol.t * Coercion.t) option
 
 val must_be_name : t -> (Name.t * Coercion.t) option
 
+val must_be_const : t -> Reg_width_const.t option
+
 (** The constant representating the given number of type "int". *)
 val const_int : Targetint_31_63.t -> t
 

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -840,7 +840,7 @@ and replace_equation_or_add_alias_to_const t name ty =
     | Bottom ->
       Misc.fatal_error "Unexpected bottom while adding alias to constant.")
 
-and add_oriented_equation ~original_name ~raise_on_bottom t simple ty
+and add_non_alias_equation ~original_name ~raise_on_bottom t simple ty
     ~(meet_type : meet_type) =
   (* Beware: if we're about to add the equation on a name which is different
      from the one that the caller passed in, then we need to make sure that the
@@ -989,7 +989,7 @@ and orient_and_add_equation ~raise_on_bottom t name ty ~meet_type =
   match inputs with
   | None -> t
   | Some (simple, t, ty) ->
-    add_oriented_equation ~original_name:name ~raise_on_bottom t simple ty
+    add_non_alias_equation ~original_name:name ~raise_on_bottom t simple ty
       ~meet_type
 
 and[@inline always] add_equation ~raise_on_bottom t name ty ~meet_type =

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -750,9 +750,25 @@ let invariant_for_new_equation (t : t) name ty =
       Misc.fatal_errorf "New equation@ %a@ =@ %a@ has unbound names@ (%a):@ %a"
         Name.print name TG.print ty Name_occurrences.print unbound_names print t)
 
+let pattern_match_equation ~name ~const simple ty =
+  (* We have [(coerce <bare_lhs> <coercion>) : <ty>]. Thus [<bare_lhs> : (coerce
+     <ty> <coercion>^-1)]. *)
+  let bare_lhs = Simple.without_coercion simple in
+  let coercion_from_bare_lhs_to_ty = Simple.coercion simple in
+  let coercion_from_ty_to_bare_lhs =
+    Coercion.inverse coercion_from_bare_lhs_to_ty
+  in
+  let ty = TG.apply_coercion ty coercion_from_ty_to_bare_lhs in
+  let name eqn_name ~coercion =
+    (* true by definition *)
+    assert (Coercion.is_id coercion);
+    name eqn_name ty
+  in
+  Simple.pattern_match bare_lhs ~name ~const:(fun c -> const c ty)
+
 exception Bottom_equation
 
-let rec add_equation0 (t : t) name ty =
+let rec replace_equation (t : t) name ty =
   (if Flambda_features.Debug.concrete_types_only_on_canonicals ()
   then
     let is_concrete =
@@ -804,7 +820,90 @@ let rec add_equation0 (t : t) name ty =
   in
   with_current_level t ~current_level
 
-and add_equation1 ~raise_on_bottom t name ty ~(meet_type : meet_type) =
+and replace_equation_or_add_alias_to_const t name ty =
+  match TG.recover_const_alias ty with
+  | None -> replace_equation t name ty
+  | Some const -> (
+    match
+      Aliases.add ~binding_time_resolver:t.binding_time_resolver
+        ~binding_times_and_modes:(names_to_types t) (aliases t)
+        ~canonical_element1:(Simple.name name)
+        ~canonical_element2:(Simple.const const)
+    with
+    | Ok { canonical_element = _; alias_of_demoted_element; t = aliases } ->
+      if not (Simple.equal alias_of_demoted_element (Simple.name name))
+      then Misc.fatal_error "Unexpected demotion of constant.";
+      let t = with_aliases t ~aliases in
+      let kind = MTC.kind_for_const const in
+      let ty = TG.alias_type_of kind (Simple.const const) in
+      replace_equation t name ty
+    | Bottom ->
+      Misc.fatal_error "Unexpected bottom while adding alias to constant.")
+
+and add_oriented_equation ~original_name ~raise_on_bottom t simple ty
+    ~(meet_type : meet_type) =
+  (* Beware: if we're about to add the equation on a name which is different
+     from the one that the caller passed in, then we need to make sure that the
+     type we assign to that name is the most precise available. This
+     necessitates calling [meet].
+
+     For example, suppose [p] is defined earlier than [x], with [p] of type
+     [Unknown] and [x] of type [ty]. If the caller says that the best type of
+     [p] is now to be "= x", then this function will add an equation on [x]
+     rather than [p], due to the definition ordering. However we should not just
+     say that [x] has type "= p", as that would forget any existing information
+     about [x]. Instead we should say that [x] has type "(= p) meet ty".
+
+     Note also that [p] and [x] may have different name modes! *)
+  let[@inline always] name eqn_name ty =
+    match meet_type with
+    | New meet_type_new -> (
+      let existing_ty = find t eqn_name (Some (TG.kind ty)) in
+      match meet_type_new t ty existing_ty with
+      | Bottom ->
+        if raise_on_bottom
+        then raise Bottom_equation
+        else replace_equation t eqn_name (MTC.bottom (TG.kind ty))
+      | Ok (meet_ty, env) -> (
+        match meet_ty with
+        | Left_input -> replace_equation_or_add_alias_to_const env eqn_name ty
+        | Right_input | Both_inputs -> env
+        | New_result ty' ->
+          replace_equation_or_add_alias_to_const env eqn_name ty'))
+    | Old meet_type_old -> (
+      if Name.equal original_name eqn_name
+      then replace_equation_or_add_alias_to_const t eqn_name ty
+      else
+        let env = Meet_env.create t in
+        let existing_ty = find t eqn_name (Some (TG.kind ty)) in
+        match meet_type_old env ty existing_ty with
+        | Bottom -> replace_equation t eqn_name (MTC.bottom (TG.kind ty))
+        | Ok (meet_ty, env_extension) ->
+          let t =
+            add_env_extension ~raise_on_bottom t env_extension ~meet_type
+          in
+          replace_equation_or_add_alias_to_const t eqn_name meet_ty)
+  in
+  pattern_match_equation simple ty ~name ~const:(fun const ty ->
+      (* If we are applying an alias-to-constant type to a name, the constant
+         becomes canonical and we need to apply the type to the constant
+         instead. This merely reduces to checking that the type is compatible
+         (e.g. if we are adding [x : (= 0)] in a context where [x : { 1, 2 }]
+         holds). *)
+      let existing_ty = MTC.type_for_const const in
+      match meet_type with
+      | New meet_type_new -> (
+        match meet_type_new t ty existing_ty with
+        | Bottom -> if raise_on_bottom then raise Bottom_equation else t
+        | Ok (_, env) -> env)
+      | Old meet_type_old -> (
+        let env = Meet_env.create t in
+        match meet_type_old env ty existing_ty with
+        | Bottom -> t
+        | Ok (_, env_extension) ->
+          add_env_extension ~raise_on_bottom t env_extension ~meet_type))
+
+and orient_and_add_equation ~raise_on_bottom t name ty ~meet_type =
   (if Flambda_features.check_light_invariants ()
   then
     let existing_ty = find t name None in
@@ -827,18 +926,17 @@ and add_equation1 ~raise_on_bottom t name ty ~(meet_type : meet_type) =
               "Directly recursive equation@ %a = %a@ disallowed:@ %a" Name.print
               name TG.print ty print t)
         ~const:(fun _ -> ()));
-  let aliases = aliases t in
-  let find_canonical name =
-    Aliases.get_canonical_ignoring_name_mode aliases name
-  in
   let inputs =
+    let aliases = aliases t in
+    let find_canonical name =
+      Aliases.get_canonical_ignoring_name_mode aliases name
+    in
     match TG.get_alias_exn ty with
     | exception Not_found ->
       (* Equations giving concrete types may only be added to the canonical
          element as known by the relevant alias tracker (the actual canonical,
          ignoring any name modes). *)
-      let canonical = find_canonical name in
-      Some (canonical, t, ty)
+      Some (find_canonical name, t, ty)
     | alias_rhs -> (
       (* Forget where [name] and [alias_rhs] came from---our job is now to
          record that they're equal. In general, they have canonical expressions
@@ -871,71 +969,31 @@ and add_equation1 ~raise_on_bottom t name ty ~(meet_type : meet_type) =
         | Ok { canonical_element; alias_of_demoted_element; t = aliases } ->
           let t = with_aliases t ~aliases in
           (* We need to change the demoted alias's type to point to the new
-             canonical element. *)
+             canonical element, and move the existing type of the demoted
+             element to the new canonical element. *)
+          let existing_ty =
+            Simple.pattern_match alias_of_demoted_element
+              ~const:MTC.type_for_const ~name:(fun name ~coercion ->
+                TG.apply_coercion (find t name (Some kind)) coercion)
+          in
           let ty = TG.alias_type_of kind canonical_element in
-          Some (alias_of_demoted_element, t, ty)
+          let t =
+            pattern_match_equation alias_of_demoted_element ty
+              ~name:(fun name ty -> replace_equation t name ty)
+              ~const:(fun _ _ ->
+                Misc.fatal_error "Unexpected demotion of constant.")
+          in
+          Some (canonical_element, t, existing_ty)
         | Bottom -> if raise_on_bottom then raise Bottom_equation else None)
   in
   match inputs with
   | None -> t
   | Some (simple, t, ty) ->
-    (* We have [(coerce <bare_lhs> <coercion>) : <ty>]. Thus [<bare_lhs> :
-       (coerce <ty> <coercion>^-1)]. *)
-    let bare_lhs = Simple.without_coercion simple in
-    let coercion_from_bare_lhs_to_ty = Simple.coercion simple in
-    let coercion_from_ty_to_bare_lhs =
-      Coercion.inverse coercion_from_bare_lhs_to_ty
-    in
-    let ty = TG.apply_coercion ty coercion_from_ty_to_bare_lhs in
-    (* Beware: if we're about to add the equation on a name which is different
-       from the one that the caller passed in, then we need to make sure that
-       the type we assign to that name is the most precise available. This
-       necessitates calling [meet].
-
-       For example, suppose [p] is defined earlier than [x], with [p] of type
-       [Unknown] and [x] of type [ty]. If the caller says that the best type of
-       [p] is now to be "= x", then this function will add an equation on [x]
-       rather than [p], due to the definition ordering. However we should not
-       just say that [x] has type "= p", as that would forget any existing
-       information about [x]. Instead we should say that [x] has type "(= p)
-       meet ty".
-
-       Note also that [p] and [x] may have different name modes! *)
-    let[@inline always] name eqn_name ~coercion =
-      assert (Coercion.is_id coercion);
-      (* true by definition *)
-      match meet_type with
-      | New meet_type_new -> (
-        let existing_ty = find t eqn_name (Some (TG.kind ty)) in
-        match meet_type_new t ty existing_ty with
-        | Bottom ->
-          if raise_on_bottom
-          then raise Bottom_equation
-          else add_equation0 t eqn_name (MTC.bottom (TG.kind ty))
-        | Ok (meet_ty, env) -> (
-          match meet_ty with
-          | Left_input -> add_equation0 env eqn_name ty
-          | Right_input | Both_inputs -> env
-          | New_result ty' -> add_equation0 env eqn_name ty'))
-      | Old meet_type_old -> (
-        if Name.equal name eqn_name
-        then add_equation0 t eqn_name ty
-        else
-          let env = Meet_env.create t in
-          let existing_ty = find t eqn_name (Some (TG.kind ty)) in
-          match meet_type_old env ty existing_ty with
-          | Bottom -> add_equation0 t eqn_name (MTC.bottom (TG.kind ty))
-          | Ok (meet_ty, env_extension) ->
-            let t =
-              add_env_extension ~raise_on_bottom t env_extension ~meet_type
-            in
-            add_equation0 t eqn_name meet_ty)
-    in
-    Simple.pattern_match bare_lhs ~name ~const:(fun _ -> t)
+    add_oriented_equation ~original_name:name ~raise_on_bottom t simple ty
+      ~meet_type
 
 and[@inline always] add_equation ~raise_on_bottom t name ty ~meet_type =
-  let ty = TG.recover_some_aliases ty in
-  match add_equation1 ~raise_on_bottom t name ty ~meet_type with
+  match orient_and_add_equation ~raise_on_bottom t name ty ~meet_type with
   | exception Binding_time_resolver_failure ->
     (* Addition of aliases between names that are both in external compilation
        units failed, e.g. due to a missing .cmx file. Simply drop the

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -3616,11 +3616,6 @@ module Head_of_kind_naked_nativeint =
 module Head_of_kind_naked_vec128 =
   Make_head_of_kind_naked_number (Vector_types.Vec128.Bit_pattern)
 
-let recover_const_alias_of_simple simple =
-  Simple.pattern_match simple
-    ~const:(fun const -> Some const)
-    ~name:(fun _ ~coercion:_ -> None)
-
 let rec recover_const_alias t : RWC.t option =
   match t with
   | Value ty -> (
@@ -3639,7 +3634,7 @@ let rec recover_const_alias t : RWC.t option =
                   | Boxed_nativeint _ | String _ | Closures _ | Array _ ) )
           }) ->
       None
-    | Ok (Equals simple) -> recover_const_alias_of_simple simple
+    | Ok (Equals simple) -> Simple.must_be_const simple
     | Ok
         (No_alias
           { is_null = Not_null;
@@ -3670,7 +3665,7 @@ let rec recover_const_alias t : RWC.t option =
     match TD.descr ty with
     | Unknown | Bottom | Ok (No_alias (Is_int _ | Get_tag _ | Is_null _)) ->
       None
-    | Ok (Equals simple) -> recover_const_alias_of_simple simple
+    | Ok (Equals simple) -> Simple.must_be_const simple
     | Ok (No_alias (Naked_immediates is)) -> (
       match Targetint_31_63.Set.get_singleton is with
       | Some i -> Some (RWC.naked_immediate i)
@@ -3678,7 +3673,7 @@ let rec recover_const_alias t : RWC.t option =
   | Naked_float32 ty -> (
     match TD.descr ty with
     | Unknown | Bottom -> None
-    | Ok (Equals simple) -> recover_const_alias_of_simple simple
+    | Ok (Equals simple) -> Simple.must_be_const simple
     | Ok (No_alias fs) -> (
       match Float32.Set.get_singleton fs with
       | Some f -> Some (RWC.naked_float32 f)
@@ -3686,7 +3681,7 @@ let rec recover_const_alias t : RWC.t option =
   | Naked_float ty -> (
     match TD.descr ty with
     | Unknown | Bottom -> None
-    | Ok (Equals simple) -> recover_const_alias_of_simple simple
+    | Ok (Equals simple) -> Simple.must_be_const simple
     | Ok (No_alias fs) -> (
       match Float.Set.get_singleton fs with
       | Some f -> Some (RWC.naked_float f)
@@ -3694,7 +3689,7 @@ let rec recover_const_alias t : RWC.t option =
   | Naked_int32 ty -> (
     match TD.descr ty with
     | Unknown | Bottom -> None
-    | Ok (Equals simple) -> recover_const_alias_of_simple simple
+    | Ok (Equals simple) -> Simple.must_be_const simple
     | Ok (No_alias is) -> (
       match Int32.Set.get_singleton is with
       | Some f -> Some (RWC.naked_int32 f)
@@ -3702,7 +3697,7 @@ let rec recover_const_alias t : RWC.t option =
   | Naked_int64 ty -> (
     match TD.descr ty with
     | Unknown | Bottom -> None
-    | Ok (Equals simple) -> recover_const_alias_of_simple simple
+    | Ok (Equals simple) -> Simple.must_be_const simple
     | Ok (No_alias is) -> (
       match Int64.Set.get_singleton is with
       | Some f -> Some (RWC.naked_int64 f)
@@ -3710,7 +3705,7 @@ let rec recover_const_alias t : RWC.t option =
   | Naked_nativeint ty -> (
     match TD.descr ty with
     | Unknown | Bottom -> None
-    | Ok (Equals simple) -> recover_const_alias_of_simple simple
+    | Ok (Equals simple) -> Simple.must_be_const simple
     | Ok (No_alias is) -> (
       match Targetint_32_64.Set.get_singleton is with
       | Some f -> Some (RWC.naked_nativeint f)
@@ -3718,7 +3713,7 @@ let rec recover_const_alias t : RWC.t option =
   | Naked_vec128 ty -> (
     match TD.descr ty with
     | Unknown | Bottom -> None
-    | Ok (Equals simple) -> recover_const_alias_of_simple simple
+    | Ok (Equals simple) -> Simple.must_be_const simple
     | Ok (No_alias is) -> (
       match Vec128.Set.get_singleton is with
       | Some f -> Some (RWC.naked_vec128 f)

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -809,4 +809,4 @@ module Head_of_kind_naked_vec128 :
     with type n = Vector_types.Vec128.Bit_pattern.t
     with type n_set = Vector_types.Vec128.Bit_pattern.Set.t
 
-val recover_some_aliases : t -> t
+val recover_const_alias : t -> Reg_width_const.t option


### PR DESCRIPTION
The function `TG.recover_some_aliases` is called by the typing environment in order to detect aliases prior to adding equations.

With the advanced meet (and also sometimes with the basic meet), this alias recovery is done before computing the meet with the existing type of the variable, which means that we can lose aliases if the meet discovers a new alias.

This patch changes the logic to perfom alias recovery after the meet has been performed, and also gives more descriptive names to the different steps of `add_equation` to make the logic more clear.

If we have:

```
x: (Variant (blocks {tag_0}) (tagged_imms ((= #0))))
```

and we add:

```
x: (Variant (blocks ⊥) (tagged_imms ⊤))
```

without this patch we get:

```
x: (Variant (blocks ⊥) (tagged_imms (= #0)))
```

with this patch we get:

```
x: (= 0)
```