### PR TITLE
Hide `value_or_null` when printing variables

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -35,9 +35,9 @@ let f y (type (a : immediate)) (x : a) = x;;
 let f y (type (a : immediate) (b : immediate)) (x : a) = x;;
 
 [%%expect{|
-val f : ('b : value_or_null) ('a : immediate). 'b -> 'a -> 'a = <fun>
-val f : ('b : value_or_null) ('a : immediate). 'b -> 'a -> 'a = <fun>
-val f : ('b : value_or_null) ('a : immediate). 'b -> 'a -> 'a = <fun>
+val f : 'b ('a : immediate). 'b -> 'a -> 'a = <fun>
+val f : 'b ('a : immediate). 'b -> 'a -> 'a = <fun>
+val f : 'b ('a : immediate). 'b -> 'a -> 'a = <fun>
 |}]
 
 let f y (type a : immediate) = y;;
@@ -46,10 +46,10 @@ let f y (type (a : immediate) (b : immediate)) = y;;
 let f y (type (a : immediate) (b : immediate) c) = y;;
 
 [%%expect{|
-val f : ('a : value_or_null). 'a -> 'a = <fun>
-val f : ('a : value_or_null). 'a -> 'a = <fun>
-val f : ('a : value_or_null). 'a -> 'a = <fun>
-val f : ('a : value_or_null). 'a -> 'a = <fun>
+val f : 'a -> 'a = <fun>
+val f : 'a -> 'a = <fun>
+val f : 'a -> 'a = <fun>
+val f : 'a -> 'a = <fun>
 |}]
 
 (* Just newtypes, no value parameters *)
@@ -157,7 +157,7 @@ let f xs = match xs with
 
 [%%expect{|
 type t = #(int * float#)
-val f : ('a : value_or_null). #('a * float#) -> #('a * float#) = <fun>
+val f : #('a * float#) -> #('a * float#) = <fun>
 |}]
 
 module M = struct
@@ -289,12 +289,10 @@ let f (local_ unique_ x) ~(local_ once_ y) ~z:(unique_ once_ z)
 
 [%%expect{|
 val f :
-  ('a : value_or_null) ('b : value_or_null) ('c : value_or_null).
-    local_ 'a @ unique ->
-    y:local_ 'b @ once ->
-    z:'c @ once unique ->
-    ?foo:local_ int @ once unique -> ?bar:local_ int -> unit -> unit =
-  <fun>
+  local_ 'a @ unique ->
+  y:local_ 'b @ once ->
+  z:'c @ once unique ->
+  ?foo:local_ int @ once unique -> ?bar:local_ int -> unit -> unit = <fun>
 |}]
 
 (* bindings *)
@@ -447,28 +445,26 @@ let f ~(x1 @ many)
 
 [%%expect{|
 val f :
-  ('b : value_or_null) ('c : value_or_null) ('d : value_or_null) 'e.
-    x1:'b ->
-    x2:local_ string ->
-    x3:local_ (string -> string) ->
-    x4:local_ ('a. 'a -> 'a) ->
-    x5:local_ 'c ->
-    x6:local_ bool ->
-    x7:local_ bool ->
-    x8:local_ unit ->
-    string ->
-    local_ 'd -> local_
-    'b * string * (string -> string) * ('e -> 'e) * 'c * string * string *
-    int array * string * (int -> local_ (int -> int)) *
-    (int -> local_ (int -> int)) @ contended =
-  <fun>
+  x1:'b ->
+  x2:local_ string ->
+  x3:local_ (string -> string) ->
+  x4:local_ ('a. 'a -> 'a) ->
+  x5:local_ 'c ->
+  x6:local_ bool ->
+  x7:local_ bool ->
+  x8:local_ unit ->
+  string ->
+  local_ 'd -> local_
+  'b * string * (string -> string) * ('e -> 'e) * 'c * string * string *
+  int array * string * (int -> local_ (int -> int)) *
+  (int -> local_ (int -> int)) @ contended = <fun>
 |}]
 
 let f1 (_ @ local) = ()
 let f2 () = let x @ local = [1; 2; 3] in f1 x [@nontail]
 
 [%%expect{|
-val f1 : ('a : value_or_null). local_ 'a -> unit = <fun>
+val f1 : local_ 'a -> unit = <fun>
 val f2 : unit -> unit = <fun>
 |}]
 
@@ -748,9 +744,7 @@ let double1 y = apply ~f:(stack_ fun x -> x + y) y [@nontail]
 let double2 y = apply ~f:(stack_ function x -> x + y) y [@nontail]
 
 [%%expect{|
-val apply :
-  ('a : value_or_null) ('b : value_or_null). f:local_ ('a -> 'b) -> 'a -> 'b =
-  <fun>
+val apply : f:local_ ('a -> 'b) -> 'a -> 'b = <fun>
 val double1 : int -> int = <fun>
 val double2 : int -> int = <fun>
 |}]
@@ -839,8 +833,7 @@ let (x : ((x:int * y:int) [@test.attr])) = (~x:1, ~y:2)
 [%%expect{|
 val z : int = 4
 val punned : int = 5
-val x_must_be_even : ('a : value_or_null) ('b : value_or_null). 'a -> 'b =
-  <fun>
+val x_must_be_even : 'a -> 'b = <fun>
 exception Odd
 val x : x:int * y:int = (~x:1, ~y:2)
 val x : x:int * y:int = (~x:1, ~y:2)
@@ -890,10 +883,7 @@ let f = fun (~foo, ~bar:bar) -> foo * 10 + bar
 let f ((~(x:int),y) : (x:int * int)) : int = x + y
 
 [%%expect{|
-val foo :
-  ('a : value_or_null) ('b : value_or_null).
-    'a -> (unit -> 'b) -> (unit -> 'b) -> 'b =
-  <fun>
+val foo : 'a -> (unit -> 'b) -> (unit -> 'b) -> 'b = <fun>
 val x : int = 1
 val y : int = 2
 val x : int = 1
@@ -1337,7 +1327,5 @@ type t = x:[%call_pos] -> int
 let f g here = g ~(here : [%call_pos])
 
 [%%expect{|
-val f :
-  ('a : value_or_null). (here:[%call_pos] -> 'a) -> lexing_position -> 'a =
-  <fun>
+val f : (here:[%call_pos] -> 'a) -> lexing_position -> 'a = <fun>
 |}]

--- a/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
@@ -378,7 +378,7 @@ let id_value x = x;;
 val make_t_bits32 : unit -> t_bits32 = <fun>
 val make_t_bits32_id : ('a : bits32). unit -> 'a t_bits32_id = <fun>
 val make_int32u : unit -> int32# = <fun>
-val id_value : ('a : value_or_null). 'a -> 'a = <fun>
+val id_value : 'a -> 'a = <fun>
 |}];;
 
 let x8_1 = id_value (make_t_bits32 ());;

--- a/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
@@ -378,7 +378,7 @@ let id_value x = x;;
 val make_t_bits64 : unit -> t_bits64 = <fun>
 val make_t_bits64_id : ('a : bits64). unit -> 'a t_bits64_id = <fun>
 val make_int64u : unit -> int64# = <fun>
-val id_value : ('a : value_or_null). 'a -> 'a = <fun>
+val id_value : 'a -> 'a = <fun>
 |}];;
 
 let x8_1 = id_value (make_t_bits64 ());;

--- a/testsuite/tests/typing-layouts-err-msg/debug_printer.compilers.reference
+++ b/testsuite/tests/typing-layouts-err-msg/debug_printer.compilers.reference
@@ -1,4 +1,4 @@
 type ('a : float64) t = 'a
-val f : ('b : value_or_null) ('a : float64). 'b -> 'a t -> unit = <fun>
+val f : 'b ('a : float64). 'b -> 'a t -> unit = <fun>
 f has the wrong type for a printing function.
 

--- a/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -133,7 +133,7 @@ type ('a : bits64) id_bits64 = 'a
 [%%expect{|
 type ('a : any) id_any = 'a
 type ('a : any_non_null) id_any_non_null = 'a
-type ('a : value_or_null) id_value_or_null = 'a
+type 'a id_value_or_null = 'a
 type 'a id_value = 'a
 type ('a : bits64) id_bits64 = 'a
 |}]

--- a/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -8,7 +8,7 @@ type ('a : value_or_null) id_value_or_null = 'a
 
 [%%expect{|
 type t_value_or_null : value_or_null
-type ('a : value_or_null) id_value_or_null = 'a
+type 'a id_value_or_null = 'a
 |}]
 
 (* Type parameters default to [value] and need
@@ -58,11 +58,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val should_not_work : 'a -> unit end
        is not included in
-         sig val should_not_work : ('a : value_or_null). 'a -> unit end
+         sig val should_not_work : 'a -> unit end
        Values do not match:
          val should_not_work : 'a -> unit
        is not included in
-         val should_not_work : ('a : value_or_null). 'a -> unit
+         val should_not_work : 'a -> unit
        The type "'a -> unit" is not compatible with the type "'b -> unit"
        The kind of 'a is value_or_null
          because of the definition of should_not_work at line 6, characters 2-57.
@@ -82,11 +82,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a X.t end
        is not included in
-         sig type ('a : value_or_null) t end
+         sig type 'a t end
        Type declarations do not match:
          type 'a t = 'a X.t
        is not included in
-         type ('a : value_or_null) t
+         type 'a t
        The problem is in the kinds of a parameter:
        The kind of 'a is value_or_null
          because of the definition of t at line 1, characters 39-66.
@@ -159,11 +159,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a end
        is not included in
-         sig val f : ('a : value_or_null). 'a -> 'a end
+         sig val f : 'a -> 'a end
        Values do not match:
          val f : 'a -> 'a
        is not included in
-         val f : ('a : value_or_null). 'a -> 'a
+         val f : 'a -> 'a
        The type "'a -> 'a" is not compatible with the type "'b -> 'b"
        The kind of 'a is value_or_null
          because of the definition of f at line 2, characters 2-40.
@@ -186,11 +186,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a end
        is not included in
-         sig val f : ('a : value_or_null). 'a -> 'a end
+         sig val f : 'a -> 'a end
        Values do not match:
          val f : 'a -> 'a
        is not included in
-         val f : ('a : value_or_null). 'a -> 'a
+         val f : 'a -> 'a
        The type "'a -> 'a" is not compatible with the type "'b -> 'b"
        The kind of 'a is value_or_null
          because of the definition of f at line 2, characters 2-40.
@@ -214,11 +214,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a end
        is not included in
-         sig val f : ('a : value_or_null). 'a -> 'a end
+         sig val f : 'a -> 'a end
        Values do not match:
          val f : 'a -> 'a
        is not included in
-         val f : ('a : value_or_null). 'a -> 'a
+         val f : 'a -> 'a
        The type "'a -> 'a" is not compatible with the type "'b -> 'b"
        The kind of 'a is value_or_null
          because of the definition of f at line 2, characters 2-41.
@@ -242,11 +242,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a end
        is not included in
-         sig val f : ('a : value_or_null). 'a -> 'a end
+         sig val f : 'a -> 'a end
        Values do not match:
          val f : 'a -> 'a
        is not included in
-         val f : ('a : value_or_null). 'a -> 'a
+         val f : 'a -> 'a
        The type "'a -> 'a" is not compatible with the type "'b -> 'b"
        The kind of 'a is value_or_null
          because of the definition of f at line 2, characters 2-41.
@@ -271,11 +271,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val f : 'a -> 'a end
        is not included in
-         sig val f : ('a : value_or_null). 'a -> 'a end
+         sig val f : 'a -> 'a end
        Values do not match:
          val f : 'a -> 'a
        is not included in
-         val f : ('a : value_or_null). 'a -> 'a
+         val f : 'a -> 'a
        The type "'a -> 'a" is not compatible with the type "'b -> 'b"
        The kind of 'a is value_or_null
          because of the definition of f at line 2, characters 2-41.
@@ -304,7 +304,7 @@ type (!'a : value_or_null) dummy
 type t = Packed : 'a dummy -> t
 
 [%%expect{|
-type (!'a : value_or_null) dummy
+type !'a dummy
 type t = Packed : 'a dummy -> t
 |}]
 
@@ -318,7 +318,7 @@ type t = Packed : 'a dummy -> t
 (* However, this works. *)
 type t = Packed : ('a : value_or_null). 'a dummy -> t
 [%%expect{|
-type t = Packed : ('a : value_or_null). 'a dummy -> t
+type t = Packed : 'a dummy -> t
 |}]
 
 (* Variables on the right side of constraints default to non-null.

--- a/testsuite/tests/typing-layouts-vec128/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-vec128/basics_alpha.ml
@@ -384,7 +384,7 @@ let id_value x = x;;
 val make_t_vec128 : unit -> t_vec128 = <fun>
 val make_t_vec128_id : ('a : vec128). unit -> 'a t_vec128_id = <fun>
 val make_int64u : unit -> int64x2# = <fun>
-val id_value : ('a : value_or_null). 'a -> 'a = <fun>
+val id_value : 'a -> 'a = <fun>
 |}];;
 
 let x8_1 = id_value (make_t_vec128 ());;

--- a/testsuite/tests/typing-layouts-word/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-word/basics_alpha.ml
@@ -377,7 +377,7 @@ let id_value x = x;;
 val make_t_word : unit -> t_word = <fun>
 val make_t_word_id : ('a : word). unit -> 'a t_word_id = <fun>
 val make_nativeintu : unit -> nativeint# = <fun>
-val id_value : ('a : value_or_null). 'a -> 'a = <fun>
+val id_value : 'a -> 'a = <fun>
 |}];;
 
 let x8_1 = id_value (make_t_word ());;

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -10,7 +10,7 @@ let use_uncontended : 'a @ uncontended -> 'a = fun x -> x
 type t : value mod uncontended = { mutable contents : string }
 [%%expect{|
 val use_as_value : 'a -> 'a = <fun>
-val use_uncontended : ('a : value_or_null). 'a -> 'a = <fun>
+val use_uncontended : 'a -> 'a = <fun>
 Line 5, characters 0-62:
 5 | type t : value mod uncontended = { mutable contents : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -1451,7 +1451,7 @@ let q () =
   ()
 
 [%%expect{|
-val ( let* ) : ('a : value_or_null). t_float64 -> 'a -> unit = <fun>
+val ( let* ) : t_float64 -> 'a -> unit = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1477,8 +1477,7 @@ let q () =
   ()
 
 [%%expect{|
-val ( let* ) :
-  ('a : value_or_null) ('b : any). 'a -> (t_float64 -> 'b) -> unit = <fun>
+val ( let* ) : 'a ('b : any). 'a -> (t_float64 -> 'b) -> unit = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1504,8 +1503,7 @@ let q () =
   assert false
 
 [%%expect{|
-val ( let* ) :
-  ('a : value_or_null) ('b : any). 'a -> ('b -> t_float64) -> unit = <fun>
+val ( let* ) : 'a ('b : any). 'a -> ('b -> t_float64) -> unit = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1531,8 +1529,7 @@ let q () =
   ()
 
 [%%expect{|
-val ( let* ) :
-  ('a : value_or_null) ('b : value_or_null). 'a -> 'b -> t_float64 = <fun>
+val ( let* ) : 'a -> 'b -> t_float64 = <fun>
 val q : unit -> t_float64 = <fun>
 |}]
 
@@ -1562,9 +1559,8 @@ let q () =
     ()
 
 [%%expect{|
-val ( let* ) : ('a : value_or_null) ('b : value_or_null). 'a -> 'b -> unit =
-  <fun>
-val ( and* ) : ('a : value_or_null). 'a -> t_float64 -> unit = <fun>
+val ( let* ) : 'a -> 'b -> unit = <fun>
+val ( and* ) : 'a -> t_float64 -> unit = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1594,9 +1590,8 @@ let q () =
     ()
 
 [%%expect{|
-val ( let* ) : ('a : value_or_null) ('b : value_or_null). 'a -> 'b -> unit =
-  <fun>
-val ( and* ) : ('a : value_or_null). t_float64 -> 'a -> unit = <fun>
+val ( let* ) : 'a -> 'b -> unit = <fun>
+val ( and* ) : t_float64 -> 'a -> unit = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1626,9 +1621,8 @@ let q () =
     ()
 
 [%%expect{|
-val ( let* ) : ('a : float64) ('b : value_or_null). 'a -> 'b -> unit = <fun>
-val ( and* ) :
-  ('a : value_or_null) ('b : value_or_null). 'a -> 'b -> t_float64 = <fun>
+val ( let* ) : ('a : float64) 'b. 'a -> 'b -> unit = <fun>
+val ( and* ) : 'a -> 'b -> t_float64 = <fun>
 val q : unit -> unit = <fun>
 |}]
 
@@ -1665,12 +1659,8 @@ let q () =
     ()
 
 [%%expect{|
-val ( let* ) : ('a : value_or_null) ('b : value_or_null). 'a -> 'b -> unit =
-  <fun>
-val ( and* ) :
-  ('a : value_or_null) ('b : value_or_null) ('c : value_or_null).
-    'a -> 'b -> 'c =
-  <fun>
+val ( let* ) : 'a -> 'b -> unit = <fun>
+val ( and* ) : 'a -> 'b -> 'c = <fun>
 Line 4, characters 9-22:
 4 |     let* x : t_float64 = assert false
              ^^^^^^^^^^^^^

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -42,7 +42,7 @@ let overwrite_shared (r : record_update) =
   let x = overwrite_ r with { x = "foo" } in
   x.x
 [%%expect{|
-val id : ('a : value_or_null). 'a -> 'a = <fun>
+val id : 'a -> 'a = <fun>
 Line 5, characters 21-22:
 5 |   let x = overwrite_ r with { x = "foo" } in
                          ^

--- a/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
@@ -19,14 +19,14 @@ let aliased_use x = x
 [%%expect{|
 (let (aliased_use/285 = (function {nlocal = 0} x/287 x/287))
   (apply (field_imm 1 (global Toploop!)) "aliased_use" aliased_use/285))
-val aliased_use : ('a : value_or_null). 'a -> 'a = <fun>
+val aliased_use : 'a -> 'a = <fun>
 |}]
 
 let unique_use (unique_ x) = x
 [%%expect{|
 (let (unique_use/288 = (function {nlocal = 0} x/290 x/290))
   (apply (field_imm 1 (global Toploop!)) "unique_use" unique_use/288))
-val unique_use : ('a : value_or_null). 'a @ unique -> 'a = <fun>
+val unique_use : 'a @ unique -> 'a = <fun>
 |}]
 
 (* This output is fine with overwriting: The [r.y] is not pushed down. *)

--- a/testsuite/tests/typing-unique/rbtree.ml
+++ b/testsuite/tests/typing-unique/rbtree.ml
@@ -470,14 +470,10 @@ type ('k, 'v) tree =
       value : 'v @@ many aliased; right : ('k, 'v) tree;
     }
   | Leaf
-val fold :
-  'a 'b ('c : value_or_null).
-    ('a -> 'b -> 'c -> 'c) -> 'c -> ('a, 'b) tree -> 'c =
-  <fun>
+val fold : ('a -> 'b -> 'c -> 'c) -> 'c -> ('a, 'b) tree -> 'c = <fun>
 val work :
-  ('a : value_or_null) ('b : value_or_null) ('c : value_or_null).
-    insert:(int -> bool -> 'a -> 'a) ->
-    fold:(('b -> bool -> int -> int) -> int -> 'a -> 'c) -> empty:'a -> 'c =
+  insert:(int -> bool -> 'a -> 'a) ->
+  fold:(('b -> bool -> int -> int) -> int -> 'a -> 'c) -> empty:'a -> 'c =
   <fun>
 Line 85, characters 16-71:
 85 |                 balance_right (Node { t with right = ins k v t.right }) [@nontail]
@@ -505,9 +501,7 @@ module Make_Okasaki :
   functor (Ord : Map.OrderedType) ->
     sig
       type 'a t = (Ord.t, 'a) tree
-      val fold :
-        'a 'b ('c : value_or_null).
-          ('a -> 'b -> 'c -> 'c) -> 'c -> ('a, 'b) tree -> 'c
+      val fold : ('a -> 'b -> 'c -> 'c) -> 'c -> ('a, 'b) tree -> 'c
       val balance_left : ('a, 'b) tree -> ('a, 'b) tree
       val balance_right : ('a, 'b) tree -> ('a, 'b) tree
       val ins : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1835,7 +1835,7 @@ let is_max jkind = sub Builtin.any_dummy_jkind jkind
 let has_layout_any jkind =
   match jkind.jkind.layout with Any -> true | _ -> false
 
-let is_value_for_printing
+let is_value_for_printing ~ignore_null
     { jkind =
         { layout;
           modes_upper_bounds;
@@ -1850,11 +1850,9 @@ let is_value_for_printing
     Layout.Const.equal const value.layout
     && Modes.equal modes_upper_bounds value.modes_upper_bounds
     && Externality.equal externality_upper_bound value.externality_upper_bound
-    &&
-    if (* CR layouts v3.0: remove this hack once [or_null] is out of [Alpha]. *)
-       Language_extension.(is_at_least Layouts Alpha)
-    then Nullability.equal nullability_upper_bound Nullability.Non_null
-    else true
+    && (ignore_null
+       || Nullability.equal nullability_upper_bound
+            value.nullability_upper_bound)
   | None -> false
 
 (*********************************)

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -556,7 +556,7 @@ val has_layout_any : ('l * allowed) t -> bool
 (** Checks whether a jkind is [value]. This really should require a [jkind_lr],
     but it works on any [jkind], because it's used in printing and is somewhat
     unprincipled. *)
-val is_value_for_printing : 'd t -> bool
+val is_value_for_printing : ignore_null:bool -> 'd t -> bool
 
 (*********************************)
 (* debugging *)


### PR DESCRIPTION
Hide most uses of `value_or_null` when printing type variables, per discussion, since we don't want to display it users by default. Unfortunately, it is now hidden even if we get an error related to nullability. This can be fixing with more fine-grained printing on errors.