### PR TITLE
handle unsupported null constants like float32 constants

### DIFF
--- a/Makefile.common-jst
+++ b/Makefile.common-jst
@@ -95,6 +95,10 @@ compiler: runtime-stdlib
           testsuite/lib/testing.cm{,x}a \
           $(ocamldir)/tools/dumpobj.bc
 
+# CR dkalinichenko: [runtest] is built using the main profile,
+# which uses the boot compiler. Use the final compiler for [runtest],
+# and implement [runtest-upstream-boot] for testing when the final compiler
+# itself is miscompiled.
 runtest: compiler
 	RUNTIME_DIR=$(RUNTIME_DIR) $(dune) runtest $(ws_main)
 

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -769,10 +769,10 @@ module Storer =
    Result = list of instructions that evaluate exp, then perform cont. *)
 
 (* CR dkalinichenko: this error happens because we run tests
-   under [flambda_backend/tests] with the stage 1 compiler instead of the
+   under [flambda_backend/tests] with the boot compiler instead of the
    final compiler. Run them using the final compiler.*)
 (* We cannot use the [float32] or [or_null] types in the compiler. *)
-external float32_is_stage1 : unit -> bool = "caml_float32_is_stage1"
+external is_boot_compiler : unit -> bool = "caml_is_boot_compiler"
 external float32_of_string : string -> Obj.t = "caml_float32_of_string"
 
 let rec contains_float32s_or_nulls = function
@@ -818,7 +818,7 @@ and comp_expr stack_info env exp sz cont =
           Koffsetclosure(pos - env_pos) :: cont
         | exception Not_found -> not_found ()
       end
-  | Lconst cst when float32_is_stage1 () ->
+  | Lconst cst when is_boot_compiler () ->
       translate_float32s_or_nulls stack_info env cst sz cont
   | Lconst cst ->
       Kconst cst :: cont

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -310,7 +310,10 @@ let rec transl_const = function
       List.iteri (fun i f -> Array.Floatarray.set res i (float_of_string f))
         fields;
       Obj.repr res
-  | Const_null -> int_as_pointer 0
+  | Const_null ->
+    if float32_is_stage1 ()
+    then Misc.fatal_error "The stage one bytecode compiler should not produce null constants."
+    else int_as_pointer 0
 
 (* Build the initial table of globals *)
 

--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -268,8 +268,8 @@ let patch_object buff patchlist =
 
 (* Translate structured constants *)
 
-(* We cannot use the [float32] type in the compiler. *)
-external float32_is_stage1 : unit -> bool = "caml_float32_is_stage1"
+(* We cannot use [float32] or [or_null] types in the compiler. *)
+external is_boot_compiler : unit -> bool = "caml_is_boot_compiler"
 external float32_of_string : string -> Obj.t = "caml_float32_of_string"
 
 external int_as_pointer : int -> Obj.t = "%int_as_pointer"
@@ -280,8 +280,8 @@ let rec transl_const = function
   | Const_base(Const_string (s, _, _)) -> Obj.repr s
   | Const_base(Const_float32 f)
   | Const_base(Const_unboxed_float32 f) ->
-      if float32_is_stage1 ()
-      then Misc.fatal_error "The stage one bytecode compiler should not produce float32 constants."
+      if is_boot_compiler ()
+      then Misc.fatal_error "The boot bytecode compiler should not produce float32 constants."
       else Obj.repr (float32_of_string f)
   | Const_base(Const_float f)
   | Const_base(Const_unboxed_float f) -> Obj.repr (float_of_string f)
@@ -311,8 +311,8 @@ let rec transl_const = function
         fields;
       Obj.repr res
   | Const_null ->
-    if float32_is_stage1 ()
-    then Misc.fatal_error "The stage one bytecode compiler should not produce null constants."
+    if is_boot_compiler ()
+    then Misc.fatal_error "The boot bytecode compiler should not produce null constants."
     else int_as_pointer 0
 
 (* Build the initial table of globals *)

--- a/middle_end/flambda2/numbers/floats/float32_stubs.c
+++ b/middle_end/flambda2/numbers/floats/float32_stubs.c
@@ -339,7 +339,7 @@ CAMLprim value compiler_float32_format(value fmt, value arg)
 // They must be weak symbols with the same names as in runtime/ because the stage
 // two compiler will link against runtime/.
 
-CAMLweakdef value caml_float32_is_stage1(value v) {
+CAMLweakdef value caml_is_boot_compiler(value v) {
   (void)v;
   return Val_true;
 }

--- a/runtime/float32.c
+++ b/runtime/float32.c
@@ -901,7 +901,7 @@ CAMLprim value caml_unboxed_float32_vect_blit(value a1, value ofs1, value a2,
   return Val_unit;
 }
 
-CAMLprim value caml_float32_is_stage1(value v) {
+CAMLprim value caml_is_boot_compiler(value v) {
   (void)v;
   return Val_false;
 }

--- a/runtime4/float32.c
+++ b/runtime4/float32.c
@@ -896,7 +896,7 @@ CAMLprim value caml_unboxed_float32_vect_blit(value a1, value ofs1, value a2,
   return Val_unit;
 }
 
-CAMLprim value caml_float32_is_stage1(value v) {
+CAMLprim value caml_is_boot_compiler(value v) {
   (void)v;
   return Val_false;
 }


### PR DESCRIPTION
Like float32 constants, null constants are not supported by the upstream bytecode marshalling functions. Since we run `flambda_backend/tests` using the stage 1/bootstrap compiler using the upstream runtime, moving `or_null` to stable runs into this problem again.

Eventually, we should just build those tests using the final compiler. But for now, it's easier to do the same trick for `or_null`.

Tested by https://github.com/ocaml-flambda/flambda-backend/pull/3565.