### PR TITLE
Actually disallow unescaped newlines in strings in ocamltests

### DIFF
--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -108,7 +108,7 @@ script = "some-directory\\
    is interpreted as the OCaml string "some-directory\\ foo".
    *)
 and string acc = parse
-  | [^ '\\' '"' ]+
+  | [^ '\\' '"' '\010' ]+
     { string (acc ^ Lexing.lexeme lexbuf) lexbuf }
   | '\\' newline blank* ('\\' (blank as blank))?
     { let space =

--- a/testsuite/tests/tool-ocamltest/child-ocamltest.sh
+++ b/testsuite/tests/tool-ocamltest/child-ocamltest.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# This script runs ocamltest on a file after having replaced CHILDTEST with
+# TEST. This allows testing that ocamltest catches syntax errors without the
+# Make-based ocamltest drivers confusing the test test for a real test.
+
+temp_tsl=$(mktemp child_test_temp_XXX.ml)
+trap 'rm -f -- "$temp_tsl"' EXIT
+
+sed -e 's/CHILDTEST/TEST/' "${tsl:?tsl must be set}" > "$temp_tsl"
+
+"${ocamlsrcdir}/ocamltest/ocamltest" "$temp_tsl" 2>&1

--- a/testsuite/tests/tool-ocamltest/string_with_unescaped_newline.tsl
+++ b/testsuite/tests/tool-ocamltest/string_with_unescaped_newline.tsl
@@ -1,0 +1,5 @@
+(* CHILDTEST
+
+ set my_var = "This string
+   has an unescaped newline.";
+ *)

--- a/testsuite/tests/tool-ocamltest/strings.ml
+++ b/testsuite/tests/tool-ocamltest/strings.ml
@@ -1,0 +1,6 @@
+(* TEST
+ set tsl = "${test_source_directory}/string_with_unescaped_newline.tsl";
+ script = "${test_source_directory}/child-ocamltest.sh";
+ exit_status = "2";
+ script;
+*)

--- a/testsuite/tests/typing-layouts-caml-modify/basics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/basics.ml
@@ -2,7 +2,7 @@
  modules = "replace_caml_modify.c";
  {
    not-macos;
-   flags = "-cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify
+   flags = "-cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify \
             -cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify_local";
    native;
  }


### PR DESCRIPTION
It transpires that #3506 did nothing. This PR completes the job, namely stopping string values from having unescaped newlines. This time I've added a test case.