### PR TITLE
Fatal error if allocations fail inside [lf_]skiplist.c

### DIFF
--- a/runtime/caml/lf_skiplist.h
+++ b/runtime/caml/lf_skiplist.h
@@ -100,7 +100,7 @@ extern void caml_lf_skiplist_free_garbage(struct lf_skiplist *sk);
    [var] designates the current element.
    [action] can refer to [var->key] and [var->data].
    [action] can safely remove the current element, i.e. call
-   [caml_skiplist_remove] on [var->key].  The traversal will
+   [caml_lf_skiplist_remove] on [var->key].  The traversal will
    continue with the skiplist element following the removed element.
    Other operations performed over the skiplist during its traversal have
    unspecified effects on the traversal. */

--- a/runtime/skiplist.c
+++ b/runtime/skiplist.c
@@ -150,8 +150,10 @@ int caml_skiplist_insert(struct skiplist * sk,
       update[i] = &sk->forward[i];
     sk->level = new_level;
   }
-  f = caml_stat_alloc(SIZEOF_SKIPCELL +
-                      (new_level + 1) * sizeof(struct skipcell *));
+  f = caml_stat_alloc_noexc(SIZEOF_SKIPCELL +
+                            (new_level + 1) * sizeof(struct skipcell *));
+  if (f == NULL)
+    caml_fatal_error("caml_skiplist_insert: out of memory");
   f->key = key;
   f->data = data;
   for (i = 0; i <= new_level; i++) {


### PR DESCRIPTION
Ported from ocaml/ocaml#13613

Surfaces OOMs, rather than getting SEGVs.