### PR TITLE
Fix debug runtime assertion location in domain.c

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -344,8 +344,8 @@ static void stw_handler(caml_domain_state* domain);
 static int handle_incoming(struct interruptor* s)
 {
   int handled = interruptor_has_pending(s);
-  CAMLassert (s->running);
   if (handled) {
+    CAMLassert (s->running);
     interruptor_set_handled(s);
 
     stw_handler(domain_self->state);


### PR DESCRIPTION
Ported from ocaml/ocaml#13408, q.v.

It only makes sense to confirm the domain interruptor is in running state if there are interrupts to handle. There is a possibility of a domain exiting while the backup thread, in BT_IN_BLOCKING_SECTION state, is waiting for the domain lock; it will then proceed to invoke handle_incoming() as there had been pending interrupts at the time it tried to acquire the domain lock, but domain termination has taken care of them.

Therefore handle_incoming() should be safe to invoke with the interruptor in non-running state, as long as there are indeed no pending interrupts.

(cherry picked from commit 1c70e4dfaf3e5b2b5f6d02e76d8f8b1ffa488b0e)