### PR TITLE
Vectorizer disabled in classic mode

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -64,6 +64,10 @@ let pass_dump_cfg_if ppf flag message c =
   then fprintf ppf "*** %s@.%a@." message (Cfg_with_layout.dump ~msg:"") c;
   c
 
+let should_vectorize () =
+  !Flambda_backend_flags.vectorize
+  && not (Flambda2_ui.Flambda_features.classic_mode ())
+
 let start_from_emit = ref true
 
 let should_save_before_emit () =
@@ -445,7 +449,7 @@ let compile_fundecl ~ppf_dump ~funcnames fd_cmm =
                   let cfg_with_infos =
                     cfg_with_layout
                     ++ (fun cfg_with_layout ->
-                         match !Flambda_backend_flags.vectorize with
+                         match should_vectorize () with
                          | false -> cfg_with_layout
                          | true ->
                            cfg_with_layout

--- a/flambda-backend/tests/backend/vectorizer/dune.inc
+++ b/flambda-backend/tests/backend/vectorizer/dune.inc
@@ -758,3 +758,32 @@
  (enabled_if (= %{context_name} "main"))
  (action
    (diff test_register_compatible_vectorized.expected test_register_compatible_vectorized.output)))
+
+(rule
+ (alias runtest)
+ (enabled_if (= %{context_name} "main"))
+ (action
+  (copy test1.ml test1_classic.ml)))
+
+(rule
+ (alias runtest)
+ (enabled_if (= %{context_name} "main"))
+ (action
+  (copy test1.mli test1_classic.mli)))
+
+(rule
+ (alias   runtest)
+ (enabled_if (= %{context_name} "main"))
+ (targets test1_classic_runner.exe test1_classic.cmx.dump)
+ (deps test1_classic.mli test1_classic.ml)
+ (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dsel -dlinear -dlive -regalloc cfg -extension simd -vectorize-max-block-size 1000 -Oclassic -vectorize -o test1_classic_runner.exe)))
+
+(rule
+ (enabled_if (= %{context_name} "main"))
+ (target test1_classic.cmx.dump.output)
+ (deps ./filter.sh test1_classic.cmx.dump)
+ (action
+  (with-outputs-to
+   %{target}
+   (with-accepted-exit-codes 1
+    (run %{deps})))))

--- a/flambda-backend/tests/backend/vectorizer/gen/gen_dune.ml
+++ b/flambda-backend/tests/backend/vectorizer/gen/gen_dune.ml
@@ -176,3 +176,14 @@ let () =
   (* can't vectorize *)
   print_test ~filter_exit_code:1 "test_register_compatible";
   ()
+
+let () =
+  (* test that vectorizer is disabled in classic mode *)
+  let enabled_if = enabled_if_main in
+  let name = "test1" in
+  let name' = name ^ "_classic" in
+  copy_file ~enabled_if (name |> impl) (name' |> impl);
+  copy_file ~enabled_if (name |> intf) (name' |> intf);
+  compile ~enabled_if ~extra_flags:"-Oclassic -vectorize" name';
+  filter_dump ~enabled_if ~exit_code:1 name';
+  ()


### PR DESCRIPTION
Disable the vectorizer when `-Oclassic` flag is passed. Added a test for the sequence of flags `-Oclassic -vectorize`.