### PR TITLE
Easy compare script

### DIFF
--- a/Makefile.common-jst
+++ b/Makefile.common-jst
@@ -441,13 +441,13 @@ debug-printers: runtime-stdlib # required for $(ws_main) to work
 	@echo To load into ocamldebug, use:
 	@echo source \"$$(realpath _build/main/$(ocamldir)/tools/debug_printers)\"
 
-# boot-install installs the bootstrapped compiler into _install. It is mostly
+# boot-_install installs the bootstrapped compiler into _install. It is mostly
 # just copied from the install phrase.
 # This allows tools/compare.sh to function as expected, which is useful because
 # it allows us to easily run the bootstrapped compiler, especially with
 # tools/compare.sh
-.PHONY: boot-install
-boot-install: runtime-stdlib
+.PHONY: boot-_install
+boot-_install: runtime-stdlib
 	rm -rf _install
 	mkdir -p _install/{bin,lib/ocaml}
 	$(cpl) _build/runtime_stdlib_install/bin/* _install/bin/
@@ -460,9 +460,10 @@ boot-install: runtime-stdlib
 	rm -f _install/lib/ocaml/compiler-libs/*.cmo
 	mkdir _install/lib/stublibs
 	find _build/default -name "dll*.so" \
-          -exec cp -f -t _install/lib/stublibs {} \+
+       -print0 | xargs -0 -I '{}' cp -f '{}' _install/lib/stublibs
 	mkdir -p _install/lib/ocaml/compiler-libs
 	cp _build/default/parser.cmly _install/lib/ocaml/compiler-libs/
 	find _build/default/ \( -name "flambda2*.cmi" \
           -or -name "flambda2*.cmti" -or -name "flambda2*.cmt" \) \
-          -exec cp -f -t _install/lib/ocaml/compiler-libs {} \+
+          -print0 | xargs -0 -I '{}' cp -f '{}' _install/lib/ocaml/compiler-libs
+

--- a/Makefile.common-jst
+++ b/Makefile.common-jst
@@ -440,3 +440,29 @@ debug-printers: runtime-stdlib # required for $(ws_main) to work
 	@echo
 	@echo To load into ocamldebug, use:
 	@echo source \"$$(realpath _build/main/$(ocamldir)/tools/debug_printers)\"
+
+# boot-install installs the bootstrapped compiler into _install. It is mostly
+# just copied from the install phrase.
+# This allows tools/compare.sh to function as expected, which is useful because
+# it allows us to easily run the bootstrapped compiler, especially with
+# tools/compare.sh
+.PHONY: boot-install
+boot-install: runtime-stdlib
+	rm -rf _install
+	mkdir -p _install/{bin,lib/ocaml}
+	$(cpl) _build/runtime_stdlib_install/bin/* _install/bin/
+	$(cpl) _build/_bootinstall/bin/* _install/bin/
+	$(cpl) -R _build/runtime_stdlib_install/lib/ocaml_runtime_stdlib/* \
+    _install/lib/ocaml/
+	rm -f _install/lib/ocaml/{META,dune-package,Makefile.config,dynlink.cmxa}
+	$(cpl) -R _build/_bootinstall/lib/ocaml/* _install/lib/ocaml/
+	rm -f _install/lib/ocaml/{META,dune-package}
+	rm -f _install/lib/ocaml/compiler-libs/*.cmo
+	mkdir _install/lib/stublibs
+	find _build/default -name "dll*.so" \
+          -exec cp -f -t _install/lib/stublibs {} \+
+	mkdir -p _install/lib/ocaml/compiler-libs
+	cp _build/default/parser.cmly _install/lib/ocaml/compiler-libs/
+	find _build/default/ \( -name "flambda2*.cmi" \
+          -or -name "flambda2*.cmti" -or -name "flambda2*.cmt" \) \
+          -exec cp -f -t _install/lib/ocaml/compiler-libs {} \+

--- a/tools/compare.sh
+++ b/tools/compare.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+libnames=(${LIBNAMES-})
+
+function construct_command {
+    local bin="$1"
+    shift
+    printf "%q" "${bin}"
+    standard_library="${STDLIB:-$("${bin}" -config-var standard_library)}" || return 1
+    for libname in "${libnames[@]}"; do
+        printf ' -I %q' "${standard_library}/${libname}"
+        printf ' %q' "${standard_library}/${libname}/${libname}.cmxa"
+    done
+    for arg in "$@"; do
+        printf ' %q' "${arg}"
+    done
+    echo
+}
+
+bin=ocamlopt.opt
+dev="$(realpath -- "${DEV-_install/bin/${bin}}")" || exit 1
+prod="${PROD-$(which "${bin}")}" || exit 1
+prod="$(STDLIB="${PROD_STDLIB}" construct_command "${prod}" "$@" ${PROD_FLAGS- -o prod})" || exit 1
+dev="$(STDLIB="${DEV_STDLIB}" construct_command "${dev}" "$@" ${DEV_FLAGS- -o dev})" || exit 1
+
+exit_code=0
+
+printf '%s\n' "${prod}" >&2
+eval "${prod}" || exit_code=1
+
+printf '%s\n' "${dev}" >&2
+eval "${dev}" || exit_code=1
+
+exit ${exit_code}

--- a/tools/compare.sh
+++ b/tools/compare.sh
@@ -5,7 +5,7 @@ set -e -u -o pipefail
 # with one installed to _install
 #
 # E.g.,
-# make boot-install
+# make boot-_install
 # export OLD='opam exec --switch=MY_OLD_SWITCH ocamlopt.opt --'
 # tools/compare.sh testsuite/tests/lib-int/test.ml -c -dcmm -dump-into-file
 # diff {old,new}.cmx.dump

--- a/tools/compare.sh
+++ b/tools/compare.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e -u -o pipefail
 
 # Use this script to compare the output of an existing compiler
 # with one installed to _install
@@ -50,22 +51,22 @@ construct_command() {
         return 1
     fi
 
-    local stdlib="$2"
+    local stdlib="$1"
     shift
 
     if [[ ${#LIB[@]} -gt 0 || ${#INCLUDE[@]} -gt 0 ]]; then
-        if [[ -z ${stdlib+x} ]]; then
+        if [[ -z ${stdlib-} ]]; then
             stdlib="$("${cmd[@]}" -config-var standard_library)" || return 1
         fi
 
         local include
         for include in "${INCLUDE[@]}"; do
-            cmd+=( "${stdlib}/${lib}/${lib}.cmxa" )
+            cmd+=( "${stdlib}/${include}/${include}.cmxa" )
         done
 
         local lib
         for lib in "${LIB[@]}"; do
-            cmd+=( '-I' "${stdlib}/${lib}/${lib}.cmxa" )
+            cmd+=( '-I' "${stdlib}/${lib}" )
         done
     fi
 


### PR DESCRIPTION
Added a script to allow you to diff old versions of the compiler with new versions.
This also involved adding `boot-install` to the makefile, so that the bootstrapped compiler can be installed.