### PR TITLE
Reduce default space overhead from 160 to 80

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -247,7 +247,7 @@ typedef uint64_t uintnat;
 /* Default speed setting for the major GC.  The heap will grow until
    the dead objects and the free list represent this percentage of the
    total size of live objects. */
-#define Percent_free_def 160
+#define Percent_free_def 80
 
 /* Default setting for the compacter: 500%
    (i.e. trigger the compacter when 5/6 of the heap is free or garbage).

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -136,12 +136,15 @@ type control =
 
     space_overhead : int;
     (** The major GC speed is computed from this parameter.
-       This is the memory that will be "wasted" because the GC does not
-       immediately collect unreachable blocks.  It is expressed as a
-       percentage of the memory used for live data.
-       The GC will work more (use more CPU time and collect
-       blocks more eagerly) if [space_overhead] is smaller.
-       Default: 120. *)
+        This is the memory that will be "wasted" because the GC does not
+        immediately collect unreachable blocks.  It is expressed as a
+        percentage of the memory used for live data.
+        The GC will work more (use more CPU time and collect
+        blocks more eagerly) if [space_overhead] is smaller.
+        On runtime 4 this doesn't account correctly for bigarrays; you
+        may find the GC works much harder than necessary to satisfy this
+        parameter.
+        Runtime 4 default: 100. Runtime 5 default: 80. *)
 
     verbose : int;
     (** This value controls the GC messages on standard error output.


### PR DESCRIPTION
160 is definitely too large a value for this parameter now. 100 is the default value for runtime4 (whereas upstream ocaml/ocaml has 120). Also runtime4 undershoots this parameter by quite a lot in the presence of big arrays. With our new pacing policy, runtime 5 does not. Some basic eyeballing of `memtrace-viewer` charts suggests that the runtime5 behaviour at 80 is pretty similar to runtime4 at 100.