### PR TITLE
Finer typing for closing over module coercion

### DIFF
--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -85,7 +85,8 @@ let typecheck_intf info ast =
         Format.(fprintf std_formatter) "%a@."
           (Printtyp.printed_signature (Unit_info.source_file info.target))
           sg);
-  ignore (Includemod.signatures info.env ~mark:Mark_both ~modes:Legacy sg sg);
+  ignore (Includemod.signatures info.env ~mark:Mark_both
+    ~modes:(Legacy None) sg sg);
   Typecore.force_delayed_checks ();
   Builtin_attributes.warn_unused ();
   Warnings.check_fatal ();

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -229,5 +229,5 @@ let (bar @ portable) () =
 Line 3, characters 19-20:
 3 |         module L = M
                        ^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+Error: "M" is a module, and modules are always nonportable, so cannot be used inside a function that is portable.
 |}]

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -29,20 +29,6 @@ module M : sig type 'a t = int val x : 'a -> unit end
 module F : functor (X : S) -> sig type t = int val x : 'a -> unit end
 |}]
 
-(* Closing over modules affects closure's modes *)
-let u =
-    let foo () =
-        let _ = (module M : S) in
-        ()
-    in
-    portable_use foo
-[%%expect{|
-Line 6, characters 17-20:
-6 |     portable_use foo
-                     ^^^
-Error: This value is "nonportable" but expected to be "portable".
-|}]
-
 let u =
     let foo () =
         let module X = struct
@@ -57,21 +43,6 @@ let u =
 Line 10, characters 17-20:
 10 |     portable_use foo
                       ^^^
-Error: This value is "nonportable" but expected to be "portable".
-|}]
-
-(* File-level modules are looked up differently and need to be tested
-separately. *)
-let u =
-    let foo () =
-        let _ = (module List : SL) in
-        ()
-    in
-    portable_use foo
-[%%expect{|
-Line 6, characters 17-20:
-6 |     portable_use foo
-                     ^^^
 Error: This value is "nonportable" but expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -926,7 +926,7 @@ module type S = sig
 end
 
 module type Module = sig
-  module M : sig include S end (* to prevent shallow_equal *)
+  module M : S
 end
 
 module type S' = sig
@@ -952,29 +952,14 @@ module type S =
     val baz : 'a -> 'a
     class cla : object  end
   end
-module type Module =
-  sig
-    module M :
-      sig
-        val x : int
-        val foo : 'a -> 'a @@ portable
-        val baz : 'a -> 'a
-        class cla : object  end
-      end
-  end
+module type Module = sig module M : S end
 module type S' =
   sig
     val x : int
     val foo : 'a -> 'a @@ portable
     val baz : 'a -> 'a
     class cla : object  end
-    module M :
-      sig
-        val x : int
-        val foo : 'a -> 'a @@ portable
-        val baz : 'a -> 'a
-        class cla : object  end
-      end
+    module M : S
   end
 module M : S
 |}]
@@ -1034,8 +1019,7 @@ let (bar @ portable) () =
 val bar : unit -> unit = <fun>
 |}]
 
-(* If module types are shallow_equal, we still close over the module, even if closing things
-  inside would be better *)
+(* If module types are shallow_equal, we still close over all the things inside the module *)
 module M_Func_portable : Func_portable = M
 
 let (bar @ portable) () =
@@ -1043,10 +1027,7 @@ let (bar @ portable) () =
   k
 [%%expect{|
 module M_Func_portable : Func_portable
-Line 4, characters 18-33:
-4 |   let k = (module M_Func_portable : Func_portable) in
-                      ^^^^^^^^^^^^^^^
-Error: "M_Func_portable" is a module, and modules are always nonportable, so cannot be used inside a function that is portable.
+val bar : unit -> (module Func_portable) = <fun>
 |}]
 
 (* Closing over a module in a module. *)

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -901,7 +901,6 @@ let () =
 [%%expect{|
 |}]
 
-(* CR zqian: finer treatment of closing over module ident with expected type. *)
 module type Int_nonportable = sig
   val x : int
 end
@@ -993,10 +992,7 @@ let (bar @ portable) () =
     let k = (module M : Func_portable) in
     k
 [%%expect{|
-Line 2, characters 20-21:
-2 |     let k = (module M : Func_portable) in
-                        ^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+val bar : unit -> (module Func_portable) = <fun>
 |}]
 
 (* Pmod_apply *)
@@ -1005,10 +1001,7 @@ let (bar @ portable) () =
   let module _ = F(M) in
   ()
 [%%expect{|
-Line 3, characters 19-20:
-3 |   let module _ = F(M) in
-                       ^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+val bar : unit -> unit = <fun>
 |}]
 
 (* Pmod_constraint *)
@@ -1018,10 +1011,7 @@ let (bar @ portable) () =
   end in
   ()
 [%%expect{|
-Line 3, characters 16-17:
-3 |     module N = (M : Func_portable)
-                    ^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+val bar : unit -> unit = <fun>
 |}]
 
 (* We will now only use Pmod_pack as example; Pmod_apply and Pexp_constraint are
@@ -1033,7 +1023,7 @@ let (bar @ portable) () =
 Line 2, characters 18-19:
 2 |   let k = (module M : Func_nonportable) in
                       ^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+Error: The value "M.baz" is nonportable, so cannot be used inside a function that is portable.
 |}]
 
 (* closing over M.x crosses modes *)
@@ -1041,10 +1031,7 @@ let (bar @ portable) () =
   let _ = (module M : Int_nonportable) in
   ()
 [%%expect{|
-Line 2, characters 18-19:
-2 |   let _ = (module M : Int_nonportable) in
-                      ^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+val bar : unit -> unit = <fun>
 |}]
 
 (* If module types are shallow_equal, we still close over the module, even if closing things
@@ -1059,7 +1046,7 @@ module M_Func_portable : Func_portable
 Line 4, characters 18-33:
 4 |   let k = (module M_Func_portable : Func_portable) in
                       ^^^^^^^^^^^^^^^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+Error: "M_Func_portable" is a module, and modules are always nonportable, so cannot be used inside a function that is portable.
 |}]
 
 (* Closing over a module in a module. *)
@@ -1070,7 +1057,7 @@ let (bar @ portable) () =
 Line 2, characters 18-20:
 2 |   let k = (module M' : Module) in
                       ^^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+Error: The value "M'.M.baz" is nonportable, so cannot be used inside a function that is portable.
 |}]
 
 module type S'_Func_portable = sig module M : Func_portable end
@@ -1080,10 +1067,7 @@ let (bar @ portable) () =
   k
 [%%expect{|
 module type S'_Func_portable = sig module M : Func_portable end
-Line 4, characters 18-20:
-4 |   let k = (module M' : S'_Func_portable) in
-                      ^^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+val bar : unit -> (module S'_Func_portable) = <fun>
 |}]
 
 (* closing over a functor is still closing over the functor *)
@@ -1098,7 +1082,7 @@ module F : functor (X : sig end) -> sig end
 Line 4, characters 18-19:
 4 |   let k = (module F : F) in
                       ^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+Error: "F" is a module, and modules are always nonportable, so cannot be used inside a function that is portable.
 |}]
 
 (* closing over class in structure is still prevented *)
@@ -1109,7 +1093,7 @@ let (bar @ portable) () =
 Line 2, characters 18-19:
 2 |   let k = (module M : Class) in
                       ^
-Error: Modules are nonportable, so cannot be used inside a function that is portable.
+Error: "M.cla" is a class, and classes are always nonportable, so cannot be used inside a function that is portable.
 |}]
 
 (* Pmod_unpack requires type equality instead of inclusion, so for a closing-over

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -126,7 +126,7 @@ let execute_phrase print_outcome ppf phr =
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv sn sg in
       ignore (Includemod.signatures ~mark:Mark_positive oldenv
-        ~modes:Legacy sg sg');
+        ~modes:(Legacy None) sg sg');
       Typecore.force_delayed_checks ();
       let shape = Shape_reduce.local_reduce Env.empty shape in
       if !Clflags.dump_shape then Shape.print ppf shape;

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -401,7 +401,8 @@ let execute_phrase print_outcome ppf phr =
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv names sg in
       let coercion =
-        Includemod.signatures oldenv ~mark:Mark_positive ~modes:Legacy sg sg'
+        Includemod.signatures oldenv ~mark:Mark_positive
+          ~modes:(Legacy None) sg sg'
       in
       Typecore.force_delayed_checks ();
       let str, sg', rewritten =

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -341,6 +341,8 @@ type lock =
 
 type locks = lock list
 
+type held_locks = locks * Longident.t * Location.t
+
 let locks_empty = []
 
 let locks_is_empty l = l = locks_empty
@@ -3781,7 +3783,7 @@ let find_cltype_index id env = find_index_tbl id env.cltypes
 
 (* Ordinary lookup functions *)
 
-let walk_locks ~loc ~env ~item ~lid mode ty locks =
+let walk_locks ~env ~item mode ty (locks, lid, loc) =
   walk_locks ~errors:true ~loc ~env ~item ~lid mode ty locks
 
 let lookup_module_path ?(use=true) ~loc ~load lid env =
@@ -4216,8 +4218,12 @@ let sharedness_hint ppf : shared_context -> _ = function
 
 let print_lock_item ppf (item, lid) =
   match item with
-  | Module -> fprintf ppf "Modules are"
-  | Class -> fprintf ppf "Classes are"
+  | Module ->
+      fprintf ppf "%a is a module, and modules are always"
+        (Style.as_inline_code !print_longident) lid
+  | Class ->
+      fprintf ppf "%a is a class, and classes are always"
+        (Style.as_inline_code !print_longident) lid
   | Value -> fprintf ppf "The value %a is"
       (Style.as_inline_code !print_longident) lid
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3228,6 +3228,7 @@ let rec lookup_module_components ~errors ~use ~loc lid env =
       let f_path, f_comp, arg = lookup_apply ~errors ~use ~loc lid env in
       let comps =
         !components_of_functor_appl' ~loc ~f_path ~f_comp ~arg env in
+      (* [Lapply] is for [F(M).t] so nothing is closed over. *)
       Papply (f_path, arg), locks_empty, comps
 
 and lookup_structure_components ~errors ~use ~loc ?(reason = Project) lid env =
@@ -3321,6 +3322,7 @@ and lookup_module ~errors ~use ~loc lid env =
   | Lapply _ as lid ->
       let path_f, comp_f, path_arg = lookup_apply ~errors ~use ~loc lid env in
       let md = md (modtype_of_functor_appl comp_f path_f path_arg) in
+      (* [Lapply] is for [F(M).t] so nothing is closed over. *)
       Papply(path_f, path_arg), md, locks_empty
 
 and lookup_dot_module ~errors ~use ~loc l s env =
@@ -3592,6 +3594,7 @@ let lookup_module_path ~errors ~use ~loc ~load lid env =
       path, locks
   | Lapply _ as lid ->
       let path_f, _comp_f, path_arg = lookup_apply ~errors ~use ~loc lid env in
+      (* [Lapply] is for [F(M).t] so nothing is closed over. *)
       Papply(path_f, path_arg), locks_empty
 
 let lookup_module_instance_path ~errors ~use ~loc ~load name env =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -207,9 +207,9 @@ type shared_context =
 type locks
 
 type held_locks = locks * Longident.t * Location.t
-(** Sometimes we get the locks for a structure [M], but either want to walk them
-later, or walk them for something else. The [Longident.t] and [Location.t]
-points to what we actually want to walk. *)
+(** Sometimes we get the locks for something, but either want to walk them later, or
+walk them for something else. The [Longident.t] and [Location.t] are only for error
+messages, and point to the variable for which we actually want to walk the locks. *)
 
 val locks_empty : locks
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -206,6 +206,11 @@ type shared_context =
 
 type locks
 
+type held_locks = locks * Longident.t * Location.t
+(** Sometimes we get the locks for a structure [M], but either want to walk them
+later, or walk them for something else. The [Longident.t] and [Location.t]
+points to what we actually want to walk. *)
+
 val locks_empty : locks
 
 val locks_is_empty : locks -> bool
@@ -272,8 +277,8 @@ type actual_mode = {
     locks and constrains [mode] and [ty]. Return the access mode of the value allowed by
     the locks. [ty] is optional as the function works on modules and classes as well, for
     which [ty] should be [None]. *)
-val walk_locks : loc:Location.t -> env:t -> item:lock_item -> lid:Longident.t ->
-  Mode.Value.l -> type_expr option -> locks -> actual_mode
+val walk_locks : env:t -> item:lock_item -> Mode.Value.l -> type_expr option ->
+  held_locks -> actual_mode
 
 val lookup_value:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -282,8 +282,8 @@ val lookup_type:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
   Path.t * type_declaration
 val lookup_module:
-  ?use:bool -> ?lock:bool -> loc:Location.t -> Longident.t -> t ->
-  Path.t * module_declaration * Mode.Value.l
+  ?use:bool -> loc:Location.t -> Longident.t -> t ->
+  Path.t * module_declaration * locks
 val lookup_modtype:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
   Path.t * modtype_declaration
@@ -607,8 +607,8 @@ val set_type_used_callback:
 val check_functor_application:
   (errors:bool -> loc:Location.t ->
    lid_whole_app:Longident.t ->
-   f0_path:Path.t -> args:(Path.t * Types.module_type * Mode.Value.l) list ->
-   arg_path:Path.t -> arg_mty:Types.module_type -> arg_mode:Mode.Value.l ->
+   f0_path:Path.t -> args:(Path.t * Types.module_type) list ->
+   arg_path:Path.t -> arg_mty:Types.module_type ->
    param_mty:Types.module_type ->
    t -> unit) ref
 (* Forward declaration to break mutual recursion with Typemod. *)

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -155,7 +155,7 @@ let value_descriptions ~loc env name
       let mode1 =
         match close_over_coercion with
         | Some held_locks ->
-          (* Similiar to [Typecore.type_ident] *)
+          (* Cross modes according to RHS type as it tends to be by the user. *)
           let mode1 = left_mode_cross env vd2.val_type mode1 in
           let mode1 =
             Env.walk_locks ~env ~item:Value mode1 (Some vd1.val_type) held_locks

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -68,15 +68,17 @@ let right_mode_cross env ty mode =
   let jkind = Ctype.type_jkind_purely env ty in
   right_mode_cross_jkind env jkind mode
 
-let left_mode_cross_jkind jkind mode =
-  let upper_bounds = Jkind.get_modal_upper_bounds jkind in
+let left_mode_cross_jkind env jkind mode =
+  let type_equal = Ctype.type_equal env in
+  let jkind_of_type = Ctype.type_jkind_purely_if_principal env in
+  let upper_bounds = Jkind.get_modal_upper_bounds ~type_equal ~jkind_of_type jkind in
   let upper_bounds = Const.alloc_as_value upper_bounds in
   Value.meet_const upper_bounds mode
 
 let left_mode_cross env ty mode=
   if not (Ctype.is_principal ty) then mode else
   let jkind = Ctype.type_jkind_purely env ty in
-  left_mode_cross_jkind jkind mode
+  left_mode_cross_jkind env jkind mode
 
 let native_repr_args nra1 nra2 =
   let rec loop i nra1 nra2 =

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -49,7 +49,7 @@ exception Dont_match of value_mismatch
 
 type mmodes =
   | All
-  | Legacy
+  | Legacy of Env.held_locks option
 
 (** Mode cross a right mode *)
 (* This is very similar to Ctype.mode_cross_right. Any bugs here are likely bugs
@@ -67,6 +67,16 @@ let right_mode_cross env ty mode =
   if not (Ctype.is_principal ty) then mode else
   let jkind = Ctype.type_jkind_purely env ty in
   right_mode_cross_jkind env jkind mode
+
+let left_mode_cross_jkind jkind mode =
+  let upper_bounds = Jkind.get_modal_upper_bounds jkind in
+  let upper_bounds = Const.alloc_as_value upper_bounds in
+  Value.meet_const upper_bounds mode
+
+let left_mode_cross env ty mode=
+  if not (Ctype.is_principal ty) then mode else
+  let jkind = Ctype.type_jkind_purely env ty in
+  left_mode_cross_jkind jkind mode
 
 let native_repr_args nra1 nra2 =
   let rec loop i nra1 nra2 =
@@ -131,17 +141,27 @@ let value_descriptions ~loc env name
       | Ok () -> ()
       | Error e -> raise (Dont_match (Modality e))
       end;
-  | Legacy when (vd1.val_modalities == vd2.val_modalities) ->
+  | Legacy close_over_coercion ->
+    match Mode.Modality.Value.to_const_opt vd2.val_modalities with
       (* [wrap_constraint_with_shape] invokes inclusion check with identical
         inferred modalities, which we need to workaround. *)
-      ()
-  | Legacy ->
+    | None -> ()
+    | Some val2_modalities ->
       let mmode1, mmode2 =
         Mode.Value.(disallow_right legacy), Mode.Value.(disallow_left legacy)
       in
       let mode1 = Mode.Modality.Value.apply vd1.val_modalities mmode1 in
-      let mode2 =
-        Mode.Modality.Value.(Const.apply (to_const_exn vd2.val_modalities) mmode2)
+      let mode2 = Mode.Modality.Value.(Const.apply val2_modalities mmode2) in
+      let mode1 =
+        match close_over_coercion with
+        | Some held_locks ->
+          (* Similiar to [Typecore.type_ident] *)
+          let mode1 = left_mode_cross env vd2.val_type mode1 in
+          let mode1 =
+            Env.walk_locks ~env ~item:Value mode1 (Some vd1.val_type) held_locks
+          in
+          mode1.mode
+        | None -> mode1
       in
       let mode2 = right_mode_cross env vd2.val_type mode2 in
       begin match Mode.Value.submode mode1 mode2 with

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -131,8 +131,24 @@ type mmodes =
   | All
   (** Check module inclusion [M1 : MT1 @ m1 <= M2 : MT2 @ m2]
       for all [m1 <= m2]. *)
-  | Legacy
-  (** Check module inclusion [M1 : MT1 @ legacy <= M2 : MT2 @ legacy]. *)
+  | Legacy of Env.held_locks option
+  (** Check module inclusion [M1 : MT1 @ legacy <= M2 : MT2 @ legacy].
+    If [M1] is a [Pmod_ident] and the current inclusion check is for its
+    coercion into [M2], we treat all surroudning functions as not closing over
+    [M1], but closing over components in [M1] required by [MT2]. Therefore, the
+    locks for [M1] are held, to be walked by each of the components
+    individually.
+
+    This is potentially unsafe as it doesn't reflect the real runtime behavior,
+    for at least two reasons:
+    - The corecion might turn out to be [coercion_none], in which case no
+    coercion happens, and the functions will be closing over the original module.
+    - Even if the coercion happens, the functions will be closing over the
+      original module and projecting needed values out of it.
+
+    The above concern can be resolved by the "ergonomics" discussion in
+    [typecore.type_ident].
+  *)
 
 val value_descriptions:
   loc:Location.t -> Env.t -> string ->

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -1049,13 +1049,12 @@ let check_modtype_inclusion ~loc env mty1 path1 mty2 =
 
 let check_functor_application_in_path
     ~errors ~loc ~lid_whole_app ~f0_path ~args
-    ~arg_path ~arg_mty ~arg_mode ~param_mty env =
-  Mode.Value.submode_exn arg_mode Mode.Value.legacy;
+    ~arg_path ~arg_mty ~param_mty env =
   match check_modtype_inclusion_raw ~loc env arg_mty arg_path param_mty with
   | Ok _ -> ()
   | Error _errs ->
       if errors then
-        let prepare_arg (arg_path, arg_mty, _arg_mode) =
+        let prepare_arg (arg_path, arg_mty) =
           let aliasable = can_alias env arg_path in
           let smd = Mtype.strengthen ~aliasable arg_mty arg_path in
           (Error.Named arg_path, smd)

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -543,10 +543,13 @@ and try_modtypes ~in_eq ~loc env ~mark subst ~modes mty1 mty2 orig_shape =
   | _ when shallow_modtypes env subst mty1 mty2 ->
     begin match modes with
       | Legacy (Some (locks, _, _)) when not (Env.locks_is_empty locks) ->
+          (* If the coercion being checked is closed over, we close over individual values
+          in the module, instead of the whole module. *)
           let mty1 = Mtype.reduce_alias_lazy env mty1 in
           let mty2 = Subst.Lazy.modtype Keep subst mty2 |> Mtype.reduce_alias_lazy env in
           begin match mty1, mty2 with
           | Some mty1, Some mty2 ->
+             (* Only for the side-effects of walking locks *)
               ignore (try_modtypes ~in_eq ~loc env ~mark subst ~modes mty1 mty2 orig_shape)
           | _, _ ->
               walk_locks ~env ~item:Module modes

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2493,10 +2493,7 @@ module Modality = struct
 
     let zap_to_id = zap_to_floor
 
-    let to_const_exn = function
-      | Const c -> c
-      | Undefined | Diff _ ->
-        Misc.fatal_error "Got infered modality but constant modality expected."
+    let to_const_opt = function Const c -> Some c | Undefined | Diff _ -> None
 
     let of_const c = Const c
 
@@ -2645,10 +2642,9 @@ module Modality = struct
         let c = Mode.Const.imply mm m in
         Const.Meet_const c
 
-    let to_const_exn = function
-      | Const c -> c
-      | Undefined | Exactly _ ->
-        Misc.fatal_error "Got inferred modality but expected constant modality."
+    let to_const_opt = function
+      | Const c -> Some c
+      | Undefined | Exactly _ -> None
 
     let of_const c = Const c
   end
@@ -2759,11 +2755,13 @@ module Modality = struct
       let monadic = Monadic.zap_to_floor monadic in
       { monadic; comonadic }
 
-    let to_const_exn t =
+    let to_const_opt t =
       let { monadic; comonadic } = t in
-      let comonadic = Comonadic.to_const_exn comonadic in
-      let monadic = Monadic.to_const_exn monadic in
-      { monadic; comonadic }
+      Option.bind (Comonadic.to_const_opt comonadic) (fun comonadic ->
+          Option.bind (Monadic.to_const_opt monadic) (fun monadic ->
+              Some { monadic; comonadic }))
+
+    let to_const_exn t = t |> to_const_opt |> Option.get
 
     let of_const { monadic; comonadic } =
       let comonadic = Comonadic.of_const comonadic in

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -645,6 +645,9 @@ module type S = sig
       (** Asserts the given modality is a const modality, and returns it. *)
       val to_const_exn : t -> Const.t
 
+      (** Checks if the given modality is a const modality *)
+      val to_const_opt : t -> Const.t option
+
       (** Inject a constant modality. *)
       val of_const : Const.t -> t
 

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -189,6 +189,8 @@ let rec scrape_lazy ~aliases env mty =
   | Some mty -> scrape_lazy ~aliases env mty
   | None -> mty
 
+let reduce_alias_lazy env mty = reduce_lazy ~aliases:true env mty
+
 let reduce_lazy env mty = reduce_lazy ~aliases:false env mty
 
 let reduce env mty =

--- a/typing/mtype.mli
+++ b/typing/mtype.mli
@@ -27,6 +27,8 @@ val scrape_alias: Env.t -> module_type -> module_type
            or abstract module type ident. *)
 val reduce_lazy:
   Env.t -> Subst.Lazy.module_type -> Subst.Lazy.module_type option
+val reduce_alias_lazy:
+  Env.t -> Subst.Lazy.module_type -> Subst.Lazy.module_type option
 val reduce: Env.t -> module_type -> module_type option
         (* Expand one toplevel module abbreviation. Return None if
            no expansion is possible. *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7072,8 +7072,8 @@ and type_ident env ?(recarg=Rejected) lid =
   *)
   (* CR modes: codify the above per-axis argument. *)
   let actual_mode =
-    Env.walk_locks ~loc:lid.loc ~env ~item:Value ~lid:lid.txt mode
-      (Some desc.val_type) locks
+    Env.walk_locks ~env ~item:Value mode (Some desc.val_type)
+      (locks, lid.txt, lid.loc)
   in
   (* We need to cross again, because the monadic fragment might have been
   weakened by the locks. Ideally, the first crossing only deals with comonadic,

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1717,10 +1717,10 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
     | Pwith_type (l,decl) ->l , With_type decl
     | Pwith_typesubst (l,decl) ->l , With_typesubst decl
     | Pwith_module (l,l') ->
-        let path, md, _ = Env.lookup_module ~lock:false ~loc l'.txt env in
+        let path, md, _ = Env.lookup_module ~loc l'.txt env in
         l , With_module {lid=l';path;md; remove_aliases}
     | Pwith_modsubst (l,l') ->
-        let path, md', _ = Env.lookup_module ~lock:false ~loc l'.txt env in
+        let path, md', _ = Env.lookup_module ~loc l'.txt env in
         l , With_modsubst (l',path,md')
     | Pwith_modtype (l,smty) ->
         let mty = transl_modtype env smty in
@@ -1913,8 +1913,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
     | Psig_modsubst pms ->
         let scope = Ctype.create_scope () in
         let path, md, _ =
-          Env.lookup_module ~loc:pms.pms_manifest.loc ~lock:false
-            pms.pms_manifest.txt env
+          Env.lookup_module ~loc:pms.pms_manifest.loc pms.pms_manifest.txt env
         in
         let aliasable = not (Env.is_functor_arg path env) in
         let md =
@@ -3520,9 +3519,7 @@ let type_module_type_of env smod =
   let tmty =
     match smod.pmod_desc with
     | Pmod_ident lid -> (* turn off strengthening in this case *)
-        let path, md, _ =
-          Env.lookup_module ~lock:false ~loc:smod.pmod_loc lid.txt env
-        in
+        let path, md, _ = Env.lookup_module ~loc:smod.pmod_loc lid.txt env in
           { mod_desc = Tmod_ident (path, lid);
             mod_type = md.md_type;
             mod_env = env;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2641,6 +2641,8 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
       in
       md, shape, Env.locks_empty
   | Pmod_functor(arg_opt, sbody) ->
+      let newenv = Env.add_escape_lock Module env in
+      let newenv = Env.add_share_lock Module newenv in
       let t_arg, ty_arg, newenv, funct_shape_param, funct_body =
         match arg_opt with
         | Unit ->
@@ -2664,15 +2666,13 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
               let id = Ident.create_scoped ~scope name in
               let shape = Shape.var md_uid id in
               let newenv = Env.add_module_declaration
-                ~shape ~arg:true ~check:true id Mp_present arg_md env
+                ~shape ~arg:true ~check:true id Mp_present arg_md newenv
               in
               Some id, newenv, id
           in
           Named (id, param, mty), Types.Named (id, mty.mty_type), newenv,
           var, true
       in
-      let newenv = Env.add_escape_lock Module newenv in
-      let newenv = Env.add_share_lock Module newenv in
       let body, body_shape = type_module true funct_body None newenv sbody in
       { mod_desc = Tmod_functor(t_arg, body);
         mod_type = Mty_functor(ty_arg, body.mod_type);

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -803,8 +803,8 @@ let merge_constraint initial_env loc sg lid constr =
         in
         let md'' = { md' with md_type = mty } in
         let newmd = Mtype.strengthen_decl ~aliasable:false md'' path in
-        ignore(Includemod.modtypes  ~mark:Mark_both ~loc sig_env ~modes:Legacy
-                 newmd.md_type md.md_type);
+        ignore(Includemod.modtypes  ~mark:Mark_both ~loc sig_env
+          ~modes:(Legacy None) newmd.md_type md.md_type);
         return
           ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
           (Pident id, lid, Some (Twith_module (path, lid')))
@@ -814,7 +814,7 @@ let merge_constraint initial_env loc sg lid constr =
         let aliasable = not (Env.is_functor_arg path sig_env) in
         ignore
           (Includemod.strengthened_module_decl ~loc ~mark:Mark_both
-             ~aliasable sig_env ~mmodes:Legacy md' path md);
+             ~aliasable sig_env ~mmodes:(Legacy None) md' path md);
         real_ids := [Pident id];
         return ~replace_by:None
           (Pident id, lid, Some (Twith_modsubst (path, lid')))
@@ -1699,7 +1699,7 @@ and transl_modtype_aux env smty =
       let aliasable = not (Env.is_functor_arg path env) in
       try
         ignore
-          (Includemod.modtypes ~loc env ~modes:Legacy
+          (Includemod.modtypes ~loc env ~modes:(Legacy None)
             ~mark:Includemod.Mark_both md.md_type tmty.mty_type);
         mkmty
           (Tmty_strengthen (tmty, path, mod_id))
@@ -2395,7 +2395,7 @@ let check_recmodule_inclusion env bindings =
           try
             Includemod.modtypes_with_shape ~shape
               ~loc:modl.mod_loc ~mark:Mark_both
-              env ~modes:Legacy mty_actual' mty_decl'
+              env ~modes:(Legacy None) mty_actual' mty_decl'
           with Includemod.Error msg ->
             raise(Error(modl.mod_loc, env, Not_included msg)) in
         let modl' =
@@ -2491,13 +2491,13 @@ let package_subtype env p1 fl1 p2 fl2 =
 
 let () = Ctype.package_subtype := package_subtype
 
-let wrap_constraint_package env mark arg mty explicit =
+let wrap_constraint_package env mark arg held_locks mty explicit =
   let mark = if mark then Includemod.Mark_both else Includemod.Mark_neither in
   let mty1 = Subst.modtype Keep Subst.identity arg.mod_type in
   let mty2 = Subst.modtype Keep Subst.identity mty in
   let coercion =
     try
-      Includemod.modtypes ~loc:arg.mod_loc env ~mark ~modes:Legacy mty1 mty2
+      Includemod.modtypes ~loc:arg.mod_loc env ~mark ~modes:(Legacy held_locks) mty1 mty2
     with Includemod.Error msg ->
       raise(Error(arg.mod_loc, env, Not_included msg)) in
   { mod_desc = Tmod_constraint(arg, mty, explicit, coercion);
@@ -2506,13 +2506,13 @@ let wrap_constraint_package env mark arg mty explicit =
     mod_attributes = [];
     mod_loc = arg.mod_loc }
 
-let wrap_constraint_with_shape env mark arg mty
+let wrap_constraint_with_shape env mark arg held_locks mty
   shape explicit =
   let mark = if mark then Includemod.Mark_both else Includemod.Mark_neither in
   let coercion, shape =
     try
       Includemod.modtypes_with_shape ~shape ~loc:arg.mod_loc env ~mark
-        ~modes:Legacy arg.mod_type mty
+        ~modes:(Legacy held_locks) arg.mod_type mty
     with Includemod.Error msg ->
       raise(Error(arg.mod_loc, env, Not_included msg)) in
   { mod_desc = Tmod_constraint(arg, mty, explicit, coercion);
@@ -2528,6 +2528,7 @@ let wrap_constraint_with_shape env mark arg mty
 type argument_summary = {
   is_syntactic_unit: bool;
   arg: Typedtree.module_expr;
+  held_locks: Env.held_locks option;
   path: Path.t option;
   shape: Shape.t
 }
@@ -2587,41 +2588,24 @@ let maybe_infer_modalities ~loc ~env ~md_mode ~mode =
     Mode.Modality.Value.id
   end
 
-type alias =
-  | No : alias
-  (** The module is in a context that doesn't treat aliases specially. *)
-  | Yes_hold_locks : alias
-  (** The module is in a context that treat alias specially. If it is indeed an
-      alias, the caller will hold the locks in the alias, and walk them when
-      later the alias is used for its content. *)
-  | Yes_walk_locks : alias
-  (** The module is in a context that treat alias specially. However, the caller
-      doesn't want to hold the locks, and therefore the locks must be eagerly
-      walked. *)
-
-let is_alias = function
-  | No -> false
-  | Yes_walk_locks | Yes_hold_locks -> true
-
-let rec type_module ?(alias=false) sttn funct_body anchor env smod =
-  let alias = if alias then Yes_walk_locks else No in
-  let md, shape, locks =
-    type_module_maybe_hold_locks ~alias sttn funct_body anchor env smod
+let rec type_module ?alias sttn funct_body anchor env smod =
+  let md, shape, held_locks =
+    type_module_maybe_hold_locks ?alias ~hold_locks:false sttn funct_body anchor env smod
   in
-  assert (Env.locks_is_empty locks);
+  assert (Option.is_none held_locks);
   md, shape
 
-and  type_module_maybe_hold_locks ~alias sttn funct_body anchor env smod =
+and  type_module_maybe_hold_locks ?(alias=false) ~hold_locks sttn funct_body anchor env smod =
   Builtin_attributes.warning_scope smod.pmod_attributes
-    (fun () -> type_module_aux ~alias sttn funct_body anchor env smod)
+    (fun () -> type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod)
 
-and type_module_aux ~alias sttn funct_body anchor env smod =
+and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
   match smod.pmod_desc with
     Pmod_ident lid ->
       let path, locks =
-        Env.lookup_module_path ~load:(not @@ is_alias alias) ~loc:smod.pmod_loc lid.txt env
+        Env.lookup_module_path ~load:(not alias) ~loc:smod.pmod_loc lid.txt env
       in
-      type_module_path_aux ~alias sttn env path locks lid smod
+      type_module_path_aux ~alias ~hold_locks sttn env path locks lid smod
   | Pmod_structure sstr ->
       let (str, sg, names, shape, _finalenv) =
         type_structure funct_body anchor env sstr in
@@ -2635,10 +2619,10 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
       let sg' = Signature_names.simplify _finalenv names sg in
       let md, shape =
         if List.length sg' = List.length sg then md, shape else
-        wrap_constraint_with_shape env false md
+        wrap_constraint_with_shape env false md None
           (Mty_signature sg') shape Tmodtype_implicit
       in
-      md, shape, Env.locks_empty
+      md, shape, None
   | Pmod_functor(arg_opt, sbody) ->
       let newenv = Env.add_escape_lock Module env in
       let newenv = Env.add_share_lock Module newenv in
@@ -2678,26 +2662,26 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
         mod_env = env;
         mod_attributes = smod.pmod_attributes;
         mod_loc = smod.pmod_loc },
-      Shape.abs funct_shape_param body_shape, Env.locks_empty
+      Shape.abs funct_shape_param body_shape, None
   | Pmod_apply _ | Pmod_apply_unit _ ->
       let md, shape = type_application smod.pmod_loc sttn funct_body env smod in
-      md, shape, Env.locks_empty
+      md, shape, None
   | Pmod_constraint(sarg, smty, smode) ->
       check_no_modal_modules ~env smode;
       let smty = Option.get smty in
-      let arg, arg_shape, locks =
-        type_module_maybe_hold_locks ~alias true funct_body anchor env sarg
+      let arg, arg_shape, held_locks =
+        type_module_maybe_hold_locks ~alias ~hold_locks:true true funct_body anchor env sarg
       in
       let mty = transl_modtype env smty in
       let md, final_shape =
-        wrap_constraint_with_shape env true arg mty.mty_type arg_shape
+        wrap_constraint_with_shape env true arg held_locks mty.mty_type arg_shape
           (Tmodtype_explicit mty)
       in
       { md with
         mod_loc = smod.pmod_loc;
         mod_attributes = smod.pmod_attributes;
       },
-      final_shape, locks
+      final_shape, None
   | Pmod_unpack sexp ->
       let exp =
         Ctype.with_local_level_if_principal
@@ -2730,14 +2714,14 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
         mod_env = env;
         mod_attributes = smod.pmod_attributes;
         mod_loc = smod.pmod_loc },
-      Shape.leaf_for_unpack, Env.locks_empty
+      Shape.leaf_for_unpack, None
   | Pmod_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
   | Pmod_instance glob ->
       Language_extension.assert_enabled ~loc:smod.pmod_loc Instances ();
       let glob = instance_name ~loc:smod.pmod_loc env glob in
       let path, locks =
-        Env.lookup_module_instance_path ~load:(not @@ is_alias alias) ~loc:smod.pmod_loc
+        Env.lookup_module_instance_path ~load:(not alias) ~loc:smod.pmod_loc
           glob env
       in
       let lid =
@@ -2747,21 +2731,20 @@ and type_module_aux ~alias sttn funct_body anchor env smod =
         in
         Location.(mkloc (Lident name) (ghostify smod.pmod_loc))
       in
-      type_module_path_aux ~alias sttn env path locks lid smod
+      type_module_path_aux ~alias ~hold_locks sttn env path locks lid smod
 
-and type_module_path_aux ~alias sttn env path locks (lid : _ loc) smod =
-  let locks =
-    match alias with
-    | Yes_hold_locks -> locks
-    | No | Yes_walk_locks ->
-        let vmode =
-          Env.walk_locks ~loc:lid.loc ~env ~item:Module ~lid:lid.txt
-            Mode.Value.(legacy |> disallow_right) None locks
-        in
-        Mode.Value.submode_exn vmode.mode Mode.Value.legacy;
-        Env.locks_empty
+and type_module_path_aux ~alias ~hold_locks sttn env path locks (lid : _ loc) smod =
+  let held_locks =
+    let held_locks = (locks, lid.txt, lid.loc) in
+    if hold_locks then Some held_locks
+    else
+      let vmode =
+        Env.walk_locks ~env ~item:Module Mode.Value.(legacy |> disallow_right)
+          None held_locks
+      in
+      Mode.Value.submode_exn vmode.mode Mode.Value.legacy;
+      None
   in
-  let alias = is_alias alias in
   let md = { mod_desc = Tmod_ident (path, lid);
              mod_type = Mty_alias path;
              mod_env = env;
@@ -2793,13 +2776,16 @@ and type_module_path_aux ~alias sttn env path locks (lid : _ loc) smod =
           { md with mod_type = mty }
     end
   in
-  md, shape, locks
+  md, shape, held_locks
 
 and type_application loc strengthen funct_body env smod =
   let rec extract_application funct_body env sargs smod =
     match smod.pmod_desc with
     | Pmod_apply(f, sarg) ->
-        let arg, shape = type_module true funct_body None env sarg in
+        let arg, shape, held_locks =
+          type_module_maybe_hold_locks ~hold_locks:true true funct_body None env
+            sarg
+        in
         let summary = {
           loc = smod.pmod_loc;
           attributes = smod.pmod_attributes;
@@ -2807,6 +2793,7 @@ and type_application loc strengthen funct_body env smod =
           arg = Some {
             is_syntactic_unit = sarg.pmod_desc = Pmod_structure [];
             arg;
+            held_locks;
             path = path_of_module arg;
             shape;
           }
@@ -2874,11 +2861,11 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
       begin match app_view with
       | { arg = None; _ } -> apply_error ()
       | { loc = app_loc; attributes = app_attributes;
-          arg = Some { shape = arg_shape; path = arg_path; arg } } ->
+          arg = Some { shape = arg_shape; path = arg_path; arg; held_locks } } ->
       let coercion =
         try Includemod.modtypes
               ~loc:arg.mod_loc ~mark:Mark_both env arg.mod_type mty_param
-              ~modes:Legacy
+              ~modes:(Legacy held_locks)
         with Includemod.Error _ -> apply_error ()
       in
       let mty_appl =
@@ -2910,7 +2897,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
             begin match
               Includemod.modtypes
                 ~loc:app_loc ~mark:Mark_neither env mty_res nondep_mty
-                ~modes:Legacy
+                ~modes:(Legacy None)
             with
             | Tcoerce_none -> ()
             | _ ->
@@ -3491,9 +3478,20 @@ let type_toplevel_phrase env sig_acc s =
   Typecore.optimise_allocations ();
   (str, sg, to_remove_from_sg, shape, env)
 
-let type_module_alias =
-  type_module_maybe_hold_locks ~alias:Yes_hold_locks true false None
+let type_module_alias env smod =
+  let md, shape, held_locks =
+    type_module_maybe_hold_locks ~alias:true ~hold_locks:true true false
+      None env smod
+  in
+  let locks =
+    match held_locks with
+    | None -> Env.locks_empty
+    | Some (locks, _, _) -> locks
+  in
+  md, shape, locks
+
 let type_module = type_module true false None
+let type_module_maybe_hold_locks = type_module_maybe_hold_locks true false None
 let type_structure = type_structure false None
 
 (* Normalize types in a signature *)
@@ -3582,13 +3580,15 @@ let type_package env m p fl =
   (* Same as Pexp_letmodule *)
   (* remember original level *)
   let outer_scope = Ctype.get_current_level () in
-  let modl, scope =
+  let modl, scope, held_locks =
     Typetexp.TyVarEnv.with_local_scope begin fun () ->
       (* type the module and create a scope in a raised level *)
       Ctype.with_local_level begin fun () ->
-        let modl, _mod_shape = type_module env m in
+        let modl, _mod_shape, held_locks =
+          type_module_maybe_hold_locks ~hold_locks:true env m
+        in
         let scope = Ctype.create_scope () in
-        modl, scope
+        modl, scope, held_locks
       end
     end
   in
@@ -3644,7 +3644,9 @@ let type_package env m p fl =
       with Ctype.Unify _ ->
         raise (Error(modl.mod_loc, env, Scoping_pack (n,ty))))
     fl';
-  let modl = wrap_constraint_package env true modl mty Tmodtype_implicit in
+  let modl =
+    wrap_constraint_package env true modl held_locks mty Tmodtype_implicit
+  in
   modl, fl'
 
 (* Fill in the forward declarations *)


### PR DESCRIPTION
This PR improves the type checking of a `Pmod_ident` that's immediately coerced. Specifically:
- When it's the argument to a functor application.
- When it's being packed into a first class module
- When it's in `Pmod_constraint`.

`Pmod_unpack` is not dealt with because it's doesn't coerce module. See comments in test for details.

# Review
- Please review by commits.
- Some of the changes interact with #2431 #3398 , care is taken to minimize the diff with upstream. The reviewer is welcome to spot further clean-ups possible.