### PR TITLE
Generally better runtime logging

### DIFF
--- a/man/ocamlrun.1
+++ b/man/ocamlrun.1
@@ -238,45 +238,62 @@ runtime).
 What GC messages to print to stderr.  This is a sum of values selected
 from the following:
 
-.B 0x001
-Start and end of major GC cycle.
+.B 0x00001
+Main events of each major GC cycle.
 
-.B 0x002
-Minor collection and major GC slice.
+.B 0x00002
+Minor collection events.
 
-.B 0x004
-Growing and shrinking of the heap.
+.B 0x00004
+Per-slice events.
 
-.B 0x008
-Resizing of stacks and memory manager tables.
-
-.B 0x010
+.B 0x00008
 Heap compaction.
 
-.BR 0x020
+.B 0x00010
+GC policy computations.
+
+.B 0x00020
+Address space reservation changes.
+
+.B 0x00040
+Major domain events (such as creation and termination).
+
+.B 0x00080
+Stop-the-world events.
+
+.B 0x00100
+Minor heap events (such as creation and resizing).
+
+.B 0x00200
+Major heap events (such as creation and teardown).
+
+.B 0x00400
+Resizing of GC tables.
+
+.B 0x00800
+Allocation and resizing of stacks.
+
+.B 0x01000
+Output GC statistics at program exit.
+
+.B 0x02000
 Change of GC parameters.
 
-.BR 0x040
-Computation of major GC slice size.
+.B 0x04000
+Calling of finalization functions.
 
-.BR 0x080
-Calling of finalisation functions.
+.B 0x08000
+Bytecode executable and shared library search at start-up.
 
-.BR 0x100
-Startup messages (loading the bytecode executable file, resolving
-shared libraries).
-
-.BR 0x200
-Computation of compaction-triggering condition.
-
-.BR 0x400
-Output GC statistics at program exit, in the same format as Gc.print_stat.
-
-.BR 0x800
+.B 0x10000
 GC debugging messages.
 
-.BR 0x1000
-Address space reservation changes.
+.B 0x20000
+Changes to the major GC mark stack.
+
+.B 0x10000000
+Do not include timestamp and domain ID in log messages.
 
 .TP
 .BR w " (window_size)"

--- a/manual/src/cmds/runtime.etex
+++ b/manual/src/cmds/runtime.etex
@@ -183,20 +183,25 @@ The following environment variables are also consulted:
   \item[v] ("verbose")  What GC messages to print to stderr.  This
   is a sum of values selected from the following:
   \begin{options}
-        \item[1   (= 0x001)] Start and end of major GC cycle.
-        \item[2   (= 0x002)] Minor collection and major GC slice.
-        \item[4   (= 0x004)] Growing and shrinking of the heap.
-        \item[8   (= 0x008)] Resizing of stacks and memory manager tables.
-        \item[16  (= 0x010)] Heap compaction.
-        \item[32  (= 0x020)] Change of GC parameters.
-        \item[64  (= 0x040)] Computation of major GC slice size.
-        \item[128 (= 0x080)] Calling of finalization functions
-        \item[256 (= 0x100)] Startup messages (loading the bytecode
-           executable file, resolving shared libraries).
-        \item[512 (= 0x200)] Computation of compaction-triggering condition.
-        \item[1024 (= 0x400)] Output GC statistics at program exit.
-        \item[2048 (= 0x800)] GC debugging messages.
-        \item[4096 (= 0x1000)] Address space reservation changes.
+        \item[1   (= 0x00001)] Main events of each major GC cycle.
+        \item[2   (= 0x00002)] Minor collection events.
+        \item[4   (= 0x00004)] Per-slice events.
+        \item[8   (= 0x00008)] Heap compaction.
+        \item[16  (= 0x00010)] GC policy computations.
+        \item[32  (= 0x00020)] Address space reservation changes.
+        \item[64  (= 0x00040)] Major domain events (such as creation and termination).
+        \item[128 (= 0x00080)] Stop-the-world events.
+        \item[256 (= 0x00100)] Minor heap events (such as creation and resizing).
+        \item[512 (= 0x00200)] Major heap events (such as creation and teardown).
+        \item[1024 (= 0x00400)] Resizing of GC tables.
+        \item[2048 (= 0x00800)] Allocation and resizing of stacks.
+        \item[4096 (= 0x01000)] Output GC statistics at program exit.
+        \item[8192 (= 0x02000)] Change of GC parameters.
+        \item[16384 (= 0x04000)] Calling of finalization functions.
+        \item[32768 (= 0x08000)] Bytecode executable and shared library search at start-up.
+        \item[65536 (= 0x10000)] GC debugging messages.
+        \item[131072 (= 0x20000)] Changes to the major GC mark stack.
+        \item[268435456 (= 0x10000000)] Do not include timestamp and domain ID in log messages.
   \end{options}
   \item[V] ("verify_heap") runs an integrity check on the heap just after
     the completion of a major GC cycle

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -507,43 +507,53 @@ CAMLextern int caml_read_directory(char_os * dirname,
 
 extern _Atomic uintnat caml_verb_gc;
 
-/* Bits which may be set in caml_verb_gc. The quotations are from the
- * OCaml manual. */
+/* Bits which may be set in caml_verb_gc. Keep in sync with the OCaml
+ * manual, the ocamlrun.1 man page, and gc.mli */
 
-/* "Start and end of major GC cycle" (unused) */
-#define CAML_GC_MSG_MAJOR           0x0001
-/* "Minor collection and major GC slice" (unused) */
-#define CAML_GC_MSG_MINOR           0x0002
-/* "Growing and shrinking of the heap" */
-#define CAML_GC_MSG_HEAPSIZE        0x0004
-/* "Resizing of stacks and memory manager tables" */
-#define CAML_GC_MSG_STACKSIZE       0x0008
-/* "Heap compaction" (unused) */
-#define CAML_GC_MSG_COMPACT         0x0010
-/* "Change of GC parameters" */
-#define CAML_GC_MSG_PARAMS          0x0020
-/* "Computation of major GC slice size" */
-#define CAML_GC_MSG_SLICESIZE       0x0040
-/* "Calling of finalization functions" */
-#define CAML_GC_MSG_FINALIZE        0x0080
-/* "Startup messages" */
-#define CAML_GC_MSG_STARTUP         0x0100
-/* "Computation of compaction-triggering condition" (unused) */
-#define CAML_GC_MSG_COMPACT_TRIGGER 0x0200
-/* "Output GC statistics at program exit" */
-#define CAML_GC_MSG_STATS           0x0400
-/* "GC debugging messages */
-#define CAML_GC_MSG_DEBUG           0x0800
-/* "Address space reservation changes" */
-#define CAML_GC_MSG_ADDRSPACE       0x1000
+/* Main events of each major GC cycle */
+#define CAML_GC_MSG_MAJOR           0x00001
+/* Minor collection events */
+#define CAML_GC_MSG_MINOR           0x00002
+/* Per-slice events */
+#define CAML_GC_MSG_SLICE           0x00004
+/* Heap compaction */
+#define CAML_GC_MSG_COMPACT         0x00008
+/* GC policy computations */
+#define CAML_GC_MSG_POLICY          0x00010
+/* Address space reservation changes */
+#define CAML_GC_MSG_ADDRSPACE       0x00020
+/* Major domain events (such as creation and termination) */
+#define CAML_GC_MSG_DOMAIN          0x00040
+/* Stop-the-world events */
+#define CAML_GC_MSG_STW             0x00080
+/* Minor heap events (such as creation and resizing) */
+#define CAML_GC_MSG_MINOR_HEAP      0x00100
+/* Major heap events (such as creation and teardown) */
+#define CAML_GC_MSG_MAJOR_HEAP      0x00200
+/* Resizing of GC tables */
+#define CAML_GC_MSG_TABLES          0x00400
+/* Allocation and resizing of stacks */
+#define CAML_GC_MSG_STACKS          0x00800
+/* Output GC statistics at program exit */
+#define CAML_GC_MSG_STATS           0x01000
+/* Change of GC parameters */
+#define CAML_GC_MSG_PARAMS          0x02000
+/* Calling of finalization functions */
+#define CAML_GC_MSG_FINALIZE        0x04000
+/* Bytecode executable and shared library search at start-up */
+#define CAML_GC_MSG_STARTUP         0x08000
+/* GC debugging messages */
+#define CAML_GC_MSG_DEBUG           0x10000
+/* Changes to the major GC mark stack */
+#define CAML_GC_MSG_MARK_STACK      0x20000
+/* Do not include timestamp and domain ID in log messages */
+#define CAML_GC_MSG_NO_TIMESTAMP    0x10000000
 
 /* Default set of messages when runtime invoked with -v */
 
-#define CAML_GC_MSG_VERBOSE (CAML_GC_MSG_MAJOR     | \
-                             CAML_GC_MSG_HEAPSIZE  | \
-                             CAML_GC_MSG_STACKSIZE | \
-                             CAML_GC_MSG_COMPACT   | \
-                             CAML_GC_MSG_PARAMS)
+#define CAML_GC_MSG_VERBOSE (CAML_GC_MSG_MAJOR           | \
+                             CAML_GC_MSG_DOMAIN          | \
+                             CAML_GC_MSG_COMPACT)
 
 /* Use to control messages which should be output at any non-zero verbosity */
 

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -51,7 +51,8 @@ static void compare_free_stack(struct compare_stack* stk)
 /* Same, then raise Out_of_memory */
 CAMLnoret static void compare_stack_overflow(struct compare_stack* stk)
 {
-  CAML_GC_MESSAGE(HEAPSIZE, "Stack overflow in structural comparison\n");
+  CAML_GC_MESSAGE(DEBUG,
+                  "Stack overflow in structural comparison.\n");
   compare_free_stack(stk);
   caml_raise_out_of_memory();
 }

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -432,14 +432,16 @@ Caml_inline void check_minor_heap(void) {
   caml_domain_state* domain_state = Caml_state;
   CAMLassert(domain_state->young_ptr == domain_state->young_end);
 
-  caml_gc_log("young_start: %p, young_end: %p, minor_heap_area_start: %p,"
-      " minor_heap_area_end: %p, minor_heap_wsz: %"
-      ARCH_SIZET_PRINTF_FORMAT "u words",
-      domain_state->young_start,
-      domain_state->young_end,
-      (value*)domain_self->minor_heap_area_start,
-      (value*)domain_self->minor_heap_area_end,
-      domain_state->minor_heap_wsz);
+  CAML_GC_MESSAGE(DEBUG,
+                  "check_minor_heap: "
+                  "young_start: %p, young_end: %p, minor_heap_area_start: %p,"
+                  " minor_heap_area_end: %p, minor_heap_wsz: %"
+                  ARCH_SIZET_PRINTF_FORMAT "u words\n",
+                  domain_state->young_start,
+                  domain_state->young_end,
+                  (value*)domain_self->minor_heap_area_start,
+                  (value*)domain_self->minor_heap_area_end,
+                  domain_state->minor_heap_wsz);
   CAMLassert(
     (/* uninitialized minor heap */
       domain_state->young_start == NULL
@@ -453,9 +455,10 @@ Caml_inline void check_minor_heap(void) {
 static void free_minor_heap(void) {
   caml_domain_state* domain_state = Caml_state;
 
-  caml_gc_log ("trying to free old minor heap: %"
-        ARCH_SIZET_PRINTF_FORMAT "uk words",
-        domain_state->minor_heap_wsz / 1024);
+  CAML_GC_MESSAGE(MINOR_HEAP,
+                  "Freeing old minor heap: %"
+                  ARCH_SIZET_PRINTF_FORMAT "uk words\n",
+                  domain_state->minor_heap_wsz / 1024);
 
   check_minor_heap();
 
@@ -485,8 +488,9 @@ static int allocate_minor_heap(asize_t wsize) {
 
   CAMLassert (wsize <= caml_minor_heap_max_wsz);
 
-  caml_gc_log ("trying to allocate minor heap: %"
-               ARCH_SIZET_PRINTF_FORMAT "uk words", wsize / 1024);
+  CAML_GC_MESSAGE(MINOR_HEAP,
+                  "Allocating minor heap: %"
+                  ARCH_SIZET_PRINTF_FORMAT "uk words\n", wsize / 1024);
 
   char name[32];
   snprintf(name, sizeof name, "minor heap %d", domain_self->id);
@@ -564,6 +568,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   CAMLassert (domain_self == 0);
 
+  CAML_GC_MESSAGE(DOMAIN, "Creating a domain.\n");
   /* take the all_domains_lock so that we can alter the STW participant
      set atomically */
   caml_plat_lock_blocking(&all_domains_lock);
@@ -785,7 +790,11 @@ init_memprof_failure:
 
 
 domain_init_complete:
-  caml_gc_log("domain init complete");
+  if (domain_self) {
+    CAML_GC_MESSAGE(DOMAIN, "Creation complete.\n");
+  } else {
+    CAML_GC_MESSAGE(DOMAIN, "Creation failed.\n");
+  }
   caml_plat_unlock(&all_domains_lock);
 }
 
@@ -834,8 +843,9 @@ static void reserve_minor_heaps_from_stw_single(void) {
   caml_minor_heaps_start = (uintnat) heaps_base;
   caml_minor_heaps_end = (uintnat) heaps_base + minor_heap_reservation_bsize;
 
-  caml_gc_log("new minor heap reserved from %p to %p",
-              (value*)caml_minor_heaps_start, (value*)caml_minor_heaps_end);
+  CAML_GC_MESSAGE(MINOR_HEAP,
+                  "Minor heaps reserved from %p to %p.\n",
+                  (value*)caml_minor_heaps_start, (value*)caml_minor_heaps_end);
 
   for (int i = 0; i < caml_params->max_domains; i++) {
     struct dom_internal* dom = &all_domains[i];
@@ -854,7 +864,7 @@ static void reserve_minor_heaps_from_stw_single(void) {
 static void unreserve_minor_heaps_from_stw_single(void) {
   uintnat size;
 
-  caml_gc_log("unreserve_minor_heaps");
+  CAML_GC_MESSAGE(MINOR_HEAP, "Unreserving minor heaps.\n");
 
   for (int i = 0; i < caml_params->max_domains; i++) {
     struct dom_internal* dom = &all_domains[i];
@@ -887,8 +897,7 @@ static
 void domain_resize_heap_reservation_from_stw_single(uintnat new_minor_wsz)
 {
   CAML_EV_BEGIN(EV_DOMAIN_RESIZE_HEAP_RESERVATION);
-  caml_gc_log("stw_resize_minor_heap_reservation: "
-              "unreserve_minor_heaps");
+  CAML_GC_MESSAGE(MINOR_HEAP, "Unreserving old minor heaps.\n");
 
   unreserve_minor_heaps_from_stw_single();
   /* new_minor_wsz is (huge)page-aligned because caml_norm_minor_heap_size has
@@ -896,7 +905,7 @@ void domain_resize_heap_reservation_from_stw_single(uintnat new_minor_wsz)
      [reserve_minor_heaps_from_stw_single].)
   */
   caml_minor_heap_max_wsz = new_minor_wsz;
-  caml_gc_log("stw_resize_minor_heap_reservation: reserve_minor_heaps");
+  CAML_GC_MESSAGE(MINOR_HEAP, "Reserving new minor heaps.\n");
   reserve_minor_heaps_from_stw_single();
   /* The call to [reserve_minor_heaps_from_stw_single] makes a new
      reservation, and it also updates the reservation boundaries of each
@@ -914,22 +923,18 @@ static void
 stw_resize_minor_heap_reservation(caml_domain_state* domain,
                                   void* minor_wsz_data,
                                   int participating_count,
-                                  caml_domain_state** participating) {
-  caml_gc_log("stw_resize_minor_heap_reservation: "
-              "caml_empty_minor_heap_no_major_slice_from_stw");
+                                  caml_domain_state** participating)
+{
+  uintnat new_minor_wsz = *(uintnat*) minor_wsz_data;
   caml_empty_minor_heap_no_major_slice_from_stw(
     domain, NULL, participating_count, participating);
 
-  caml_gc_log("stw_resize_minor_heap_reservation: free_minor_heap");
   free_minor_heap();
 
   Caml_global_barrier_if_final(participating_count) {
-    uintnat new_minor_wsz = (uintnat) minor_wsz_data;
     domain_resize_heap_reservation_from_stw_single(new_minor_wsz);
   }
 
-  caml_gc_log("stw_resize_minor_heap_reservation: "
-              "allocate_minor_heap");
   /* Note: each domain allocates its own minor heap. This seems
      important to get good NUMA behavior. We don't want a single
      domain to allocate all minor heaps, which could create locality
@@ -937,15 +942,20 @@ stw_resize_minor_heap_reservation(caml_domain_state* domain,
   if (allocate_minor_heap(Caml_state->minor_heap_wsz) < 0) {
     caml_fatal_error("Fatal error: No memory for minor heap");
   }
+  CAML_GC_MESSAGE(MINOR_HEAP,
+                  "Changed minor heap max wsize to "
+                  "%"ARCH_INTNAT_PRINTF_FORMAT"u.\n",
+                  new_minor_wsz);
 }
 
 void caml_update_minor_heap_max(uintnat requested_wsz) {
-  caml_gc_log("Changing heap_max_wsz from %" ARCH_INTNAT_PRINTF_FORMAT
-              "u to %" ARCH_INTNAT_PRINTF_FORMAT "u.",
+  CAML_GC_MESSAGE(MINOR_HEAP,
+                  "Changing minor heap max wsize from %" ARCH_INTNAT_PRINTF_FORMAT
+                  "u to %" ARCH_INTNAT_PRINTF_FORMAT "u.\n",
               caml_minor_heap_max_wsz, requested_wsz);
   while (requested_wsz > caml_minor_heap_max_wsz) {
     caml_try_run_on_all_domains(
-      &stw_resize_minor_heap_reservation, (void*)requested_wsz, 0);
+      &stw_resize_minor_heap_reservation, (void*)&requested_wsz, 0);
   }
   check_minor_heap();
 }
@@ -1256,8 +1266,9 @@ static void* domain_thread_func(void* v)
   if (domain_self) {
     install_backup_thread(domain_self);
 
-    caml_gc_log("Domain starting (unique_id = %"ARCH_INTNAT_PRINTF_FORMAT"u)",
-                domain_self->interruptor.unique_id);
+    CAML_GC_MESSAGE(DOMAIN,
+                    "Domain starting (unique ID %"ARCH_INTNAT_PRINTF_FORMAT"u)\n",
+                    domain_self->interruptor.unique_id);
     CAML_EV_LIFECYCLE(EV_DOMAIN_SPAWN, getpid());
     /* FIXME: ignoring errors during domain initialization is unsafe
        and/or can deadlock. */
@@ -1289,8 +1300,6 @@ static void* domain_thread_func(void* v)
        destroyed by [caml_mutex_finalize] finaliser while it remains
        locked, leading to undefined behaviour. */
     free_domain_ml_values(ml_values);
-  } else {
-    caml_gc_log("Failed to create domain");
   }
 #ifndef _WIN32
   caml_free_signal_stack(signal_stack);
@@ -1319,6 +1328,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
                                     sizeof(struct domain_ml_values));
   init_domain_ml_values(p.ml_values, callback, term_sync);
 
+  CAML_GC_MESSAGE(DOMAIN, "Creating a child domain.\n");
   err = pthread_create(&th, 0, domain_thread_func, (void*)&p);
 
   if (err) {
@@ -1450,7 +1460,7 @@ static void decrement_stw_domains_still_processing(void)
     caml_plat_lock_blocking(&all_domains_lock);
     atomic_store_release(&stw_leader, 0);
     caml_plat_broadcast(&all_domains_cond);
-    caml_gc_log("clearing stw leader");
+    CAML_GC_MESSAGE(STW, "End of STW.\n");
     caml_plat_unlock(&all_domains_lock);
   }
 }
@@ -1611,7 +1621,7 @@ int caml_try_run_on_all_domains_with_spin_work(
   int i;
   caml_domain_state* domain_state = domain_self->state;
 
-  caml_gc_log("requesting STW, sync=%d", sync);
+  CAML_GC_MESSAGE(STW, "Request STW, sync=%d\n", sync);
 
   /* Don't touch the lock if there's already a stw leader
      OR we can't get the lock.
@@ -1651,7 +1661,7 @@ int caml_try_run_on_all_domains_with_spin_work(
   atomic_store_release(&stw_leader, (uintnat)domain_self);
 
   CAML_EV_BEGIN(EV_STW_LEADER);
-  caml_gc_log("causing STW");
+  CAML_GC_MESSAGE(STW, "Stopping the world.\n");
 
   /* set up all fields for this stw_request; they must be available
      for domains when they get interrupted */
@@ -2024,7 +2034,7 @@ static void domain_terminate (void)
   struct interruptor* s = &domain_self->interruptor;
   int finished = 0;
 
-  caml_gc_log("Domain terminating");
+  CAML_GC_MESSAGE(DOMAIN, "Domain terminating.\n");
   s->terminating = 1;
 
   /* Join ongoing systhreads, if necessary, and then run user-defined

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -470,7 +470,7 @@ static void extern_failwith(struct caml_extern_state* s, char *msg)
 
 static void extern_stack_overflow(struct caml_extern_state* s)
 {
-  CAML_GC_MESSAGE(HEAPSIZE,
+  CAML_GC_MESSAGE(DEBUG,
                   "Stack overflow in marshaling value\n");
   free_extern_output(s);
   caml_raise_out_of_memory();

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -108,9 +108,10 @@ void caml_change_max_stack_size (uintnat new_max_wsize)
 
   if (new_max_wsize < wsize) new_max_wsize = wsize;
   if (new_max_wsize != caml_max_stack_wsize){
-    caml_gc_log ("Changing stack limit to %"
-                 ARCH_INTNAT_PRINTF_FORMAT "uk bytes",
-                     new_max_wsize * sizeof (value) / 1024);
+    CAML_GC_MESSAGE(STACKS,
+                    "Changing stack limit to %"
+                    ARCH_INTNAT_PRINTF_FORMAT "uk bytes\n",
+                    Bsize_wsize(new_max_wsize) / 1024);
   }
   caml_max_stack_wsize = new_max_wsize;
 }
@@ -810,13 +811,15 @@ int caml_try_realloc_stack(asize_t required_space)
   } while (wsize < stack_used + required_space);
 
   if (wsize > 4096 / sizeof(value)) {
-    caml_gc_log ("Growing stack to %"
-                 ARCH_INTNAT_PRINTF_FORMAT "uk bytes",
-                 (uintnat) wsize * sizeof(value) / 1024);
+    CAML_GC_MESSAGE(STACKS,
+                    "Growing stack to %"
+                    ARCH_INTNAT_PRINTF_FORMAT "uk bytes\n",
+                    Bsize_wsize(wsize) / 1024);
   } else {
-    caml_gc_log ("Growing stack to %"
-                 ARCH_INTNAT_PRINTF_FORMAT "u bytes",
-                 (uintnat) wsize * sizeof(value));
+    CAML_GC_MESSAGE(STACKS,
+                    "Growing stack to %"
+                    ARCH_INTNAT_PRINTF_FORMAT "u bytes\n",
+                    Bsize_wsize(wsize) * sizeof(value));
   }
 
   new_stack = caml_alloc_stack_noexc(wsize,

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -246,17 +246,12 @@ CAMLprim value caml_gc_set(value v)
   }
 
   if (newminwsz > caml_minor_heap_max_wsz) {
-    caml_gc_log ("update minor heap max: %"
-                 ARCH_INTNAT_PRINTF_FORMAT "uk words", newminwsz / 1024);
+    CAML_GC_MESSAGE(PARAMS, "New minor heap max: %"
+                    ARCH_INTNAT_PRINTF_FORMAT "uk words\n", newminwsz / 1024);
     caml_update_minor_heap_max(newminwsz);
   }
   CAMLassert(newminwsz <= caml_minor_heap_max_wsz);
   if (newminwsz != Caml_state->minor_heap_wsz) {
-    caml_gc_log ("current minor heap size: %"
-                 ARCH_SIZET_PRINTF_FORMAT "uk words",
-                 Caml_state->minor_heap_wsz / 1024);
-    caml_gc_log ("set minor heap size: %"
-                 ARCH_INTNAT_PRINTF_FORMAT "uk words", newminwsz / 1024);
     /* FIXME: when (newminwsz > caml_minor_heap_max_wsz) and
        (newminwsz != Caml_state->minor_heap_wsz) are both true,
        the current domain reallocates its own minor heap twice. */
@@ -281,7 +276,7 @@ CAMLprim value caml_gc_minor(value v)
 static value gc_major_exn(int compaction)
 {
   CAML_EV_BEGIN(EV_EXPLICIT_GC_MAJOR);
-  caml_gc_log ("Major GC cycle requested");
+  CAML_GC_MESSAGE(MAJOR, "Major GC cycle requested\n");
   caml_empty_minor_heaps_once();
   caml_finish_major_cycle(compaction);
   caml_reset_major_pacing();
@@ -304,7 +299,7 @@ static value gc_full_major_exn(void)
   int i;
   value exn = Val_unit;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_FULL_MAJOR);
-  caml_gc_log ("Full Major GC requested");
+  CAML_GC_MESSAGE(MAJOR, "Full Major GC requested\n");
   /* In general, it can require up to 3 GC cycles for a
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
@@ -388,9 +383,9 @@ void caml_init_gc (void)
 #endif
   caml_percent_free = norm_pfree (caml_params->init_percent_free);
   caml_max_percent_free = norm_pmax (caml_params->init_max_percent_free);
-  caml_gc_log ("Initial stack limit: %"
-               ARCH_INTNAT_PRINTF_FORMAT "uk bytes",
-               caml_params->init_max_stack_wsz / 1024 * sizeof (value));
+  CAML_GC_MESSAGE(STACKS, "Initial stack limit: %"
+                  ARCH_INTNAT_PRINTF_FORMAT "uk bytes\n",
+                  Bsize_wsize(caml_params->init_max_stack_wsz) / 1024);
 
   caml_custom_major_ratio =
       norm_custom_maj (caml_params->init_custom_major_ratio);

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -337,7 +337,8 @@ static void readfloats(struct caml_intern_state* s,
 
 CAMLnoret static void intern_stack_overflow(struct caml_intern_state* s)
 {
-  CAML_GC_MESSAGE(HEAPSIZE, "Stack overflow in un-marshaling value\n");
+  CAML_GC_MESSAGE(DEBUG,
+                  "Stack overflow in un-marshaling value\n");
   intern_cleanup(s);
   caml_raise_out_of_memory();
 }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -610,7 +610,7 @@ void caml_local_realloc(void)
   for (i = Caml_state->local_sp; i < 0; i += sizeof(value)) {
     *((header_t*)(arena + s->next_length + i)) = Local_uninit_hd;
   }
-  CAML_GC_MESSAGE(STACKSIZE,
+  CAML_GC_MESSAGE(STACKS,
                   "Growing local stack to %"ARCH_INTNAT_PRINTF_FORMAT"d kB\n",
                   s->next_length / 1024);
   s->count++;

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -150,7 +150,7 @@ CAMLprim value caml_realloc_global(value size)
   actual_size = Wosize_val(old_global_data);
   if (requested_size >= actual_size) {
     requested_size = (requested_size + 0x100) & 0xFFFFFF00;
-    CAML_GC_MESSAGE(STACKSIZE, "Growing global data to %"
+    CAML_GC_MESSAGE(TABLES, "Growing global data to %"
                      ARCH_INTNAT_PRINTF_FORMAT "u entries\n",
                      requested_size);
     new_global_data = caml_alloc_shr(requested_size, 0);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -92,7 +92,7 @@ static void clear_table (struct generic_table *tbl,
     tbl->ptr = tbl->base;
     tbl->limit = tbl->threshold;
   } else {
-    CAML_GC_MESSAGE (STACKSIZE, "Shrinking %s to %ldk bytes\n",
+    CAML_GC_MESSAGE (TABLES, "Shrinking %s to %ldk bytes\n",
                      name,
                      (long)((maxsz * element_size) / 1024));
     alloc_generic_table(tbl, Caml_state->minor_heap_wsz, 256, element_size);
@@ -596,7 +596,7 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
 
   prev_alloc_words = domain->allocated_words;
 
-  caml_gc_log ("Minor collection of domain %d starting", domain->id);
+  CAML_GC_MESSAGE(MINOR, "Minor collection starting.\n");
   CAML_EV_BEGIN(EV_MINOR);
   call_timing_hook(&caml_minor_gc_begin_hook);
 
@@ -649,16 +649,17 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
 
       /* if we're the last domain this time, cover all the remaining refs */
       if( curr_idx == participating_count-1 ) {
-        caml_gc_log("taking remainder");
         ref_end = foreign_major_ref->ptr;
       }
 
-      caml_gc_log("idx: %d, foreign_domain: %d, ref_size: %"
-        ARCH_INTNAT_PRINTF_FORMAT"d, refs_per_domain: %"
-        ARCH_INTNAT_PRINTF_FORMAT"d, ref_base: %p, ref_ptr: %p, ref_start: %p"
-        ", ref_end: %p",
-        participating_idx, foreign_domain->id, major_ref_size, refs_per_domain,
-        foreign_major_ref->base, foreign_major_ref->ptr, ref_start, ref_end);
+      CAML_GC_MESSAGE(MINOR,
+                      "Oldifying foreign refs from domain %d, count %"
+                      ARCH_INTNAT_PRINTF_FORMAT"d [%p, %p), per participant %"
+                      ARCH_INTNAT_PRINTF_FORMAT"d. Participant %d oldifying [%p, %p).\n",
+                      foreign_domain->id, major_ref_size,
+                      foreign_major_ref->base, foreign_major_ref->ptr,
+                      refs_per_domain, participating_idx,
+                      ref_start, ref_end);
 
       for( r = ref_start ; r < foreign_major_ref->ptr && r < ref_end ; r++ )
       {
@@ -707,18 +708,20 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
                           domain, false);
   CAML_EV_END(EV_MINOR_MEMPROF_ROOTS);
 
+  CAML_GC_MESSAGE(MINOR, "roots complete (%d roots). Mopping up.\n",
+                  remembered_roots);
   CAML_EV_BEGIN(EV_MINOR_REMEMBERED_SET_PROMOTE);
   mopup_result_s mopup_result = oldify_mopup (&st, 1); /* ephemerons promoted here */
   result.locked_ephemerons = mopup_result.locked_ephemerons;
   CAML_EV_END(EV_MINOR_REMEMBERED_SET_PROMOTE);
   CAML_EV_END(EV_MINOR_REMEMBERED_SET);
-  caml_gc_log("promoted %d roots, %" ARCH_INTNAT_PRINTF_FORMAT "u bytes",
-              remembered_roots, st.live_bytes);
-
+  CAML_GC_MESSAGE(MINOR, "Promoted %"ARCH_INTNAT_PRINTF_FORMAT"u bytes.\n",
+                  st.live_bytes);
 #ifdef DEBUG
   caml_global_barrier(participating_count);
-  caml_gc_log("ref_base: %p, ref_ptr: %p",
-    self_minor_tables->major_ref.base, self_minor_tables->major_ref.ptr);
+  CAML_GC_MESSAGE(DEBUG, "major ref table [%p, %p).\n",
+                  self_minor_tables->major_ref.base,
+                  self_minor_tables->major_ref.ptr);
   for (r = self_minor_tables->major_ref.base;
        r < self_minor_tables->major_ref.ptr; r++) {
     value vnew = **r;
@@ -736,10 +739,23 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
   if (scan_roots_hook != NULL)
     (*scan_roots_hook)(&oldify_one, oldify_scanning_flags, &st, domain);
 
+  CAML_GC_MESSAGE(MINOR, "Local roots done. Mopping up.\n");
   CAML_EV_BEGIN(EV_MINOR_LOCAL_ROOTS_PROMOTE);
   (void)oldify_mopup (&st, 0); /* ignore result as we're not doing ephemerons */
   CAML_EV_END(EV_MINOR_LOCAL_ROOTS_PROMOTE);
   CAML_EV_END(EV_MINOR_LOCAL_ROOTS);
+  if (minor_allocated_bytes) {
+    CAML_GC_MESSAGE(MINOR,
+                    "Promoted %"ARCH_INTNAT_PRINTF_FORMAT"u bytes "
+                    "(%2.0f%% of %u KB)\n",
+                    st.live_bytes,
+                    (100.0 * st.live_bytes) / minor_allocated_bytes,
+                    (unsigned)(minor_allocated_bytes + 512)/1024);
+  } else {
+    CAML_GC_MESSAGE(MINOR,
+                    "Promoted %"ARCH_INTNAT_PRINTF_FORMAT"u bytes (of zero)\n",
+                    st.live_bytes);
+  }
 
   CAML_EV_BEGIN(EV_MINOR_MEMPROF_CLEAN);
   caml_memprof_after_minor_gc(domain);
@@ -789,10 +805,6 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
   CAML_EV_COUNTER(EV_C_MINOR_ALLOCATED, minor_allocated_bytes);
 
   CAML_EV_END(EV_MINOR);
-  caml_gc_log ("Minor collection of domain %d completed: %2.0f%% of %u KB live",
-               domain->id,
-               100.0 * (double)st.live_bytes / (double)minor_allocated_bytes,
-               (unsigned)(minor_allocated_bytes + 512)/1024);
 
   /* leave the barrier */
   if( participating_count > 1 ) {
@@ -914,7 +926,7 @@ int caml_do_opportunistic_major_slice
   if (work_available) {
     /* NB: need to put guard around the ev logs to prevent spam when we poll */
     uintnat log_events =
-        atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_SLICESIZE;
+        atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_SLICE;
     if (log_events) CAML_EV_BEGIN(EV_MAJOR_MARK_OPPORTUNISTIC);
     caml_opportunistic_major_collection_slice(Major_slice_work_min);
     if (log_events) CAML_EV_END(EV_MAJOR_MARK_OPPORTUNISTIC);
@@ -964,13 +976,12 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
     nonatomic_increment_counter(&caml_minor_cycles_started);
   }
 
-  caml_gc_log("running stw empty_minor_heap_promote");
   promote_result_s prom =
     caml_empty_minor_heap_promote(domain, participating_count, participating);
 
   if (prom.locked_ephemerons) {
     CAML_EV_BEGIN(EV_MINOR_EPHE_CLEAN);
-    caml_gc_log("cleaning minor ephemerons");
+    CAML_GC_MESSAGE(MINOR, "Cleaning minor ephemerons.\n");
     ephe_clean_minor(domain);
     CAML_EV_END(EV_MINOR_EPHE_CLEAN);
   }
@@ -980,22 +991,22 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
     caml_mark_roots_stw(participating_count, participating);
 
   CAML_EV_BEGIN(EV_MINOR_FINALIZED);
-  caml_gc_log("finalizing dead minor custom blocks");
+  CAML_GC_MESSAGE(MINOR, "Finalizing dead minor custom blocks.\n");
   custom_finalize_minor(domain);
   CAML_EV_END(EV_MINOR_FINALIZED);
 
   CAML_EV_BEGIN(EV_MINOR_DEPENDENT);
-  caml_gc_log("accounting for minor blocks with dependent memory");
+  CAML_GC_MESSAGE(MINOR, "Accounting for minor blocks with dependent memory.\n");
   dependent_accounting_minor(domain);
   CAML_EV_END(EV_MINOR_DEPENDENT);
 
   CAML_EV_BEGIN(EV_MINOR_FINALIZERS_ADMIN);
-  caml_gc_log("running finalizer data structure book-keeping");
+  CAML_GC_MESSAGE(MINOR, "Finalizer data structure book-keeping.\n");
   caml_final_update_last_minor(domain);
   CAML_EV_END(EV_MINOR_FINALIZERS_ADMIN);
 
   CAML_EV_BEGIN(EV_MINOR_CLEAR);
-  caml_gc_log("running stw empty_minor_heap_domain_clear");
+  CAML_GC_MESSAGE(MINOR, "Clearing minor heap data structures.\n");
   caml_empty_minor_heap_domain_clear(domain);
 
 #ifdef DEBUG
@@ -1007,9 +1018,8 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
 
   CAML_EV_END(EV_MINOR_CLEAR);
 
-  caml_gc_log("finished stw empty_minor_heap");
   CAMLassert(domain->young_ptr == domain->young_end);
-
+  CAML_GC_MESSAGE(MINOR, "Minor collection done.\n");
   Caml_state->in_minor_collection = 0;
 }
 
@@ -1047,7 +1057,7 @@ int caml_try_empty_minor_heap_on_all_domains (void)
   CAMLassert(!caml_domain_is_in_stw());
   #endif
 
-  caml_gc_log("requesting stw empty_minor_heap");
+  CAML_GC_MESSAGE(MINOR, "Requesting minor collection.\n");
   uintnat mark_requested;
   return caml_try_run_on_all_domains_with_spin_work(
     1, /* synchronous */
@@ -1169,7 +1179,7 @@ static void realloc_generic_table
                          element_size);
   }else if (tbl->limit == tbl->threshold){
     CAML_EV_COUNTER (ev_counter_name, 1);
-    CAML_GC_MESSAGE(STACKSIZE, msg_threshold, 0);
+    CAML_GC_MESSAGE(TABLES, msg_threshold, 0);
     tbl->limit = tbl->end;
     caml_request_minor_gc ();
   }else{
@@ -1178,7 +1188,7 @@ static void realloc_generic_table
 
     tbl->size *= 2;
     sz = (tbl->size + tbl->reserve) * element_size;
-    CAML_GC_MESSAGE(STACKSIZE, msg_growing, (intnat) sz/1024);
+    CAML_GC_MESSAGE(TABLES, msg_growing, (intnat) sz/1024);
     tbl->base = caml_stat_resize_noexc (tbl->base, sz);
     if (tbl->base == NULL){
       caml_fatal_error ("%s", msg_error);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -86,9 +86,8 @@ static void print_log(const char* msg, int newline, va_list ap)
 {
   char buf[GC_LOG_LENGTH];
   int pos = 0;
-  if (caml_verb_gc & 0x1000) {
-    pos += caml_format_timestamp(buf, sizeof(buf),
-                                 caml_verb_gc & 0x2000);
+  if (!(atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_NO_TIMESTAMP)) {
+    pos += caml_format_timestamp(buf, sizeof(buf), 1);
   }
   pos += snprintf(buf+pos, sizeof(buf)-pos,
                   "[%02d] ",

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -147,6 +147,28 @@ type control =
     (** This value controls the GC messages on standard error output.
        It is a sum of some of the following flags, to print messages
        on the corresponding events:
+        - [0x00001]    Main events of each major GC cycle
+        - [0x00002]    Minor collection events
+        - [0x00004]    Per-slice events
+        - [0x00008]    Heap compaction
+        - [0x00010]    GC policy computations
+        - [0x00020]    Address space reservation changes
+        - [0x00040]    Major domain events (such as creation and termination)
+        - [0x00080]    Stop-the-world events
+        - [0x00100]    Minor heap events (such as creation and resizing)
+        - [0x00200]    Major heap events (such as creation and teardown)
+        - [0x00400]    Resizing of GC tables
+        - [0x00800]    Allocation and resizing of stacks
+        - [0x01000]    Output GC statistics at program exit
+        - [0x02000]    Change of GC parameters
+        - [0x04000]    Calling of finalization functions
+        - [0x08000]    Bytecode executable and shared library search at start-up
+        - [0x10000]    GC debugging messages
+        - [0x20000]    Changes to the major GC mark stack
+        - [0x10000000] Do not include timestamp and domain ID in log messages
+
+        For runtime 4, the flags are as follows (although the messages
+        produced may not fit these descriptions very well):
        - [0x0001] Start and end of major GC cycle.
        - [0x0002] Minor collection and major GC slice.
        - [0x0004] Growing and shrinking of the heap.
@@ -159,7 +181,8 @@ type control =
        - [0x0200] Computation of compaction-triggering condition.
        - [0x0400] Output GC statistics at program exit.
        - [0x0800] GC debugging messages.
-       - [0x1000] Address space reservation changes.
+       - [0x1000] Include domain ID in log messages.
+       - [0x2000] Include timestamp in log messages.
        Default: 0. *)
 
     max_overhead : int;


### PR DESCRIPTION
Since #3584 it's clear that runtime logging is a bit rubbish: some control bits were unused, others were overloaded (especially 0x400, `caml_gc_log`), some important things weren't being logged, and logs were dominated by non-useful messages. This PR is an overhaul of all that: retaining the underlying mechanism but turning almost all `caml_gc_log` messages into `CAML_GC_MESSAGE` messages of an appropriate category. Also: creating new categories, adding some messages, removing others.
Reviewer should test with various `OCAMLRUNPARAM=v=` values.
This includes and is dependent on #3584. There will be a small merge conflict with #3585.