### PR TITLE
Fix ocamltest line numbers after multiline comments, strings

### DIFF
--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -114,6 +114,7 @@ and string acc = parse
     { let space =
         match blank with None -> "" | Some blank -> String.make 1 blank
       in
+      Lexing.new_line lexbuf;
       string (acc ^ space) lexbuf }
   | '\\'
     {string (acc ^ "\\") lexbuf}
@@ -137,6 +138,11 @@ and comment = parse
     {
       let pos = List.hd !comment_start_pos in
       lexer_error_at pos "unterminated comment"
+    }
+  | newline
+    {
+      Lexing.new_line lexbuf;
+      comment lexbuf
     }
   | _
     {


### PR DESCRIPTION
(Backport of ocaml/ocaml#13775)

Any multiline string or comment in an ocamltest throws off the line numbers in output:

    (* TEST
     (* This is
        a long comment *)

     fail; (* this is line 5 *)
    *)

     ... testing 'main.ml' with line 4 (fail) => failed (the fail action always fails)

This PR fixes both strings and comments.