### PR TITLE
Fix runtime deadlocks with judicious use of caml_plat_non_blocking

### DIFF
--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -447,14 +447,15 @@ static unsigned int hash_value_name(char const *name)
 
 CAMLprim value caml_register_named_value(value vname, value val)
 {
-  struct named_value * nv;
   const char * name = String_val(vname);
   size_t namelen = strlen(name);
   unsigned int h = hash_value_name(name);
   int found = 0;
 
-  caml_plat_lock_blocking(&named_value_lock);
-  for (nv = named_value_table[h]; nv != NULL; nv = nv->next) {
+  caml_plat_lock_non_blocking(&named_value_lock);
+  for (struct named_value *nv = named_value_table[h];
+       nv != NULL;
+       nv = nv->next) {
     if (strcmp(name, nv->name) == 0) {
       caml_modify_generational_global_root(&nv->val, val);
       found = 1;
@@ -462,7 +463,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
     }
   }
   if (!found) {
-    nv = (struct named_value *)
+    struct named_value *nv = (struct named_value *)
       caml_stat_alloc(sizeof(struct named_value) + namelen);
     memcpy(nv->name, name, namelen + 1);
     nv->val = val;
@@ -476,9 +477,8 @@ CAMLprim value caml_register_named_value(value vname, value val)
 
 CAMLexport const value* caml_named_value(char const *name)
 {
-  struct named_value * nv;
-  caml_plat_lock_blocking(&named_value_lock);
-  for (nv = named_value_table[hash_value_name(name)];
+  caml_plat_lock_non_blocking(&named_value_lock);
+  for (struct named_value *nv = named_value_table[hash_value_name(name)];
        nv != NULL;
        nv = nv->next) {
     if (strcmp(name, nv->name) == 0){
@@ -492,11 +492,11 @@ CAMLexport const value* caml_named_value(char const *name)
 
 CAMLexport void caml_iterate_named_values(caml_named_action f)
 {
-  int i;
-  caml_plat_lock_blocking(&named_value_lock);
-  for(i = 0; i < Named_value_size; i++){
-    struct named_value * nv;
-    for (nv = named_value_table[i]; nv != NULL; nv = nv->next) {
+  caml_plat_lock_non_blocking(&named_value_lock);
+  for (int i = 0; i < Named_value_size; i++){
+    for (struct named_value *nv = named_value_table[i];
+         nv != NULL;
+         nv = nv->next) {
       f( Op_val(nv->val), nv->name );
     }
   }

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -52,8 +52,12 @@ struct channel {
 
 enum {
   CHANNEL_FLAG_FROM_SOCKET = 1,  /* For Windows */
-  CHANNEL_FLAG_MANAGED_BY_GC = 4,  /* Free and close using GC finalization */
-  CHANNEL_TEXT_MODE = 8,           /* "Text mode" for Windows and Cygwin */
+  CHANNEL_FLAG_MANAGED_BY_GC = 4,  /* Free and close using GC finalization. */
+  /* Note: For backwards-compatibility, channels without the flag
+     CHANNEL_FLAG_MANAGED_BY_GC can be used inside single-threaded
+     programs without locking. As a consequence, using such a channel
+     from an asynchronous callback can result in deadlocks. */
+  CHANNEL_TEXT_MODE = 8, /* "Text mode" for Windows and Cygwin */
   CHANNEL_FLAG_UNBUFFERED = 16     /* Unbuffered (for output channels only) */
 };
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -101,6 +101,12 @@ typedef pthread_cond_t custom_condvar;
    The domain lock must be held in order to call
    [caml_plat_lock_non_blocking].
 
+   It is possible to combine calls to [caml_plat_lock_non_blocking] on
+   a mutex from the mutator holding the domain lock with calls to
+   [caml_plat_lock_blocking] on another mutator that has released
+   their domain lock, but not with calls to [caml_plat_lock_blocking]
+   from a STW section or a custom block finaliser.
+
    These functions never raise exceptions; errors are fatal. Thus, for
    usages where bugs are susceptible to be introduced by users, the
    functions from caml/sync.h should be used instead.

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -130,7 +130,14 @@ unsigned char *caml_digest_of_code_fragment(struct code_fragment *cf) {
   /* Note: this approach is a bit heavy-handed as we take a lock in
      all cases. It would be possible to take a lock only in the
      DIGEST_LATER case, which occurs at most once per fragment, by
-     using double-checked locking -- see #11791. */
+     using double-checked locking -- see #11791.
+
+     Note: we use [caml_plat_lock_blocking] despite holding the domain
+     lock because this is called by intern.c and extern.c, both of
+     which share state between threads of the same domain. The
+     critical section must therefore remain short and not allocate
+     (nor cause other potential STW).
+  */
   caml_plat_lock_blocking(&cf->mutex);
   {
     if (cf->digest_status == DIGEST_IGNORE) {

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -83,7 +83,9 @@ void caml_reset_domain_alloc_stats(caml_domain_state *local)
 static caml_plat_mutex orphan_lock = CAML_PLAT_MUTEX_INITIALIZER;
 static struct alloc_stats orphaned_alloc_stats = {0,};
 
-void caml_accum_orphan_alloc_stats(struct alloc_stats *acc) {
+void caml_accum_orphan_alloc_stats(struct alloc_stats *acc)
+{
+  /* This is called from the collector as well as from the mutator. */
   caml_plat_lock_blocking(&orphan_lock);
   caml_accum_alloc_stats(acc, &orphaned_alloc_stats);
   caml_plat_unlock(&orphan_lock);
@@ -97,6 +99,7 @@ void caml_orphan_alloc_stats(caml_domain_state *domain) {
   caml_reset_domain_alloc_stats(domain);
 
   /* push them into the orphan stats */
+  /* This is called from the collector as well as from the mutator. */
   caml_plat_lock_blocking(&orphan_lock);
   caml_accum_alloc_stats(&orphaned_alloc_stats, &alloc_stats);
   caml_plat_unlock(&orphan_lock);

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -27,6 +27,10 @@
 #include "caml/callback.h"
 #include "caml/fail.h"
 
+/* This mutex must be locked with [caml_plat_lock_blocking] from the
+   mutator, because caml_{register,remove}_{generational_}roots can be
+   called in places where the domain lock is not safe to be
+   released. */
 static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
 /* Greater than zero when the current thread is scanning the roots */

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -701,7 +701,7 @@ CAMLprim value caml_runtime_events_user_register(value event_name,
 
 
   /* Pre-allocate to avoid STW while holding [user_events_lock]. */
-  list_item = caml_alloc_small(2, 0);
+  list_item = caml_alloc(2, 0);
 
   /* [user_events_lock] can be acquired during STW, so we must use
      caml_plat_lock_blocking and be careful to avoid triggering any
@@ -716,8 +716,8 @@ CAMLprim value caml_runtime_events_user_register(value event_name,
   }
 
   // event is added to the list of known events
-  Field(list_item, 0) = event;
-  Field(list_item, 1) = user_events;
+  Store_field(list_item, 0, event);
+  Store_field(list_item, 1, user_events);
   caml_modify_generational_global_root(&user_events, list_item);
   // end critical section
   caml_plat_unlock(&user_events_lock);

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -374,6 +374,7 @@ static void runtime_events_create_from_stw_single(void) {
 
     // at the same instant: snapshot user_events list and set
     // runtime_events_enabled to 1
+    /* calling from STW */
     caml_plat_lock_blocking(&user_events_lock);
     value current_user_event = user_events;
     atomic_store_release(&runtime_events_enabled, 1);
@@ -699,6 +700,12 @@ CAMLprim value caml_runtime_events_user_register(value event_name,
   Field(event, 3) = event_tag;
 
 
+  /* Pre-allocate to avoid STW while holding [user_events_lock]. */
+  list_item = caml_alloc_small(2, 0);
+
+  /* [user_events_lock] can be acquired during STW, so we must use
+     caml_plat_lock_blocking and be careful to avoid triggering any
+     STW while holding it */
   caml_plat_lock_blocking(&user_events_lock);
   // critical section: when we update the user_events list we need to make sure
   // it is not updated while we construct the pointer to the next element
@@ -709,7 +716,6 @@ CAMLprim value caml_runtime_events_user_register(value event_name,
   }
 
   // event is added to the list of known events
-  list_item = caml_alloc_small(2, 0);
   Field(list_item, 0) = event;
   Field(list_item, 1) = user_events;
   caml_modify_generational_global_root(&user_events, list_item);


### PR DESCRIPTION
Ported from ocaml/ocaml#13227 and ocaml/ocaml#13714.
(note that #13714 reverted parts of #13227 and then took a different path; this combines both upstream PRs).