### PR TITLE
If runtime events ring is inactive after callback, do not write to it

### DIFF
--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -760,6 +760,11 @@ CAMLprim value caml_runtime_events_user_write(
       caml_raise(res);
     }
 
+    /* Need to check whether the ring is active again as the ring might
+     * potentially have been destroyed during the callback. */
+    if ( !ring_is_active() )
+      CAMLreturn(Val_unit);
+
     uintnat len_bytes = Int_val(res);
     uintnat len_64bit_word = (len_bytes + sizeof(uint64_t)) / sizeof(uint64_t);
     uintnat offset_index = len_64bit_word * sizeof(uint64_t) - 1;


### PR DESCRIPTION
Ported from ocaml/ocaml#13522, q.v.

Need to check whether the ring is still active after a callback. It may be possible that ring has been destroyed during the execution of the callback.

(cherry picked from commit bf63f888ccd49e8fc93685b677a576d4c89437d4)