### PR TITLE
Turn lib-runtime-events tests back on (with some alert tweaks)

### DIFF
--- a/testsuite/tests/lib-runtime-events/test.ml
+++ b/testsuite/tests/lib-runtime-events/test.ml
@@ -1,19 +1,9 @@
 (* TEST
- {
-   runtime4;
-   skip;
- }{
-   reason="this runtime_events test is currently broken, to be fixed later";
-   skip;
- }
-*)
-
-(* Header to start from when this test gets fixed:
- {
-   runtime4;
-   skip;
- }{
    modules = "stubs.c";
+ {
+   runtime4;
+   skip;
+ }{
    include runtime_events;
    runtime5;
    { bytecode; }

--- a/testsuite/tests/lib-runtime-events/test_caml.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml.ml
@@ -3,16 +3,6 @@
    runtime4;
    skip;
  }{
-   reason="this runtime_events test is currently broken, to be fixed later";
-   skip;
- }
-*)
-
-(* Header to start from when this test gets fixed:
- {
-   runtime4;
-   skip;
- }{
    include runtime_events;
    runtime5;
    { bytecode; }

--- a/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
@@ -1,7 +1,14 @@
 (* TEST
- include runtime_events;
- reason = "CR OCaml 5 domains";
- skip;
+ {
+   runtime4;
+   skip;
+ }{
+   include runtime_events;
+   runtime5;
+   flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
+   { bytecode; }
+   { native; }
+ }
 *)
 open Runtime_events
 

--- a/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
@@ -1,7 +1,14 @@
 (* TEST
- include runtime_events;
- reason = "CR OCaml 5 domains";
- skip;
+ {
+   runtime4;
+   skip;
+ }{
+   include runtime_events;
+   runtime5;
+   flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
+   { bytecode; }
+   { native; }
+ }
 *)
 open Runtime_events
 

--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -1,17 +1,18 @@
 (* TEST
- include runtime_events;
- include unix;
- set OCAMLRUNPARAM = "e=6";
- reason = "CR OCaml 5 domains";
- skip;
- hasunix;
  {
-   native;
+   runtime4;
+   skip;
  }{
-   bytecode;
+   include runtime_events;
+   runtime5;
+   flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
+   include unix;
+   set OCAMLRUNPARAM = "e=6";
+   hasunix;
+   { bytecode; }
+   { native; }
  }
 *)
-
 type Runtime_events.User.tag += Ev
 let ev = Runtime_events.User.register "ev" Ev Runtime_events.Type.int
 


### PR DESCRIPTION
lib-runtime-events works fine (or at least well enough to pass tests) so the tests should be turned back on (with the multi-domain/parallel alerts disabled as necessary).