### PR TITLE
A series of runtime-events fixes ported from upstream

### DIFF
--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -373,6 +373,7 @@ end
 external start : unit -> unit = "caml_ml_runtime_events_start"
 external pause : unit -> unit = "caml_ml_runtime_events_pause"
 external resume : unit -> unit = "caml_ml_runtime_events_resume"
+external path : unit -> string option = "caml_ml_runtime_events_path"
 
 external create_cursor : (string * int) option -> cursor
                                         = "caml_ml_runtime_events_create_cursor"

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -269,6 +269,10 @@ val start : unit -> unit
   a set of callbacks to be called for each type of event.
 *)
 
+val path : unit -> string option
+(** If runtime events are being collected, [path ()] returns [Some p] where [p]
+  is a path to the runtime events file. Otherwise, it returns None. *)
+
 val pause : unit -> unit
 (** [pause ()] will pause the collection of events in the runtime.
    Traces are collected if the program has called [Runtime_events.start ()] or

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -149,17 +149,23 @@ typedef char* caml_stat_string;
    the request fails, and so requires the runtime lock to be held.
 */
 CAMLextern caml_stat_string caml_stat_strdup(const char *s);
-#ifdef _WIN32
-CAMLextern wchar_t* caml_stat_wcsdup(const wchar_t *s);
-#endif
 
 /* [caml_stat_strdup_noexc] is a variant of [caml_stat_strdup] that returns NULL
    in case the request fails, and doesn't require the runtime lock.
 */
 CAMLextern caml_stat_string caml_stat_strdup_noexc(const char *s);
 
-/* [caml_stat_strconcat(nargs, strings)] concatenates NULL-terminated [strings]
-   (an array of [char*] of size [nargs]) into a new string, dropping all NULLs,
+#ifdef _WIN32
+/* On Windows, [caml_stat_wcsdup] and [caml_stat_wcsdup_noexc] are the
+ * obvious equivalents of [caml_stat_strdup] and
+ * [caml_stat_strdup_noexc] for wide characters.
+ */
+CAMLextern wchar_t* caml_stat_wcsdup(const wchar_t *s);
+CAMLextern wchar_t* caml_stat_wcsdup_noexc(const wchar_t *s);
+#endif
+
+/* [caml_stat_strconcat(nargs, strings)] concatenates null-terminated [strings]
+   (an array of [char*] of size [nargs]) into a new string, dropping all NULs,
    except for the very last one. It throws an OCaml exception in case the
    request fails, and so requires the runtime lock to be held.
 */

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -409,10 +409,12 @@ extern double caml_log1p(double);
 #define clock_os caml_win32_clock
 
 #define caml_stat_strdup_os caml_stat_wcsdup
+#define caml_stat_strdup_noexc_os caml_stat_wcsdup_noexc
 #define caml_stat_strconcat_os caml_stat_wcsconcat
 
 #define caml_stat_strdup_to_os caml_stat_strdup_to_utf16
 #define caml_stat_strdup_of_os caml_stat_strdup_of_utf16
+#define caml_stat_strdup_noexc_of_os caml_stat_strdup_noexc_of_utf16
 #define caml_copy_string_of_os caml_copy_string_of_utf16
 
 #else /* _WIN32 */
@@ -449,10 +451,12 @@ extern double caml_log1p(double);
 #define clock_os clock
 
 #define caml_stat_strdup_os caml_stat_strdup
+#define caml_stat_strdup_noexc_os caml_stat_strdup_noexc
 #define caml_stat_strconcat_os caml_stat_strconcat
 
 #define caml_stat_strdup_to_os caml_stat_strdup
 #define caml_stat_strdup_of_os caml_stat_strdup
+#define caml_stat_strdup_noexc_of_os caml_stat_strdup_noexc
 #define caml_copy_string_of_os caml_copy_string
 
 #endif /* _WIN32 */

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -176,12 +176,25 @@ extern void caml_init_os_params(void);
 */
 CAMLextern wchar_t* caml_stat_strdup_to_utf16(const char *s);
 
-/* [caml_stat_strdup_of_utf16(s)] returns a NULL-terminated copy of [s],
+/* [caml_stat_strdup_noexc_of_utf16(s)] returns a null-terminated copy of [s],
    re-encoded in UTF-8 if [caml_windows_unicode_runtime_enabled] is non-zero or
    the current Windows code page otherwise.
 
-   The returned string is allocated with [caml_stat_alloc], so it should be free
-   using [caml_stat_free].
+   The returned string is allocated with [caml_stat_alloc_noexc], so
+   it should be freed using [caml_stat_free].
+
+   If allocation fails, this returns NULL.
+*/
+CAMLextern char* caml_stat_strdup_noexc_of_utf16(const wchar_t *s);
+
+/* [caml_stat_strdup_of_utf16(s)] returns a null-terminated copy of [s],
+   re-encoded in UTF-8 if [caml_windows_unicode_runtime_enabled] is non-zero or
+   the current Windows code page otherwise.
+
+   The returned string is allocated with [caml_stat_alloc_noexc], so
+   it should be freed using [caml_stat_free].
+
+   If allocation fails, this raises Out_of_memory.
 */
 CAMLextern char* caml_stat_strdup_of_utf16(const wchar_t *s);
 

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -280,8 +280,10 @@ void caml_runtime_events_destroy(void);
    in a forked child */
 CAMLextern void caml_runtime_events_post_fork(void);
 
-/* Returns the location of the runtime_events for the current process if started
-   or NULL otherwise */
+/* Return the path of the ring buffers file of this process, or NULL
+   if runtime events are not enabled. This is used in the consumer to
+   read the ring buffers of the current process. Always returns a
+   freshly-allocated string. */
 CAMLextern char_os* caml_runtime_events_current_location(void);
 
 /* Functions for putting runtime data on to the runtime_events. These are all

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -954,13 +954,21 @@ CAMLexport caml_stat_string caml_stat_strdup(const char *s)
 
 #ifdef _WIN32
 
-CAMLexport wchar_t * caml_stat_wcsdup(const wchar_t *s)
+CAMLexport wchar_t * caml_stat_wcsdup_noexc(const wchar_t *s)
 {
   int slen = wcslen(s);
   wchar_t* result = caml_stat_alloc((slen + 1)*sizeof(wchar_t));
   if (result == NULL)
-    caml_fatal_out_of_memory();
+    return NULL;
   memcpy(result, s, (slen + 1)*sizeof(wchar_t));
+  return result;
+}
+
+CAMLexport wchar_t * caml_stat_wcsdup(const wchar_t *s)
+{
+  wchar_t* result = caml_stat_wcsdup_noexc(s);
+  if (result == NULL)
+    caml_raise_out_of_memory();
   return result;
 }
 

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -486,20 +486,26 @@ CAMLprim value caml_ml_runtime_events_resume(value vunit) {
   caml_runtime_events_resume(); return Val_unit;
 }
 
-CAMLprim value caml_ml_runtime_events_path(value vunit) {
+CAMLprim value caml_ml_runtime_events_path(value vunit)
+{
   CAMLparam0();
-  CAMLlocal1 (res);
-  res = Val_none;
+  CAMLlocal2(res, str);
+
   if (atomic_load_acquire(&runtime_events_enabled)) {
-    res = caml_alloc_small(1, Tag_some);
     /* The allocation might GC, which could allow another domain to
-     * nuke current_ring_loc, so we check again. */
-    if (atomic_load_acquire(&runtime_events_enabled)) {
-      Field(res, 0) = caml_copy_string_of_os(current_ring_loc);
-    } else {
-      res = Val_none;
-    }
+     * nuke current_ring_loc, so we snapshot it first. */
+
+    char_os* current_ring_loc_str = caml_stat_strdup_os(current_ring_loc);
+
+    res = caml_alloc(1, Tag_some);
+    str = caml_copy_string_of_os(current_ring_loc_str);
+    Store_field(res, 0, str);
+
+    caml_stat_free(current_ring_loc_str);
+  } else {
+    res = Val_none;
   }
+
   CAMLreturn(res);
 }
 

--- a/runtime4/win32.c
+++ b/runtime4/win32.c
@@ -942,15 +942,25 @@ CAMLexport wchar_t* caml_stat_strdup_to_utf16(const char *s)
   return ws;
 }
 
-CAMLexport caml_stat_string caml_stat_strdup_of_utf16(const wchar_t *s)
+CAMLexport caml_stat_string caml_stat_strdup_noexc_of_utf16(const wchar_t *s)
 {
   caml_stat_string out;
   int retcode;
 
-  retcode = win_wide_char_to_multi_byte(s, -1, NULL, 0);
-  out = caml_stat_alloc(retcode);
-  win_wide_char_to_multi_byte(s, -1, out, retcode);
+  retcode = caml_win32_wide_char_to_multi_byte(s, -1, NULL, 0);
+  out = caml_stat_alloc_noexc(retcode);
+  if (out != NULL) {
+    caml_win32_wide_char_to_multi_byte(s, -1, out, retcode);
+  }
 
+  return out;
+}
+
+CAMLexport caml_stat_string caml_stat_strdup_of_utf16(const wchar_t *s)
+{
+  caml_stat_string out = caml_stat_strdup_noexc_of_utf16(s);
+  if (out == NULL)
+    caml_raise_out_of_memory();
   return out;
 }
 

--- a/testsuite/tests/lib-runtime-events/test_corrupted.ml
+++ b/testsuite/tests/lib-runtime-events/test_corrupted.ml
@@ -1,0 +1,136 @@
+(* TEST
+{
+   runtime4;
+   skip;
+}{
+   include runtime_events;
+   include unix;
+   runtime5;
+   libunix;
+   set OCAML_RUNTIME_EVENTS_PRESERVE = "1";
+   { bytecode; }
+   { native; }
+ }
+*)
+
+  let runtime_begin _ _ _ = ()
+  let runtime_end _ _ _ = ()
+  let runtime_counter _ _ _ _ = ()
+  let alloc _ _ _ = ()
+  let lifecycle _ _ _ _ = ()
+  let lost_events _ _ = ()
+  let callbacks = Runtime_events.Callbacks.create
+    ~runtime_begin ~runtime_end ~runtime_counter ~alloc ~lifecycle ~lost_events ()
+
+  let parse path_pid =
+    let cursor =
+        Runtime_events.create_cursor path_pid in
+    let finally () = Runtime_events.free_cursor cursor in
+    Fun.protect ~finally @@ fun () ->
+    Runtime_events.read_poll cursor callbacks None
+
+  let parse_corrupted path_pid =
+    try let (_:int) = parse path_pid in ()
+    with Failure _ | Invalid_argument _ ->
+      (* parsing corrupted rings, raises exceptions,
+         this is expected *)
+      ()
+
+  let buf = Bytes.create (8 * 8)
+
+  let with_ring ring_file f =
+    let fd = Unix.openfile ring_file [Unix.O_RDWR] 0 in
+    let finally () = Unix.close fd in
+    Fun.protect ~finally @@ fun () ->
+    let size = Int64.to_int Unix.LargeFile.((fstat fd).st_size) in
+    let n = Unix.read fd buf 0 (Bytes.length buf) in
+    assert (n = Bytes.length buf);
+    let version = Bytes.get_int64_ne buf 0 in
+    assert (version = 1L);
+    (* this needs to be updated if on-disk layout changes *)
+    let data_offset = Bytes.get_int64_ne buf (6*8) in
+
+    let write_event_header is_runtime event_type event_id event_length =
+      let (<<:) i n = Int64.(shift_left (of_int i) n) and (|:) = Int64.logor in
+      (* see runtime_events.h *)
+      let event_header =
+        (event_length <<: 54) |:
+        (is_runtime <<: 53) |:
+        (event_type <<: 49) |:
+        (event_id <<: 36)
+      in
+      Bytes.set_int64_ne buf 0 event_header;
+      let n = Unix.LargeFile.lseek fd data_offset Unix.SEEK_SET in
+      assert (n = data_offset);
+      let n = Unix.write fd buf 0 (Bytes.length buf) in
+      assert (n = Bytes.length buf)
+    in
+
+    let write_metadata_header offset value =
+      let offset = Int64.of_int offset in
+      let n = Unix.LargeFile.lseek fd offset Unix.SEEK_SET in
+      assert (n = offset);
+      Bytes.set_int64_ne buf 0 value;
+      let n = Unix.write fd buf 0 (Bytes.length buf) in
+      assert (n = Bytes.length buf)
+    in
+
+    f ~size ~write_event_header ~write_metadata_header
+
+  (* this tests the preservation of ring buffers after termination *)
+
+  let () =
+    (* start runtime_events now to avoid a race *)
+    let parent_cwd = Sys.getcwd () in
+    let child_pid = Unix.fork () in
+    if child_pid == 0 then begin
+      (* we are in the child, so start Runtime_events *)
+      Runtime_events.start ();
+      (* this creates a ring buffer. Now exit. *)
+    end else begin
+      (* now wait for our child to finish *)
+      Unix.wait () |> ignore;
+      (* child has finished. We now have a valid ring *)
+      let ring_file =
+          Filename.concat parent_cwd (string_of_int child_pid ^ ".events")
+      and path_pid = Some (parent_cwd, child_pid);
+         in
+      let finally () = Unix.unlink ring_file in
+      Fun.protect ~finally @@ fun () ->
+      with_ring ring_file @@ fun ~size ~write_event_header ~write_metadata_header ->
+      (* we must succeed parsing it as is *)
+      let n = parse path_pid in
+      assert (n > 0);
+      let original = Bytes.to_string buf in
+
+      (* now overwrite various fields, corrupting the ring,
+         and check that we don't crash (raising exceptions is fine).
+       *)
+      for offset = 8 downto 0 do
+        [0L; size * 3/4 |> Int64.of_int; size * 2 |> Int64.of_int;
+         Int64.max_int; Int64.min_int; Int64.(shift_right_logical max_int 1)
+        ] |> List.iter @@ fun value ->
+        write_metadata_header (8 * offset) value;
+        parse_corrupted path_pid;
+        (* restore original, we only corrupt and test one offset at a time,
+           otherwise we may not find missing bounds checks if we exit early
+           due to bounds error on an earlier offset
+         *)
+        Bytes.blit_string original 0 buf 0 (Bytes.length buf);
+      done;
+      (* restore metadata header, so we have a valid ring again *)
+      write_metadata_header 0 1L (* version *);
+
+      for is_runtime = 0 to 1 do
+        for event_type = 0 to 15 (* event type is 4 bits *) do
+          for event_id = 0 to 64 (* event_id is 13 bits, but not all used yet *) do
+            for length = 0 to 3 (* short lengths trigger uninit read bugs *) do
+                (* modify just 1 event in the otherwise valid ring *)
+                write_event_header is_runtime event_type event_id length;
+                (* parse ring *)
+                parse_corrupted path_pid;
+            done
+          done
+        done;
+      done;
+    end

--- a/testsuite/tests/lib-runtime-events/test_create_cursor_failures.ml
+++ b/testsuite/tests/lib-runtime-events/test_create_cursor_failures.ml
@@ -1,0 +1,50 @@
+(* TEST
+{
+   runtime4;
+   skip;
+}{
+   runtime5;
+   include unix;
+   include runtime_events;
+   libunix;
+   { bytecode; }
+   { native; }
+ }
+*)
+
+(* Tests that [create_cursor]:
+ * - fails on [None] if runtime events haven't been started
+ * - doesn't double-free when it fails to attach to [None]
+ * - does manage to attach to this process if we provide the right PID
+ *)
+
+let create_and_free ?(pid) () =
+  try
+    let dir_and_pid = Option.map (fun p -> ".", p) pid in
+    let cur = Runtime_events.create_cursor dir_and_pid in
+    Runtime_events.free_cursor cur;
+    print_endline "OK"
+  with Failure msg -> print_endline msg
+
+let start_and_pause () =
+  Runtime_events.start ();
+  Runtime_events.pause ()
+
+(* Windows workaround to get the correct PID *)
+let find_events_pid cursor =
+  Scanf.sscanf (Option.get (Runtime_events.path())) "%d.events" Fun.id
+
+(* force failure of [create_cursor None] *)
+let make_unreadable () =
+  Unix.chmod (Option.get (Runtime_events.path())) 0o000
+
+let () =
+  create_and_free (); (* fail, not started *)
+  start_and_pause ();
+  let pid = find_events_pid () in
+  create_and_free ~pid (); (* success *)
+  create_and_free (); (* success *)
+  make_unreadable ();
+  create_and_free ~pid (); (* fail, cannot open *)
+  create_and_free (); (* fail, cannot open *)
+  create_and_free (); (* fail, cannot open *)

--- a/testsuite/tests/lib-runtime-events/test_create_cursor_failures.reference
+++ b/testsuite/tests/lib-runtime-events/test_create_cursor_failures.reference
@@ -1,0 +1,6 @@
+Runtime_events: no ring for current process.          Was runtime_events started?
+OK
+OK
+Runtime_events: could not create cursor for specified path.
+Runtime_events: could not create cursor for specified path.
+Runtime_events: could not create cursor for specified path.


### PR DESCRIPTION
Ports of ocaml/ocaml#13297 and ocaml/ocaml#13419.

Data races on metadata, overflow in multiplication, failure with short message length, failure with corrupted rings, uninitialized data reads. Clean recovery from various initialisation failures.

Bugs found by ASAN, -fsanitize=memory -fsanitize-memory-track-origins, AFL, and inspection, and mostly reproducible by included test-cases.