### PR TITLE
flambda2-types: Make meet return a new typing env

### DIFF
--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -389,16 +389,6 @@ let mark_parameters_as_toplevel t params =
   in
   { t with variables_defined_at_toplevel }
 
-let define_variable_and_extend_typing_environment t var kind env_extension =
-  let t = (define_variable [@inlined hint]) t var kind in
-  let typing_env = TE.add_env_extension t.typing_env env_extension in
-  { t with typing_env }
-
-let add_variable_and_extend_typing_environment t var ty env_extension =
-  let t = (add_variable [@inlined hint]) t var ty in
-  let typing_env = TE.add_env_extension t.typing_env env_extension in
-  { t with typing_env }
-
 let extend_typing_environment t env_extension =
   (* There doesn't seem any need to augment [t.variables_defined_at_toplevel]
      here for the existential variables, since they will have [In_types]

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -117,20 +117,6 @@ val add_parameters_with_unknown_types :
 
 val mark_parameters_as_toplevel : t -> Bound_parameters.t -> t
 
-val define_variable_and_extend_typing_environment :
-  t ->
-  Bound_var.t ->
-  Flambda_kind.t ->
-  Flambda2_types.Typing_env_extension.t ->
-  t
-
-val add_variable_and_extend_typing_environment :
-  t ->
-  Bound_var.t ->
-  Flambda2_types.t ->
-  Flambda2_types.Typing_env_extension.t ->
-  t
-
 val extend_typing_environment :
   t -> Flambda2_types.Typing_env_extension.With_extra_variables.t -> t
 

--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -167,9 +167,8 @@ let add_equations_on_params typing_env ~is_recursive ~params:params'
                  [Invalid], but this seems an unusual situation, so we don't do
                  that currently. *)
               TE.add_equation typing_env name (T.bottom raw_kind)
-            | Ok (meet_ty, env_extension) ->
-              let typing_env = TE.add_equation typing_env name meet_ty in
-              TE.add_env_extension typing_env env_extension
+            | Ok (meet_ty, typing_env) ->
+              TE.add_equation typing_env name meet_ty
           else TE.add_equation typing_env name param_type
         in
         add_equations_on_params typing_env params param_types)

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -50,17 +50,20 @@ type simplify_function_body =
 
 let simplify_projection dacc ~original_term ~deconstructing ~shape ~result_var
     ~result_kind =
-  let env = DA.typing_env dacc in
-  match T.meet_shape env deconstructing ~shape ~result_var ~result_kind with
+  let denv = DA.denv dacc in
+  let denv = DE.define_variable denv result_var result_kind in
+  let env = DE.typing_env denv in
+  match T.meet_shape env deconstructing ~shape with
   | Bottom ->
-    let dacc = DA.add_variable dacc result_var (T.bottom result_kind) in
-    Simplify_primitive_result.create_invalid dacc
-  | Ok env_extension ->
-    let dacc =
-      DA.map_denv dacc ~f:(fun denv ->
-          DE.define_variable_and_extend_typing_environment denv result_var
-            result_kind env_extension)
+    let denv =
+      DE.add_equation_on_variable denv (Bound_var.var result_var)
+        (T.bottom result_kind)
     in
+    let dacc = DA.with_denv dacc denv in
+    Simplify_primitive_result.create_invalid dacc
+  | Ok env ->
+    let denv = DE.with_typing_env denv env in
+    let dacc = DA.with_denv dacc denv in
     Simplify_primitive_result.create original_term ~try_reify:true dacc
 
 let update_exn_continuation_extra_args uacc ~exn_cont_use_id apply =

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -542,8 +542,7 @@ let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
   let shape = T.this_naked_immediate arm in
   match T.meet typing_env_at_use scrutinee_ty shape with
   | Bottom -> arms, dacc
-  | Ok (_meet_ty, env_extension) ->
-    let env_at_use = TE.add_env_extension typing_env_at_use env_extension in
+  | Ok (_meet_ty, env_at_use) ->
     let denv_at_use = DE.with_typing_env (DA.denv dacc) env_at_use in
     let args = AC.args action in
     let use_kind =

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
@@ -19,45 +19,39 @@ open! Simplify_import
 let simplify_make_block ~original_prim ~(block_kind : P.Block_kind.t)
     ~(mutable_or_immutable : Mutability.t) alloc_mode dacc ~original_term _dbg
     ~args_with_tys ~result_var =
-  let env_extension : _ Or_bottom.t =
+  let typing_env = DA.typing_env dacc in
+  let typing_env : _ Or_bottom.t =
     match block_kind with
     | Naked_floats | Mixed _ ->
       (* No useful subkind information *)
-      Ok TEE.empty
+      Ok typing_env
     | Values (_tag, field_kinds) ->
       if List.compare_lengths args_with_tys field_kinds <> 0
       then
         Misc.fatal_errorf
           "Shape in [Make_block] of different length from argument list:@ %a"
           Named.print original_term;
-      let typing_env = DA.typing_env dacc in
       List.fold_left2
-        (fun env_extension arg_kind (arg, _arg_ty) : _ Or_bottom.t ->
+        (fun typing_env arg_kind (arg, _arg_ty) : _ Or_bottom.t ->
           let open Or_bottom.Let_syntax in
-          let<* env_extension = env_extension in
+          let<* typing_env = typing_env in
           Simple.pattern_match' arg
             ~var:(fun _ ~coercion:_ : _ Or_bottom.t ->
-              let<* _ty, env_extension' =
+              let<+ _ty, typing_env =
                 T.meet typing_env
                   (T.alias_type_of (K.With_subkind.kind arg_kind) arg)
                   (T.unknown_with_subkind arg_kind)
               in
-              let<+ env_extension =
-                T.Typing_env_extension.meet typing_env env_extension
-                  env_extension'
-              in
-              env_extension)
-            ~const:(fun _ : _ Or_bottom.t -> Ok env_extension)
-            ~symbol:(fun _ ~coercion:_ : _ Or_bottom.t -> Ok env_extension))
-        (Or_bottom.Ok TEE.empty) field_kinds args_with_tys
+              typing_env)
+            ~const:(fun _ : _ Or_bottom.t -> Ok typing_env)
+            ~symbol:(fun _ ~coercion:_ : _ Or_bottom.t -> Ok typing_env))
+        (Or_bottom.Ok typing_env) field_kinds args_with_tys
   in
-  match env_extension with
+  match typing_env with
   | Bottom -> SPR.create_invalid dacc
-  | Ok env_extension ->
+  | Ok typing_env ->
     let dacc =
-      DA.map_denv dacc ~f:(fun denv ->
-          DE.map_typing_env denv ~f:(fun typing_env ->
-              TE.add_env_extension typing_env env_extension))
+      DA.map_denv dacc ~f:(fun denv -> DE.with_typing_env denv typing_env)
     in
     let ty =
       let fields = List.map snd args_with_tys in
@@ -115,24 +109,24 @@ let simplify_make_array (array_kind : P.Array_kind.t)
        list:@ array_kind=%a@ num args=%d@ %a"
       P.Array_kind.print array_kind (List.length args) Named.print original_term;
   let env_extension =
+    let typing_env = DA.typing_env dacc in
     match element_kind with
-    | None -> Or_bottom.Ok TEE.empty
+    | None -> Or_bottom.Ok typing_env
     | Some element_kind ->
       let initial_element_type = T.unknown_with_subkind element_kind in
-      let typing_env = DA.typing_env dacc in
       List.fold_left
-        (fun env_extension element_type ->
+        (fun typing_env element_type ->
           let open Or_bottom.Let_syntax in
-          let<* env_extension = env_extension in
-          let<* _, env_extension' =
+          let<* typing_env = typing_env in
+          let<+ _, typing_env =
             T.meet typing_env initial_element_type element_type
           in
-          TEE.meet typing_env env_extension env_extension')
-        (Or_bottom.Ok TEE.empty) tys
+          typing_env)
+        (Or_bottom.Ok typing_env) tys
   in
   match env_extension with
   | Bottom -> SPR.create_invalid dacc
-  | Ok env_extension ->
+  | Ok typing_env ->
     let ty =
       let alloc_mode = Alloc_mode.For_allocations.as_type alloc_mode in
       let element_kind : _ Or_unknown_or_bottom.t =
@@ -155,8 +149,8 @@ let simplify_make_array (array_kind : P.Array_kind.t)
     in
     let dacc =
       DA.map_denv dacc ~f:(fun denv ->
-          DE.add_variable_and_extend_typing_environment denv result_var ty
-            env_extension)
+          let denv = DE.with_typing_env denv typing_env in
+          DE.add_variable denv result_var ty)
     in
     SPR.create named ~try_reify:true dacc
 

--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -21,9 +21,7 @@ let add_equation_on_var denv var shape =
   let kind = T.kind shape in
   let var_type = T.alias_type_of kind (Simple.var var) in
   match T.meet (DE.typing_env denv) var_type shape with
-  | Ok (_ty, env_extension) ->
-    DE.map_typing_env denv ~f:(fun tenv ->
-        TE.add_env_extension tenv env_extension)
+  | Ok (_ty, typing_env) -> DE.with_typing_env denv typing_env
   | Bottom ->
     Misc.fatal_errorf "Meet failed whereas prove and meet previously succeeded"
 

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -177,8 +177,7 @@ and make_optimistic_fields ~add_tag_to_name ~depth ~recursive tenv param_type
       "Context is meet of type: %a@\nwith shape: %a@\nin env: @\n%a@." T.print
       param_type T.print shape TE.print tenv;
     raise exn
-  | Ok (_, env_extension) ->
-    let tenv = TE.add_env_extension tenv env_extension in
+  | Ok (_, tenv) ->
     let fields =
       List.map2
         (fun epa var_type : U.field_decision ->

--- a/middle_end/flambda2/tests/api_tests/extension_meet.ml
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.ml
@@ -6,7 +6,6 @@ open Flambda2_numbers
 open Flambda2_term_basics
 module T = Flambda2_types
 module TE = Flambda2_types.Typing_env
-module TEE = Flambda2_types.Typing_env_extension
 
 let _test_recursive_meet () =
   let env =
@@ -55,7 +54,7 @@ let _test_recursive_meet () =
   Format.eprintf "Environment: %a@." TE.print env;
   match T.meet env ty1 ty2 with
   | Ok (ty, ext) ->
-    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TEE.print ext
+    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TE.print ext
   | Bottom -> Format.eprintf "Bottom@."
 
 let _test_bottom_detection () =
@@ -88,7 +87,7 @@ let _test_bottom_detection () =
   Format.eprintf "Environment: %a@." TE.print env;
   match T.meet env ty1 ty2 with
   | Ok (ty, ext) ->
-    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TEE.print ext
+    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TE.print ext
   | Bottom -> Format.eprintf "Bottom@."
 
 let _test_bottom_recursive () =
@@ -128,7 +127,7 @@ let _test_bottom_recursive () =
   Format.eprintf "Environment: %a@." TE.print env;
   match T.meet env (alias n_x) ty_cell1 with
   | Ok (ty, ext) ->
-    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TEE.print ext
+    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TE.print ext
   | Bottom ->
     let[@inline never] [@local never] breakpoint () = () in
     breakpoint ();
@@ -177,7 +176,7 @@ let test_double_recursion () =
   Format.eprintf "Environment: %a@." TE.print env;
   match T.meet env (alias n_x) (alias n_y) with
   | Ok (ty, ext) ->
-    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TEE.print ext
+    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TE.print ext
   | Bottom -> Format.eprintf "Bottom@."
 
 let _ =

--- a/middle_end/flambda2/tests/api_tests/extension_meet.ml
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.ml
@@ -53,8 +53,9 @@ let _test_recursive_meet () =
   in
   Format.eprintf "Environment: %a@." TE.print env;
   match T.meet env ty1 ty2 with
-  | Ok (ty, ext) ->
-    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TE.print ext
+  | Ok (ty, env) ->
+    Format.eprintf "Result type: %a@.New environment:@ %a@." T.print ty TE.print
+      env
   | Bottom -> Format.eprintf "Bottom@."
 
 let _test_bottom_detection () =
@@ -86,8 +87,9 @@ let _test_bottom_detection () =
   in
   Format.eprintf "Environment: %a@." TE.print env;
   match T.meet env ty1 ty2 with
-  | Ok (ty, ext) ->
-    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TE.print ext
+  | Ok (ty, env) ->
+    Format.eprintf "Result type: %a@.New environment:@ %a@." T.print ty TE.print
+      env
   | Bottom -> Format.eprintf "Bottom@."
 
 let _test_bottom_recursive () =
@@ -126,8 +128,9 @@ let _test_bottom_recursive () =
   in
   Format.eprintf "Environment: %a@." TE.print env;
   match T.meet env (alias n_x) ty_cell1 with
-  | Ok (ty, ext) ->
-    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TE.print ext
+  | Ok (ty, env) ->
+    Format.eprintf "Result type: %a@.New environment:@ %a@." T.print ty TE.print
+      env
   | Bottom ->
     let[@inline never] [@local never] breakpoint () = () in
     breakpoint ();
@@ -175,8 +178,9 @@ let test_double_recursion () =
   let env = TE.add_equation env n_z ty_z in
   Format.eprintf "Environment: %a@." TE.print env;
   match T.meet env (alias n_x) (alias n_y) with
-  | Ok (ty, ext) ->
-    Format.eprintf "Result type: %a@.Extension:@ %a@." T.print ty TE.print ext
+  | Ok (ty, env) ->
+    Format.eprintf "Result type: %a@.New environment:@ %a@." T.print ty TE.print
+      env
   | Bottom -> Format.eprintf "Bottom@."
 
 let _ =

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -34,11 +34,7 @@ module Typing_env = struct
   module Alias_set = Aliases.Alias_set
 end
 
-module Typing_env_extension = struct
-  include Typing_env_extension
-
-  let meet = Meet_and_join.meet_env_extension
-end
+module Typing_env_extension = Typing_env_extension
 
 type typing_env = Typing_env.t
 

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -75,8 +75,6 @@ module Typing_env_extension : sig
 
   val add_or_replace_equation : t -> Name.t -> flambda_type -> t
 
-  val meet : typing_env -> t -> t -> t Or_bottom.t
-
   module With_extra_variables : sig
     type t
 
@@ -247,15 +245,9 @@ module Typing_env : sig
     t -> min_name_mode:Name_mode.t -> Simple.t -> Alias_set.t
 end
 
-val meet : Typing_env.t -> t -> t -> (t * Typing_env_extension.t) Or_bottom.t
+val meet : Typing_env.t -> t -> t -> (t * Typing_env.t) Or_bottom.t
 
-val meet_shape :
-  Typing_env.t ->
-  t ->
-  shape:t ->
-  result_var:Bound_var.t ->
-  result_kind:Flambda_kind.t ->
-  Typing_env_extension.t Or_bottom.t
+val meet_shape : Typing_env.t -> t -> shape:t -> Typing_env.t Or_bottom.t
 
 val join :
   ?bound_name:Name.t ->

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -15,17 +15,30 @@
 let meet env t1 t2 =
   if Flambda_features.use_better_meet ()
   then Meet_and_join_new.meet env t1 t2
-  else Meet_and_join_old.meet (Typing_env.Meet_env.create env) t1 t2
+  else
+    match Meet_and_join_old.meet (Typing_env.Meet_env.create env) t1 t2 with
+    | Bottom -> Or_bottom.Bottom
+    | Ok (ty, env_extension) ->
+      Or_bottom.Ok
+        ( ty,
+          Typing_env.add_env_extension env env_extension
+            ~meet_type:(Old Meet_and_join_old.meet) )
 
 let[@inline] meet_type () =
   if Flambda_features.use_better_meet ()
   then Typing_env.New Meet_and_join_new.meet_type
   else Typing_env.Old Meet_and_join_old.meet
 
-let meet_shape env t ~shape ~result_var ~result_kind =
+let meet_shape env t ~shape =
   if Flambda_features.use_better_meet ()
-  then Meet_and_join_new.meet_shape env t ~shape ~result_var ~result_kind
-  else Meet_and_join_old.meet_shape env t ~shape ~result_var ~result_kind
+  then Meet_and_join_new.meet_shape env t ~shape
+  else
+    match Meet_and_join_old.meet_shape env t ~shape with
+    | Bottom -> Or_bottom.Bottom
+    | Ok env_extension ->
+      Or_bottom.Ok
+        (Typing_env.add_env_extension env env_extension
+           ~meet_type:(Old Meet_and_join_old.meet))
 
 let meet_env_extension env t1 t2 =
   if Flambda_features.use_better_meet ()

--- a/middle_end/flambda2/types/meet_and_join.mli
+++ b/middle_end/flambda2/types/meet_and_join.mli
@@ -16,7 +16,7 @@ val meet :
   Typing_env.t ->
   Type_grammar.t ->
   Type_grammar.t ->
-  (Type_grammar.t * Typing_env_extension.t) Or_bottom.t
+  (Type_grammar.t * Typing_env.t) Or_bottom.t
 
 val meet_type : unit -> Typing_env.meet_type
 
@@ -24,9 +24,7 @@ val meet_shape :
   Typing_env.t ->
   Type_grammar.t ->
   shape:Type_grammar.t ->
-  result_var:Bound_var.t ->
-  result_kind:Flambda_kind.t ->
-  Typing_env_extension.t Or_bottom.t
+  Typing_env.t Or_bottom.t
 
 val meet_env_extension :
   Typing_env.t ->

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -2299,27 +2299,16 @@ let meet env ty1 ty2 : _ Or_bottom.t =
   if TE.is_bottom env
   then Bottom
   else
-    let scope = TE.current_scope env in
-    let scoped_env = TE.increment_scope env in
-    match meet scoped_env ty1 ty2 with
+    match meet env ty1 ty2 with
     | Bottom _ -> Bottom
-    | Ok (r, scoped_env) ->
+    | Ok (r, env) ->
       let res_ty = extract_value r ty1 ty2 in
-      if TG.is_obviously_bottom res_ty
-      then Bottom
-      else
-        let env_extension = TE.cut_as_extension scoped_env ~cut_after:scope in
-        Ok (res_ty, env_extension)
+      if TG.is_obviously_bottom res_ty then Bottom else Ok (res_ty, env)
 
-let meet_shape env t ~shape ~result_var ~result_kind : _ Or_bottom.t =
+let meet_shape env t ~shape : _ Or_bottom.t =
   if TE.is_bottom env
   then Bottom
-  else
-    let result = Bound_name.create_var result_var in
-    let env = TE.add_definition env result result_kind in
-    match meet env t shape with
-    | Bottom -> Bottom
-    | Ok (_, env_extension) -> Ok env_extension
+  else match meet env t shape with Bottom -> Bottom | Ok (_, env) -> Ok env
 
 let meet_env_extension env ext1 ext2 : _ Or_bottom.t =
   if TE.is_bottom env

--- a/middle_end/flambda2/types/meet_and_join_new.mli
+++ b/middle_end/flambda2/types/meet_and_join_new.mli
@@ -19,7 +19,7 @@ val meet :
   Typing_env.t ->
   Type_grammar.t ->
   Type_grammar.t ->
-  (Type_grammar.t * Typing_env_extension.t) Or_bottom.t
+  (Type_grammar.t * Typing_env.t) Or_bottom.t
 
 (** Least upper bound of two types. *)
 val join :
@@ -33,9 +33,7 @@ val meet_shape :
   Typing_env.t ->
   Type_grammar.t ->
   shape:Type_grammar.t ->
-  result_var:Bound_var.t ->
-  result_kind:Flambda_kind.t ->
-  Typing_env_extension.t Or_bottom.t
+  Typing_env.t Or_bottom.t
 
 val meet_env_extension :
   Typing_env.t ->

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -1913,11 +1913,9 @@ and join_env_extension env (ext1 : TEE.t) (ext2 : TEE.t) : TEE.t =
   in
   TEE.from_map equations
 
-let meet_shape env t ~shape ~result_var ~result_kind : _ Or_bottom.t =
+let meet_shape env t ~shape : _ Or_bottom.t =
   if TE.is_bottom env
   then Bottom
   else
-    let result = Bound_name.create_var result_var in
-    let env = TE.add_definition env result result_kind in
     let<+ _meet_ty, env_extension = meet (Meet_env.create env) t shape in
     env_extension

--- a/middle_end/flambda2/types/meet_and_join_old.mli
+++ b/middle_end/flambda2/types/meet_and_join_old.mli
@@ -33,8 +33,6 @@ val meet_shape :
   Typing_env.t ->
   Type_grammar.t ->
   shape:Type_grammar.t ->
-  result_var:Bound_var.t ->
-  result_kind:Flambda_kind.t ->
   Typing_env_extension.t Or_bottom.t
 
 val meet_env_extension :


### PR DESCRIPTION
Make the `meet` function return a new typing env rather than an extension. This is preparatory work for the new join algorithm, which might create new variables (`meet` can call `join`), but env extensions cannot hold variables.

An alternative would be to return env extensions with new variables, but we are internally building a new typing env anyways -- it doesn't make much sense to cut it then immediately add it back to the same env, so we might as well just return the typing env directly.