### PR TITLE
Fix runtime5 Nix build

### DIFF
--- a/runtime/dune
+++ b/runtime/dune
@@ -59,7 +59,7 @@
  (action
    (progn
      (run %{dep:gen_primitives.sh} primitives %{deps})
-     (with-stdout-to prims.c (run %{dep:gen_primsc.sh} primitives %{deps})))))
+     (with-stdout-to prims.c (run bash %{dep:gen_primsc.sh} primitives %{deps})))))
 
 (rule
  (targets libasmrun.a libasmrund.a libasmruni.a libasmrun_pic.a


### PR DESCRIPTION
Told dune to run gen_primsc.sh with bash explicitly.