### PR TITLE
Remember with bounds in unboxed products without `-infer-with-bounds`

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/no_infer_with_bounds.ml
+++ b/testsuite/tests/typing-jkind-bounds/no_infer_with_bounds.ml
@@ -17,14 +17,20 @@ let f (x : #( (int -> int) list * int ref list ) @@ nonportable contended) =
   use_portable x
 
 [%%expect{|
-val f : #((int -> int) list * int ref list) @ contended -> unit = <fun>
+Line 2, characters 15-16:
+2 |   use_portable x
+                   ^
+Error: This value is "nonportable" but expected to be "portable".
 |}]
 
 let f (x : #( (int -> int) list * int ref list ) @@ nonportable contended) =
   use_uncontended x
 
 [%%expect{|
-val f : #((int -> int) list * int ref list) @ contended -> unit = <fun>
+Line 2, characters 18-19:
+2 |   use_uncontended x
+                      ^
+Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 let f (x : #( unit list * string list ) @@ nonportable contended) =

--- a/testsuite/tests/typing-jkind-bounds/no_infer_with_bounds.ml
+++ b/testsuite/tests/typing-jkind-bounds/no_infer_with_bounds.ml
@@ -1,0 +1,36 @@
+(* TEST
+   expect;
+*)
+
+(****************************)
+(* Test 1: unboxed products *)
+
+let use_portable (_ : (_ : value & value) @@ portable) = ()
+let use_uncontended (_ : (_ : value & value) @@ uncontended) = ()
+
+[%%expect{|
+val use_portable : ('a : value & value). 'a @ portable -> unit = <fun>
+val use_uncontended : ('a : value & value). 'a -> unit = <fun>
+|}]
+
+let f (x : #( (int -> int) list * int ref list ) @@ nonportable contended) =
+  use_portable x
+
+[%%expect{|
+val f : #((int -> int) list * int ref list) @ contended -> unit = <fun>
+|}]
+
+let f (x : #( (int -> int) list * int ref list ) @@ nonportable contended) =
+  use_uncontended x
+
+[%%expect{|
+val f : #((int -> int) list * int ref list) @ contended -> unit = <fun>
+|}]
+
+let f (x : #( unit list * string list ) @@ nonportable contended) =
+  use_portable x;
+  use_uncontended x
+
+[%%expect{|
+val f : #(unit list * string list) @ contended -> unit = <fun>
+|}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1679,8 +1679,8 @@ module Jkind_desc = struct
         in
         { layout; mod_bounds; with_bounds }
       else
-        let folder (layouts, bounds) (ty, _) =
-          let { jkind = { layout; mod_bounds; with_bounds = _ };
+        let folder (layouts, mod_boundss, with_boundss) (ty, _) =
+          let { jkind = { layout; mod_bounds; with_bounds };
                 annotation = _;
                 history = _;
                 has_warned = _;
@@ -1688,16 +1688,17 @@ module Jkind_desc = struct
               } =
             jkind_of_type ty
           in
-          layout :: layouts, Mod_bounds.join bounds mod_bounds
+          ( layout :: layouts,
+            Mod_bounds.join mod_bounds mod_boundss,
+            With_bounds.join with_bounds with_boundss )
         in
-        let layouts, mod_bounds =
-          List.fold_left folder ([], Mod_bounds.min) tys_modalities
+        let layouts, mod_bounds, with_bounds =
+          List.fold_left folder
+            ([], Mod_bounds.min, No_with_bounds)
+            tys_modalities
         in
         let layouts = List.rev layouts in
-        { layout = Layout.Product layouts;
-          mod_bounds;
-          with_bounds = No_with_bounds
-        }
+        { layout = Layout.Product layouts; mod_bounds; with_bounds }
 
   let get t = Layout_and_axes.map Layout.get t
 


### PR DESCRIPTION
This corrects a small oversight. The first commit includes a test that shows that there previously was a soundness bug; the second commit fixes things.

Review: @glittershark 

(The bug was introduced in [this commit](https://github.com/ocaml-flambda/flambda-backend/commit/b7f5a58dd9ed7c951f16fdcae2a1d3dbbc5d16ee#diff-8b6d4083f9de4c12c6a1774cca3f746ae96583c6b2545655c90f809fe41fa413R1240), presumably as we were rebasing.)