### PR TITLE
Add a flag to control inference of with-bounds on type decls

### DIFF
--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -21,7 +21,7 @@ jobs:
         path: 'flambda_backend'
 
     - name: Setup OCaml ${{ matrix.ocaml-compiler }}
-      uses: ocaml/setup-ocaml@v2
+      uses: ocaml/setup-ocaml@v3
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -758,6 +758,10 @@ let mk_allow_illegal_crossing f =
   "-allow-illegal-crossing", Arg.Unit f,
   "Type declarations will not be checked along the portability or contention axes"
 
+let mk_infer_with_bounds f =
+  "-infer-with-bounds", Arg.Unit f,
+  "Infer with-bounds on kinds for type declarations. May impact performance."
+
 let mk_dump_dir f =
   "-dump-dir", Arg.String f,
   "redirects any file(s) that would be outputted as a result of other flags\n\
@@ -956,6 +960,7 @@ module type Common_options = sig
   val _no_extension : string -> unit
   val _extension_universe : string -> unit
   val _allow_illegal_crossing : unit -> unit
+  val _infer_with_bounds : unit -> unit
   val _noassert : unit -> unit
   val _nolabels : unit -> unit
   val _nostdlib : unit -> unit
@@ -1244,6 +1249,7 @@ struct
     mk_no_extension F._no_extension;
     mk_extension_universe F._extension_universe;
     mk_allow_illegal_crossing F._allow_illegal_crossing;
+    mk_infer_with_bounds F._infer_with_bounds;
     mk_for_pack_byt F._for_pack;
     mk_g_byt F._g;
     mk_no_g F._no_g;
@@ -1376,6 +1382,7 @@ struct
     mk_no_extension F._no_extension;
     mk_extension_universe F._extension_universe;
     mk_allow_illegal_crossing F._allow_illegal_crossing;
+    mk_infer_with_bounds F._infer_with_bounds;
     mk_noassert F._noassert;
     mk_noinit F._noinit;
     mk_nolabels F._nolabels;
@@ -1471,6 +1478,7 @@ struct
     mk_no_extension F._no_extension;
     mk_extension_universe F._extension_universe;
     mk_allow_illegal_crossing F._allow_illegal_crossing;
+    mk_infer_with_bounds F._infer_with_bounds;
     mk_for_pack_opt F._for_pack;
     mk_g_opt F._g;
     mk_no_g F._no_g;
@@ -1663,6 +1671,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_no_extension F._no_extension;
     mk_extension_universe F._extension_universe;
     mk_allow_illegal_crossing F._allow_illegal_crossing;
+    mk_infer_with_bounds F._infer_with_bounds;
     mk_no_float_const_prop F._no_float_const_prop;
     mk_noassert F._noassert;
     mk_noinit F._noinit;
@@ -1772,6 +1781,7 @@ struct
     mk_no_extension F._no_extension;
     mk_extension_universe F._extension_universe;
     mk_allow_illegal_crossing F._allow_illegal_crossing;
+    mk_infer_with_bounds F._infer_with_bounds;
     mk_noassert F._noassert;
     mk_nolabels F._nolabels;
     mk_nostdlib F._nostdlib;
@@ -1884,6 +1894,7 @@ module Default = struct
     let _extension_universe s =
       Language_extension.(set_universe_and_enable_all_of_string_exn s)
     let _allow_illegal_crossing = set Clflags.allow_illegal_crossing
+    let _infer_with_bounds = set Clflags.infer_with_bounds
     let _noassert = set noassert
     let _nolabels = set classic
     let _nostdlib = set no_std_include

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -35,6 +35,7 @@ module type Common_options = sig
   val _no_extension : string -> unit
   val _extension_universe : string -> unit
   val _allow_illegal_crossing : unit -> unit
+  val _infer_with_bounds : unit -> unit
   val _noassert : unit -> unit
   val _nolabels : unit -> unit
   val _nostdlib : unit -> unit

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -26,7 +26,8 @@
    -bin-annot
    -nostdlib
    -safe-string
-   -strict-formats))
+   -strict-formats
+   -infer-with-bounds))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))
  (preprocess

--- a/testsuite/tests/typing-immediate/immediate.ml
+++ b/testsuite/tests/typing-immediate/immediate.ml
@@ -160,7 +160,7 @@ end;;
 Line 2, characters 2-41:
 2 |   type t = Foo of int | Bar [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immediate
          because of the annotation on the declaration of the type t.
@@ -174,7 +174,7 @@ end;;
 Line 2, characters 2-38:
 2 |   type t = { foo : int } [@@immediate]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immediate
          because of the annotation on the declaration of the type t.

--- a/testsuite/tests/typing-jkind-bounds/allow_illegal_crossing.ml
+++ b/testsuite/tests/typing-jkind-bounds/allow_illegal_crossing.ml
@@ -1,6 +1,6 @@
 (* TEST
  {
-   flags = "-allow-illegal-crossing";
+   flags = "-allow-illegal-crossing -infer-with-bounds";
    expect;
  }
 *)

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -1,10 +1,10 @@
 (* TEST
  include stdlib_upstream_compatible;
- flags = "-infer-with-kinds";
+ flags = "-infer-with-bounds";
  {
    expect;
  }{
-   flags += "-extension layouts_beta";
+   flags += " -extension layouts_beta";
    expect;
  }
 *)

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -1,9 +1,10 @@
 (* TEST
  include stdlib_upstream_compatible;
+ flags = "-infer-with-bounds";
  {
    expect;
  }{
-   flags = "-extension layouts_beta";
+   flags += "-extension layouts_beta";
    expect;
  }
 *)

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -1,6 +1,6 @@
 (* TEST
  include stdlib_upstream_compatible;
- flags = "-infer-with-bounds";
+ flags = "-infer-with-kinds";
  {
    expect;
  }{

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension small_numbers";
+ flags = "-infer-with-bounds -extension small_numbers";
  expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -1,4 +1,5 @@
 (* TEST
+    flags = "-infer-with-bounds";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -1,4 +1,5 @@
 (* TEST
+    flags = "-infer-with-bounds";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/define_with_kinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/define_with_kinds.ml
@@ -12,7 +12,7 @@ and 'a rec2 =
   | Foo2 of 'a rec1 * int
   | Bar2 of 'a
 
-type ('a : value & value) unboxed_rec = #{ x : 'a ; y : string }
+type ('a : value & value) unboxed_record = #{ x : 'a ; y : string }
 
 module type Optionish = sig
   type 'a my_option =

--- a/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/define_with_kinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/define_with_kinds.ml
@@ -1,0 +1,27 @@
+type 'a my_list =
+  | Nil
+  | Cons of 'a * 'a my_list
+
+type 'a my_ref = { mutable contents : 'a }
+
+type 'a rec1 =
+  | Foo1 of 'a rec2 * int
+  | Bar1 of 'a
+
+and 'a rec2 =
+  | Foo2 of 'a rec1 * int
+  | Bar2 of 'a
+
+type ('a : value & value) unboxed_rec = #{ x : 'a ; y : string }
+
+module type Optionish = sig
+  type 'a my_option =
+    | Nothing
+    | Just of 'a
+end
+
+module Optionish2 = struct
+  type 'a my_option =
+    | Nothing
+    | Just of 'a
+end

--- a/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
+++ b/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
@@ -273,3 +273,18 @@ end
 [%%expect{|
 module Option2 : sig type 'a my_option = Nothing | Just of 'a end
 |}]
+
+module rec Foo : Optionish = Foo
+[%%expect{|
+module rec Foo : Define_with_kinds.Optionish
+|}]
+
+type 'a my_option2 = 'a Optionish2.my_option =
+  | Nothing
+  | Just of 'a
+[%%expect{|
+type 'a my_option2 =
+  'a Define_with_kinds.Optionish2.my_option =
+    Nothing
+  | Just of 'a
+|}]

--- a/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
+++ b/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
@@ -1,0 +1,275 @@
+(* TEST
+   readonly_files = "define_with_kinds.ml";
+   setup-ocamlc.byte-build-env;
+   module = "define_with_kinds.ml";
+   flags = "-infer-with-bounds -extension layouts_beta";
+   ocamlc.byte;
+   flags = "-I ocamlc.byte ocamlc.byte/define_with_kinds.cmo -extension layouts_beta";
+   expect;
+*)
+
+open Define_with_kinds
+
+let use_global : 'a @ global -> unit = fun _ -> ()
+let use_unique : 'a @ unique -> unit = fun _ -> ()
+let use_uncontended : 'a @ uncontended -> unit = fun _ -> ()
+let use_portable : 'a @ portable -> unit = fun _ -> ()
+let use_many : 'a @ many -> unit = fun _ -> ()
+
+type ('a : value mod global) require_global
+type ('a : value mod unique) require_unique
+type ('a : value mod uncontended) require_uncontended
+type ('a : value mod portable) require_portable
+type ('a : value mod many) require_many
+type ('a : value mod non_null) require_nonnull
+type ('a : value mod external_) require_external
+[%%expect{|
+val use_global : 'a -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_many : 'a -> unit = <fun>
+type ('a : value mod global) require_global
+type ('a : value mod unique) require_unique
+type ('a : value mod uncontended) require_uncontended
+type ('a : value mod portable) require_portable
+type ('a : value mod many) require_many
+type 'a require_nonnull
+type ('a : value mod external_) require_external
+|}]
+
+type my_list_test = int my_list require_portable
+(* CR layouts v2.8: fix principal case *)
+[%%expect{|
+type my_list_test = int Define_with_kinds.my_list require_portable
+|}, Principal{|
+Line 1, characters 20-31:
+1 | type my_list_test = int my_list require_portable
+                        ^^^^^^^^^^^
+Error: This type "int Define_with_kinds.my_list" should be an instance of type
+         "('a : value mod portable)"
+       The kind of int Define_with_kinds.my_list is immutable_data.
+       But the kind of int Define_with_kinds.my_list must be a subkind of
+         value mod portable
+         because of the definition of require_portable at line 12, characters 0-47.
+|}]
+
+type my_list_test = int ref my_list require_portable
+[%%expect{|
+type my_list_test = int ref Define_with_kinds.my_list require_portable
+|}, Principal{|
+Line 1, characters 20-35:
+1 | type my_list_test = int ref my_list require_portable
+                        ^^^^^^^^^^^^^^^
+Error: This type "int ref Define_with_kinds.my_list"
+       should be an instance of type "('a : value mod portable)"
+       The kind of int ref Define_with_kinds.my_list is immutable_data.
+       But the kind of int ref Define_with_kinds.my_list must be a subkind of
+         value mod portable
+         because of the definition of require_portable at line 12, characters 0-47.
+|}]
+
+type my_list_test = (int -> int) my_list require_portable
+[%%expect{|
+Line 1, characters 20-40:
+1 | type my_list_test = (int -> int) my_list require_portable
+                        ^^^^^^^^^^^^^^^^^^^^
+Error: This type "(int -> int) Define_with_kinds.my_list"
+       should be an instance of type "('a : value mod portable)"
+       The kind of (int -> int) Define_with_kinds.my_list is immutable_data.
+       But the kind of (int -> int) Define_with_kinds.my_list must be a subkind of
+         value mod portable
+         because of the definition of require_portable at line 12, characters 0-47.
+|}]
+
+type t_test = int my_list require_global
+[%%expect{|
+Line 1, characters 14-25:
+1 | type t_test = int my_list require_global
+                  ^^^^^^^^^^^
+Error: This type "int Define_with_kinds.my_list" should be an instance of type
+         "('a : value mod global)"
+       The kind of int Define_with_kinds.my_list is immutable_data.
+       But the kind of int Define_with_kinds.my_list must be a subkind of
+         value mod global
+         because of the definition of require_global at line 9, characters 0-43.
+|}]
+
+type my_list_test = int ref my_list require_uncontended
+[%%expect{|
+Line 1, characters 20-35:
+1 | type my_list_test = int ref my_list require_uncontended
+                        ^^^^^^^^^^^^^^^
+Error: This type "int ref Define_with_kinds.my_list"
+       should be an instance of type "('a : value mod uncontended)"
+       The kind of int ref Define_with_kinds.my_list is immutable_data.
+       But the kind of int ref Define_with_kinds.my_list must be a subkind of
+         value mod uncontended
+         because of the definition of require_uncontended at line 11, characters 0-53.
+|}]
+
+type my_list_test = int my_ref my_list require_uncontended
+[%%expect{|
+Line 1, characters 20-38:
+1 | type my_list_test = int my_ref my_list require_uncontended
+                        ^^^^^^^^^^^^^^^^^^
+Error: This type "int Define_with_kinds.my_ref Define_with_kinds.my_list"
+       should be an instance of type "('a : value mod uncontended)"
+       The kind of int Define_with_kinds.my_ref Define_with_kinds.my_list is
+         immutable_data.
+       But the kind of int Define_with_kinds.my_ref Define_with_kinds.my_list must be a subkind of
+         value mod uncontended
+         because of the definition of require_uncontended at line 11, characters 0-53.
+|}]
+
+type my_list_test = int my_ref my_list require_portable
+(* CR layouts v2.8: fix principal case *)
+[%%expect{|
+type my_list_test =
+    int Define_with_kinds.my_ref Define_with_kinds.my_list require_portable
+|}, Principal{|
+Line 1, characters 20-38:
+1 | type my_list_test = int my_ref my_list require_portable
+                        ^^^^^^^^^^^^^^^^^^
+Error: This type "int Define_with_kinds.my_ref Define_with_kinds.my_list"
+       should be an instance of type "('a : value mod portable)"
+       The kind of int Define_with_kinds.my_ref Define_with_kinds.my_list is
+         immutable_data.
+       But the kind of int Define_with_kinds.my_ref Define_with_kinds.my_list must be a subkind of
+         value mod portable
+         because of the definition of require_portable at line 12, characters 0-47.
+|}]
+
+
+(*******)
+
+let foo (t : int my_list @@ contended) = use_uncontended t
+[%%expect{|
+val foo : int Define_with_kinds.my_list @ contended -> unit = <fun>
+|}]
+
+let foo (t : int my_ref my_list @@ contended) = use_uncontended t
+[%%expect{|
+Line 1, characters 64-65:
+1 | let foo (t : int my_ref my_list @@ contended) = use_uncontended t
+                                                                    ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let foo (t : (int -> int) my_list @@ contended) = use_portable t
+[%%expect{|
+val foo : (int -> int) Define_with_kinds.my_list @ portable contended -> unit =
+  <fun>
+|}]
+
+let foo (t : (int -> int) my_ref my_list @@ contended) = use_uncontended t
+[%%expect{|
+Line 1, characters 73-74:
+1 | let foo (t : (int -> int) my_ref my_list @@ contended) = use_uncontended t
+                                                                             ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let foo (t : (int -> int) my_ref my_list @@ contended) = use_global t
+[%%expect{|
+Line 1, characters 68-69:
+1 | let foo (t : (int -> int) my_ref my_list @@ contended) = use_global t
+                                                                        ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+(********)
+
+let foo (t : int rec1) = use_portable t
+[%%expect{|
+val foo : int Define_with_kinds.rec1 -> unit = <fun>
+|}]
+
+let foo (t : (int -> int) rec1) = use_portable t
+[%%expect{|
+val foo : (int -> int) Define_with_kinds.rec1 @ portable -> unit = <fun>
+|}]
+
+let foo (t : int rec1 @@ contended) = use_uncontended t
+[%%expect{|
+val foo : int Define_with_kinds.rec1 @ contended -> unit = <fun>
+|}]
+
+let foo (t : int my_ref rec1 @@ contended) = use_uncontended t
+[%%expect{|
+Line 1, characters 61-62:
+1 | let foo (t : int my_ref rec1 @@ contended) = use_uncontended t
+                                                                 ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let foo (t : int ref rec1 @@ contended) = use_uncontended t
+[%%expect{|
+Line 1, characters 58-59:
+1 | let foo (t : int ref rec1 @@ contended) = use_uncontended t
+                                                              ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+(******)
+
+let use_uncontended_three_values : ('a : (value & value) & value) @ uncontended -> unit = fun _ -> ()
+let use_portable_three_values : ('a : (value & value) & value) @ portable -> unit = fun _ -> ()
+
+let foo (t : #(int * int) unboxed_rec @@ contended) = use_uncontended_three_values t
+[%%expect{|
+val use_uncontended_three_values : ('a : (value & value) & value). 'a -> unit =
+  <fun>
+val use_portable_three_values :
+  ('a : (value & value) & value). 'a @ portable -> unit = <fun>
+val foo : #(int * int) Define_with_kinds.unboxed_rec @ contended -> unit =
+  <fun>
+|}]
+
+let foo (t : #(int my_ref * int) unboxed_rec @@ contended) = use_uncontended_three_values t
+[%%expect{|
+Line 1, characters 90-91:
+1 | let foo (t : #(int my_ref * int) unboxed_rec @@ contended) = use_uncontended_three_values t
+                                                                                              ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let foo (t : #((int -> int) * int) unboxed_rec @@ nonportable) = use_portable_three_values t
+[%%expect{|
+Line 1, characters 91-92:
+1 | let foo (t : #((int -> int) * int) unboxed_rec @@ nonportable) = use_portable_three_values t
+                                                                                               ^
+Error: This value is "nonportable" but expected to be "portable".
+|}, Principal{|
+Line 1, characters 91-92:
+1 | let foo (t : #((int -> int) * int) unboxed_rec @@ nonportable) = use_portable_three_values t
+                                                                                               ^
+Error: This expression has type
+         "#((int -> int) * int) Define_with_kinds.unboxed_rec"
+       but an expression was expected of type "('a : (value & value) & value)"
+       The kind of #((int -> int) * int) Define_with_kinds.unboxed_rec is
+         (immediate & immediate) & immediate.
+       But the kind of #((int -> int) * int) Define_with_kinds.unboxed_rec must be a subkind of
+         (value & value) & value
+         because of the definition of use_portable_three_values at line 2, characters 84-95.
+|}]
+
+(******)
+
+module Option : Optionish = struct
+  type 'a my_option =
+    | Nothing
+    | Just of 'a
+end
+[%%expect{|
+module Option : Define_with_kinds.Optionish
+|}]
+
+module Option2 : module type of Optionish2 = struct
+  type 'a my_option =
+    | Nothing
+    | Just of 'a
+end
+[%%expect{|
+module Option2 : sig type 'a my_option = Nothing | Just of 'a end
+|}]

--- a/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
+++ b/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
@@ -216,40 +216,40 @@ Error: This value is "contended" but expected to be "uncontended".
 let use_uncontended_three_values : ('a : (value & value) & value) @ uncontended -> unit = fun _ -> ()
 let use_portable_three_values : ('a : (value & value) & value) @ portable -> unit = fun _ -> ()
 
-let foo (t : #(int * int) unboxed_rec @@ contended) = use_uncontended_three_values t
+let foo (t : #(int * int) unboxed_record @@ contended) = use_uncontended_three_values t
 [%%expect{|
 val use_uncontended_three_values : ('a : (value & value) & value). 'a -> unit =
   <fun>
 val use_portable_three_values :
   ('a : (value & value) & value). 'a @ portable -> unit = <fun>
-val foo : #(int * int) Define_with_kinds.unboxed_rec @ contended -> unit =
+val foo : #(int * int) Define_with_kinds.unboxed_record @ contended -> unit =
   <fun>
 |}]
 
-let foo (t : #(int my_ref * int) unboxed_rec @@ contended) = use_uncontended_three_values t
+let foo (t : #(int my_ref * int) unboxed_record @@ contended) = use_uncontended_three_values t
 [%%expect{|
-Line 1, characters 90-91:
-1 | let foo (t : #(int my_ref * int) unboxed_rec @@ contended) = use_uncontended_three_values t
-                                                                                              ^
+Line 1, characters 93-94:
+1 | let foo (t : #(int my_ref * int) unboxed_record @@ contended) = use_uncontended_three_values t
+                                                                                                 ^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
-let foo (t : #((int -> int) * int) unboxed_rec @@ nonportable) = use_portable_three_values t
+let foo (t : #((int -> int) * int) unboxed_record @@ nonportable) = use_portable_three_values t
 [%%expect{|
-Line 1, characters 91-92:
-1 | let foo (t : #((int -> int) * int) unboxed_rec @@ nonportable) = use_portable_three_values t
-                                                                                               ^
+Line 1, characters 94-95:
+1 | let foo (t : #((int -> int) * int) unboxed_record @@ nonportable) = use_portable_three_values t
+                                                                                                  ^
 Error: This value is "nonportable" but expected to be "portable".
 |}, Principal{|
-Line 1, characters 91-92:
-1 | let foo (t : #((int -> int) * int) unboxed_rec @@ nonportable) = use_portable_three_values t
-                                                                                               ^
+Line 1, characters 94-95:
+1 | let foo (t : #((int -> int) * int) unboxed_record @@ nonportable) = use_portable_three_values t
+                                                                                                  ^
 Error: This expression has type
-         "#((int -> int) * int) Define_with_kinds.unboxed_rec"
+         "#((int -> int) * int) Define_with_kinds.unboxed_record"
        but an expression was expected of type "('a : (value & value) & value)"
-       The kind of #((int -> int) * int) Define_with_kinds.unboxed_rec is
+       The kind of #((int -> int) * int) Define_with_kinds.unboxed_record is
          (immediate & immediate) & immediate.
-       But the kind of #((int -> int) * int) Define_with_kinds.unboxed_rec must be a subkind of
+       But the kind of #((int -> int) * int) Define_with_kinds.unboxed_record must be a subkind of
          (value & value) & value
          because of the definition of use_portable_three_values at line 2, characters 84-95.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -1,5 +1,6 @@
 (* TEST
-    expect;
+   flags = "-infer-with-bounds";
+   expect;
 *)
 
 let use_global : 'a @ global -> unit = fun _ -> ()

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -1,5 +1,6 @@
 (* TEST
-    expect;
+   flags = "-infer-with-bounds";
+   expect;
 *)
 
 let use_global : 'a @ global -> unit = fun _ -> ()

--- a/testsuite/tests/typing-jkind-bounds/right_kinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/right_kinds.ml
@@ -1,5 +1,6 @@
 (* TEST
-    expect;
+   flags = "-infer-with-bounds";
+   expect;
 *)
 
 (* Test that "with" syntax isn't allowed in locations that expect a right-kind *)

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -1,4 +1,5 @@
 (* TEST
+    flags = "-infer-with-bounds";
     expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -1,4 +1,5 @@
 (* TEST
+    flags = "-infer-with-bounds";
     expect;
 *)
 

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -21,8 +21,7 @@ Lines 2-4, characters 2-16:
 4 |     | This of 'a
 Error: The kind of type "'a or_null" is value_or_null
          because it is the primitive value_or_null type or_null.
-       But the kind of type "'a or_null" must be a subkind of
-         value mod many with 'a uncontended with 'a portable with 'a
+       But the kind of type "'a or_null" must be a subkind of value
          because of the definition of t at lines 2-4, characters 2-16.
 |}]
 

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -952,7 +952,7 @@ Line 1, characters 19-27:
                        ^^^^^^^^
 Error: This type "string t" = "#(string u * string u)"
        should be an instance of type "('a : any mod global)"
-       The kind of string t is immediate & immediate
+       The kind of string t is value & value
          because it is an unboxed tuple.
        But the kind of string t must be a subkind of any mod global
          because of the definition of needs_any_mod_global at line 4, characters 0-47.
@@ -969,7 +969,8 @@ Line 3, characters 9-30:
              ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "#(int * string * int)" should be an instance of type
          "('a : any mod external_)"
-       The kind of #(int * string * int) is immediate & immediate & immediate
+       The kind of #(int * string * int) is
+         immutable_data & immutable_data & immutable_data
          because it is an unboxed tuple.
        But the kind of #(int * string * int) must be a subkind of
          any mod external_

--- a/testsuite/tests/typing-layouts-products/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-products/basics_alpha.ml
@@ -66,27 +66,7 @@ type t2 : any_non_null
 Line 3, characters 0-39:
 3 | type t3 : any mod non_null = #(t1 * t2);;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "#(t1 * t2)" is
-         any mod global with t1
-t2 unique with t1
-t2 many with t1
-t2
-                 uncontended with t1
-t2 portable with t1
-t2
-                 external_ with t1
-t2 non_null with t1
-t2
-         & any mod global with t1
-t2 unique with t1
-t2 many with t1
-t2
-                   uncontended with t1
-t2 portable with t1
-t2
-                   external_ with t1
-t2 non_null with t1
-t2
+Error: The kind of type "#(t1 * t2)" is any & any
          because it is an unboxed tuple.
        But the kind of type "#(t1 * t2)" must be a subkind of any_non_null
          because of the definition of t3 at line 3, characters 0-39.
@@ -101,27 +81,7 @@ type t2 : any_non_null
 Line 3, characters 0-45:
 3 | type t3 : any & any mod non_null = #(t1 * t2);;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "#(t1 * t2)" is
-         any mod global with t1
-t2 unique with t1
-t2 many with t1
-t2
-                 uncontended with t1
-t2 portable with t1
-t2
-                 external_ with t1
-t2 non_null with t1
-t2
-         & any mod global with t1
-t2 unique with t1
-t2 many with t1
-t2
-                   uncontended with t1
-t2 portable with t1
-t2
-                   external_ with t1
-t2 non_null with t1
-t2
+Error: The kind of type "#(t1 * t2)" is any & any
          because it is an unboxed tuple.
        But the kind of type "#(t1 * t2)" must be a subkind of
          any_non_null & any_non_null
@@ -137,27 +97,7 @@ type t2 : any_non_null
 Line 3, characters 0-62:
 3 | type t3 : (any mod non_null) & (any mod non_null) = #(t1 * t2);;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "#(t1 * t2)" is
-         any mod global with t1
-t2 unique with t1
-t2 many with t1
-t2
-                 uncontended with t1
-t2 portable with t1
-t2
-                 external_ with t1
-t2 non_null with t1
-t2
-         & any mod global with t1
-t2 unique with t1
-t2 many with t1
-t2
-                   uncontended with t1
-t2 portable with t1
-t2
-                   external_ with t1
-t2 non_null with t1
-t2
+Error: The kind of type "#(t1 * t2)" is any & any
          because it is an unboxed tuple.
        But the kind of type "#(t1 * t2)" must be a subkind of
          any_non_null & any_non_null

--- a/testsuite/tests/typing-layouts-unboxed-records/basics.ml
+++ b/testsuite/tests/typing-layouts-unboxed-records/basics.ml
@@ -436,15 +436,13 @@ and 'a t_imm = 'a t_immediate_id
 and ('a : float64, 'b : immediate, 'ptr) t =
   #{ptr : 'ptr; x : 'a; y : 'a t_float; z : 'b; w : 'b t_imm}
 [%%expect{|
-type ('a : float64) t_float = 'a t_float64_id
-and ('a : immediate) t_imm = 'a t_immediate_id
-and ('a : float64, 'b : immediate, 'ptr) t = #{
-  ptr : 'ptr;
-  x : 'a;
-  y : 'a t_float;
-  z : 'b;
-  w : 'b t_imm;
-}
+Lines 3-4, characters 0-61:
+3 | and ('a : float64, 'b : immediate, 'ptr) t =
+4 |   #{ptr : 'ptr; x : 'a; y : 'a t_float; z : 'b; w : 'b t_imm}
+Error: The layout of type "t" is value & float64 & any & value & any
+         because it is an unboxed record.
+       But the layout of type "t" must be representable
+         because it is an unboxed record.
 |}];;
 
 (* We don't yet have syntax for setting an unboxed record field.
@@ -760,34 +758,7 @@ Line 1, characters 0-61:
 1 | type q : any mod portable = #{ x : int -> int; y : int -> q }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "q" is
-         value_or_null mod global with int -> int
-int -> q
-                           unique with int -> int
-int -> q
-                           many with int -> int
-int -> q
-                           uncontended with int -> int
-int -> q
-                           portable with int -> int
-int -> q
-                           external_ with int -> int
-int -> q
-                           non_null with int -> int
-int -> q
-         & value_or_null mod global with int -> int
-int -> q
-                             unique with int -> int
-int -> q
-                             many with int -> int
-int -> q
-                             uncontended with int -> int
-int -> q
-                             portable with int -> int
-int -> q
-                             external_ with int -> int
-int -> q
-                             non_null with int -> int
-int -> q
+         value mod unique uncontended & value mod unique uncontended
          because it is an unboxed record.
        But the kind of type "q" must be a subkind of
          value_or_null mod portable & value_or_null mod portable

--- a/testsuite/tests/typing-layouts-unboxed-records/basics_from_unboxed_tuples_tests.ml
+++ b/testsuite/tests/typing-layouts-unboxed-records/basics_from_unboxed_tuples_tests.ml
@@ -985,7 +985,7 @@ Line 1, characters 19-27:
 1 | type should_fail = string t needs_any_mod_global
                        ^^^^^^^^
 Error: This type "string t" should be an instance of type "('a : any mod global)"
-       The kind of string t is immediate & immediate
+       The kind of string t is value & value
          because of the definition of t at line 2, characters 0-47.
        But the kind of string t must be a subkind of any mod global
          because of the definition of needs_any_mod_global at line 4, characters 0-47.
@@ -1003,7 +1003,8 @@ Line 4, characters 9-17:
              ^^^^^^^^
 Error: This type "s_record" should be an instance of type
          "('a : any mod external_)"
-       The kind of s_record is immediate & immediate & immediate
+       The kind of s_record is
+         immutable_data & immutable_data & immutable_data
          because of the definition of s_record at line 3, characters 0-51.
        But the kind of s_record must be a subkind of any mod external_
          because of the definition of t at line 1, characters 0-31.

--- a/testsuite/tests/typing-layouts/modules.ml
+++ b/testsuite/tests/typing-layouts/modules.ml
@@ -1,9 +1,10 @@
 (* TEST
  include stdlib_upstream_compatible;
+ flags = "-infer-with-bounds";
  {
    expect;
  }{
-   flags = "-extension layouts_beta";
+   flags += "-extension layouts_beta";
    expect;
  }
 *)

--- a/testsuite/tests/typing-layouts/modules.ml
+++ b/testsuite/tests/typing-layouts/modules.ml
@@ -4,7 +4,7 @@
  {
    expect;
  }{
-   flags += "-extension layouts_beta";
+   flags += " -extension layouts_beta";
    expect;
  }
 *)

--- a/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -283,7 +283,7 @@ type ('a : void) t4_void
 type t4 = M4.s t4_val;;
 [%%expect {|
 module F4 : functor (X : sig type t end) -> sig type s = Foo of X.t end
-module M4 : sig type s : immutable_data end
+module M4 : sig type s end
 type 'a t4_val
 type ('a : void) t4_void
 type t4 = M4.s t4_val

--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags = "-infer-with-bounds";
  expect;
 *)
 

--- a/testsuite/tests/typing-modal-kinds/expected_mode.ml
+++ b/testsuite/tests/typing-modal-kinds/expected_mode.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags = "-infer-with-bounds";
  expect;
 *)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2192,7 +2192,9 @@ let rec estimate_type_jkind ~expand_component env ty =
         just to throw most of it away will go away once we get [layout_of]. *)
      let jkinds = List.map (estimate_type_jkind ~expand_component env) tys in
      let layouts = List.map Jkind.extract_layout jkinds in
-     Jkind.Builtin.product ~jkind_of_first_type:(fun () ->
+     Jkind.Builtin.product
+       ~jkind_of_type:(estimate_type_jkind ~expand_component env)
+       ~jkind_of_first_type:(fun () ->
        match jkinds with
          | first_jkind :: _ -> first_jkind
          | _ -> Misc.fatal_error

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1268,7 +1268,7 @@ module Jkind_desc = struct
         let upper_bounds =
           List.fold_right
             (fun ty bounds ->
-               Bounds.add_baggage ~deep_only:false ~baggage:ty bounds)
+              Bounds.add_baggage ~deep_only:false ~baggage:ty bounds)
             tys
             (Bounds.min |> Bounds.disallow_right)
         in

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1254,7 +1254,7 @@ module Jkind_desc = struct
     let immediate = of_const Const.Builtin.immediate.jkind
   end
 
-  let product ~jkind_of_first_type tys layouts =
+  let product ~jkind_of_first_type ~jkind_of_type tys layouts =
     (* CR layouts v2.8: We can probably drop this special case once we
        have proper subsumption. The general algorithm gets the right
        jkind, but the subsumption check fails because it can't recognize
@@ -1262,15 +1262,35 @@ module Jkind_desc = struct
     match layouts with
     | [_] -> (jkind_of_first_type ()).jkind
     | _ ->
-      let layout = Layout.product layouts in
-      let upper_bounds =
-        List.fold_right
-          (fun ty bounds ->
-            Bounds.add_baggage ~deep_only:false ~baggage:ty bounds)
-          tys
-          (Bounds.min |> Bounds.disallow_right)
-      in
-      { layout; upper_bounds }
+      if !Clflags.infer_with_bounds
+      then
+        let layout = Layout.product layouts in
+        let upper_bounds =
+          List.fold_right
+            (fun ty bounds ->
+               Bounds.add_baggage ~deep_only:false ~baggage:ty bounds)
+            tys
+            (Bounds.min |> Bounds.disallow_right)
+        in
+        { layout; upper_bounds }
+      else
+        let folder (layouts, bounds) ty =
+          let { jkind = { layout; upper_bounds };
+                annotation = _;
+                history = _;
+                has_warned = _
+              } =
+            jkind_of_type ty
+          in
+          layout :: layouts, Bounds.join bounds upper_bounds
+        in
+        let layouts, upper_bounds =
+          List.fold_left folder ([], Bounds.min |> Bounds.disallow_right) tys
+        in
+        let layouts = List.rev layouts in
+        { layout = Layout.Product layouts;
+          upper_bounds = Bounds.disallow_right upper_bounds
+        }
 
   let get t = Layout_and_axes.map Layout.get t
 
@@ -1345,8 +1365,10 @@ module Builtin = struct
     fresh_jkind Jkind_desc.Builtin.immediate ~annotation:(mk_annot "immediate")
       ~why:(Immediate_creation why)
 
-  let product ~jkind_of_first_type ~why tys layouts =
-    let desc = Jkind_desc.product ~jkind_of_first_type tys layouts in
+  let product ~jkind_of_first_type ~jkind_of_type ~why tys layouts =
+    let desc =
+      Jkind_desc.product ~jkind_of_first_type ~jkind_of_type tys layouts
+    in
     fresh_jkind_poly desc ~annotation:None ~why:(Product_creation why)
 
   let product_of_sorts ~why arity =
@@ -1472,16 +1494,18 @@ let add_labels_as_baggage lbls jkind =
 let for_boxed_record lbls =
   if all_void_labels lbls
   then Builtin.immediate ~why:Empty_record
-  else
+  else if !Clflags.infer_with_bounds
+  then
     let is_mutable = has_mutable_label lbls in
     let base =
       (if is_mutable then Builtin.mutable_data else Builtin.immutable_data)
         ~why:Boxed_record
     in
     add_labels_as_baggage lbls base
+  else Builtin.value ~why:Boxed_record
 
 (* CR layouts v2.8: This should take modalities into account. *)
-let for_unboxed_record ~jkind_of_first_type lbls =
+let for_unboxed_record ~jkind_of_first_type ~jkind_of_type lbls =
   let open Types in
   let tys = List.map (fun lbl -> lbl.ld_type) lbls in
   let layouts =
@@ -1489,7 +1513,8 @@ let for_unboxed_record ~jkind_of_first_type lbls =
       (fun lbl -> lbl.ld_sort |> Layout.Const.of_sort_const |> Layout.of_const)
       lbls
   in
-  Builtin.product ~jkind_of_first_type ~why:Unboxed_record tys layouts
+  Builtin.product ~jkind_of_first_type ~jkind_of_type ~why:Unboxed_record tys
+    layouts
 
 (* CR layouts v2.8: This should take modalities into account. *)
 let for_boxed_variant cstrs =
@@ -1502,7 +1527,8 @@ let for_boxed_variant cstrs =
          | Cstr_record lbls -> all_void_labels lbls)
        cstrs
   then Builtin.immediate ~why:Enumeration
-  else
+  else if !Clflags.infer_with_bounds
+  then
     let is_mutable =
       List.exists
         (fun cstr ->
@@ -1535,6 +1561,7 @@ let for_boxed_variant cstrs =
         | Cstr_record lbls -> add_labels_as_baggage lbls jkind
       in
       List.fold_right add_cstr_args cstrs base
+  else Builtin.value ~why:Boxed_variant
 
 let for_arrow =
   fresh_jkind

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -314,6 +314,7 @@ module Builtin : sig
       generalized if need be.  *)
   val product :
     jkind_of_first_type:(unit -> jkind_l) ->
+    jkind_of_type:(Types.type_expr -> jkind_l) ->
     why:History.product_creation_reason ->
     Types.type_expr list ->
     Sort.t Layout.t list ->
@@ -420,6 +421,7 @@ val for_boxed_record : Types.label_declaration list -> jkind_l
     unboxed record must match that of the single field. *)
 val for_unboxed_record :
   jkind_of_first_type:(unit -> jkind_l) ->
+  jkind_of_type:(Types.type_expr -> jkind_l) ->
   Types.label_declaration list ->
   jkind_l
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1870,6 +1870,7 @@ let update_decl_jkind env dpath decl =
           in
           let type_jkind =
             Jkind.for_unboxed_record
+              ~jkind_of_type:(Ctype.estimate_type_jkind env)
               ~jkind_of_first_type:(fun () ->
                 match lbls with
                 | [lbl] -> Ctype.estimate_type_jkind env lbl.ld_type

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -223,6 +223,7 @@ let afl_inst_ratio = ref 100           (* -afl-inst-ratio *)
 let function_sections = ref false      (* -function-sections *)
 let probes = ref Config.probes         (* -probes *)
 let allow_illegal_crossing = ref false (* -allow_illegal_crossing *)
+let infer_with_bounds = ref false       (* -infer-with-bounds *)
 let simplify_rounds = ref None        (* -rounds *)
 let default_simplify_rounds = ref 1        (* -rounds *)
 let rounds () =

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -227,6 +227,7 @@ val afl_inst_ratio : int ref
 val function_sections : bool ref
 val probes : bool ref
 val allow_illegal_crossing : bool ref
+val infer_with_bounds : bool ref
 
 val all_passes : string list ref
 val dumped_pass : string -> bool


### PR DESCRIPTION
Add a new flag, -infer-with-bounds, which enables inference of
with-bounds (called "baggage" as of this commit, but to be renamed to
with-bounds later) on type declarations. This defaults to false, and has to be
turned on per-compilation-unit, because we are concerned about the performance
impact of rolling out with-kind inference and want to do so gradually.

If the flag is off, we restore the original inferred kinds prior to the
introduction of with-bounds.