### PR TITLE
Revert "override shallow_modtypes when closed over" from #3554

### DIFF
--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -541,22 +541,7 @@ and try_modtypes ~in_eq ~loc env ~mark subst ~modes mty1 mty2 orig_shape =
   in
   match mty1, mty2 with
   | _ when shallow_modtypes env subst mty1 mty2 ->
-    begin match modes with
-      | Legacy (Some (locks, _, _)) when not (Env.locks_is_empty locks) ->
-          (* If the coercion being checked is closed over, we close over individual values
-          in the module, instead of the whole module. *)
-          let mty1 = Mtype.reduce_alias_lazy env mty1 in
-          let mty2 = Subst.Lazy.modtype Keep subst mty2 |> Mtype.reduce_alias_lazy env in
-          begin match mty1, mty2 with
-          | Some mty1, Some mty2 ->
-             (* Only for the side-effects of walking locks *)
-              ignore (try_modtypes ~in_eq ~loc env ~mark subst ~modes mty1 mty2 orig_shape)
-          | _, _ ->
-              walk_locks ~env ~item:Module modes
-          end
-      | _ ->
-        walk_locks ~env ~item:Module modes
-    end;
+    walk_locks ~env ~item:Module modes;
     Ok (Tcoerce_none, orig_shape)
 
   | (Mty_alias p1, _) when not (is_alias mty2) -> begin

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -190,8 +190,6 @@ let rec scrape_lazy ~aliases env mty =
   | Some mty -> scrape_lazy ~aliases env mty
   | None -> mty
 
-let reduce_alias_lazy env mty = reduce_lazy ~aliases:true env mty
-
 let reduce_lazy env mty = reduce_lazy ~aliases:false env mty
 
 let reduce env mty =

--- a/typing/mtype.mli
+++ b/typing/mtype.mli
@@ -27,8 +27,6 @@ val scrape_alias: Env.t -> module_type -> module_type
            or abstract module type ident. *)
 val reduce_lazy:
   Env.t -> Subst.Lazy.module_type -> Subst.Lazy.module_type option
-val reduce_alias_lazy:
-  Env.t -> Subst.Lazy.module_type -> Subst.Lazy.module_type option
 val reduce: Env.t -> module_type -> module_type option
         (* Expand one toplevel module abbreviation. Return None if
            no expansion is possible. *)


### PR DESCRIPTION
This reverts commit dc3bba2c814d20fc222c975c1140da401871728b.

The additional traversals of module types cause performance regressions in files with many packs.