### PR TITLE
Reimplement Axis_set in terms of a bitfield

### DIFF
--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -211,7 +211,8 @@ module Axis_collection : sig
 end
 
 module Axis_set : sig
-  type t
+  (** A set of [Axis.t], represented as a bitfield for efficiency. *)
+  type t [@@immediate]
 
   val empty : t
 
@@ -234,6 +235,8 @@ module Axis_set : sig
   val is_subset : t -> t -> bool
 
   val complement : t -> t
+
+  val to_seq : t -> Axis.packed Seq.t
 
   val to_list : t -> Axis.packed list
 


### PR DESCRIPTION
Reimplement Jkind_axis.Axis_set.t in terms of a bitfield, rather than a record
with 7 booleans, for improved performance. This is showing up as rather hot in a
profile, so it's worth microoptimizing.