### PR TITLE
Rename OCAMLRUNPARAM i= and j= equates to avoid runtime4 clash

### DIFF
--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -260,6 +260,11 @@ struct stack_info* caml_alloc_stack_noexc(mlsize_t wosize, value hval,
 /* try to grow the stack until at least required_size words are available.
    returns nonzero on success */
 CAMLextern int caml_try_realloc_stack (asize_t required_wsize);
+
+/* Parameters settable with OCAMLRUNPARAM */
+extern uintnat caml_init_main_stack_wsz;   /* -Xmain_stack_size= */
+extern uintnat caml_init_thread_stack_wsz; /* -Xthread_stack_size= */
+
 CAMLextern uintnat caml_get_init_stack_wsize(int thread_stack_wsz);
 void caml_change_max_stack_size (uintnat new_max_wsize);
 void caml_maybe_expand_stack(void);

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -48,8 +48,6 @@ struct caml_params {
   uintnat init_custom_minor_max_bsz;
   uintnat init_custom_work_clamp;
 
-  uintnat init_main_stack_wsz;
-  uintnat init_thread_stack_wsz;
   uintnat init_max_stack_wsz;
 
   uintnat backtrace_enabled;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -61,14 +61,18 @@ static_assert(sizeof(struct stack_info) == Stack_ctx_words * sizeof(value), "");
 
 static _Atomic int64_t fiber_id = 0;
 
+/* Parameters settable with OCAMLRUNPARAM */
+uintnat caml_init_main_stack_wsz = 0;   /* -Xmain_stack_size= */
+uintnat caml_init_thread_stack_wsz = 0; /* -Xthread_stack_size= */
+
 uintnat caml_get_init_stack_wsize (int thread_stack_wsz)
 {
 #if defined(NATIVE_CODE) && !defined(STACK_CHECKS_ENABLED)
   uintnat init_stack_wsize =
     thread_stack_wsz < 0
-    ? caml_params->init_main_stack_wsz
-    : caml_params->init_thread_stack_wsz > 0
-    ? caml_params->init_thread_stack_wsz : thread_stack_wsz;
+    ? caml_init_main_stack_wsz
+    : caml_init_thread_stack_wsz > 0
+    ? caml_init_thread_stack_wsz : thread_stack_wsz;
 #else
   (void) thread_stack_wsz;
   uintnat init_stack_wsize = Wsize_bsize(Stack_init_bsize);

--- a/runtime4/gc_ctrl.c
+++ b/runtime4/gc_ctrl.c
@@ -757,7 +757,7 @@ CAMLprim value caml_runtime_parameters (value unit)
 #define F_S "%"ARCH_SIZET_PRINTF_FORMAT"u"
 
   CAMLassert (unit == Val_unit);
-  /* keep in sync with runtime4 and with parse_ocamlrunparam */
+  /* keep in sync with runtime5 and with parse_ocamlrunparam */
   return caml_alloc_sprintf
     ("a=%d,b=%d,c=%d,h="F_Z",H="F_Z
      ",i="F_Z",l="F_Z",m="F_Z",M="F_Z",n="F_Z

--- a/runtime4/gc_ctrl.c
+++ b/runtime4/gc_ctrl.c
@@ -753,16 +753,22 @@ extern int caml_parser_trace;
 
 CAMLprim value caml_runtime_parameters (value unit)
 {
-#define F_Z ARCH_INTNAT_PRINTF_FORMAT
-#define F_S ARCH_SIZET_PRINTF_FORMAT
+#define F_Z "%"ARCH_INTNAT_PRINTF_FORMAT"u"
+#define F_S "%"ARCH_SIZET_PRINTF_FORMAT"u"
 
   CAMLassert (unit == Val_unit);
+  /* keep in sync with runtime4 and with parse_ocamlrunparam */
   return caml_alloc_sprintf
-    ("a=%d,b=%d,H=%"F_Z"u,i=%"F_Z"u,l=%"F_Z"u,o=%"F_Z"u,O=%"F_Z"u,p=%d,"
-     "s=%"F_S"u,t=%"F_Z"u,v=%"F_Z"u,w=%d,W=%"F_Z"u",
+    ("a=%d,b=%d,c=%d,h="F_Z",H="F_Z
+     ",i="F_Z",l="F_Z",m="F_Z",M="F_Z",n="F_Z
+     ",o="F_Z",O="F_Z",p=%d,s="F_S",t="F_Z
+     ",v="F_Z",w=%d,W="F_Z"",
      /* a */ (int) caml_allocation_policy,
      /* b */ (int) Caml_state->backtrace_active,
-     /* h */ /* missing */ /* FIXME add when changed to min_heap_size */
+     /* c */ caml_cleanup_on_exit,
+     /* d: runtime 5 max domains */
+     /* e: runtime 5 runtime_events size */
+     /* h */ caml_init_heap_wsz,
      /* H */ caml_use_huge_pages,
      /* i */ caml_major_heap_increment,
 #ifdef NATIVE_CODE
@@ -770,15 +776,20 @@ CAMLprim value caml_runtime_parameters (value unit)
 #else
      /* l */ caml_max_stack_size,
 #endif
+     /* m */ caml_custom_minor_ratio,
+     /* M */ caml_custom_major_ratio,
+     /* n */ caml_custom_minor_max_bsz,
      /* o */ caml_percent_free,
      /* O */ caml_percent_max,
      /* p */ caml_parser_trace,
-     /* R */ /* missing */
+     /* R */ /* missing: see stdlib/hashtbl.mli */
      /* s */ Caml_state->minor_heap_wsz,
      /* t */ caml_trace_level,
      /* v */ caml_verb_gc,
+     /* V: runtime 5 verify heap */
      /* w */ caml_major_window,
      /* W */ caml_runtime_warnings
+     /* X: runtime 5 gc tweaks */
      );
 #undef F_Z
 #undef F_S

--- a/runtime4/startup_aux.c
+++ b/runtime4/startup_aux.c
@@ -19,6 +19,7 @@
    and native code. */
 
 #include <stdio.h>
+#include <string.h>
 #include "caml/backtrace.h"
 #include "caml/memory.h"
 #include "caml/callback.h"
@@ -100,21 +101,48 @@ static void scanmult (char_os *opt, uintnat *var)
   }
 }
 
+/* for compatibility with runtime 5 */
+
+static void parse_gc_tweak(char_os** opt_p)
+{
+  char_os *opt = *opt_p;
+  char_os *name = opt;
+  while (*opt != '\0') {
+    if (*opt == '=') {
+      if (opt - name == sizeof("help") -1 &&
+          memcmp(name, "help", opt - name) == 0) { /* TODO: strncmp_os */
+        fprintf(stderr, "No GC tweaks available in runtime4/\n");
+      } else {
+        fprintf(stderr, "Ignored unknown GC tweak '%.*s': "
+                "no HC tweaks available in runtime4.\n",
+                (int)(opt - name), name);
+      }
+      break;
+    } else {
+      opt++;
+    }
+  }
+  *opt_p = opt;
+}
+
 static void parse_ocamlrunparam(char_os* opt)
 {
   uintnat p;
   if (opt != NULL){
     while (*opt != '\0'){
       switch (*opt++){
+      /* keep in sync with runtime4 and with caml_runtime_parameters() */
       case 'a': scanmult (opt, &caml_init_policy); break;
       case 'b': scanmult (opt, &p); caml_record_backtraces(p); break;
       case 'c': scanmult (opt, &p); caml_cleanup_on_exit = (p != 0); break;
+      case 'd': break; /* max domains in runtime 5 */
+      case 'e': break; /* runtime events size in runtime 5 */
       case 'h': scanmult (opt, &caml_init_heap_wsz); break;
       case 'H': scanmult (opt, &caml_use_huge_pages); break;
       case 'i': scanmult (opt, &caml_init_heap_chunk_sz); break;
       case 'l': scanmult (opt, &caml_init_max_stack_wsz); break;
-      case 'M': scanmult (opt, &caml_init_custom_major_ratio); break;
       case 'm': scanmult (opt, &caml_init_custom_minor_ratio); break;
+      case 'M': scanmult (opt, &caml_init_custom_major_ratio); break;
       case 'n': scanmult (opt, &caml_init_custom_minor_max_bsz); break;
       case 'o': scanmult (opt, &caml_init_percent_free); break;
       case 'O': scanmult (opt, &caml_init_max_percent_free); break;
@@ -123,8 +151,10 @@ static void parse_ocamlrunparam(char_os* opt)
       case 's': scanmult (opt, &caml_init_minor_heap_wsz); break;
       case 't': scanmult (opt, &caml_trace_level); break;
       case 'v': scanmult (opt, &caml_verb_gc); break;
+      case 'V': break; /* verify heap in runtime 5 */
       case 'w': scanmult (opt, &caml_init_major_window); break;
       case 'W': scanmult (opt, &caml_runtime_warnings); break;
+      case 'X': parse_gc_tweak(&opt); break; /* gc tweaks in runtime 5 */
       case ',': continue;
       }
       while (*opt != '\0'){

--- a/runtime4/startup_aux.c
+++ b/runtime4/startup_aux.c
@@ -114,7 +114,7 @@ static void parse_gc_tweak(char_os** opt_p)
         fprintf(stderr, "No GC tweaks available in runtime4/\n");
       } else {
         fprintf(stderr, "Ignored unknown GC tweak '%.*s': "
-                "no HC tweaks available in runtime4.\n",
+                "no GC tweaks available in runtime4.\n",
                 (int)(opt - name), name);
       }
       break;


### PR DESCRIPTION
Last year we added `OCAMLRUNPARAM=i=<N>,j=<M>` to control initial stack sizes. This clashes with runtime4's `OCAMLRUNPARAM=i=<N>` to control major heap increment size (which we might want to reintroduce). This PR changes `i=` and `j=` to `Xmain_stack_size=` and `Xthread_stack_size=`, and also brings the relevant parts of runtime4 and runtime5 into sync, reordering items, adding omitted items, and adding comments, so that such conflicts can't arise again.
To be clear: there's plenty still to dislike about `OCAMLRUNPARAM` parsing (consider for example the effect of setting `OCAMLRUNPARAM=ocaml`, or `OCAMLRUNPARAM=compaction`, or almost any typo, or the strange treatment of `v` as multiplier suffix), but this is a baseline to reduce friction in a runtime4/runtime5 transition, and to allow major heap increment size to be set in future.