### PR TITLE
Avoid free of uninitialized pointer in st_stubs.c

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -684,6 +684,7 @@ static void caml_thread_domain_initialize_hook(void)
   new_thread->backtrace_last_exn = Val_unit;
   new_thread->memprof = caml_memprof_main_thread(Caml_state);
   new_thread->is_main = 1;
+  new_thread->signal_stack = NULL;
 
   st_tls_set(caml_thread_key, new_thread);
 


### PR DESCRIPTION
Ported from ocaml/ocaml#13400, q.v.

Calling caml_c_thread_unregister() will (amongst many other things) free the caml_thread_t signal_stack entry of the current thread.  The OCaml runtime initializes the main thread using special code in caml_thread_domain_initialize_hook, but this leaves the signal_stack entry uninitialized.

If you use glibc tunables to enable malloc checking, and especially use the malloc.perturb feature[1], then uninitialized areas of memory are filled with a repeating pattern.  This causes the process to crash if you free an uninitialized pointer.

Thus any program which calls caml_c_thread_unregister on the main thread, and is using glibc malloc checking, will crash.

Fix this by initializing the signal_stack to NULL (since free(NULL) is permitted and does nothing).