### PR TITLE
Fix build compatibility with old versions of `gcc`

### DIFF
--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -1041,7 +1041,12 @@ CAMLexport wchar_t* caml_stat_wcsconcat(int n, ...)
    Users can still customize the behavior of AddressSanitizer via the
    [ASAN_OPTIONS] environment variable at runtime.
    */
-const char *__attribute__((used, retain))
+const char *
+#ifdef __clang___
+__attribute__((used, retain))
+#else
+__attribute__((used))
+#endif
 __asan_default_options(void) {
   return "detect_leaks=false,"
          "halt_on_error=false,"

--- a/runtime4/memory.c
+++ b/runtime4/memory.c
@@ -1178,7 +1178,12 @@ CAMLexport wchar_t* caml_stat_wcsconcat(int n, ...)
    Users can still customize the behavior of AddressSanitizer via the
    [ASAN_OPTIONS] environment variable at runtime.
    */
-const char *__attribute__((used, retain))
+const char *
+#ifdef __clang___
+__attribute__((used, retain))
+#else
+__attribute__((used))
+#endif
 __asan_default_options(void) {
   return "detect_leaks=false,"
          "halt_on_error=false,"

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -436,7 +436,13 @@ void open_files(void)
       open_error(interface_file_name);
 }
 
-const char * __attribute__((used, retain)) __asan_default_options(void) {
+const char *
+#ifdef __clang___
+__attribute__((used, retain))
+#else
+__attribute__((used))
+#endif
+__asan_default_options(void) {
   return "detect_leaks=false,"
          "halt_on_error=false,"
          "detect_stack_use_after_return=false";


### PR DESCRIPTION
Make the build work under old versions of `gcc` that don't support the `retain` attribute