### PR TITLE
Smaller functorized test in `test_gen_u_array.ml`

### DIFF
--- a/testsuite/tests/typing-layouts-arrays/test_gen_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_gen_u_array.ml
@@ -246,7 +246,6 @@ module Test (A : S) : sig end = struct
   test_length 256;
   test_length 1000;
   test_length 1001;
-  test_length 123456;
 
   (* [init] *)
   let a = A.init 1000 I.of_int in
@@ -603,24 +602,24 @@ module Test (A : S) : sig end = struct
   assert (A.exists f a);
 
   (* [mem] *)
-  let a = A.init 7777 I.of_int in
+  let a = A.init 777 I.of_int in
   assert (A.mem (I.of_int 0) a);
-  assert (A.mem (I.of_int 7776) a);
+  assert (A.mem (I.of_int 776) a);
   assert (not (A.mem ((I.of_int (-1))) a));
-  assert (not (A.mem (I.of_int 7777) a));
+  assert (not (A.mem (I.of_int 777) a));
   let check v =
-    A.set a 1000 v;
+    A.set a 100 v;
     assert (A.mem v a);
   in
   List.iter check [I.max_val; I.min_val; (I.of_int (-1)); (I.of_int 0)];
 
-  let a = A.init 7778 I.of_int in
+  let a = A.init 778 I.of_int in
   assert (A.mem (I.of_int 0) a);
-  assert (A.mem (I.of_int 7777) a);
+  assert (A.mem (I.of_int 777) a);
   assert (not (A.mem ((I.of_int (-1))) a));
-  assert (not (A.mem (I.of_int 7778) a));
+  assert (not (A.mem (I.of_int 778) a));
   let check v =
-    A.set a 1001 v;
+    A.set a 101 v;
     assert (A.mem v a);
   in
   List.iter check [I.max_val; I.min_val; (I.of_int (-1)); (I.of_int 0)];
@@ -733,9 +732,9 @@ module Test (A : S) : sig end = struct
     check_sort s I.compare a; (* already sorted *)
     check_sort s (fun x y -> I.compare y x) a; (* reverse-sorted *)
 
-    let a = A.init 50000 rand_val in
+    let a = A.init 500 rand_val in
     check_sort s I.compare a;
-    let a = A.init 50001 rand_val in
+    let a = A.init 501 rand_val in
     check_sort s I.compare a;
     let a = A.make 1000 (I.of_int 1) in
     check_sort s I.compare a;


### PR DESCRIPTION
Use smaller array sizes for tests using `typing-layout-arrays/test_gen_u_array.ml`. Improves wall clock time of `make runtest-upstream` by ~2x (103s->53s).

---
### "Experiment log" for all changes I tried

This isn't necessary for reviewing the PR, but I'm leaving these notes for posterity. 

| Change                                | Real time of `make runtest-upstream` (1 trial)            |
|---------------------------------------|-------------------------|
| Baseline (main at c1a05006ae)                             | 103s  |
| Split generated tests (see [`split-makearray-dynamic-tests`](https://github.com/ocaml-flambda/flambda-backend/compare/split-makearray-dynamic-tests))                | 105s                    |
| Delete generated tests                    | 97s                     |
| Smaller functorized tests (this PR)         | 52s            |
| Smaller functorized tests & split generated tests | 53s                     |
| Delete FTABMAD*                            | 83s                     |
| Delete FTABMAD & split generated tests    | 72s                     |

*Key:
- Generated tests: tests run by `testsuite/tests/typing-layouts-arrays/run_makearray_dynamic_tests.ml`
- Functorized tests: all tests using `typing-layout-arrays/test_gen_u_array.ml`
- FTBAMAD: the subset of functorized tests added by https://github.com/ocaml-flambda/flambda-backend/pull/3460