### PR TITLE
build: Only set OCAMLPARAM if BUILD_OCAMLPARAM is defined

### DIFF
--- a/Makefile.common-jst
+++ b/Makefile.common-jst
@@ -25,6 +25,12 @@ define dune_boot_context
     (env-vars ("OCAMLPARAM" ""))))))
 endef
 
+ifneq ($(origin BUILD_OCAMLPARAM), undefined)
+ENV_VARS := (env-vars ("OCAMLPARAM" "$(BUILD_OCAMLPARAM)"))
+else
+ENV_VARS :=
+endif
+
 define dune_runtime_stdlib_context
 (lang dune 2.8)
 (context (default
@@ -35,7 +41,7 @@ define dune_runtime_stdlib_context
     (OCAMLLIB ("$(CURDIR)/_build/_bootinstall/lib/ocaml")))
   (env (_
     (flags (:standard -warn-error +A -alert -unsafe_multidomain))
-    (env-vars ("OCAMLPARAM" "$(BUILD_OCAMLPARAM)"))))))
+    $(ENV_VARS)))))
 endef
 
 define dune_main_context
@@ -50,7 +56,7 @@ define dune_main_context
     (flags (:standard -warn-error +A -alert -unsafe_multidomain))
     ; We never want to build the compiler itself with AddressSanitizer enabled.
     (ocamlopt_flags (:standard -fno-asan))
-    (env-vars ("OCAMLPARAM" "$(BUILD_OCAMLPARAM)"))))))
+    $(ENV_VARS)))))
 endef
 
 


### PR DESCRIPTION
Setting the value of OCAMLPARAM in the workspace file is useful for CI, but annoying for local development as OCAMLPARAM is a good way to selectively enable features when testing.

This patch sets the value of OCAMLPARAM while building the stdlib or compiler to the value of BUILD_OCAMLPARAM, unless BUILD_OCAMLPARAM is not defined.