### PR TITLE
Name the explicit constants used with caml_verb_gc (runtime5)

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -499,19 +499,70 @@ CAMLextern int caml_read_directory(char_os * dirname,
 
 #ifdef CAML_INTERNALS
 
-/* GC flags and messages */
+/* runtime message flags. Settable with v= in OCAMLRUNPARAM */
 
 extern atomic_uintnat caml_verb_gc;
 
-void caml_gc_log (char *, ...)
-#ifdef __GNUC__
-  __attribute__ ((format (printf, 1, 2)))
+/* Bits which may be set in caml_verb_gc. The quotations are from the
+ * OCaml manual. */
+
+/* "Start and end of major GC cycle" (unused) */
+#define CAML_GC_MSG_MAJOR           0x0001
+/* "Minor collection and major GC slice" (unused) */
+#define CAML_GC_MSG_MINOR           0x0002
+/* "Growing and shrinking of the heap" */
+#define CAML_GC_MSG_HEAPSIZE        0x0004
+/* "Resizing of stacks and memory manager tables" */
+#define CAML_GC_MSG_STACKSIZE       0x0008
+/* "Heap compaction" (unused) */
+#define CAML_GC_MSG_COMPACT         0x0010
+/* "Change of GC parameters" */
+#define CAML_GC_MSG_PARAMS          0x0020
+/* "Computation of major GC slice size" */
+#define CAML_GC_MSG_SLICESIZE       0x0040
+/* "Calling of finalization functions" */
+#define CAML_GC_MSG_FINALIZE        0x0080
+/* "Startup messages" */
+#define CAML_GC_MSG_STARTUP         0x0100
+/* "Computation of compaction-triggering condition" (unused) */
+#define CAML_GC_MSG_COMPACT_TRIGGER 0x0200
+/* "Output GC statistics at program exit" */
+#define CAML_GC_MSG_STATS           0x0400
+/* "GC debugging messages */
+#define CAML_GC_MSG_DEBUG           0x0800
+/* "Address space reservation changes" */
+#define CAML_GC_MSG_ADDRSPACE       0x1000
+
+/* Default set of messages when runtime invoked with -v */
+
+#define CAML_GC_MSG_VERBOSE (CAML_GC_MSG_MAJOR     | \
+                             CAML_GC_MSG_HEAPSIZE  | \
+                             CAML_GC_MSG_STACKSIZE | \
+                             CAML_GC_MSG_COMPACT   | \
+                             CAML_GC_MSG_PARAMS)
+
+/* Use to control messages which should be output at any non-zero verbosity */
+
+#define CAML_GC_MSG_ANY (-1)
+
+/* output message if caml_verb_gc includes any bits in `category`. */
+
+void caml_gc_message (int category, const char *, ...)
+#if __has_attribute(format) || defined(__GNUC__)
+  __attribute__ ((format (printf, 2, 3)))
 #endif
 ;
 
-void caml_gc_message (int, char *, ...)
-#ifdef __GNUC__
-  __attribute__ ((format (printf, 2, 3)))
+/* Short-hand for calls to `caml_gc_message` */
+
+#define CAML_GC_MESSAGE(category, ...) \
+    caml_gc_message(CAML_GC_MSG_ ## category, __VA_ARGS__)
+
+/* Output message if CAML_GC_MSG_DEBUG is set */
+
+void caml_gc_log (const char *, ...)
+#if __has_attribute(format) || defined(__GNUC__)
+  __attribute__ ((format (printf, 1, 2)))
 #endif
 ;
 

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -51,7 +51,7 @@ static void compare_free_stack(struct compare_stack* stk)
 /* Same, then raise Out_of_memory */
 CAMLnoret static void compare_stack_overflow(struct compare_stack* stk)
 {
-  caml_gc_message (0x04, "Stack overflow in structural comparison\n");
+  CAML_GC_MESSAGE(HEAPSIZE, "Stack overflow in structural comparison\n");
   compare_free_stack(stk);
   caml_raise_out_of_memory();
 }

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -144,7 +144,7 @@ static void open_shared_lib(char_os * name)
 
   realname = caml_search_dll_in_path(&caml_shared_libs_path, name);
   u8 = caml_stat_strdup_of_os(realname);
-  caml_gc_message(0x100, "Loading shared library %s\n", u8);
+  CAML_GC_MESSAGE(STARTUP, "Loading shared library %s\n", u8);
   caml_stat_free(u8);
   caml_enter_blocking_section();
   handle = caml_dlopen(realname, 1);
@@ -311,7 +311,7 @@ CAMLprim value caml_dynlink_open_lib(value mode, value filename)
   value result;
   char_os * p;
 
-  caml_gc_message(0x100, "Opening shared library %s\n",
+  CAML_GC_MESSAGE(STARTUP, "Opening shared library %s\n",
                   String_val(filename));
   p = caml_stat_strdup_to_os(String_val(filename));
   caml_enter_blocking_section();

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -470,7 +470,8 @@ static void extern_failwith(struct caml_extern_state* s, char *msg)
 
 static void extern_stack_overflow(struct caml_extern_state* s)
 {
-  caml_gc_message (0x04, "Stack overflow in marshaling value\n");
+  CAML_GC_MESSAGE(HEAPSIZE,
+                  "Stack overflow in marshaling value\n");
   free_extern_output(s);
   caml_raise_out_of_memory();
 }

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -151,7 +151,8 @@ value caml_final_do_calls_exn(void)
   if (fi->running_finalisation_function) return Val_unit;
   if (fi->todo_head != NULL) {
     call_timing_hook(&caml_finalise_begin_hook);
-    caml_gc_message (0x80, "Calling finalisation functions.\n");
+    CAML_GC_MESSAGE(FINALIZE,
+                    "Calling finalisation functions.\n");
     while (1) {
       while (fi->todo_head != NULL && fi->todo_head->size == 0) {
         struct final_todo *next_head = fi->todo_head->next;
@@ -168,7 +169,8 @@ value caml_final_do_calls_exn(void)
       fi->running_finalisation_function = 0;
       if (Is_exception_result(res)) return res;
     }
-    caml_gc_message (0x80, "Done calling finalisation functions.\n");
+    CAML_GC_MESSAGE(FINALIZE,
+                    "Done calling finalisation functions.\n");
     call_timing_hook(&caml_finalise_end_hook);
   }
   return Val_unit;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -187,14 +187,15 @@ CAMLprim value caml_gc_set(value v)
 
   if (newpf != caml_percent_free){
     caml_percent_free = newpf;
-    caml_gc_message (0x20, "New space overhead: %"
-                     ARCH_INTNAT_PRINTF_FORMAT "u%%\n", caml_percent_free);
+    CAML_GC_MESSAGE(PARAMS,
+                    "New space overhead: %" ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
+                    caml_percent_free);
   }
 
   if (newpm != caml_max_percent_free) {
     caml_max_percent_free = newpm;
-    caml_gc_message (0x20, "New max space overhead: %"
-                     ARCH_INTNAT_PRINTF_FORMAT "u%%\n", caml_max_percent_free);
+    CAML_GC_MESSAGE(PARAMS, "New max space overhead: %"
+                    ARCH_INTNAT_PRINTF_FORMAT "u%%\n", caml_max_percent_free);
   }
 
   atomic_store_relaxed(&caml_verb_gc, new_verb_gc);
@@ -203,29 +204,29 @@ CAMLprim value caml_gc_set(value v)
   if (Wosize_val (v) >= 11){
     if (new_custom_maj != caml_custom_major_ratio){
       caml_custom_major_ratio = new_custom_maj;
-      caml_gc_message (0x20, "New custom major ratio: %"
-                       ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
-                       caml_custom_major_ratio);
+      CAML_GC_MESSAGE(PARAMS, "New custom major ratio: %"
+                      ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
+                      caml_custom_major_ratio);
     }
     if (new_custom_min != caml_custom_minor_ratio){
       caml_custom_minor_ratio = new_custom_min;
-      caml_gc_message (0x20, "New custom minor ratio: %"
-                       ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
-                       caml_custom_minor_ratio);
+      CAML_GC_MESSAGE(PARAMS, "New custom minor ratio: %"
+                      ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
+                      caml_custom_minor_ratio);
     }
     if (new_custom_sz != caml_custom_minor_max_bsz){
       caml_custom_minor_max_bsz = new_custom_sz;
-      caml_gc_message (0x20, "New custom minor size limit: %"
-                       ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
-                       caml_custom_minor_max_bsz);
+      CAML_GC_MESSAGE(PARAMS, "New custom minor size limit: %"
+                      ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
+                      caml_custom_minor_max_bsz);
     }
   }
 
   /* Minor heap size comes last because it will trigger a minor collection
      (thus invalidating [v]) and it can raise [Out_of_memory]. */
   if (newminwsz != Caml_state->minor_heap_wsz) {
-    caml_gc_message (0x20, "New minor heap size: %"
-                     ARCH_INTNAT_PRINTF_FORMAT "uk words\n", newminwsz / 1024);
+    CAML_GC_MESSAGE(PARAMS, "New minor heap size: %"
+                    ARCH_INTNAT_PRINTF_FORMAT "uk words\n", newminwsz / 1024);
   }
 
   if (newminwsz > caml_minor_heap_max_wsz) {
@@ -388,25 +389,6 @@ void caml_init_gc (void)
   caml_percent_free = norm_pfree (percent_fr);
   caml_max_percent_free = norm_pmax (percent_m);
   caml_init_major_heap (major_heap_size);
-  caml_gc_message (0x20, "Initial minor heap size: %luk bytes\n",
-                   Caml_state->minor_heap_size / 1024);
-  caml_gc_message (0x20, "Initial major heap size: %luk bytes\n",
-                   major_heap_size / 1024);
-  caml_gc_message (0x20, "Initial space overhead: %"
-                   ARCH_INTNAT_PRINTF_FORMAT "u%%\n", caml_percent_free);
-  caml_gc_message (0x20, "Initial max overhead: %"
-                   ARCH_INTNAT_PRINTF_FORMAT "u%%\n", caml_max_percent_free);
-  if (caml_major_heap_increment > 1000){
-    caml_gc_message (0x20, "Initial heap increment: %"
-                     ARCH_INTNAT_PRINTF_FORMAT "uk words\n",
-                     caml_major_heap_increment / 1024);
-  }else{
-    caml_gc_message (0x20, "Initial heap increment: %"
-                     ARCH_INTNAT_PRINTF_FORMAT "u%%\n",
-                     caml_major_heap_increment);
-  }
-  caml_gc_message (0x20, "Initial allocation policy: %d\n",
-                   caml_allocation_policy);
 */
 }
 

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -337,7 +337,7 @@ static void readfloats(struct caml_intern_state* s,
 
 CAMLnoret static void intern_stack_overflow(struct caml_intern_state* s)
 {
-  caml_gc_message (0x04, "Stack overflow in un-marshaling value\n");
+  CAML_GC_MESSAGE(HEAPSIZE, "Stack overflow in un-marshaling value\n");
   intern_cleanup(s);
   caml_raise_out_of_memory();
 }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -742,36 +742,36 @@ static void update_major_slice_work(intnat howmuch,
 
   extra_work = (intnat) (my_extra_count * (double) total_cycle_work);
 
-  caml_gc_message (0x40, "heap_words = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "u\n",
-                   (uintnat)heap_words);
-  caml_gc_message (0x40, "allocated_words = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "u\n",
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "heap_words = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
+                  (uintnat)heap_words);
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "allocated_words = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
                    my_alloc_count);
-  caml_gc_message (0x40, "allocated_words_direct = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "u\n",
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "allocated_words_direct = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
                    my_alloc_direct_count);
-  caml_gc_message (0x40, "alloc work-to-do = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "d\n",
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "alloc work-to-do = %" ARCH_INTNAT_PRINTF_FORMAT "d\n",
                    alloc_work);
-  caml_gc_message (0x40, "dependent_words = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "u\n",
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "dependent_words = %" ARCH_INTNAT_PRINTF_FORMAT "u\n",
                    my_dependent_count);
-  caml_gc_message (0x40, "dependent work-to-do = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "d\n",
-                   dependent_work);
-  caml_gc_message (0x40, "extra_heap_resources = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "uu\n",
-                   (uintnat) (my_extra_count * 1000000));
-  caml_gc_message (0x40, "extra work-to-do = %"
-                         ARCH_INTNAT_PRINTF_FORMAT "d\n",
-                   extra_work);
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "dependent work-to-do = %" ARCH_INTNAT_PRINTF_FORMAT "d\n",
+                  dependent_work);
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "extra_heap_resources = %" ARCH_INTNAT_PRINTF_FORMAT "uu\n",
+                  (uintnat) (my_extra_count * 1000000));
+  CAML_GC_MESSAGE(SLICESIZE,
+                  "extra work-to-do = %" ARCH_INTNAT_PRINTF_FORMAT "d\n",
+                  extra_work);
 
   intnat offheap_work = max2 (dependent_work, extra_work);
   intnat clamp = alloc_work * caml_custom_work_max_multiplier;
   if (offheap_work > clamp) {
-    caml_gc_message(0x40, "Work clamped to %"
-                          ARCH_INTNAT_PRINTF_FORMAT "d\n",
+    CAML_GC_MESSAGE(SLICESIZE, "Work clamped to %"
+                    ARCH_INTNAT_PRINTF_FORMAT "d\n",
                     clamp);
     offheap_work = clamp;
   }
@@ -1492,7 +1492,7 @@ static bool should_compact_from_stw_single(int compaction_mode)
   if (compaction_mode == Compaction_none) {
     return false;
   } else if (compaction_mode == Compaction_forced) {
-    caml_gc_message (0x200, "Forced compaction.\n");
+    CAML_GC_MESSAGE (COMPACT_TRIGGER, "Forced compaction.\n");
     return true;
   }
   CAMLassert (compaction_mode == Compaction_auto);
@@ -1500,13 +1500,13 @@ static bool should_compact_from_stw_single(int compaction_mode)
   /* runtime 4 algorithm, as close as possible.
    * TODO: revisit this in future. */
   if (caml_max_percent_free >= 1000 * 1000) {
-    caml_gc_message (0x200,
+    CAML_GC_MESSAGE (COMPACT_TRIGGER,
                      "Max percent free %"ARCH_INTNAT_PRINTF_FORMAT"u%%:"
                      "compaction off.\n", caml_max_percent_free);
     return false;
   }
   if (caml_major_cycles_completed < 3) {
-    caml_gc_message (0x200,
+    CAML_GC_MESSAGE (COMPACT_TRIGGER,
                      "Only %"ARCH_INTNAT_PRINTF_FORMAT"u major cycles: "
                      "compaction off.\n", caml_major_cycles_completed);
     return false;
@@ -1525,7 +1525,7 @@ static bool should_compact_from_stw_single(int compaction_mode)
   double current_overhead = 100.0 * free_words / live_words;
 
   bool compacting = current_overhead >= caml_max_percent_free;
-  caml_gc_message (0x200, "Current overhead: %"
+  CAML_GC_MESSAGE (COMPACT_TRIGGER, "Current overhead: %"
                    ARCH_INTNAT_PRINTF_FORMAT "u%% %s %"
                    ARCH_INTNAT_PRINTF_FORMAT "u%%: %scompacting.\n",
                    (uintnat) current_overhead,
@@ -1547,9 +1547,9 @@ static void cycle_major_heap_from_stw_single(
               (long unsigned int)caml_major_cycles_completed);
 
   caml_major_cycles_completed++;
-  caml_gc_message(0x40, "Starting major GC cycle\n");
+  CAML_GC_MESSAGE(SLICESIZE, "Starting major GC cycle\n");
 
-  if (atomic_load_relaxed(&caml_verb_gc) & 0x400) {
+  if (atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_STATS) {
     struct gc_stats s;
     intnat heap_words, not_garbage_words, swept_words;
 
@@ -1836,7 +1836,8 @@ static void major_collection_slice(intnat howmuch,
   int may_access_gc_phase = (mode != Slice_opportunistic);
 
   int log_events = mode != Slice_opportunistic ||
-                   (atomic_load_relaxed(&caml_verb_gc) & 0x40);
+                   (atomic_load_relaxed(&caml_verb_gc) &
+                    CAML_GC_MSG_SLICESIZE);
 
   update_major_slice_work(howmuch, may_access_gc_phase);
 

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -590,7 +590,7 @@ void caml_local_realloc(void)
   for (i = s->saved_sp; i < 0; i += sizeof(value)) {
     *((header_t*)(arena + s->next_length + i)) = Local_uninit_hd;
   }
-  caml_gc_message(0x08,
+  CAML_GC_MESSAGE(STACKSIZE,
                   "Growing local stack to %"ARCH_INTNAT_PRINTF_FORMAT"d kB\n",
                   s->next_length / 1024);
   s->count++;

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -150,7 +150,7 @@ CAMLprim value caml_realloc_global(value size)
   actual_size = Wosize_val(old_global_data);
   if (requested_size >= actual_size) {
     requested_size = (requested_size + 0x100) & 0xFFFFFF00;
-    caml_gc_message (0x08, "Growing global data to %"
+    CAML_GC_MESSAGE(STACKSIZE, "Growing global data to %"
                      ARCH_INTNAT_PRINTF_FORMAT "u entries\n",
                      requested_size);
     new_global_data = caml_alloc_shr(requested_size, 0);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -93,7 +93,7 @@ static void clear_table (struct generic_table *tbl,
     tbl->ptr = tbl->base;
     tbl->limit = tbl->threshold;
   } else {
-    caml_gc_message (0x08, "Shrinking %s to %ldk bytes\n",
+    CAML_GC_MESSAGE (STACKSIZE, "Shrinking %s to %ldk bytes\n",
                      name,
                      (long)((maxsz * element_size) / 1024));
     alloc_generic_table(tbl, Caml_state->minor_heap_wsz, 256, element_size);
@@ -819,7 +819,8 @@ int caml_do_opportunistic_major_slice
   int work_available = caml_opportunistic_major_work_available(domain_state);
   if (work_available) {
     /* NB: need to put guard around the ev logs to prevent spam when we poll */
-    uintnat log_events = atomic_load_relaxed(&caml_verb_gc) & 0x40;
+    uintnat log_events =
+        atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_SLICESIZE;
     if (log_events) CAML_EV_BEGIN(EV_MAJOR_MARK_OPPORTUNISTIC);
     caml_opportunistic_major_collection_slice(Major_slice_work_min);
     if (log_events) CAML_EV_END(EV_MAJOR_MARK_OPPORTUNISTIC);
@@ -1061,7 +1062,7 @@ static void realloc_generic_table
                          element_size);
   }else if (tbl->limit == tbl->threshold){
     CAML_EV_COUNTER (ev_counter_name, 1);
-    caml_gc_message (0x08, msg_threshold, 0);
+    CAML_GC_MESSAGE(STACKSIZE, msg_threshold, 0);
     tbl->limit = tbl->end;
     caml_request_minor_gc ();
   }else{
@@ -1070,7 +1071,7 @@ static void realloc_generic_table
 
     tbl->size *= 2;
     sz = (tbl->size + tbl->reserve) * element_size;
-    caml_gc_message (0x08, msg_growing, (intnat) sz/1024);
+    CAML_GC_MESSAGE(STACKSIZE, msg_growing, (intnat) sz/1024);
     tbl->base = caml_stat_resize_noexc (tbl->base, sz);
     if (tbl->base == NULL){
       caml_fatal_error ("%s", msg_error);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -82,7 +82,7 @@ void caml_alloc_point_here(void)
 
 atomic_uintnat caml_verb_gc = 0;
 
-static void print_log(char* msg, int newline, va_list ap)
+static void print_log(const char* msg, int newline, va_list ap)
 {
   char buf[GC_LOG_LENGTH];
   int pos = 0;
@@ -101,9 +101,9 @@ static void print_log(char* msg, int newline, va_list ap)
   fflush(stderr);
 }
 
-void caml_gc_log (char *msg, ...)
+void caml_gc_log (const char *msg, ...)
 {
-  if ((atomic_load_relaxed(&caml_verb_gc) & 0x800) != 0) {
+  if ((atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_DEBUG) != 0) {
     va_list ap;
     va_start (ap, msg);
     print_log(msg, 1, ap);
@@ -111,7 +111,7 @@ void caml_gc_log (char *msg, ...)
   }
 }
 
-void caml_gc_message (int level, char *msg, ...)
+void caml_gc_message (int level, const char *msg, ...)
 {
   if ((atomic_load_relaxed(&caml_verb_gc) & level) != 0){
     va_list ap;

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -405,13 +405,15 @@ void* caml_mem_map(uintnat size, int reserve_only, const char* name)
   void* mem = caml_plat_mem_map(size, reserve_only, name);
 
   if (mem == 0) {
-    caml_gc_message(0x1000, "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d bytes failed",
-                            size);
+    CAML_GC_MESSAGE(ADDRSPACE,
+                    "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d bytes failed",
+                    size);
     return 0;
   }
 
-  caml_gc_message(0x1000, "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                          " bytes at %p for %s\n", size, mem, name);
+  CAML_GC_MESSAGE(ADDRSPACE,
+                  "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
+                  " bytes at %p for %s\n", size, mem, name);
 
   return mem;
 }
@@ -419,24 +421,27 @@ void* caml_mem_map(uintnat size, int reserve_only, const char* name)
 void* caml_mem_commit(void* mem, uintnat size, const char* name)
 {
   CAMLassert(Is_page_aligned(size));
-  caml_gc_message(0x1000, "commit %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                          " bytes at %p for %s\n", size, mem, name);
+  CAML_GC_MESSAGE(ADDRSPACE,
+                  "commit %" ARCH_INTNAT_PRINTF_FORMAT "d"
+                  " bytes at %p for %s\n", size, mem, name);
   return caml_plat_mem_commit(mem, size, name);
 }
 
 void caml_mem_decommit(void* mem, uintnat size, const char* name)
 {
   if (size) {
-    caml_gc_message(0x1000, "decommit %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                            " bytes at %p for %s\n", size, mem, name);
+    CAML_GC_MESSAGE(ADDRSPACE,
+                    "decommit %" ARCH_INTNAT_PRINTF_FORMAT "d"
+                    " bytes at %p for %s\n", size, mem, name);
     caml_plat_mem_decommit(mem, size, name);
   }
 }
 
 void caml_mem_unmap(void* mem, uintnat size)
 {
-  caml_gc_message(0x1000, "munmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
-                          " bytes at %p\n", size, mem);
+  CAML_GC_MESSAGE(ADDRSPACE,
+                  "munmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
+                  " bytes at %p\n", size, mem);
   caml_plat_mem_unmap(mem, size);
 }
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1435,7 +1435,7 @@ static void compact_algorithm_52(caml_domain_state* domain_state,
     caml_plat_lock_blocking(&pool_freelist.lock);
     pool_freelist.active_pools -= freed_pools;
     caml_plat_unlock(&pool_freelist.lock);
-    caml_gc_message(0x010, "Freed (and unmapped) %lu pools.\n", freed_pools);
+    CAML_GC_MESSAGE(COMPACT, "Freed (and unmapped) %lu pools.\n", freed_pools);
   } else { /* not unmapping */
     pool* cur_pool = evacuated_pools;
     pool* last = NULL;
@@ -1457,7 +1457,7 @@ static void compact_algorithm_52(caml_domain_state* domain_state,
       pool_freelist.active_pools -= freed_pools;
       caml_plat_unlock(&pool_freelist.lock);
     }
-    caml_gc_message(0x010, "Freed %lu pools.\n", freed_pools);
+    CAML_GC_MESSAGE(COMPACT, "Freed %lu pools.\n", freed_pools);
   }
 
   caml_global_barrier(participating_count);
@@ -1482,7 +1482,7 @@ static void compact_algorithm_52(caml_domain_state* domain_state,
 
       pool_freelist.free = NULL;
       caml_plat_unlock(&pool_freelist.lock);
-      caml_gc_message(0x010, "Also unmapped %lu pools from free list.\n", unmapped);
+      CAML_GC_MESSAGE(COMPACT, "Also unmapped %lu pools from free list.\n", unmapped);
     }
   }
   CAML_EV_END(EV_COMPACT_RELEASE);
@@ -1828,7 +1828,7 @@ void compact_release_freelist(void)
   pool_freelist.free = new_free_list;
 
   caml_stat_free(free_pools);
-  caml_gc_message(0x010,
+  CAML_GC_MESSAGE(COMPACT,
                   "Released %lu pools; %lu remaining on free list.\n",
                   unmapped, remaining);
 done:
@@ -2171,7 +2171,8 @@ void caml_compact_heap(caml_domain_state* domain_state,
   if (participants[0] == Caml_state) {
      /* We are done, increment the compaction count */
     atomic_fetch_add(&caml_compactions_count, 1);
-    caml_gc_message(0x010, "Compaction %lu completed (algorithm %lu).\n",
+    CAML_GC_MESSAGE(COMPACT,
+                    "Compaction %lu completed (algorithm %lu).\n",
                     caml_compactions_count,
                     caml_compaction_algorithm);
   }

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -83,7 +83,7 @@ static void init_startup_params(void)
 #ifdef DEBUG
   // Silenced in flambda-backend to make it easier to run tests that
   // check program output.
-  // atomic_store_relaxed(&caml_verb_gc, 0x3F);
+  // atomic_store_relaxed(&caml_verb_gc, CAML_GC_MSG_VERBOSE | CAML_GC_MSG_MINOR);
 #endif
 #ifndef NATIVE_CODE
   cds_file = caml_secure_getenv(T("CAML_DEBUG_FILE"));

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -124,12 +124,12 @@ int caml_attempt_open(char_os **name, struct exec_trailer *trail,
 
   truename = caml_search_exe_in_path(*name);
   u8 = caml_stat_strdup_of_os(truename);
-  caml_gc_message(0x100, "Opening bytecode executable %s\n", u8);
+  CAML_GC_MESSAGE(STARTUP, "Opening bytecode executable %s\n", u8);
   caml_stat_free(u8);
   fd = open_os(truename, O_RDONLY | O_BINARY);
   if (fd == -1) {
     caml_stat_free(truename);
-    caml_gc_message(0x100, "Cannot open file\n");
+    CAML_GC_MESSAGE(STARTUP, "Cannot open file\n");
     if (errno == EMFILE)
       return NO_FDS;
     else
@@ -140,7 +140,7 @@ int caml_attempt_open(char_os **name, struct exec_trailer *trail,
     if (err < 2 || (buf [0] == '#' && buf [1] == '!')) {
       close(fd);
       caml_stat_free(truename);
-      caml_gc_message(0x100, "Rejected #! script\n");
+      CAML_GC_MESSAGE(STARTUP, "Rejected #! script\n");
       return BAD_BYTECODE;
     }
   }
@@ -148,7 +148,7 @@ int caml_attempt_open(char_os **name, struct exec_trailer *trail,
   if (err != 0) {
     close(fd);
     caml_stat_free(truename);
-    caml_gc_message(0x100, "Not a bytecode executable\n");
+    CAML_GC_MESSAGE(STARTUP, "Not a bytecode executable\n");
     return err;
   }
   *name = truename;
@@ -318,7 +318,7 @@ static int parse_command_line(char_os **argv)
         params->trace_level += 1; /* ignored unless DEBUG mode */
         break;
       case 'v':
-        atomic_store_relaxed(&caml_verb_gc, 0x001+0x004+0x008+0x010+0x020);
+        atomic_store_relaxed(&caml_verb_gc, CAML_GC_MSG_VERBOSE);
         break;
       case 'p':
         for (j = 0; caml_names_of_builtin_cprim[j] != NULL; j++)
@@ -464,7 +464,7 @@ CAMLexport void caml_main(char_os **argv)
 #ifdef DEBUG
   // Silenced in flambda-backend to make it easier to run tests that
   // check program output.
-  // caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
+  // CAML_GC_MESSAGE (ANY, "### OCaml runtime: debug mode ###\n");
 #endif
   if (!caml_startup_aux(/* pooling */ caml_params->cleanup_on_exit))
     return;
@@ -607,7 +607,7 @@ CAMLexport value caml_startup_code_exn(
 #ifdef DEBUG
   // Silenced in flambda-backend to make it easier to run tests that
   // check program output.
-  // caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
+  // CAML_GC_MESSAGE (ANY, "### OCaml runtime: debug mode ###\n");
 #endif
   if (caml_params->cleanup_on_exit)
     pooling = 1;

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -107,7 +107,7 @@ value caml_startup_common(char_os **argv, int pooling)
 #ifdef DEBUG
   // Silenced in flambda-backend to make it easier to run tests that
   // check program output.
-  // caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
+  // CAML_GC_MESSAGE (ANY, "### OCaml runtime: debug mode ###\n");
 #endif
   if (caml_params->cleanup_on_exit)
     pooling = 1;

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -136,7 +136,7 @@ CAMLexport void caml_do_exit(int retcode)
   caml_domain_state* domain_state = Caml_state;
   struct gc_stats s;
 
-  if ((atomic_load_relaxed(&caml_verb_gc) & 0x400) != 0) {
+  if ((atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_STATS) != 0) {
     caml_compute_gc_stats(&s);
     {
       /* cf caml_gc_counters */
@@ -159,28 +159,32 @@ CAMLexport void caml_do_exit(int retcode)
         top_heap_words = caml_top_heap_words(Caml_state->shared_heap);
       }
 
-      caml_gc_message(0x400, "allocated_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-                    (intnat)allocated_words);
-      caml_gc_message(0x400, "minor_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-                    (intnat) minwords);
-      caml_gc_message(0x400, "promoted_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-                      (intnat) s.alloc_stats.promoted_words);
-      caml_gc_message(0x400, "major_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
-                      (intnat) majwords);
-      caml_gc_message(0x400,
+      CAML_GC_MESSAGE(STATS,
+          "allocated_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+          (intnat)allocated_words);
+      CAML_GC_MESSAGE(STATS,
+          "minor_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+          (intnat) minwords);
+      CAML_GC_MESSAGE(STATS,
+          "promoted_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+          (intnat) s.alloc_stats.promoted_words);
+      CAML_GC_MESSAGE(STATS,
+          "major_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+          (intnat) majwords);
+      CAML_GC_MESSAGE(STATS,
           "minor_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
           (intnat) atomic_load(&caml_minor_collections_count));
-      caml_gc_message(0x400,
+      CAML_GC_MESSAGE(STATS,
           "major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
           caml_major_cycles_completed);
-      caml_gc_message(0x400,
+      CAML_GC_MESSAGE(STATS,
           "forced_major_collections: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
           (intnat)s.alloc_stats.forced_major_collections);
-      caml_gc_message(0x400, "heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+      CAML_GC_MESSAGE(STATS, "heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
                     heap_words);
-      caml_gc_message(0x400, "top_heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
+      CAML_GC_MESSAGE(STATS, "top_heap_words: %"ARCH_INTNAT_PRINTF_FORMAT"d\n",
                       top_heap_words);
-      caml_gc_message(0x400, "mean_space_overhead: %lf\n",
+      CAML_GC_MESSAGE(STATS, "mean_space_overhead: %lf\n",
                       caml_mean_space_overhead());
     }
   }

--- a/runtime4/win32.c
+++ b/runtime4/win32.c
@@ -167,7 +167,7 @@ wchar_t * caml_search_in_path(struct ext_table * path, const wchar_t * name)
          /* not sure what empty path components mean under Windows */
     fullname = caml_stat_wcsconcat(3, dir, L"\\", name);
     u8 = caml_stat_strdup_of_utf16(fullname);
-    caml_gc_message(0x100, "Searching %s\n", u8);
+    CAML_GC_MESSAGE(STARTUP, "Searching %s\n", u8);
     caml_stat_free(u8);
     if (_wstati64(fullname, &st) == 0 && S_ISREG(st.st_mode))
       return fullname;
@@ -175,7 +175,7 @@ wchar_t * caml_search_in_path(struct ext_table * path, const wchar_t * name)
   }
  not_found:
   u8 = caml_stat_strdup_of_utf16(name);
-  caml_gc_message(0x100, "%s not found in search path\n", u8);
+  CAML_GC_MESSAGE(STARTUP, "%s not found in search path\n", u8);
   caml_stat_free(u8);
   return caml_stat_wcsdup(name);
 }
@@ -199,7 +199,7 @@ CAMLexport wchar_t * caml_search_exe_in_path(const wchar_t * name)
                          &filepart);
     if (retcode == 0) {
       u8 = caml_stat_strdup_of_utf16(name);
-      caml_gc_message(0x100, "%s not found in search path\n", u8);
+      CAML_GC_MESSAGE(STARTUP, "%s not found in search path\n", u8);
       caml_stat_free(u8);
       caml_stat_free(fullname);
       return caml_stat_strdup_os(name);

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -146,17 +146,19 @@ type control =
     (** This value controls the GC messages on standard error output.
        It is a sum of some of the following flags, to print messages
        on the corresponding events:
-       - [0x001] Start and end of major GC cycle.
-       - [0x002] Minor collection and major GC slice.
-       - [0x004] Growing and shrinking of the heap.
-       - [0x008] Resizing of stacks and memory manager tables.
-       - [0x010] Heap compaction.
-       - [0x020] Change of GC parameters.
-       - [0x040] Computation of major GC slice size.
-       - [0x080] Calling of finalisation functions.
-       - [0x100] Bytecode executable and shared library search at start-up.
-       - [0x200] Computation of compaction-triggering condition.
-       - [0x400] Output GC statistics at program exit.
+       - [0x0001] Start and end of major GC cycle.
+       - [0x0002] Minor collection and major GC slice.
+       - [0x0004] Growing and shrinking of the heap.
+       - [0x0008] Resizing of stacks and memory manager tables.
+       - [0x0010] Heap compaction.
+       - [0x0020] Change of GC parameters.
+       - [0x0040] Computation of major GC slice size.
+       - [0x0080] Calling of finalisation functions.
+       - [0x0100] Bytecode executable and shared library search at start-up.
+       - [0x0200] Computation of compaction-triggering condition.
+       - [0x0400] Output GC statistics at program exit.
+       - [0x0800] GC debugging messages.
+       - [0x1000] Address space reservation changes.
        Default: 0. *)
 
     max_overhead : int;


### PR DESCRIPTION
The runtime has many uses of explicit constants such as `0x400` which name bits in the `caml_verb_gc` variable set by `OCAMLRUNPARAM=v=` or the `verbose` field in `Gc.set`. This change introduces names in the runtime for all of those bits (and identifies those which are not currently used). Note that this doesn't fix the fact that the usage of the bits is inconsistent. This is a port and fixup of ocaml/ocaml#13441.