### PR TITLE
Only run `memset` when stack checks are enabled

### DIFF
--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -939,7 +939,7 @@ void caml_free_stack (struct stack_info* stack)
     stack->exception_ptr =
       (void*)(cache[stack->cache_bucket]);
     cache[stack->cache_bucket] = stack;
-#ifdef DEBUG
+#if defined(DEBUG) && defined(STACK_CHECKS_ENABLED)
     memset(Stack_base(stack), 0x42,
            (Stack_high(stack)-Stack_base(stack))*sizeof(value));
 #endif

--- a/testsuite/tests/effects/test1.ml
+++ b/testsuite/tests/effects/test1.ml
@@ -1,9 +1,11 @@
 (* TEST
- skip;
+  runtime5;
+  { bytecode; }
+  { native; }
 *)
 
-open Effect
-open Effect.Deep
+open Stdlib__Effect
+open Stdlib__Effect.Deep
 
 type _ t += E : unit t
 


### PR DESCRIPTION
When stack checks are disabled, `memset` tries to access the guarded page of the stack, causing a segfault.

This issue was introduced in #3384 and only shows ups when running effects with debug runtime.