### PR TITLE
AddressSanitizer build compatibility fixes

### DIFF
--- a/build_ocaml_compiler.sexp
+++ b/build_ocaml_compiler.sexp
@@ -24,5 +24,6 @@
    stack_allocation
    poll_insertion
    runtime5
+   address_sanitizer
    ))
  )

--- a/configure.ac
+++ b/configure.ac
@@ -2640,7 +2640,7 @@ AS_IF([test x"$enable_frame_pointers" = "xyes" -o x"$enable_address_sanitizer" =
 ## Address Sanitizer
 
 AS_IF([test x"$enable_address_sanitizer" = "xyes"],
-  [AS_CASE(["$host,$cc_basename"],
+  [AS_CASE(["$host,$ocaml_cc_vendor"],
     [x86_64-*-linux*,gcc-*|x86_64-*-linux*,clang-*],
       [common_cflags="$common_cflags -fsanitize=address -fsanitize-recover=address"
        oc_ldflags="$oc_ldflags -fsanitize=address -fsanitize-recover=address"


### PR DESCRIPTION
Fix the `autoconf` test condition used for detecting if AddressSanitizer is supported on the current system, and add AddressSanitizer to the list of recognized compiler "features" so that we can deploy it internally through the usual means.