### PR TITLE
Document Datalog's scheduling functions

### DIFF
--- a/middle_end/flambda2/datalog/cursor.mli
+++ b/middle_end/flambda2/datalog/cursor.mli
@@ -89,6 +89,40 @@ val naive_fold :
 
 val naive_iter : 'v t -> Table.Map.t -> ('v Constant.hlist -> unit) -> unit
 
+(** Run a [cursor] using seminaive evaluation.
+
+    Seminaive evaluation aims at iterating over the {b new} outputs of the query
+    obtained by incrementally updating the database.
+
+    [previous] represents the old state of the database -- outputs derived
+    only from facts in [previous] are not found by seminaive evaluation.
+
+    [current] represents the new state of the database, obtained by adding the
+    [diff] to [previous]. We are only interested in outputs derived from at
+    least one (but maybe more than one) fact in [diff].
+
+    Seminaive evaluation is built on the bilinearity of the join operator with
+    respect to the database concatenation operator [+].
+    Suppose that we have a binary query on [P] and [Q]; the output is computed
+    by iterating over [join(P, Q)]. If [P = P + ΔP] and [Q = P + ΔQ], we can
+    rewrite:
+
+    ```
+    join(P + ΔP, Q + ΔQ) = join(P, Q) + join(ΔP, Q) + join(P + ΔP, ΔQ)
+    ```
+
+    Seminaive evaluation ignores the [join(P, Q)] term and only computes the
+    last two terms. Note that the term [join(P + ΔP, ΔQ)] does not need to be
+    further decomposed, so that in the general case we only need to combine
+    linearly many terms of the form:
+
+    ```
+    join(P₁ + ΔP₁, …, Pᵢ-₁ + ΔPᵢ-₁, ΔPᵢ, Pᵢ+₁, …, Pₙ
+    ```
+
+    The terms on the left use the [current] databse, the middle term uses the
+    [diff] database, and the terms on the right use the [previous] database.
+*)
 val seminaive_run :
   'v t ->
   previous:Table.Map.t ->

--- a/middle_end/flambda2/datalog/datalog.ml
+++ b/middle_end/flambda2/datalog/datalog.ml
@@ -49,6 +49,8 @@ module Term = struct
     | var :: vars -> Parameter var :: parameters vars
 end
 
+type atom = Atom : ('t, 'k, unit) Table.Id.t * 'k Term.hlist -> atom
+
 module String = struct
   include Heterogenous_list.Make (struct
     type 'a t = string

--- a/middle_end/flambda2/datalog/datalog.mli
+++ b/middle_end/flambda2/datalog/datalog.mli
@@ -27,6 +27,8 @@ module Term : sig
   val constant : 'a -> 'a t
 end
 
+type atom = Atom : ('t, 'k, unit) Table.Id.t * 'k Term.hlist -> atom
+
 module String : sig
   include Heterogenous_list.S with type 'a t := string
 end

--- a/middle_end/flambda2/datalog/flambda2_datalog.ml
+++ b/middle_end/flambda2/datalog/flambda2_datalog.ml
@@ -237,35 +237,13 @@ module Datalog = struct
 
   type rule = Schedule.rule
 
-  type atom = Atom : ('t, 'k, unit) Table.Id.t * 'k Term.hlist -> atom
-
   type deduction =
     [ `Atom of atom
     | `And of deduction list ]
 
   let and_ atoms = `And atoms
 
-  let deduce (atoms : deduction) =
-    let rec fold f atoms acc =
-      match atoms with
-      | `Atom atom -> f atom acc
-      | `And atoms ->
-        List.fold_left (fun acc atoms -> fold f atoms acc) acc atoms
-    in
-    let builder = Schedule.create_builder () in
-    let callbacks =
-      fold
-        (fun (Atom (tid, args)) callbacks ->
-          let fn = Schedule.add_rule builder tid in
-          create_callback (Schedule.call_rule_fn fn)
-            ~name:(Table.Id.name tid ^ ".insert")
-            args
-          :: callbacks)
-        atoms []
-    in
-    map_program (execute callbacks) (fun cursor ->
-        let cursor = Cursor.With_parameters.without_parameters cursor in
-        Schedule.build builder cursor)
+  let deduce = Schedule.deduce
 
   type hypothesis =
     [ `Atom of atom

--- a/middle_end/flambda2/datalog/schedule.ml
+++ b/middle_end/flambda2/datalog/schedule.ml
@@ -13,21 +13,45 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** An ['a incremental] represents a value (database or table), paired with
+    another copy representing the latest changes to the value. *)
 type 'a incremental =
   { current : 'a;
     difference : 'a
   }
 
+let incremental ~difference ~current = { current; difference }
+
+let incremental_get f t = { current = f t.current; difference = f t.difference }
+
+let incremental_set f v t =
+  { current = f v.current t.current; difference = f v.difference t.difference }
+
+(** A [binder] is a reference to the state of a single table during evaluation.
+    It contains the state of the table at the start of evaluation, the current
+    state of the table, and the difference between those. *)
 type binder =
   | Binder :
       { table_id : ('t, 'k, 'v) Table.Id.t;
-        initial : 't incremental ref;
+        previous : 't ref;
         current : 't incremental ref
       }
       -> binder
 
 let print_binder ppf (Binder { table_id; _ }) = Table.Id.print ppf table_id
 
+(** A rule consists of:
+
+      - A [Cursor.t] to iterates on the entries produced by the right-hand
+        side of the rule (hypotheses);
+
+      - A list of [binder]s that are bound to the tables appearing in the
+        left-hand side of the rule (conclusion) and updated throughout rule
+        evaluation;
+
+      - An unique identifier for logging/tracing purposes.
+
+    The cursor embeds callbacks to update the [binder]s. *)
 type rule =
   | Rule :
       { cursor : 'a Cursor.t;
@@ -36,12 +60,67 @@ type rule =
       }
       -> rule
 
-(* Rule identifiers are only used for statistics collection at the moment. *)
+type deduction =
+  [ `Atom of Datalog.atom
+  | `And of deduction list ]
+
 let fresh_rule_id =
   let cnt = ref 0 in
   fun () ->
     incr cnt;
     !cnt
+
+let find_or_create_ref (type t k v) binders (table_id : (t, k, v) Table.Id.t) :
+    t incremental ref =
+  let uid = Table.Id.uid table_id in
+  match Hashtbl.find_opt binders uid with
+  | None ->
+    let empty = Trie.empty (Table.Id.is_trie table_id) in
+    let current = ref (incremental ~difference:empty ~current:empty) in
+    let previous = ref empty in
+    Hashtbl.replace binders uid (Binder { table_id; previous; current });
+    current
+  | Some (Binder { table_id = other_table_id; previous = _; current }) ->
+    let Equal = Table.Id.provably_equal_exn other_table_id table_id in
+    current
+
+let deduce (atoms : deduction) =
+  let rec fold f atoms acc =
+    match atoms with
+    | `Atom atom -> f atom acc
+    | `And atoms -> List.fold_left (fun acc atoms -> fold f atoms acc) acc atoms
+  in
+  let binders : (int, binder) Hashtbl.t = Hashtbl.create 17 in
+  let callbacks =
+    fold
+      (fun (Datalog.Atom (tid, args)) callbacks ->
+        let is_trie = Table.Id.is_trie tid in
+        let table_ref = find_or_create_ref binders tid in
+        Datalog.create_callback
+          ~name:(Table.Id.name tid ^ ".insert")
+          (fun keys ->
+            let incremental_table = !table_ref in
+            match Trie.find_opt is_trie keys incremental_table.current with
+            | Some _ -> ()
+            | None ->
+              table_ref
+                := incremental
+                     ~current:
+                       (Trie.add_or_replace is_trie keys ()
+                          incremental_table.current)
+                     ~difference:
+                       (Trie.add_or_replace is_trie keys ()
+                          incremental_table.difference))
+          args
+        :: callbacks)
+      atoms []
+  in
+  let binders =
+    Hashtbl.fold (fun _ binder binders -> binder :: binders) binders []
+  in
+  Datalog.map_program (Datalog.execute callbacks) (fun cursor ->
+      let cursor = Cursor.With_parameters.without_parameters cursor in
+      Rule { cursor; binders; rule_id = fresh_rule_id () })
 
 type stats = (int, rule * float) Hashtbl.t
 
@@ -63,81 +142,42 @@ let print_stats ppf stats =
     stats;
   Format.fprintf ppf "@]"
 
-let incremental ~difference ~current = { current; difference }
+(** Evaluate a single rule using semi-naive evaluation.
 
-type builder = { tables : (int, binder) Hashtbl.t }
+    The [previous], [diff], and [current] parameters represent the state of the
+    database in which we are evaluating the cursor (see the documentaion of
+    {!Cursor.seminaive_run}).
 
-let create_builder () = { tables = Hashtbl.create 17 }
+    The [incremental_db] parameter is the database where we are accumulating the
+    result of the rule, and its new value is returned.
 
-type 'k rule_fn = 'k Heterogenous_list.Constant.hlist -> unit
-
-let call_rule_fn f args = f args
-
-let find_or_create_ref (type t k v) { tables } (table_id : (t, k, v) Table.Id.t)
-    : t incremental ref =
-  let uid = Table.Id.uid table_id in
-  match Hashtbl.find_opt tables uid with
-  | None ->
-    let empty = Trie.empty (Table.Id.is_trie table_id) in
-    let initial = ref (incremental ~difference:empty ~current:empty) in
-    let current = ref !initial in
-    Hashtbl.replace tables uid (Binder { table_id; initial; current });
-    current
-  | Some (Binder { table_id = other_table_id; initial = _; current }) ->
-    let Equal = Table.Id.provably_equal_exn other_table_id table_id in
-    current
-
-let add_rule builder tid : _ rule_fn =
-  let is_trie = Table.Id.is_trie tid in
-  let table_ref = find_or_create_ref builder tid in
-  fun keys ->
-    let incremental_table = !table_ref in
-    match Trie.find_opt is_trie keys incremental_table.current with
-    | Some _ -> ()
-    | None ->
-      table_ref
-        := incremental
-             ~current:
-               (Trie.add_or_replace is_trie keys () incremental_table.current)
-             ~difference:
-               (Trie.add_or_replace is_trie keys () incremental_table.difference)
-
-let build builder cursor =
-  let binders =
-    Hashtbl.fold (fun _ binder binders -> binder :: binders) builder.tables []
-  in
-  Rule { cursor; binders; rule_id = fresh_rule_id () }
-
+    {b Note}: there needs not be any relationship between the input database
+    represented by the [(previous, diff, current)] triple and the output
+    database [incremental_db].
+*)
 let run_rule_incremental ?stats ~previous ~diff ~current incremental_db
     (Rule { binders; cursor; _ } as rule) =
   List.iter
-    (fun (Binder { table_id; initial; current }) ->
-      let table =
-        incremental
-          ~current:(Table.Map.get table_id incremental_db.current)
-          ~difference:(Table.Map.get table_id incremental_db.difference)
+    (fun (Binder { table_id; previous; current }) ->
+      let incremental_table =
+        incremental_get (Table.Map.get table_id) incremental_db
       in
-      initial := table;
-      current := table)
+      previous := incremental_table.current;
+      current := incremental_table)
     binders;
   let time0 = Sys.time () in
   Cursor.seminaive_run cursor ~previous ~diff ~current;
   let time1 = Sys.time () in
   let seminaive_time = time1 -. time0 in
   Option.iter (fun stats -> add_timing ~stats rule seminaive_time) stats;
-  let set_if_changed db table_id ~before ~after =
-    if after == before then db else Table.Map.set table_id after db
-  in
   List.fold_left
-    (fun incremental_db (Binder { table_id; initial; current }) ->
-      let initial = !initial and current = !current in
-      incremental
-        ~current:
-          (set_if_changed incremental_db.current table_id
-             ~before:initial.current ~after:current.current)
-        ~difference:
-          (set_if_changed incremental_db.difference table_id
-             ~before:initial.difference ~after:current.difference))
+    (fun incremental_db (Binder { table_id; previous; current }) ->
+      let previous = !previous and { current; difference } = !current in
+      if previous == current
+      then incremental_db
+      else
+        incremental_set (Table.Map.set table_id) { current; difference }
+          incremental_db)
     incremental_db binders
 
 type t =
@@ -148,29 +188,48 @@ let fixpoint schedule = Fixpoint schedule
 
 let saturate rules = Saturate rules
 
-let run_rules_incremental ?stats rules ~previous ~diff ~current =
+let run_rules_incremental ?stats rules ~previous ~diff ~current incremental_db =
   List.fold_left
     (run_rule_incremental ?stats ~previous ~diff ~current)
-    (incremental ~current ~difference:Table.Map.empty)
-    rules
+    incremental_db rules
 
-let rec saturate_rules_incremental ?stats ~previous ~diff ~current rules
-    full_diff =
-  let incremental_db =
-    run_rules_incremental ?stats ~previous ~diff ~current rules
-  in
-  if Table.Map.is_empty incremental_db.difference
-  then incremental ~current ~difference:full_diff
-  else
-    saturate_rules_incremental ?stats ~previous:current
-      ~diff:incremental_db.difference ~current:incremental_db.current rules
-      (Table.Map.concat ~earlier:full_diff ~later:incremental_db.difference)
+(** Repeatedly apply the rules in [rules] to the database [current] until
+    reaching a fixpoint.
 
+    Returns an incremental database containing the new state of [current] along
+    with all the new facts added during saturation.
+*)
 let saturate_rules_incremental ?stats rules ~previous ~diff ~current =
+  let rec saturate_rules_incremental ?stats ~previous ~diff ~current rules
+      full_diff =
+    (* After one call to [run_rules_incremental], all deductions from facts in
+       [current] have been processed, so we only need to keep evaluating rules
+       with at least one fact in [incremental_db.difference]. *)
+    let incremental_db =
+      run_rules_incremental ?stats ~previous ~diff ~current rules
+        (incremental ~current ~difference:Table.Map.empty)
+    in
+    if Table.Map.is_empty incremental_db.difference
+    then incremental ~current ~difference:full_diff
+    else
+      saturate_rules_incremental ?stats ~previous:current
+        ~diff:incremental_db.difference ~current:incremental_db.current rules
+        (Table.Map.concat ~earlier:full_diff ~later:incremental_db.difference)
+  in
   saturate_rules_incremental ?stats rules Table.Map.empty ~previous ~diff
     ~current
 
+(** Run the evaluation functions in [fns] until reaching a fixpoint.
+*)
 let run_list_incremental fns ~previous ~diff ~current =
+  (* Each evaluation of a rule that produced changes is associated with a
+     timestamp (the initial used-provided [diff] is at timestamp [0]), and each
+     evaluation function is associated with the state of the database last time
+     it was run (initially [previous]) and the corresponding timestamp
+     (initially [-1]).
+
+     Before evaluating a function [fn], we compute the diff since its previous
+     run by concatenating all the diffs with a higher timestamp. *)
   let rec cut ~cut_after result = function
     | [] -> result
     | (ts, diff) :: diffs ->

--- a/middle_end/flambda2/datalog/schedule.mli
+++ b/middle_end/flambda2/datalog/schedule.mli
@@ -13,16 +13,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type builder
-
-val create_builder : unit -> builder
-
-type 'a rule_fn
-
-val call_rule_fn : 'a rule_fn -> 'a Heterogenous_list.Constant.hlist -> unit
-
-val add_rule : builder -> ('t, 'k, unit) Table.Id.t -> 'k rule_fn
-
 type stats
 
 val create_stats : unit -> stats
@@ -31,7 +21,11 @@ val print_stats : Format.formatter -> stats -> unit
 
 type rule
 
-val build : builder -> 'a Cursor.t -> rule
+type deduction =
+  [ `Atom of Datalog.atom
+  | `And of deduction list ]
+
+val deduce : deduction -> (Heterogenous_list.nil, rule) Datalog.program
 
 type t
 


### PR DESCRIPTION
And also explain seminaive evaluation, which was missing.

Note to reviewer: there is a small code change to rename the `initial` field of a `Binder` to `previous`, and not store the diff there. There is also some code reorganization (in particular some code is moved to `Schedul` from `Flambda2_datalog` to avoid exposing a clunky API from the `Schedule` module), but the code itself is not changed.