### PR TITLE
flambda2: Continuation shortcuts

### DIFF
--- a/middle_end/flambda2/simplify/env/upwards_env.ml
+++ b/middle_end/flambda2/simplify/env/upwards_env.ml
@@ -14,31 +14,67 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type continuation_shortcut =
+  { params : Bound_parameters.t;
+    continuation : Continuation.t;
+    args : Simple.t list
+  }
+
+let apply_continuation_shortcut { params; continuation; args } shortcut_args =
+  let subst =
+    List.fold_left2
+      (fun subst param arg -> Variable.Map.add param arg subst)
+      Variable.Map.empty
+      (Bound_parameters.vars params)
+      shortcut_args
+  in
+  ( continuation,
+    List.map
+      (fun arg ->
+        Simple.pattern_match' arg
+          ~var:(fun var ~coercion ->
+            match Variable.Map.find var subst with
+            | exception Not_found -> arg
+            | simple -> Simple.apply_coercion_exn simple coercion)
+          ~symbol:(fun _ ~coercion:_ -> arg)
+          ~const:(fun _ -> arg))
+      args )
+
+let print_continuation_shortcut ppf { params; continuation; args } =
+  Format.fprintf ppf "\\%a -> %a(%a)" Bound_parameters.print params
+    Continuation.print continuation
+    (Format.pp_print_list
+       ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
+       Simple.print)
+    args
+
 type t =
   { continuations : Continuation_in_env.t Continuation.Map.t;
-    continuation_aliases : Continuation.t Continuation.Map.t;
+    continuation_shortcuts : continuation_shortcut Continuation.Map.t;
     apply_cont_rewrites : Apply_cont_rewrite.t Continuation.Map.t;
     are_rebuilding_terms : Are_rebuilding_terms.t
   }
 
 let create are_rebuilding_terms =
   { continuations = Continuation.Map.empty;
-    continuation_aliases = Continuation.Map.empty;
+    continuation_shortcuts = Continuation.Map.empty;
     apply_cont_rewrites = Continuation.Map.empty;
     are_rebuilding_terms
   }
 
 let [@ocamlformat "disable"] print ppf
-    { continuations; continuation_aliases;
-      apply_cont_rewrites; are_rebuilding_terms } =
+    { continuations;
+      apply_cont_rewrites; are_rebuilding_terms ;
+      continuation_shortcuts } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(continuations@ %a)@]@ \
-      @[<hov 1>(continuation_aliases@ %a)@]@ \
+      @[<hov 1>(continuation_shortcuts@ %a)@]@ \
       @[<hov 1>(apply_cont_rewrites@ %a)@]\
       )@]"
     (Continuation.Map.print (Continuation_in_env.print are_rebuilding_terms))
     continuations
-    (Continuation.Map.print Continuation.print) continuation_aliases
+    (Continuation.Map.print print_continuation_shortcut)
+    continuation_shortcuts
     (Continuation.Map.print Apply_cont_rewrite.print)
     apply_cont_rewrites
 
@@ -51,33 +87,22 @@ let find_continuation t cont =
 
 let mem_continuation t cont = Continuation.Map.mem cont t.continuations
 
-let check_alias_transitivity t cont alias_for =
+let check_shortcut_transitivity t cont shortcut_to =
   if Flambda_features.check_invariants ()
-     && Continuation.Map.mem alias_for t.continuation_aliases
+     && Continuation.Map.mem shortcut_to t.continuation_shortcuts
   then
     Misc.fatal_errorf
-      "@[<hov 2>The continuation alias map does not represent thetransitive \
+      "@[<hov 2>The continuation alias map does not represent the transitive \
        closure of alias equations on continuations:@ %a, alias for %a, is \
        already bound in %a@]"
-      Continuation.print alias_for Continuation.print cont print t
+      Continuation.print shortcut_to Continuation.print cont print t
 
-let resolve_continuation_aliases t cont =
-  match Continuation.Map.find cont t.continuation_aliases with
-  | exception Not_found -> cont
-  | alias_for ->
-    check_alias_transitivity t cont alias_for;
-    alias_for
-
-let resolve_exn_continuation_aliases t exn_cont =
-  let cont = Exn_continuation.exn_handler exn_cont in
-  match Continuation.Map.find cont t.continuation_aliases with
-  | exception Not_found -> exn_cont
-  | alias_for ->
-    check_alias_transitivity t cont alias_for;
-    Exn_continuation.with_exn_handler exn_cont alias_for
-
-let continuation_arity t cont =
-  find_continuation t cont |> Continuation_in_env.arity
+let find_continuation_shortcut t cont =
+  match Continuation.Map.find cont t.continuation_shortcuts with
+  | exception Not_found -> None
+  | shortcut_to ->
+    check_shortcut_transitivity t cont shortcut_to.continuation;
+    Some shortcut_to
 
 let add_continuation0 t cont cont_in_env =
   let continuations = Continuation.Map.add cont cont_in_env t.continuations in
@@ -93,26 +118,24 @@ let add_non_inlinable_continuation t cont ~params ~handler =
 let add_invalid_continuation t cont arity =
   add_continuation0 t cont (Invalid { arity })
 
-let add_continuation_alias t cont arity ~alias_for =
-  let alias_for = resolve_continuation_aliases t alias_for in
-  let alias_for_arity = continuation_arity t alias_for in
-  if not (Flambda_arity.equal_ignoring_subkinds arity alias_for_arity)
-  then
-    Misc.fatal_errorf
-      "%a (arity %a) cannot be an alias for %a (arity %a) since the two \
-       continuations differ in arity"
-      Continuation.print cont Flambda_arity.print arity Continuation.print
-      alias_for Flambda_arity.print alias_for_arity;
-  if Continuation.Map.mem cont t.continuation_aliases
-  then
-    Misc.fatal_errorf
-      "Cannot add continuation alias %a (as alias for %a); the continuation is \
-       already deemed to be an alias"
-      Continuation.print cont Continuation.print alias_for;
-  let continuation_aliases =
-    Continuation.Map.add cont alias_for t.continuation_aliases
+let add_continuation_shortcut t cont ~params ~shortcut_to ~args =
+  let shortcut_to, args =
+    match find_continuation_shortcut t shortcut_to with
+    | None -> shortcut_to, args
+    | Some shortcut -> apply_continuation_shortcut shortcut args
   in
-  { t with continuation_aliases }
+  if Continuation.Map.mem cont t.continuation_shortcuts
+  then
+    Misc.fatal_errorf
+      "Cannot add continuation shortcut %a (as shortcut to%a); the \
+       continuation is already deemed to be a shortcut"
+      Continuation.print cont Continuation.print shortcut_to;
+  let continuation_shortcuts =
+    Continuation.Map.add cont
+      { params; continuation = shortcut_to; args }
+      t.continuation_shortcuts
+  in
+  { t with continuation_shortcuts }
 
 let add_linearly_used_inlinable_continuation t cont ~params ~handler
     ~free_names_of_handler ~cost_metrics_of_handler =

--- a/middle_end/flambda2/simplify/env/upwards_env.mli
+++ b/middle_end/flambda2/simplify/env/upwards_env.mli
@@ -32,11 +32,12 @@ val add_non_inlinable_continuation :
 val add_invalid_continuation :
   t -> Continuation.t -> [`Unarized] Flambda_arity.t -> t
 
-val add_continuation_alias :
+val add_continuation_shortcut :
   t ->
   Continuation.t ->
-  [`Unarized] Flambda_arity.t ->
-  alias_for:Continuation.t ->
+  params:Bound_parameters.t ->
+  shortcut_to:Continuation.t ->
+  args:Simple.t list ->
   t
 
 val add_linearly_used_inlinable_continuation :
@@ -55,10 +56,17 @@ val find_continuation : t -> Continuation.t -> Continuation_in_env.t
 
 val mem_continuation : t -> Continuation.t -> bool
 
-val resolve_continuation_aliases : t -> Continuation.t -> Continuation.t
+type continuation_shortcut =
+  { params : Bound_parameters.t;
+    continuation : Continuation.t;
+    args : Simple.t list
+  }
 
-val resolve_exn_continuation_aliases :
-  t -> Exn_continuation.t -> Exn_continuation.t
+val apply_continuation_shortcut :
+  continuation_shortcut -> Simple.t list -> Continuation.t * Simple.t list
+
+val find_continuation_shortcut :
+  t -> Continuation.t -> continuation_shortcut option
 
 val add_apply_cont_rewrite : t -> Continuation.t -> Apply_cont_rewrite.t -> t
 

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -686,6 +686,18 @@ let rewrite_apply_cont0 uacc rewrite ~ctx id apply_cont :
   | Invalid -> Invalid { message = "" }
   | Ok (extra_lets, args) -> (
     let apply_cont = Apply_cont.update_args apply_cont ~args in
+    let apply_cont =
+      match
+        UE.find_continuation_shortcut (UA.uenv uacc)
+          (Apply_cont.continuation apply_cont)
+      with
+      | None -> apply_cont
+      | Some shortcut ->
+        let cont, args =
+          UE.apply_continuation_shortcut shortcut (Apply_cont.args apply_cont)
+        in
+        Apply_cont.with_continuation_and_args apply_cont cont ~args
+    in
     match extra_lets with
     | [] -> Apply_cont apply_cont
     | _ :: _ ->
@@ -722,10 +734,25 @@ let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
     | Continuation cont -> cont
     | Apply_cont apply_cont -> Apply_cont.continuation apply_cont
   in
-  let original_cont = cont in
-  let cont = UE.resolve_continuation_aliases uenv cont in
-  match UE.find_apply_cont_rewrite uenv original_cont with
-  | None -> This_continuation cont
+  let[@local] shortcut_this_continuation_if_possible () :
+      rewrite_fixed_arity_continuation0_result =
+    (* Apply the shortcut if we can, but not if we are rewriting a
+       [Continuation] since we would need a wrapper anyways. *)
+    match cont_or_apply_cont with
+    | Continuation cont -> This_continuation cont
+    | Apply_cont apply_cont -> (
+      let cont = Apply_cont.continuation apply_cont in
+      match UE.find_continuation_shortcut (UA.uenv uacc) cont with
+      | None -> This_continuation cont
+      | Some shortcut ->
+        let cont, args =
+          UE.apply_continuation_shortcut shortcut (Apply_cont.args apply_cont)
+        in
+        Apply_cont (Apply_cont.with_continuation_and_args apply_cont cont ~args)
+      )
+  in
+  match UE.find_apply_cont_rewrite uenv cont with
+  | None -> shortcut_this_continuation_if_possible ()
   | Some rewrite when Apply_cont_rewrite.does_nothing rewrite ->
     let arity_in_rewrite = Apply_cont_rewrite.original_params_arity rewrite in
     if not (Flambda_arity.equal_ignoring_subkinds arity arity_in_rewrite)
@@ -735,7 +762,7 @@ let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
          match arity %a in rewrite:@ %a"
         Flambda_arity.print arity Flambda_arity.print arity_in_rewrite
         Apply_cont_rewrite.print rewrite;
-    This_continuation cont
+    shortcut_this_continuation_if_possible ()
   | Some rewrite -> (
     let new_wrapper params expr ~free_names
         ~cost_metrics:cost_metrics_of_handler =
@@ -759,7 +786,7 @@ let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
         { cont; handler; free_names_of_handler; cost_metrics_of_handler }
     in
     match cont_or_apply_cont with
-    | Continuation cont -> (
+    | Continuation _ -> (
       (* In this case, any generated [Apply_cont] will sit inside a wrapper that
          binds [kinded_params]. *)
       let params =
@@ -832,10 +859,10 @@ let rewrite_fixed_arity_continuation uacc cont ~use_id arity ~around =
     (* CR gbury: add a case to [Flambda.Invalid.t] for invalid extra args after
        unboxing ? *)
     uacc, RE.create_invalid (Message message)
-  | This_continuation cont -> around uacc cont
+  | This_continuation cont -> around cont
   | Apply_cont _ -> assert false
   | New_wrapper new_let_cont ->
-    let body, uacc = around uacc new_let_cont.cont in
+    let body, uacc = around new_let_cont.cont in
     bind_let_cont body uacc new_let_cont
 
 let rewrite_fixed_arity_apply uacc ~use_id arity apply =
@@ -855,12 +882,9 @@ let rewrite_fixed_arity_apply uacc ~use_id arity apply =
       Apply.print apply
   | Some use_id, Return cont ->
     rewrite_fixed_arity_continuation uacc cont ~use_id arity
-      ~around:(fun uacc return_cont ->
-        let exn_cont =
-          UE.resolve_exn_continuation_aliases (UA.uenv uacc)
-            (Apply.exn_continuation apply)
-        in
+      ~around:(fun return_cont ->
         let apply =
-          Apply.with_continuations apply (Return return_cont) exn_cont
+          Apply.with_continuations apply (Return return_cont)
+            (Apply.exn_continuation apply)
         in
         make_apply apply)

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -67,11 +67,6 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
   let uenv = UA.uenv uacc in
   let cont = AC.continuation apply_cont in
   let rewrite = UE.find_apply_cont_rewrite uenv cont in
-  (* CR gbury: when rewriting aliases, we may lose some information that was in
-     the kinds of the continuation being rewritten (e.g. is the continuation
-     bein rewritten had more kind/sub-kind information on its parameters than
-     its alias). We should think of a way to preserve that information. *)
-  let cont = UE.resolve_continuation_aliases uenv cont in
   let create_apply_cont ~apply_cont_to_expr =
     (* The function returned by this code accepts another function, which will
        be called with the [Apply_cont] expression after subjecting it to any
@@ -103,7 +98,14 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
     in
     after_rebuild expr uacc
   in
-  match UE.find_continuation uenv cont with
+  (* We need to look up the continuation before applying any rewrites, which
+     means we must manually resolve any relevant shortcut. *)
+  let shortcut_cont =
+    match UE.find_continuation_shortcut uenv cont with
+    | Some { continuation; _ } -> continuation
+    | None -> cont
+  in
+  match UE.find_continuation uenv shortcut_cont with
   | Linearly_used_and_inlinable
       { params; handler; free_names_of_handler; cost_metrics_of_handler } ->
     (* We must not fail to inline here, since we've already decided that the
@@ -119,6 +121,12 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
        (branches can be moved by the backend, their runtime depends on the
        branch predictor...). Underestimating the number of removed branches is
        fine. *)
+    if not (Continuation.equal cont shortcut_cont)
+    then
+      Misc.fatal_errorf
+        "Non-linear shortcut from %a to linear continuation %a would break \
+         linearity."
+        Continuation.print cont Continuation.print shortcut_cont;
     inline_linearly_used_continuation uacc ~create_apply_cont ~params ~handler
       ~free_names_of_handler ~cost_metrics_of_handler
   | Invalid { arity = _ } ->

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -275,7 +275,7 @@ let add_extra_params_for_mutable_unboxing cont uacc extra_params_and_args =
 
 type behaviour =
   | Invalid
-  | Alias_for of Continuation.t
+  | Shortcut_to of Continuation.t * Simple.t list
   | Unknown
 
 let get_removed_aliased_params uacc cont =
@@ -664,10 +664,7 @@ let rebuild_single_non_recursive_handler ~at_unit_toplevel
                 | Some _ -> Unknown
                 | None ->
                   let args = Apply_cont.args apply_cont in
-                  let params = Bound_parameters.simples params in
-                  if Misc.Stdlib.List.compare Simple.compare args params = 0
-                  then Alias_for (Apply_cont.continuation apply_cont)
-                  else Unknown)
+                  Shortcut_to (Apply_cont.continuation apply_cont, args))
               | None ->
                 if RE.can_be_removed_as_invalid handler
                      (UA.are_rebuilding_terms uacc)
@@ -678,9 +675,8 @@ let rebuild_single_non_recursive_handler ~at_unit_toplevel
           | Invalid ->
             let arity = Bound_parameters.arity params in
             UE.add_invalid_continuation uenv cont arity
-          | Alias_for alias_for ->
-            let arity = Bound_parameters.arity params in
-            UE.add_continuation_alias uenv cont arity ~alias_for
+          | Shortcut_to (shortcut_to, args) ->
+            UE.add_continuation_shortcut uenv cont ~params ~shortcut_to ~args
           | Unknown ->
             UE.add_non_inlinable_continuation uenv cont ~params
               ~handler:(if is_cold then Unknown else Known handler)


### PR DESCRIPTION
Replace the continuation alias mechanism with a more general continuation shortcut mechanism.

A continuation shortcut is a let_cont whose body is an arbitrary apply_cont. A continuation alias is a special case of continuation shortcuts where the arguments of the apply_cont are exactly the parameters of the let_cont.

Shortcuts are detected and resolved in the upwards pass after rewriting the apply_cont, so that we should never output code containing continuation shortcuts (except when used as return or exception continuation).

This should help generate simpler control flow for later Simplify or To_cmm passes, and make the output of `-dflambda` easier to follow.

Fixes #3210