### PR TITLE
Separate the mechanisms and APIs for dependent memory and custom blocks

### DIFF
--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -33,6 +33,7 @@ type runtime_counter =
 | EV_C_MAJOR_HEAP_POOL_FRAG_WORDS
 | EV_C_MAJOR_HEAP_POOL_LIVE_BLOCKS
 | EV_C_MAJOR_HEAP_LARGE_BLOCKS
+| EV_C_REQUEST_MINOR_REALLOC_DEPENDENT_TABLE
 
 type runtime_phase =
 | EV_EXPLICIT_GC_SET
@@ -84,6 +85,7 @@ type runtime_phase =
 | EV_COMPACT_FORWARD
 | EV_COMPACT_RELEASE
 | EV_MINOR_EPHE_CLEAN
+| EV_MINOR_DEPENDENT
 
 type lifecycle =
   EV_RING_START
@@ -122,6 +124,8 @@ let runtime_counter_name counter =
       "major_heap_pool_live_blocks"
   | EV_C_MAJOR_HEAP_LARGE_BLOCKS ->
       "major_heap_large_blocks"
+  | EV_C_REQUEST_MINOR_REALLOC_DEPENDENT_TABLE ->
+      "request_minor_realloc_dependent_table"
 
 let runtime_phase_name phase =
   match phase with
@@ -174,6 +178,7 @@ let runtime_phase_name phase =
   | EV_COMPACT_FORWARD -> "compaction_forward"
   | EV_COMPACT_RELEASE -> "compaction_release"
   | EV_MINOR_EPHE_CLEAN -> "minor_ephe_clean"
+  | EV_MINOR_DEPENDENT -> "minor_dependent"
 
 let lifecycle_name lifecycle =
   match lifecycle with

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -87,6 +87,8 @@ Live blocks of a Domain's major heap pools.
 (**
 Live blocks of a Domain's major heap large allocations.
 @since 5.1 *)
+| EV_C_REQUEST_MINOR_REALLOC_DEPENDENT_TABLE
+(** Reallocation of the table of dependent memory from minor heap *)
 
 (** The type for span events emitted by the runtime. *)
 type runtime_phase =
@@ -139,6 +141,7 @@ type runtime_phase =
 | EV_COMPACT_FORWARD
 | EV_COMPACT_RELEASE
 | EV_MINOR_EPHE_CLEAN
+| EV_MINOR_DEPENDENT
 
 (** Lifecycle events for the ring itself. *)
 type lifecycle =

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -81,7 +81,7 @@ enum caml_ba_subarray {
 struct caml_ba_proxy {
   atomic_uintnat refcount;      /* Reference count */
   void * data;                  /* Pointer to base of actual data */
-  uintnat size;                 /* Size of data in bytes (if mapped file) */
+  uintnat size;                 /* Size of data in bytes */
 };
 
 struct caml_ba_array {

--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -53,6 +53,7 @@ extern "C" {
 
 
 CAMLextern uintnat caml_custom_major_ratio;
+CAMLextern uintnat caml_custom_minor_ratio;
 
 CAMLextern value caml_alloc_custom(const struct custom_operations * ops,
                                    uintnat size, /*size in bytes*/

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -142,7 +142,7 @@ DOMAIN_STATE(int, unique_id)
 DOMAIN_STATE(value, dls_root)
 /* Domain-local state */
 
-/* How much external memory is currenty held by the minor and major heap. */
+/* How much external memory is currenty held by the minor heap. */
 DOMAIN_STATE(uintnat, minor_dependent_bsz)
 
 /* How much work needs to be done (by all domains) before we stop this slice. */

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -90,6 +90,10 @@ DOMAIN_STATE(uintnat, allocated_words_direct)
 /* Number of words allocated directly to the major heap since the latest
    slice. (subset of allocated_words) */
 
+DOMAIN_STATE(uintnat, allocated_dependent_bytes)
+/* Number of external bytes whose pointers were promoted or allocated in
+   the major heap since latest slice. */
+
 DOMAIN_STATE(uintnat, swept_words)
 
 DOMAIN_STATE(uintnat, major_slice_epoch)
@@ -138,11 +142,8 @@ DOMAIN_STATE(int, unique_id)
 DOMAIN_STATE(value, dls_root)
 /* Domain-local state */
 
-DOMAIN_STATE(double, extra_heap_resources)
-DOMAIN_STATE(double, extra_heap_resources_minor)
-
-DOMAIN_STATE(uintnat, dependent_size)
-DOMAIN_STATE(uintnat, dependent_allocated)
+/* How much external memory is currenty held by the minor and major heap. */
+DOMAIN_STATE(uintnat, minor_dependent_bsz)
 
 /* How much work needs to be done (by all domains) before we stop this slice. */
 DOMAIN_STATE(intnat, slice_target)
@@ -165,6 +166,9 @@ DOMAIN_STATE(struct caml_intern_state*, intern_state)
 DOMAIN_STATE(uintnat, stat_minor_words)
 DOMAIN_STATE(uintnat, stat_promoted_words)
 DOMAIN_STATE(uintnat, stat_major_words)
+DOMAIN_STATE(uintnat, stat_minor_dependent_bytes)
+DOMAIN_STATE(uintnat, stat_promoted_dependent_bytes)
+DOMAIN_STATE(uintnat, stat_major_dependent_bytes)
 DOMAIN_STATE(intnat, stat_forced_major_collections)
 DOMAIN_STATE(uintnat, stat_blocks_marked)
 

--- a/runtime/caml/gc_stats.h
+++ b/runtime/caml/gc_stats.h
@@ -41,6 +41,7 @@ struct heap_stats {
   intnat large_words;
   intnat large_max_words;
   intnat large_blocks;
+  intnat dependent_bytes;
 };
 
 /* Note: accumulating stats then removing them is not a no-op, as
@@ -56,6 +57,9 @@ struct alloc_stats {
   uint64_t minor_words;
   uint64_t promoted_words;
   uint64_t major_words;
+  uint64_t minor_dependent_bytes;
+  uint64_t promoted_dependent_bytes;
+  uint64_t major_dependent_bytes;
   uint64_t forced_major_collections;
 };
 void caml_accum_alloc_stats(

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -120,6 +120,7 @@ typedef enum {
     EV_COMPACT_FORWARD,
     EV_COMPACT_RELEASE,
     EV_MINOR_EPHE_CLEAN,
+    EV_MINOR_DEPENDENT,
 } ev_runtime_phase;
 
 typedef enum {
@@ -140,6 +141,7 @@ typedef enum {
     EV_C_MAJOR_HEAP_POOL_FRAG_WORDS,
     EV_C_MAJOR_HEAP_POOL_LIVE_BLOCKS,
     EV_C_MAJOR_HEAP_LARGE_BLOCKS,
+    EV_C_REQUEST_MINOR_REALLOC_DEPENDENT_TABLE,
 } ev_runtime_counter;
 
 typedef enum {

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -39,6 +39,9 @@ value* caml_shared_try_alloc(struct caml_heap_state*,
 /* If we were to grow the shared heap, how much would we grow it? */
 uintnat caml_shared_heap_grow_bsize(void);
 
+/* Update the dependent_bytes field of the heap stats. */
+void caml_add_dependent_bytes (struct caml_heap_state *local, intnat n);
+
 /* Copy the domain-local heap stats into a heap stats sample. */
 void caml_collect_heap_stats_sample(
   struct caml_heap_state* local,

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -17,6 +17,7 @@
 
 #include <string.h>
 #include <assert.h>
+#include <stdbool.h>
 
 #include "caml/alloc.h"
 #include "caml/camlatomic.h"
@@ -53,8 +54,8 @@ mlsize_t caml_custom_get_max_major (void)
 
 static value alloc_custom_gen (const struct custom_operations * ops,
                                uintnat bsz,
-                               int minor_ok,
-                               int local)
+                               bool minor_ok,
+                               bool local)
 {
   mlsize_t wosize;
   CAMLparam0();
@@ -91,7 +92,7 @@ CAMLexport value caml_alloc_custom(const struct custom_operations * ops,
                                    mlsize_t mem,
                                    mlsize_t max)
 {
-  return alloc_custom_gen(ops, bsz, /* minor_ok: */ 1, /* local: */ 0);
+  return alloc_custom_gen(ops, bsz, /* minor_ok: */ true, /* local: */ false);
 }
 
 CAMLexport value caml_alloc_custom_local(const struct custom_operations * ops,
@@ -103,7 +104,7 @@ CAMLexport value caml_alloc_custom_local(const struct custom_operations * ops,
     caml_invalid_argument(
       "caml_alloc_custom_local: finalizers not supported");
 
-  return alloc_custom_gen(ops, bsz, /* minor_ok: */ 1, /* local: */ 1);
+  return alloc_custom_gen(ops, bsz, /* minor_ok: */ true, /* local: */ true);
 }
 
 CAMLexport value caml_alloc_custom_mem(const struct custom_operations * ops,
@@ -120,7 +121,7 @@ CAMLexport value caml_alloc_custom_mem(const struct custom_operations * ops,
 
   value v = alloc_custom_gen (ops, bsz,
                               /* minor_ok: */ (mem <= max_minor_single),
-                              /* local: */ 0);
+                              /* local: */ false);
   size_t mem_words = (mem + sizeof(value) - 1) / sizeof(value);
   caml_memprof_sample_block(v, mem_words, mem_words, CAML_MEMPROF_SRC_CUSTOM);
   return v;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -658,11 +658,8 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   CAMLassert(!interruptor_has_pending(s));
 
-  domain_state->extra_heap_resources = 0.0;
-  domain_state->extra_heap_resources_minor = 0.0;
-
-  domain_state->dependent_size = 0;
-  domain_state->dependent_allocated = 0;
+  domain_state->allocated_dependent_bytes = 0;
+  domain_state->minor_dependent_bsz = 0;
 
   domain_state->major_work_done_between_slices = 0;
 

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -38,6 +38,7 @@ void caml_accum_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
   acc->large_max_words = intnat_max(acc->large_max_words, acc->large_words);
   acc->large_max_words = intnat_max(acc->large_max_words, h->large_max_words);
   acc->large_blocks += h->large_blocks;
+  acc->dependent_bytes += h->dependent_bytes;
 }
 
 void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
@@ -48,6 +49,7 @@ void caml_remove_heap_stats(struct heap_stats* acc, const struct heap_stats* h)
   acc->pool_frag_words -= h->pool_frag_words;
   acc->large_words -= h->large_words;
   acc->large_blocks -= h->large_blocks;
+  acc->dependent_bytes -= h->dependent_bytes;
 }
 
 void caml_accum_alloc_stats(
@@ -57,6 +59,9 @@ void caml_accum_alloc_stats(
   acc->minor_words += s->minor_words;
   acc->promoted_words += s->promoted_words;
   acc->major_words += s->major_words;
+  acc->minor_dependent_bytes += s->minor_dependent_bytes;
+  acc->promoted_dependent_bytes += s->promoted_dependent_bytes;
+  acc->major_dependent_bytes += s->major_dependent_bytes;
   acc->forced_major_collections += s->forced_major_collections;
 }
 
@@ -67,6 +72,9 @@ void caml_collect_alloc_stats_sample(
   sample->minor_words = local->stat_minor_words;
   sample->promoted_words = local->stat_promoted_words;
   sample->major_words = local->stat_major_words;
+  sample->minor_dependent_bytes = local->stat_minor_dependent_bytes;
+  sample->promoted_dependent_bytes = local->stat_promoted_dependent_bytes;
+  sample->major_dependent_bytes = local->stat_major_dependent_bytes;
   sample->forced_major_collections = local->stat_forced_major_collections;
 }
 
@@ -75,6 +83,9 @@ void caml_reset_domain_alloc_stats(caml_domain_state *local)
   local->stat_minor_words = 0;
   local->stat_promoted_words = 0;
   local->stat_major_words = 0;
+  local->stat_minor_dependent_bytes = 0;
+  local->stat_promoted_dependent_bytes = 0;
+  local->stat_major_dependent_bytes = 0;
   local->stat_forced_major_collections = 0;
 }
 

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -715,7 +715,7 @@ static void intern_rec(struct caml_intern_state* s,
           s->intern_obj_table[s->obj_counter++] = v;
         if (ops->finalize != NULL && Is_young(v)) {
           /* Remember that the block has a finalizer. */
-          add_to_custom_table (&d->minor_tables->custom, v, 0, 1);
+          add_to_custom_table (&d->minor_tables->custom, v);
         }
         break;
       }

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -238,50 +238,47 @@ CAMLexport CAMLweakdef void caml_modify (volatile value *fp, value val)
 */
 CAMLexport void caml_alloc_dependent_memory (value v, mlsize_t nbytes)
 {
-  /* No-op for now */
+  if (nbytes == 0) return;
+  CAMLassert (Is_block (v));
+  if (Is_young (v)){
+    Caml_state->stat_minor_dependent_bytes += nbytes;
+    add_to_dependent_table (&Caml_state->minor_tables->dependent, v, nbytes);
+    Caml_state->minor_dependent_bsz += nbytes;
+    if (Caml_state->minor_dependent_bsz >
+          Bsize_wsize (Caml_state->minor_heap_wsz)
+          / 100 * caml_custom_minor_ratio){
+      caml_request_minor_gc ();
+    }
+  }else{
+    caml_add_dependent_bytes (Caml_state->shared_heap, nbytes);
+    Caml_state->allocated_dependent_bytes += nbytes;
+    /* FIXME sdolan: what's the right condition here? */
+    if (Caml_state->allocated_dependent_bytes
+        >= caml_custom_get_max_major() / 5){
+      CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
+      caml_request_major_slice(1);
+    }
+  }
 }
 
 CAMLexport void caml_free_dependent_memory (value v, mlsize_t nbytes)
 {
-  /* No-op for now */
+  CAMLassert (Is_block (v));
+  if (Is_young (v)){
+    Caml_state->minor_dependent_bsz -= nbytes;
+  }else{
+    caml_add_dependent_bytes (Caml_state->shared_heap, -nbytes);
+  }
 }
 
-/* Use this function to tell the major GC to speed up when you use
-   finalized blocks to automatically deallocate resources (other
-   than memory). The GC will do at least one cycle every [max]
-   allocated resources; [res] is the number of resources allocated
-   this time.
-   Note that only [res/max] is relevant.  The units (and kind of
-   resource) can change between calls to [caml_adjust_gc_speed].
-
-   If [max] = 0, then we use a number proportional to the major heap
-   size and [caml_custom_major_ratio]. In this case, [mem] should
-   be a number of bytes and the trade-off between GC work and space
-   overhead is under the control of the user through
-   [caml_custom_major_ratio].
-*/
 CAMLexport void caml_adjust_gc_speed (mlsize_t res, mlsize_t max)
 {
-  if (max == 0) max = caml_custom_get_max_major ();
-  if (res > max) res = max;
-  Caml_state->extra_heap_resources += (double) res / (double) max;
-  if (Caml_state->extra_heap_resources > 0.2){
-    CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ADJUST_GC_SPEED, 1);
-    caml_request_major_slice (1);
-  }
+  /* No-op, present only for compatibility */
 }
 
-/* This function is analogous to [caml_adjust_gc_speed]. When the
-   accumulated sum of [res/max] values reaches 1, a minor GC is
-   triggered.
-*/
 CAMLexport void caml_adjust_minor_gc_speed (mlsize_t res, mlsize_t max)
 {
-  if (max == 0) max = 1;
-  Caml_state->extra_heap_resources_minor += (double) res / (double) max;
-  if (Caml_state->extra_heap_resources_minor > 1.0) {
-    caml_request_minor_gc ();
-  }
+  /* No-op, present only for compatibility */
 }
 
 /* You must use [caml_intialize] to store the initial value in a field of a

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -244,17 +244,17 @@ CAMLexport void caml_alloc_dependent_memory (value v, mlsize_t nbytes)
     Caml_state->stat_minor_dependent_bytes += nbytes;
     add_to_dependent_table (&Caml_state->minor_tables->dependent, v, nbytes);
     Caml_state->minor_dependent_bsz += nbytes;
-    if (Caml_state->minor_dependent_bsz >
-          Bsize_wsize (Caml_state->minor_heap_wsz)
-          / 100 * caml_custom_minor_ratio){
+    uintnat max_minor =
+      Bsize_wsize (Caml_state->minor_heap_wsz) / 100 * caml_custom_minor_ratio;
+    if (Caml_state->minor_dependent_bsz > max_minor) {
       caml_request_minor_gc ();
     }
-  }else{
+  } else {
     caml_add_dependent_bytes (Caml_state->shared_heap, nbytes);
     Caml_state->allocated_dependent_bytes += nbytes;
     /* FIXME sdolan: what's the right condition here? */
-    if (Caml_state->allocated_dependent_bytes
-        >= caml_custom_get_max_major() / 5){
+    uintnat max_major = caml_custom_get_max_major() / 5;
+    if (Caml_state->allocated_dependent_bytes > max_major){
       CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
       caml_request_major_slice(1);
     }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -760,6 +760,11 @@ static void adopt_all_pool_stats_with_lock(struct caml_heap_state *adopter) {
   memset(&pool_freelist.stats, 0, sizeof(pool_freelist.stats));
 }
 
+void caml_add_dependent_bytes (struct caml_heap_state *local, intnat n)
+{
+  local->stats.dependent_bytes += n;
+}
+
 void caml_collect_heap_stats_sample(
   struct caml_heap_state* local,
   struct heap_stats* sample)


### PR DESCRIPTION
Previously, allocating a block with caml_alloc_custom or caml_alloc_custom_mem would both register a custom block finaliser and accelerate the GC.

Now, caml_alloc_custom(_mem) has no effect on GC, and the functions caml_adjust_gc_speed and caml_adjust_minor_gc_speed become noops. The GC speed increase for dependent memory happens only through caml_alloc_dependent_memory and caml_free_dependent_memory.

The function caml_alloc_custom_dep is available to call both caml_alloc_custom and caml_alloc_dependent_memory. However, the user must ensure to call caml_free_dependent_memory in their finaliser. (Bigarrays have already been updated to use this API in a previous patch)

This is to pave the way for a new GC pacing policy. However, no change to pacing is made by this patch - the GC should perform as previously on e.g. bigarray values, which have been ported to use the new API.

(Most of the code in this patch was written by @damiendoligez )