### PR TITLE
flambda2-types: It is OK to add an alias between constants

### DIFF
--- a/middle_end/flambda2/types/env/aliases.ml
+++ b/middle_end/flambda2/types/env/aliases.ml
@@ -809,19 +809,11 @@ let add ~binding_time_resolver ~binding_times_and_modes t
       ~then_:(Coercion.inverse (Simple.coercion element1_with_coercion))
   in
   if Flambda_features.check_light_invariants ()
-  then (
+  then
     if Simple.equal canonical_element1 canonical_element2
     then
       Misc.fatal_errorf "Cannot alias an element to itself: %a" Simple.print
         canonical_element1;
-    Simple.pattern_match canonical_element1
-      ~name:(fun _ ~coercion:_ -> ())
-      ~const:(fun const1 ->
-        Simple.pattern_match canonical_element2
-          ~name:(fun _ ~coercion:_ -> ())
-          ~const:(fun const2 ->
-            Misc.fatal_errorf "Cannot add alias between two consts: %a, %a"
-              Reg_width_const.print const1 Reg_width_const.print const2)));
   let open Or_bottom.Let_syntax in
   let<+ t, which_element =
     add_alias ~binding_time_resolver ~binding_times_and_modes t


### PR DESCRIPTION
We have an invariant that asserts we cannot add aliases between constants, but we actually support it (by returning `Bottom`).

If we have `y` with an env extension on tag 0 that states `x` has type `= 0`, and we later perform a switch on `x = 1` then `Get_tag y = 0`, this would add the env extension to the environment and we want to deduce this is an impossible case from the equation `0 = 1`.