### PR TITLE
Prefer generic mode error message for `stack_`

### DIFF
--- a/testsuite/tests/typing-modes/stack.ml
+++ b/testsuite/tests/typing-modes/stack.ml
@@ -17,13 +17,54 @@ Line 1, characters 12-31:
 Error: This value escapes its region.
 |}]
 
-let f = ref (stack_ ((fun x -> x) : _ @@ global ))
+let f = ref (stack_ (42, 42))
 [%%expect{|
-Line 1, characters 20-49:
-1 | let f = ref (stack_ ((fun x -> x) : _ @@ global ))
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 12-29:
+1 | let f = ref (stack_ (42, 42))
+                ^^^^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]
+
+let f () =
+  let g = stack_ ((42, 42) : _ @@ global ) in
+  ()
+[%%expect{|
+Line 2, characters 17-42:
+2 |   let g = stack_ ((42, 42) : _ @@ global ) in
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This allocation cannot be on the stack.
 |}]
+
+let f () =
+  let g = ref (stack_ ((42, 42) : _ @@ global )) in
+  ()
+[%%expect{|
+Line 2, characters 22-47:
+2 |   let g = ref (stack_ ((42, 42) : _ @@ global )) in
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This allocation cannot be on the stack.
+|}]
+
+let f () =
+  let g = stack_ (fun x y -> x : 'a -> 'a -> 'a) in
+  ()
+[%%expect{|
+Line 2, characters 17-48:
+2 |   let g = stack_ (fun x y -> x : 'a -> 'a -> 'a) in
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This allocation cannot be on the stack.
+|}]
+
+let f () =
+  let g = ref (stack_ (fun x y -> x : 'a -> 'a -> 'a)) in
+  ()
+[%%expect{|
+Line 2, characters 22-53:
+2 |   let g = ref (stack_ (fun x y -> x : 'a -> 'a -> 'a)) in
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This allocation cannot be on the stack.
+|}]
+
 
 let f = ref (stack_ (2, 3))
 [%%expect{|

--- a/testsuite/tests/typing-modes/stack.ml
+++ b/testsuite/tests/typing-modes/stack.ml
@@ -39,10 +39,10 @@ let f () =
   let g = ref (stack_ ((42, 42) : _ @@ global )) in
   ()
 [%%expect{|
-Line 2, characters 22-47:
+Line 2, characters 14-48:
 2 |   let g = ref (stack_ ((42, 42) : _ @@ global )) in
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This allocation cannot be on the stack.
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value escapes its region.
 |}]
 
 let f () =
@@ -59,10 +59,10 @@ let f () =
   let g = ref (stack_ (fun x y -> x : 'a -> 'a -> 'a)) in
   ()
 [%%expect{|
-Line 2, characters 22-53:
+Line 2, characters 14-54:
 2 |   let g = ref (stack_ (fun x y -> x : 'a -> 'a -> 'a)) in
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This allocation cannot be on the stack.
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value escapes its region.
 |}]
 
 


### PR DESCRIPTION
`stack_ exp` could trigger mode error for two reasons:
- The surroudning expression expects it to be `global`. For example, `ref (stack_ (42, 42))`. This should give the same error message as a typical mode error.
- The `exp` itself cannot be stack allocated for reasons of its own. There are two cases this can happen as follows. Ideally we want the error message to be more detailed, but that's difficult. Currently it just gives `Cannot stack allocate` for both cases.
  -  Uncurried functions. `stack_ (fun x y -> x : 'a -> 'a -> 'a)` (the inner function is `global`, therefore the outer function has to be `global` too).
  - Explicit mode annotation. E.g., `stack_ ((42, 42) : _ @@ global)`.

**_What this PR does:_**
It's possible that `stack_ exp` fails for both reasons, in which case we prefer the first reason for error messages.