### PR TITLE
Control -infer-with-bounds from an attribute

### DIFF
--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -92,6 +92,7 @@ let builtin_attrs =
   ; "nolabels"
   ; "flambda_oclassic"
   ; "flambda_o3"
+  ; "infer_with_bounds"
   ; "afl_inst_ratio"
   ; "local_opt"
   ; "curry"; "extension.curry"
@@ -571,6 +572,11 @@ let flambda_o3_attribute attr =
     ~name:"flambda_o3"
     ~f:(fun () -> if Config.flambda || Config.flambda2 then Clflags.set_o3 ())
 
+let infer_with_bounds_attribute attr =
+  clflags_attribute_without_payload' attr
+    ~name:"infer_with_bounds"
+    ~f:(fun () -> Clflags.infer_with_bounds := true)
+
 let inline_attribute attr =
   when_attribute_is ["inline"; "ocaml.inline"] attr ~f:(fun () ->
     let err_msg =
@@ -635,6 +641,7 @@ let parse_standard_interface_attributes attr =
   principal_attribute attr;
   noprincipal_attribute attr;
   nolabels_attribute attr;
+  infer_with_bounds_attribute attr;
   zero_alloc_attribute ~in_signature:true attr;
   unsafe_allow_any_mode_crossing_attribute attr
 
@@ -647,6 +654,7 @@ let parse_standard_implementation_attributes attr =
   afl_inst_ratio_attribute attr;
   flambda_o3_attribute attr;
   flambda_oclassic_attribute attr;
+  infer_with_bounds_attribute attr;
   zero_alloc_attribute ~in_signature:false attr;
   unsafe_allow_any_mode_crossing_attribute attr
 

--- a/testsuite/tests/typing-jkind-bounds/attribute.ml
+++ b/testsuite/tests/typing-jkind-bounds/attribute.ml
@@ -1,0 +1,36 @@
+(* TEST
+   expect;
+   flags = "-extension layouts_alpha";
+*)
+
+type 'a t1 = { x : 'a }
+
+[@@@infer_with_bounds]
+
+type 'a t2 = { x : 'a }
+
+[%%expect{|
+type 'a t1 = { x : 'a; }
+type 'a t2 = { x : 'a; }
+|}]
+
+let use_portable (_ @ portable) = ()
+
+[%%expect{|
+val use_portable : 'a @ portable -> unit = <fun>
+|}]
+
+let f1 (x : int t1 @@ nonportable) = use_portable x
+
+[%%expect{|
+Line 1, characters 50-51:
+1 | let f1 (x : int t1 @@ nonportable) = use_portable x
+                                                      ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+let f2 (x : int t2 @@ nonportable) = use_portable x
+
+[%%expect{|
+val f2 : int t2 -> unit = <fun>
+|}]

--- a/testsuite/tests/warnings/w53.compilers.reference
+++ b/testsuite/tests/warnings/w53.compilers.reference
@@ -188,1369 +188,1359 @@ File "w53.ml", line 105, characters 15-31:
                      ^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "flambda_oclassic" attribute cannot appear in this context
 
-File "w53.ml", line 112, characters 21-35:
-112 |   type 'a t1 = 'a [@@afl_inst_ratio 42] (* rejected *)
+File "w53.ml", line 112, characters 28-45:
+112 |   type 'a t = { x : 'a } [@@infer_with_bounds] (* rejected *)
+                                  ^^^^^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "infer_with_bounds" attribute cannot appear in this context
+
+File "w53.ml", line 118, characters 28-45:
+118 |   type 'a t = { x : 'a } [@@infer_with_bounds] (* rejected *)
+                                  ^^^^^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "infer_with_bounds" attribute cannot appear in this context
+
+File "w53.ml", line 124, characters 21-35:
+124 |   type 'a t1 = 'a [@@afl_inst_ratio 42] (* rejected *)
                            ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "afl_inst_ratio" attribute cannot appear in this context
 
-File "w53.ml", line 114, characters 19-33:
-114 |   type s1 = Foo1 [@afl_inst_ratio 42] (* rejected *)
+File "w53.ml", line 126, characters 19-33:
+126 |   type s1 = Foo1 [@afl_inst_ratio 42] (* rejected *)
                          ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "afl_inst_ratio" attribute cannot appear in this context
 
-File "w53.ml", line 116, characters 16-30:
-116 |   val x : int [@afl_inst_ratio 42] (* rejected *)
+File "w53.ml", line 128, characters 16-30:
+128 |   val x : int [@afl_inst_ratio 42] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "afl_inst_ratio" attribute cannot appear in this context
 
-File "w53.ml", line 118, characters 6-20:
-118 |   [@@@afl_inst_ratio 42] (* rejected *)
+File "w53.ml", line 130, characters 6-20:
+130 |   [@@@afl_inst_ratio 42] (* rejected *)
             ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "afl_inst_ratio" attribute cannot appear in this context
 
-File "w53.ml", line 122, characters 21-35:
-122 |   type 'a t1 = 'a [@@afl_inst_ratio 42] (* rejected *)
+File "w53.ml", line 134, characters 21-35:
+134 |   type 'a t1 = 'a [@@afl_inst_ratio 42] (* rejected *)
                            ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "afl_inst_ratio" attribute cannot appear in this context
 
-File "w53.ml", line 124, characters 19-33:
-124 |   type s1 = Foo1 [@afl_inst_ratio 42] (* rejected *)
+File "w53.ml", line 136, characters 19-33:
+136 |   type s1 = Foo1 [@afl_inst_ratio 42] (* rejected *)
                          ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "afl_inst_ratio" attribute cannot appear in this context
 
-File "w53.ml", line 126, characters 14-28:
-126 |   let x = 5 [@afl_inst_ratio 42] (* rejected *)
+File "w53.ml", line 138, characters 14-28:
+138 |   let x = 5 [@afl_inst_ratio 42] (* rejected *)
                     ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "afl_inst_ratio" attribute cannot appear in this context
 
-File "w53.ml", line 133, characters 21-26:
-133 |   type 'a t1 = 'a [@@curry 42] (* rejected *)
+File "w53.ml", line 145, characters 21-26:
+145 |   type 'a t1 = 'a [@@curry 42] (* rejected *)
                            ^^^^^
 Warning 53 [misplaced-attribute]: the "curry" attribute cannot appear in this context
 
-File "w53.ml", line 135, characters 19-24:
-135 |   type s1 = Foo1 [@curry 42] (* rejected *)
+File "w53.ml", line 147, characters 19-24:
+147 |   type s1 = Foo1 [@curry 42] (* rejected *)
                          ^^^^^
 Warning 53 [misplaced-attribute]: the "curry" attribute cannot appear in this context
 
-File "w53.ml", line 137, characters 16-21:
-137 |   val x : int [@curry 42] (* rejected *)
+File "w53.ml", line 149, characters 16-21:
+149 |   val x : int [@curry 42] (* rejected *)
                       ^^^^^
 Warning 53 [misplaced-attribute]: the "curry" attribute cannot appear in this context
 
-File "w53.ml", line 139, characters 6-11:
-139 |   [@@@curry 42] (* rejected *)
+File "w53.ml", line 151, characters 6-11:
+151 |   [@@@curry 42] (* rejected *)
             ^^^^^
 Warning 53 [misplaced-attribute]: the "curry" attribute cannot appear in this context
 
-File "w53.ml", line 143, characters 21-26:
-143 |   type 'a t1 = 'a [@@curry 42] (* rejected *)
+File "w53.ml", line 155, characters 21-26:
+155 |   type 'a t1 = 'a [@@curry 42] (* rejected *)
                            ^^^^^
 Warning 53 [misplaced-attribute]: the "curry" attribute cannot appear in this context
 
-File "w53.ml", line 145, characters 19-24:
-145 |   type s1 = Foo1 [@curry 42] (* rejected *)
+File "w53.ml", line 157, characters 19-24:
+157 |   type s1 = Foo1 [@curry 42] (* rejected *)
                          ^^^^^
 Warning 53 [misplaced-attribute]: the "curry" attribute cannot appear in this context
 
-File "w53.ml", line 147, characters 14-19:
-147 |   let x = 5 [@curry 42] (* rejected *)
+File "w53.ml", line 159, characters 14-19:
+159 |   let x = 5 [@curry 42] (* rejected *)
                     ^^^^^
 Warning 53 [misplaced-attribute]: the "curry" attribute cannot appear in this context
 
-File "w53.ml", line 149, characters 6-11:
-149 |   [@@@curry 42] (* rejected *)
+File "w53.ml", line 161, characters 6-11:
+161 |   [@@@curry 42] (* rejected *)
             ^^^^^
 Warning 53 [misplaced-attribute]: the "curry" attribute cannot appear in this context
 
-File "w53.ml", line 153, characters 21-30:
-153 |   type 'a t1 = 'a [@@local_opt] (* rejected *)
+File "w53.ml", line 165, characters 21-30:
+165 |   type 'a t1 = 'a [@@local_opt] (* rejected *)
                            ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "local_opt" attribute cannot appear in this context
 
-File "w53.ml", line 154, characters 19-28:
-154 |   type s1 = Foo1 [@local_opt] (* rejected *)
+File "w53.ml", line 166, characters 19-28:
+166 |   type s1 = Foo1 [@local_opt] (* rejected *)
                          ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "local_opt" attribute cannot appear in this context
 
-File "w53.ml", line 155, characters 19-28:
-155 |   val x : int64 [@@local_opt] (* rejected *)
+File "w53.ml", line 167, characters 19-28:
+167 |   val x : int64 [@@local_opt] (* rejected *)
                          ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "local_opt" attribute cannot appear in this context
 
-File "w53.ml", line 158, characters 39-48:
-158 |   external z : int64 -> int64 = "x" [@@local_opt] (* rejected *)
+File "w53.ml", line 170, characters 39-48:
+170 |   external z : int64 -> int64 = "x" [@@local_opt] (* rejected *)
                                              ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "local_opt" attribute cannot appear in this context
 
-File "w53.ml", line 162, characters 21-30:
-162 |   type 'a t1 = 'a [@@local_opt] (* rejected *)
+File "w53.ml", line 174, characters 21-30:
+174 |   type 'a t1 = 'a [@@local_opt] (* rejected *)
                            ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "local_opt" attribute cannot appear in this context
 
-File "w53.ml", line 163, characters 19-28:
-163 |   type s1 = Foo1 [@local_opt] (* rejected *)
+File "w53.ml", line 175, characters 19-28:
+175 |   type s1 = Foo1 [@local_opt] (* rejected *)
                          ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "local_opt" attribute cannot appear in this context
 
-File "w53.ml", line 164, characters 25-34:
-164 |   let x : int64 = 42L [@@local_opt] (* rejected *)
+File "w53.ml", line 176, characters 25-34:
+176 |   let x : int64 = 42L [@@local_opt] (* rejected *)
                                ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "local_opt" attribute cannot appear in this context
 
-File "w53.ml", line 167, characters 39-48:
-167 |   external z : int64 -> int64 = "x" [@@local_opt] (* rejected *)
+File "w53.ml", line 179, characters 39-48:
+179 |   external z : int64 -> int64 = "x" [@@local_opt] (* rejected *)
                                              ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "local_opt" attribute cannot appear in this context
 
-File "w53.ml", line 172, characters 20-25:
-172 |   type 'a t1 = 'a [@local]
+File "w53.ml", line 184, characters 20-25:
+184 |   type 'a t1 = 'a [@local]
                           ^^^^^
 Warning 53 [misplaced-attribute]: the "local" attribute cannot appear in this context
 
-File "w53.ml", line 173, characters 21-27:
-173 |   type 'a t1' = 'a [@global]
+File "w53.ml", line 185, characters 21-27:
+185 |   type 'a t1' = 'a [@global]
                            ^^^^^^
 Warning 53 [misplaced-attribute]: the "global" attribute cannot appear in this context
 
-File "w53.ml", line 175, characters 24-29:
-175 |   type t2 = { x : int [@local] }
+File "w53.ml", line 187, characters 24-29:
+187 |   type t2 = { x : int [@local] }
                               ^^^^^
 Warning 53 [misplaced-attribute]: the "local" attribute cannot appear in this context
 
-File "w53.ml", line 176, characters 25-31:
-176 |   type t2' = { x : int [@global] }
+File "w53.ml", line 188, characters 25-31:
+188 |   type t2' = { x : int [@global] }
                                ^^^^^^
 Warning 53 [misplaced-attribute]: the "global" attribute cannot appear in this context
 
-File "w53.ml", line 178, characters 27-32:
-178 |   val x : 'a list -> ('a [@local]) list
+File "w53.ml", line 190, characters 27-32:
+190 |   val x : 'a list -> ('a [@local]) list
                                  ^^^^^
 Warning 53 [misplaced-attribute]: the "local" attribute cannot appear in this context
 
-File "w53.ml", line 179, characters 28-34:
-179 |   val x' : 'a list -> ('a [@global]) list
+File "w53.ml", line 191, characters 28-34:
+191 |   val x' : 'a list -> ('a [@global]) list
                                   ^^^^^^
 Warning 53 [misplaced-attribute]: the "global" attribute cannot appear in this context
 
-File "w53.ml", line 181, characters 32-37:
-181 |   val y : 'a -> f:(('a -> 'b) [@local]) -> 'b
+File "w53.ml", line 193, characters 32-37:
+193 |   val y : 'a -> f:(('a -> 'b) [@local]) -> 'b
                                       ^^^^^
 Warning 53 [misplaced-attribute]: the "local" attribute cannot appear in this context
 
-File "w53.ml", line 182, characters 33-39:
-182 |   val y' : 'a -> f:(('a -> 'b) [@global]) -> 'b
+File "w53.ml", line 194, characters 33-39:
+194 |   val y' : 'a -> f:(('a -> 'b) [@global]) -> 'b
                                        ^^^^^^
 Warning 53 [misplaced-attribute]: the "global" attribute cannot appear in this context
 
-File "w53.ml", line 184, characters 16-21:
-184 |   val z : 'a [@@local]
+File "w53.ml", line 196, characters 16-21:
+196 |   val z : 'a [@@local]
                       ^^^^^
 Warning 53 [misplaced-attribute]: the "local" attribute cannot appear in this context
 
-File "w53.ml", line 185, characters 17-23:
-185 |   val z' : 'a [@@global]
+File "w53.ml", line 197, characters 17-23:
+197 |   val z' : 'a [@@global]
                        ^^^^^^
 Warning 53 [misplaced-attribute]: the "global" attribute cannot appear in this context
 
-File "w53.ml", line 187, characters 17-22:
-187 |   val w : 'a [@@@local]
+File "w53.ml", line 199, characters 17-22:
+199 |   val w : 'a [@@@local]
                        ^^^^^
 Warning 53 [misplaced-attribute]: the "local" attribute cannot appear in this context
 
-File "w53.ml", line 188, characters 18-24:
-188 |   val w' : 'a [@@@global]
+File "w53.ml", line 200, characters 18-24:
+200 |   val w' : 'a [@@@global]
                         ^^^^^^
 Warning 53 [misplaced-attribute]: the "global" attribute cannot appear in this context
 
-File "w53.ml", line 193, characters 20-25:
-193 |   type 'a t1 = 'a [@local]
+File "w53.ml", line 205, characters 20-25:
+205 |   type 'a t1 = 'a [@local]
                           ^^^^^
 Warning 53 [misplaced-attribute]: the "local" attribute cannot appear in this context
 
-File "w53.ml", line 194, characters 21-27:
-194 |   type 'a t1' = 'a [@global]
+File "w53.ml", line 206, characters 21-27:
+206 |   type 'a t1' = 'a [@global]
                            ^^^^^^
 Warning 53 [misplaced-attribute]: the "global" attribute cannot appear in this context
 
-File "w53.ml", line 196, characters 24-29:
-196 |   type t2 = { x : int [@local] }
+File "w53.ml", line 208, characters 24-29:
+208 |   type t2 = { x : int [@local] }
                               ^^^^^
 Warning 53 [misplaced-attribute]: the "local" attribute cannot appear in this context
 
-File "w53.ml", line 197, characters 25-31:
-197 |   type t2' = { x : int [@global] }
+File "w53.ml", line 209, characters 25-31:
+209 |   type t2' = { x : int [@global] }
                                ^^^^^^
 Warning 53 [misplaced-attribute]: the "global" attribute cannot appear in this context
 
-File "w53.ml", line 199, characters 13-18:
-199 |   let f (a [@local]) = a
+File "w53.ml", line 211, characters 13-18:
+211 |   let f (a [@local]) = a
                    ^^^^^
 Warning 53 [misplaced-attribute]: the "local" attribute cannot appear in this context
 
-File "w53.ml", line 200, characters 13-19:
-200 |   let g (a [@global]) = a
+File "w53.ml", line 212, characters 13-19:
+212 |   let g (a [@global]) = a
                    ^^^^^^
 Warning 53 [misplaced-attribute]: the "global" attribute cannot appear in this context
 
-File "w53.ml", line 205, characters 20-24:
-205 |   type 'a t1 = 'a [@tail] (* rejected *)
+File "w53.ml", line 217, characters 20-24:
+217 |   type 'a t1 = 'a [@tail] (* rejected *)
                           ^^^^
 Warning 53 [misplaced-attribute]: the "tail" attribute cannot appear in this context
 
-File "w53.ml", line 206, characters 21-28:
-206 |   type 'a t1' = 'a [@nontail] (* rejected *)
+File "w53.ml", line 218, characters 21-28:
+218 |   type 'a t1' = 'a [@nontail] (* rejected *)
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "nontail" attribute cannot appear in this context
 
-File "w53.ml", line 208, characters 24-28:
-208 |   type t2 = { x : int [@tail] } (* rejected *)
+File "w53.ml", line 220, characters 24-28:
+220 |   type t2 = { x : int [@tail] } (* rejected *)
                               ^^^^
 Warning 53 [misplaced-attribute]: the "tail" attribute cannot appear in this context
 
-File "w53.ml", line 209, characters 25-32:
-209 |   type t2' = { x : int [@nontail] } (* rejected *)
+File "w53.ml", line 221, characters 25-32:
+221 |   type t2' = { x : int [@nontail] } (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "nontail" attribute cannot appear in this context
 
-File "w53.ml", line 211, characters 32-36:
-211 |   val y : 'a -> f:(('a -> 'b) [@tail]) -> 'b (* rejected *)
+File "w53.ml", line 223, characters 32-36:
+223 |   val y : 'a -> f:(('a -> 'b) [@tail]) -> 'b (* rejected *)
                                       ^^^^
 Warning 53 [misplaced-attribute]: the "tail" attribute cannot appear in this context
 
-File "w53.ml", line 212, characters 33-40:
-212 |   val y' : 'a -> f:(('a -> 'b) [@nontail]) -> 'b (* rejected *)
+File "w53.ml", line 224, characters 33-40:
+224 |   val y' : 'a -> f:(('a -> 'b) [@nontail]) -> 'b (* rejected *)
                                        ^^^^^^^
 Warning 53 [misplaced-attribute]: the "nontail" attribute cannot appear in this context
 
-File "w53.ml", line 214, characters 16-20:
-214 |   val z : 'a [@@tail] (* rejected *)
+File "w53.ml", line 226, characters 16-20:
+226 |   val z : 'a [@@tail] (* rejected *)
                       ^^^^
 Warning 53 [misplaced-attribute]: the "tail" attribute cannot appear in this context
 
-File "w53.ml", line 215, characters 17-24:
-215 |   val z' : 'a [@@nontail] (* rejected *)
+File "w53.ml", line 227, characters 17-24:
+227 |   val z' : 'a [@@nontail] (* rejected *)
                        ^^^^^^^
 Warning 53 [misplaced-attribute]: the "nontail" attribute cannot appear in this context
 
-File "w53.ml", line 217, characters 6-10:
-217 |   [@@@tail] (* rejected *)
+File "w53.ml", line 229, characters 6-10:
+229 |   [@@@tail] (* rejected *)
             ^^^^
 Warning 53 [misplaced-attribute]: the "tail" attribute cannot appear in this context
 
-File "w53.ml", line 218, characters 6-13:
-218 |   [@@@nontail] (* rejected *)
+File "w53.ml", line 230, characters 6-13:
+230 |   [@@@nontail] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "nontail" attribute cannot appear in this context
 
-File "w53.ml", line 222, characters 13-17:
-222 |   let f (a [@tail]) = a (* rejected *)
+File "w53.ml", line 234, characters 13-17:
+234 |   let f (a [@tail]) = a (* rejected *)
                    ^^^^
 Warning 53 [misplaced-attribute]: the "tail" attribute cannot appear in this context
 
-File "w53.ml", line 223, characters 14-21:
-223 |   let f' (a [@nontail]) = a (* rejected *)
+File "w53.ml", line 235, characters 14-21:
+235 |   let f' (a [@nontail]) = a (* rejected *)
                     ^^^^^^^
 Warning 53 [misplaced-attribute]: the "nontail" attribute cannot appear in this context
 
-File "w53.ml", line 225, characters 8-12:
-225 |   let [@tail] g a = a (* rejected *)
+File "w53.ml", line 237, characters 8-12:
+237 |   let [@tail] g a = a (* rejected *)
               ^^^^
 Warning 53 [misplaced-attribute]: the "tail" attribute cannot appear in this context
 
-File "w53.ml", line 226, characters 8-15:
-226 |   let [@nontail] g' a = a (* rejected *)
+File "w53.ml", line 238, characters 8-15:
+238 |   let [@nontail] g' a = a (* rejected *)
               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "nontail" attribute cannot appear in this context
 
-File "w53.ml", line 228, characters 16-20:
-228 |   let h a = a [@tail] (* rejected *)
+File "w53.ml", line 240, characters 16-20:
+240 |   let h a = a [@tail] (* rejected *)
                       ^^^^
 Warning 53 [misplaced-attribute]: the "tail" attribute cannot appear in this context
 
-File "w53.ml", line 229, characters 17-24:
-229 |   let h' a = a [@nontail] (* rejected *)
+File "w53.ml", line 241, characters 17-24:
+241 |   let h' a = a [@nontail] (* rejected *)
                        ^^^^^^^
 Warning 53 [misplaced-attribute]: the "nontail" attribute cannot appear in this context
 
-File "w53.ml", line 239, characters 17-22:
-239 |   let f2 = fun [@boxed] (type a) (x : a) -> x (* rejected *)
+File "w53.ml", line 251, characters 17-22:
+251 |   let f2 = fun [@boxed] (type a) (x : a) -> x (* rejected *)
                        ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 243, characters 21-28:
-243 |   type 'a t1 = 'a [@@builtin] (* rejected *)
+File "w53.ml", line 255, characters 21-28:
+255 |   type 'a t1 = 'a [@@builtin] (* rejected *)
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "builtin" attribute cannot appear in this context
 
-File "w53.ml", line 244, characters 19-26:
-244 |   type s1 = Foo1 [@builtin] (* rejected *)
+File "w53.ml", line 256, characters 19-26:
+256 |   type s1 = Foo1 [@builtin] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "builtin" attribute cannot appear in this context
 
-File "w53.ml", line 245, characters 17-24:
-245 |   val x : int [@@builtin] (* rejected *)
+File "w53.ml", line 257, characters 17-24:
+257 |   val x : int [@@builtin] (* rejected *)
                        ^^^^^^^
 Warning 53 [misplaced-attribute]: the "builtin" attribute cannot appear in this context
 
-File "w53.ml", line 247, characters 22-29:
-247 |   external y : (int [@builtin]) -> (int [@builtin]) = "x" "y" (* rejected *)
+File "w53.ml", line 259, characters 22-29:
+259 |   external y : (int [@builtin]) -> (int [@builtin]) = "x" "y" (* rejected *)
                             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "builtin" attribute cannot appear in this context
 
-File "w53.ml", line 247, characters 42-49:
-247 |   external y : (int [@builtin]) -> (int [@builtin]) = "x" "y" (* rejected *)
+File "w53.ml", line 259, characters 42-49:
+259 |   external y : (int [@builtin]) -> (int [@builtin]) = "x" "y" (* rejected *)
                                                 ^^^^^^^
 Warning 53 [misplaced-attribute]: the "builtin" attribute cannot appear in this context
 
-File "w53.ml", line 252, characters 21-28:
-252 |   type 'a t1 = 'a [@@builtin] (* rejected *)
+File "w53.ml", line 264, characters 21-28:
+264 |   type 'a t1 = 'a [@@builtin] (* rejected *)
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "builtin" attribute cannot appear in this context
 
-File "w53.ml", line 253, characters 19-26:
-253 |   type s1 = Foo1 [@builtin] (* rejected *)
+File "w53.ml", line 265, characters 19-26:
+265 |   type s1 = Foo1 [@builtin] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "builtin" attribute cannot appear in this context
 
-File "w53.ml", line 254, characters 22-29:
-254 |   let x : int = 42 [@@builtin] (* rejected *)
+File "w53.ml", line 266, characters 22-29:
+266 |   let x : int = 42 [@@builtin] (* rejected *)
                             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "builtin" attribute cannot appear in this context
 
-File "w53.ml", line 256, characters 22-29:
-256 |   external y : (int [@builtin]) -> (int [@builtin]) = "x" "y" (* rejected *)
+File "w53.ml", line 268, characters 22-29:
+268 |   external y : (int [@builtin]) -> (int [@builtin]) = "x" "y" (* rejected *)
                             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "builtin" attribute cannot appear in this context
 
-File "w53.ml", line 256, characters 42-49:
-256 |   external y : (int [@builtin]) -> (int [@builtin]) = "x" "y" (* rejected *)
+File "w53.ml", line 268, characters 42-49:
+268 |   external y : (int [@builtin]) -> (int [@builtin]) = "x" "y" (* rejected *)
                                                 ^^^^^^^
 Warning 53 [misplaced-attribute]: the "builtin" attribute cannot appear in this context
 
-File "w53.ml", line 261, characters 21-31:
-261 |   type 'a t1 = 'a [@@no_effects] (* rejected *)
+File "w53.ml", line 273, characters 21-31:
+273 |   type 'a t1 = 'a [@@no_effects] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_effects" attribute cannot appear in this context
 
-File "w53.ml", line 262, characters 19-29:
-262 |   type s1 = Foo1 [@no_effects] (* rejected *)
+File "w53.ml", line 274, characters 19-29:
+274 |   type s1 = Foo1 [@no_effects] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_effects" attribute cannot appear in this context
 
-File "w53.ml", line 263, characters 17-27:
-263 |   val x : int [@@no_effects] (* rejected *)
+File "w53.ml", line 275, characters 17-27:
+275 |   val x : int [@@no_effects] (* rejected *)
                        ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_effects" attribute cannot appear in this context
 
-File "w53.ml", line 265, characters 22-32:
-265 |   external y : (int [@no_effects]) -> (int [@no_effects]) = "x" "y" (* rejected *)
+File "w53.ml", line 277, characters 22-32:
+277 |   external y : (int [@no_effects]) -> (int [@no_effects]) = "x" "y" (* rejected *)
                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_effects" attribute cannot appear in this context
 
-File "w53.ml", line 265, characters 45-55:
-265 |   external y : (int [@no_effects]) -> (int [@no_effects]) = "x" "y" (* rejected *)
+File "w53.ml", line 277, characters 45-55:
+277 |   external y : (int [@no_effects]) -> (int [@no_effects]) = "x" "y" (* rejected *)
                                                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_effects" attribute cannot appear in this context
 
-File "w53.ml", line 270, characters 21-31:
-270 |   type 'a t1 = 'a [@@no_effects] (* rejected *)
+File "w53.ml", line 282, characters 21-31:
+282 |   type 'a t1 = 'a [@@no_effects] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_effects" attribute cannot appear in this context
 
-File "w53.ml", line 271, characters 19-29:
-271 |   type s1 = Foo1 [@no_effects] (* rejected *)
+File "w53.ml", line 283, characters 19-29:
+283 |   type s1 = Foo1 [@no_effects] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_effects" attribute cannot appear in this context
 
-File "w53.ml", line 272, characters 22-32:
-272 |   let x : int = 42 [@@no_effects] (* rejected *)
+File "w53.ml", line 284, characters 22-32:
+284 |   let x : int = 42 [@@no_effects] (* rejected *)
                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_effects" attribute cannot appear in this context
 
-File "w53.ml", line 274, characters 22-32:
-274 |   external y : (int [@no_effects]) -> (int [@no_effects]) = "x" "y" (* rejected *)
+File "w53.ml", line 286, characters 22-32:
+286 |   external y : (int [@no_effects]) -> (int [@no_effects]) = "x" "y" (* rejected *)
                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_effects" attribute cannot appear in this context
 
-File "w53.ml", line 274, characters 45-55:
-274 |   external y : (int [@no_effects]) -> (int [@no_effects]) = "x" "y" (* rejected *)
+File "w53.ml", line 286, characters 45-55:
+286 |   external y : (int [@no_effects]) -> (int [@no_effects]) = "x" "y" (* rejected *)
                                                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_effects" attribute cannot appear in this context
 
-File "w53.ml", line 279, characters 21-33:
-279 |   type 'a t1 = 'a [@@no_coeffects] (* rejected *)
+File "w53.ml", line 291, characters 21-33:
+291 |   type 'a t1 = 'a [@@no_coeffects] (* rejected *)
                            ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_coeffects" attribute cannot appear in this context
 
-File "w53.ml", line 280, characters 19-31:
-280 |   type s1 = Foo1 [@no_coeffects] (* rejected *)
+File "w53.ml", line 292, characters 19-31:
+292 |   type s1 = Foo1 [@no_coeffects] (* rejected *)
                          ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_coeffects" attribute cannot appear in this context
 
-File "w53.ml", line 281, characters 17-29:
-281 |   val x : int [@@no_coeffects] (* rejected *)
+File "w53.ml", line 293, characters 17-29:
+293 |   val x : int [@@no_coeffects] (* rejected *)
                        ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_coeffects" attribute cannot appear in this context
 
-File "w53.ml", line 283, characters 22-34:
-283 |   external y : (int [@no_coeffects]) -> (int [@no_coeffects]) = "x" "y" (* rejected *)
+File "w53.ml", line 295, characters 22-34:
+295 |   external y : (int [@no_coeffects]) -> (int [@no_coeffects]) = "x" "y" (* rejected *)
                             ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_coeffects" attribute cannot appear in this context
 
-File "w53.ml", line 283, characters 47-59:
-283 |   external y : (int [@no_coeffects]) -> (int [@no_coeffects]) = "x" "y" (* rejected *)
+File "w53.ml", line 295, characters 47-59:
+295 |   external y : (int [@no_coeffects]) -> (int [@no_coeffects]) = "x" "y" (* rejected *)
                                                      ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_coeffects" attribute cannot appear in this context
 
-File "w53.ml", line 288, characters 21-33:
-288 |   type 'a t1 = 'a [@@no_coeffects] (* rejected *)
+File "w53.ml", line 300, characters 21-33:
+300 |   type 'a t1 = 'a [@@no_coeffects] (* rejected *)
                            ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_coeffects" attribute cannot appear in this context
 
-File "w53.ml", line 289, characters 19-31:
-289 |   type s1 = Foo1 [@no_coeffects] (* rejected *)
+File "w53.ml", line 301, characters 19-31:
+301 |   type s1 = Foo1 [@no_coeffects] (* rejected *)
                          ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_coeffects" attribute cannot appear in this context
 
-File "w53.ml", line 290, characters 22-34:
-290 |   let x : int = 42 [@@no_coeffects] (* rejected *)
+File "w53.ml", line 302, characters 22-34:
+302 |   let x : int = 42 [@@no_coeffects] (* rejected *)
                             ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_coeffects" attribute cannot appear in this context
 
-File "w53.ml", line 292, characters 22-34:
-292 |   external y : (int [@no_coeffects]) -> (int [@no_coeffects]) = "x" "y" (* rejected *)
+File "w53.ml", line 304, characters 22-34:
+304 |   external y : (int [@no_coeffects]) -> (int [@no_coeffects]) = "x" "y" (* rejected *)
                             ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_coeffects" attribute cannot appear in this context
 
-File "w53.ml", line 292, characters 47-59:
-292 |   external y : (int [@no_coeffects]) -> (int [@no_coeffects]) = "x" "y" (* rejected *)
+File "w53.ml", line 304, characters 47-59:
+304 |   external y : (int [@no_coeffects]) -> (int [@no_coeffects]) = "x" "y" (* rejected *)
                                                      ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "no_coeffects" attribute cannot appear in this context
 
-File "w53.ml", line 297, characters 21-44:
-297 |   type 'a t1 = 'a [@@only_generative_effects] (* rejected *)
+File "w53.ml", line 309, characters 21-44:
+309 |   type 'a t1 = 'a [@@only_generative_effects] (* rejected *)
                            ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
 
-File "w53.ml", line 298, characters 19-42:
-298 |   type s1 = Foo1 [@only_generative_effects] (* rejected *)
+File "w53.ml", line 310, characters 19-42:
+310 |   type s1 = Foo1 [@only_generative_effects] (* rejected *)
                          ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
 
-File "w53.ml", line 299, characters 17-40:
-299 |   val x : int [@@only_generative_effects] (* rejected *)
+File "w53.ml", line 311, characters 17-40:
+311 |   val x : int [@@only_generative_effects] (* rejected *)
                        ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
 
-File "w53.ml", line 301, characters 22-45:
-301 |   external y : (int [@only_generative_effects]) -> (int [@only_generative_effects]) = "x" "y" (* rejected *)
+File "w53.ml", line 313, characters 22-45:
+313 |   external y : (int [@only_generative_effects]) -> (int [@only_generative_effects]) = "x" "y" (* rejected *)
                             ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
 
-File "w53.ml", line 301, characters 58-81:
-301 |   external y : (int [@only_generative_effects]) -> (int [@only_generative_effects]) = "x" "y" (* rejected *)
+File "w53.ml", line 313, characters 58-81:
+313 |   external y : (int [@only_generative_effects]) -> (int [@only_generative_effects]) = "x" "y" (* rejected *)
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
 
-File "w53.ml", line 306, characters 21-44:
-306 |   type 'a t1 = 'a [@@only_generative_effects] (* rejected *)
+File "w53.ml", line 318, characters 21-44:
+318 |   type 'a t1 = 'a [@@only_generative_effects] (* rejected *)
                            ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
 
-File "w53.ml", line 307, characters 19-42:
-307 |   type s1 = Foo1 [@only_generative_effects] (* rejected *)
+File "w53.ml", line 319, characters 19-42:
+319 |   type s1 = Foo1 [@only_generative_effects] (* rejected *)
                          ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
 
-File "w53.ml", line 308, characters 22-45:
-308 |   let x : int = 42 [@@only_generative_effects] (* rejected *)
+File "w53.ml", line 320, characters 22-45:
+320 |   let x : int = 42 [@@only_generative_effects] (* rejected *)
                             ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
 
-File "w53.ml", line 310, characters 22-45:
-310 |   external y : (int [@only_generative_effects]) -> (int [@only_generative_effects]) = "x" "y" (* rejected *)
+File "w53.ml", line 322, characters 22-45:
+322 |   external y : (int [@only_generative_effects]) -> (int [@only_generative_effects]) = "x" "y" (* rejected *)
                             ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
 
-File "w53.ml", line 310, characters 58-81:
-310 |   external y : (int [@only_generative_effects]) -> (int [@only_generative_effects]) = "x" "y" (* rejected *)
+File "w53.ml", line 322, characters 58-81:
+322 |   external y : (int [@only_generative_effects]) -> (int [@only_generative_effects]) = "x" "y" (* rejected *)
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "only_generative_effects" attribute cannot appear in this context
 
-File "w53.ml", line 315, characters 21-34:
-315 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
+File "w53.ml", line 327, characters 21-34:
+327 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
                            ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 316, characters 19-32:
-316 |   type s1 = Foo1 [@error_message ""] (* rejected *)
+File "w53.ml", line 328, characters 19-32:
+328 |   type s1 = Foo1 [@error_message ""] (* rejected *)
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 317, characters 17-30:
-317 |   val x : int [@@error_message ""] (* rejected *)
+File "w53.ml", line 329, characters 17-30:
+329 |   val x : int [@@error_message ""] (* rejected *)
                        ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 319, characters 22-35:
-319 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+File "w53.ml", line 331, characters 22-35:
+331 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
                             ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 319, characters 51-64:
-319 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+File "w53.ml", line 331, characters 51-64:
+331 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
                                                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 321, characters 39-52:
-321 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+File "w53.ml", line 333, characters 39-52:
+333 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
                                              ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 324, characters 43-56:
-324 |     (int as ('a:value)[@error_message ""][@error_message ""]) (* reject second *)
+File "w53.ml", line 336, characters 43-56:
+336 |     (int as ('a:value)[@error_message ""][@error_message ""]) (* reject second *)
                                                  ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 328, characters 21-34:
-328 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
+File "w53.ml", line 340, characters 21-34:
+340 |   type 'a t1 = 'a [@@error_message ""] (* rejected *)
                            ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 329, characters 19-32:
-329 |   type s1 = Foo1 [@error_message ""] (* rejected *)
+File "w53.ml", line 341, characters 19-32:
+341 |   type s1 = Foo1 [@error_message ""] (* rejected *)
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 330, characters 22-35:
-330 |   let x : int = 42 [@@error_message ""] (* rejected *)
+File "w53.ml", line 342, characters 22-35:
+342 |   let x : int = 42 [@@error_message ""] (* rejected *)
                             ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 332, characters 22-35:
-332 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+File "w53.ml", line 344, characters 22-35:
+344 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
                             ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 332, characters 51-64:
-332 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
+File "w53.ml", line 344, characters 51-64:
+344 |   external y : (int [@error_message ""]) -> (int [@error_message ""]) = (* rejected *)
                                                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 334, characters 39-52:
-334 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
+File "w53.ml", line 346, characters 39-52:
+346 |   external z : int -> int = "x" "y" [@@error_message ""] (* rejected *)
                                              ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 336, characters 45-58:
-336 |   let f1 v: ((_ : value)[@error_message ""][@error_message ""]) = v (* reject second *)
+File "w53.ml", line 348, characters 45-58:
+348 |   let f1 v: ((_ : value)[@error_message ""][@error_message ""]) = v (* reject second *)
                                                    ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 337, characters 46-59:
-337 |   let f2 v: (('a : value)[@error_message ""][@error_message ""]) = v (* reject second *)
+File "w53.ml", line 349, characters 46-59:
+349 |   let f2 v: (('a : value)[@error_message ""][@error_message ""]) = v (* reject second *)
                                                     ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "error_message" attribute cannot appear in this context
 
-File "w53.ml", line 341, characters 21-32:
-341 |   type 'a t1 = 'a [@@layout_poly] (* rejected *)
+File "w53.ml", line 353, characters 21-32:
+353 |   type 'a t1 = 'a [@@layout_poly] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "layout_poly" attribute cannot appear in this context
 
-File "w53.ml", line 342, characters 19-30:
-342 |   type s1 = Foo1 [@layout_poly] (* rejected *)
+File "w53.ml", line 354, characters 19-30:
+354 |   type s1 = Foo1 [@layout_poly] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "layout_poly" attribute cannot appear in this context
 
-File "w53.ml", line 343, characters 19-30:
-343 |   val x : int64 [@@layout_poly] (* rejected *)
+File "w53.ml", line 355, characters 19-30:
+355 |   val x : int64 [@@layout_poly] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "layout_poly" attribute cannot appear in this context
 
-File "w53.ml", line 345, characters 24-35:
-345 |   external y : (int64 [@layout_poly]) -> (int64 [@layout_poly]) = "%identity" (* rejected *)
+File "w53.ml", line 357, characters 24-35:
+357 |   external y : (int64 [@layout_poly]) -> (int64 [@layout_poly]) = "%identity" (* rejected *)
                               ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "layout_poly" attribute cannot appear in this context
 
-File "w53.ml", line 345, characters 50-61:
-345 |   external y : (int64 [@layout_poly]) -> (int64 [@layout_poly]) = "%identity" (* rejected *)
+File "w53.ml", line 357, characters 50-61:
+357 |   external y : (int64 [@layout_poly]) -> (int64 [@layout_poly]) = "%identity" (* rejected *)
                                                         ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "layout_poly" attribute cannot appear in this context
 
-File "w53.ml", line 350, characters 21-32:
-350 |   type 'a t1 = 'a [@@layout_poly] (* rejected *)
+File "w53.ml", line 362, characters 21-32:
+362 |   type 'a t1 = 'a [@@layout_poly] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "layout_poly" attribute cannot appear in this context
 
-File "w53.ml", line 351, characters 19-30:
-351 |   type s1 = Foo1 [@layout_poly] (* rejected *)
+File "w53.ml", line 363, characters 19-30:
+363 |   type s1 = Foo1 [@layout_poly] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "layout_poly" attribute cannot appear in this context
 
-File "w53.ml", line 352, characters 25-36:
-352 |   let x : int64 = 42L [@@layout_poly] (* rejected *)
+File "w53.ml", line 364, characters 25-36:
+364 |   let x : int64 = 42L [@@layout_poly] (* rejected *)
                                ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "layout_poly" attribute cannot appear in this context
 
-File "w53.ml", line 354, characters 24-35:
-354 |   external y : (int64 [@layout_poly]) -> (int64 [@layout_poly]) = "%identity" (* rejected *)
+File "w53.ml", line 366, characters 24-35:
+366 |   external y : (int64 [@layout_poly]) -> (int64 [@layout_poly]) = "%identity" (* rejected *)
                               ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "layout_poly" attribute cannot appear in this context
 
-File "w53.ml", line 354, characters 50-61:
-354 |   external y : (int64 [@layout_poly]) -> (int64 [@layout_poly]) = "%identity" (* rejected *)
+File "w53.ml", line 366, characters 50-61:
+366 |   external y : (int64 [@layout_poly]) -> (int64 [@layout_poly]) = "%identity" (* rejected *)
                                                         ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "layout_poly" attribute cannot appear in this context
 
-File "w53.ml", line 359, characters 21-31:
-359 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
+File "w53.ml", line 371, characters 21-31:
+371 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 360, characters 19-29:
-360 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
+File "w53.ml", line 372, characters 19-29:
+372 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 363, characters 22-32:
-363 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53.ml", line 375, characters 22-32:
+375 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 363, characters 45-55:
-363 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53.ml", line 375, characters 45-55:
+375 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                                                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 364, characters 39-49:
-364 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53.ml", line 376, characters 39-49:
+376 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 365, characters 12-22:
-365 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53.ml", line 377, characters 12-22:
+377 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 367, characters 9-19:
-367 |   class[@zero_alloc] c : (* rejected *)
+File "w53.ml", line 379, characters 9-19:
+379 |   class[@zero_alloc] c : (* rejected *)
                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 369, characters 11-21:
-369 |       val[@zero_alloc] foo : int * int (* rejected *)
+File "w53.ml", line 381, characters 11-21:
+381 |       val[@zero_alloc] foo : int * int (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 370, characters 11-21:
-370 |       val[@zero_alloc] bar : int -> int (* rejected *)
+File "w53.ml", line 382, characters 11-21:
+382 |       val[@zero_alloc] bar : int -> int (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 371, characters 14-24:
-371 |       method[@zero_alloc] baz : int * int (* rejected *)
+File "w53.ml", line 383, characters 14-24:
+383 |       method[@zero_alloc] baz : int * int (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 372, characters 14-24:
-372 |       method[@zero_alloc] boz : int -> int (* rejected *)
+File "w53.ml", line 384, characters 14-24:
+384 |       method[@zero_alloc] boz : int -> int (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 377, characters 21-31:
-377 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
+File "w53.ml", line 389, characters 21-31:
+389 |   type 'a t1 = 'a [@@zero_alloc] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 378, characters 19-29:
-378 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
+File "w53.ml", line 390, characters 19-29:
+390 |   type s1 = Foo1 [@zero_alloc] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 379, characters 22-32:
-379 |   let x : int = 42 [@@zero_alloc] (* rejected *)
+File "w53.ml", line 391, characters 22-32:
+391 |   let x : int = 42 [@@zero_alloc] (* rejected *)
                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 381, characters 7-17:
-381 |   let[@zero_alloc] w = 42 (* rejected *)
+File "w53.ml", line 393, characters 7-17:
+393 |   let[@zero_alloc] w = 42 (* rejected *)
              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 385, characters 22-32:
-385 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53.ml", line 397, characters 22-32:
+397 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 385, characters 45-55:
-385 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
+File "w53.ml", line 397, characters 45-55:
+397 |   external y : (int [@zero_alloc]) -> (int [@zero_alloc]) = "x" (* rejected *)
                                                    ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 386, characters 39-49:
-386 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
+File "w53.ml", line 398, characters 39-49:
+398 |   external z : int -> int = "x" "y" [@@zero_alloc] (* rejected *)
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 387, characters 12-22:
-387 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
+File "w53.ml", line 399, characters 12-22:
+399 |   external[@zero_alloc] q : int -> int = "x" "y" (* rejected *)
                   ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 389, characters 9-19:
-389 |   class[@zero_alloc] foo _y = (* rejected *)
+File "w53.ml", line 401, characters 9-19:
+401 |   class[@zero_alloc] foo _y = (* rejected *)
                ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 391, characters 10-20:
-391 |     (fun[@zero_alloc] z -> (* rejected *)
+File "w53.ml", line 403, characters 10-20:
+403 |     (fun[@zero_alloc] z -> (* rejected *)
                 ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 393, characters 11-21:
-393 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
+File "w53.ml", line 405, characters 11-21:
+405 |       val[@zero_alloc] bar = (4, 5) (* rejected *)
                  ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 395, characters 14-24:
-395 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
-                    ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
-
 File "w53.ml", line 407, characters 14-24:
-407 |     ((boz x)[@zero_alloc assume]) (* rejected *)
+407 |       method[@zero_alloc] baz x = (f (z+10), x+1) (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 412, characters 7-17:
-412 |   let[@zero_alloc assume] foo = (* rejected *)
+File "w53.ml", line 419, characters 14-24:
+419 |     ((boz x)[@zero_alloc assume]) (* rejected *)
+                    ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
+
+File "w53.ml", line 424, characters 7-17:
+424 |   let[@zero_alloc assume] foo = (* rejected *)
              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 416, characters 7-17:
-416 |   let[@zero_alloc] bar = (* rejected *)
+File "w53.ml", line 428, characters 7-17:
+428 |   let[@zero_alloc] bar = (* rejected *)
              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "zero_alloc" attribute cannot appear in this context
 
-File "w53.ml", line 422, characters 24-29:
-422 |   type t1 = { x : int [@boxed] } (* rejected *)
+File "w53.ml", line 434, characters 24-29:
+434 |   type t1 = { x : int [@boxed] } (* rejected *)
                               ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 424, characters 16-21:
-424 |   val x : int [@boxed] (* rejected *)
+File "w53.ml", line 436, characters 16-21:
+436 |   val x : int [@boxed] (* rejected *)
                       ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 428, characters 17-22:
-428 |   val y : int [@@boxed] (* rejected *)
+File "w53.ml", line 440, characters 17-22:
+440 |   val y : int [@@boxed] (* rejected *)
                        ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 430, characters 6-11:
-430 |   [@@@boxed] (* rejected *)
+File "w53.ml", line 442, characters 6-11:
+442 |   [@@@boxed] (* rejected *)
             ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 434, characters 16-21:
-434 |   let x = (42 [@boxed], 84) (* rejected *)
+File "w53.ml", line 446, characters 16-21:
+446 |   let x = (42 [@boxed], 84) (* rejected *)
                       ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 436, characters 16-21:
-436 |   let y = 10 [@@boxed] (* rejected *)
+File "w53.ml", line 448, characters 16-21:
+448 |   let y = 10 [@@boxed] (* rejected *)
                       ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 438, characters 6-11:
-438 |   [@@@boxed] (* rejected *)
+File "w53.ml", line 450, characters 6-11:
+450 |   [@@@boxed] (* rejected *)
             ^^^^^
 Warning 53 [misplaced-attribute]: the "boxed" attribute cannot appear in this context
 
-File "w53.ml", line 445, characters 16-26:
-445 |   val x : int [@deprecated] (* rejected *)
+File "w53.ml", line 457, characters 16-26:
+457 |   val x : int [@deprecated] (* rejected *)
                       ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 451, characters 6-16:
-451 |   [@@@deprecated] (* rejected *)
+File "w53.ml", line 463, characters 6-16:
+463 |   [@@@deprecated] (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 455, characters 14-24:
-455 |   let x = 5 [@deprecated] (* rejected *)
+File "w53.ml", line 467, characters 14-24:
+467 |   let x = 5 [@deprecated] (* rejected *)
                     ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 457, characters 16-26:
-457 |   let y = 10 [@@deprecated] (* rejected *)
+File "w53.ml", line 469, characters 16-26:
+469 |   let y = 10 [@@deprecated] (* rejected *)
                       ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 459, characters 6-16:
-459 |   [@@@deprecated] (* rejected *)
+File "w53.ml", line 471, characters 6-16:
+471 |   [@@@deprecated] (* rejected *)
             ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated" attribute cannot appear in this context
 
-File "w53.ml", line 464, characters 19-37:
-464 |   type t1 = Foo1 [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 476, characters 19-37:
+476 |   type t1 = Foo1 [@deprecated_mutable] (* rejected *)
                          ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 466, characters 16-34:
-466 |   val x : int [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 478, characters 16-34:
+478 |   val x : int [@deprecated_mutable] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 468, characters 21-39:
-468 |   type 'a t2 = 'a [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 480, characters 21-39:
+480 |   type 'a t2 = 'a [@@deprecated_mutable] (* rejected *)
                            ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 472, characters 24-42:
-472 |   type t4 = { x : int [@deprecated_mutable] } (* rejected *)
+File "w53.ml", line 484, characters 24-42:
+484 |   type t4 = { x : int [@deprecated_mutable] } (* rejected *)
                               ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 474, characters 17-35:
-474 |   val y : int [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 486, characters 17-35:
+486 |   val y : int [@@deprecated_mutable] (* rejected *)
                        ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 476, characters 6-24:
-476 |   [@@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 488, characters 6-24:
+488 |   [@@@deprecated_mutable] (* rejected *)
             ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 480, characters 14-32:
-480 |   let x = 5 [@deprecated_mutable] (* rejected *)
+File "w53.ml", line 492, characters 14-32:
+492 |   let x = 5 [@deprecated_mutable] (* rejected *)
                     ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 482, characters 16-34:
-482 |   let y = 10 [@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 494, characters 16-34:
+494 |   let y = 10 [@@deprecated_mutable] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 484, characters 6-24:
-484 |   [@@@deprecated_mutable] (* rejected *)
+File "w53.ml", line 496, characters 6-24:
+496 |   [@@@deprecated_mutable] (* rejected *)
             ^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "deprecated_mutable" attribute cannot appear in this context
 
-File "w53.ml", line 489, characters 32-46:
-489 |   type t1 = Foo1 of int * int [@explicit_arity] (* rejected *)
+File "w53.ml", line 501, characters 32-46:
+501 |   type t1 = Foo1 of int * int [@explicit_arity] (* rejected *)
                                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 491, characters 16-30:
-491 |   val x : int [@explicit_arity] (* rejected *)
+File "w53.ml", line 503, characters 16-30:
+503 |   val x : int [@explicit_arity] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 493, characters 20-34:
-493 |   type 'a t2 = 'a [@explicit_arity] (* rejected *)
+File "w53.ml", line 505, characters 20-34:
+505 |   type 'a t2 = 'a [@explicit_arity] (* rejected *)
                           ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 495, characters 17-31:
-495 |   val y : int [@@explicit_arity] (* rejected *)
+File "w53.ml", line 507, characters 17-31:
+507 |   val y : int [@@explicit_arity] (* rejected *)
                        ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 497, characters 6-20:
-497 |   [@@@explicit_arity] (* rejected *)
+File "w53.ml", line 509, characters 6-20:
+509 |   [@@@explicit_arity] (* rejected *)
             ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 501, characters 14-28:
-501 |   let x = 5 [@explicit_arity] (* rejected *)
+File "w53.ml", line 513, characters 14-28:
+513 |   let x = 5 [@explicit_arity] (* rejected *)
                     ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 503, characters 16-30:
-503 |   let y = 10 [@@explicit_arity] (* rejected *)
+File "w53.ml", line 515, characters 16-30:
+515 |   let y = 10 [@@explicit_arity] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 505, characters 6-20:
-505 |   [@@@explicit_arity] (* rejected *)
+File "w53.ml", line 517, characters 6-20:
+517 |   [@@@explicit_arity] (* rejected *)
             ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "explicit_arity" attribute cannot appear in this context
 
-File "w53.ml", line 510, characters 18-27:
-510 |   type t1 = int [@immediate] (* rejected *)
+File "w53.ml", line 522, characters 18-27:
+522 |   type t1 = int [@immediate] (* rejected *)
                         ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 514, characters 16-25:
-514 |   val x : int [@immediate] (* rejected *)
+File "w53.ml", line 526, characters 16-25:
+526 |   val x : int [@immediate] (* rejected *)
                       ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 515, characters 17-26:
-515 |   val x : int [@@immediate] (* rejected *)
+File "w53.ml", line 527, characters 17-26:
+527 |   val x : int [@@immediate] (* rejected *)
                        ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 517, characters 6-15:
-517 |   [@@@immediate] (* rejected *)
+File "w53.ml", line 529, characters 6-15:
+529 |   [@@@immediate] (* rejected *)
             ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 518, characters 6-17:
-518 |   [@@@immediate64] (* rejected *)
+File "w53.ml", line 530, characters 6-17:
+530 |   [@@@immediate64] (* rejected *)
             ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 522, characters 15-24:
-522 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
+File "w53.ml", line 534, characters 15-24:
+534 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
                      ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 522, characters 32-43:
-522 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
+File "w53.ml", line 534, characters 32-43:
+534 |   let x = (4 [@immediate], 42 [@immediate64]) (* rejected *)
                                       ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 523, characters 21-30:
-523 |   let y = (4, 42) [@@immediate] (* rejected *)
+File "w53.ml", line 535, characters 21-30:
+535 |   let y = (4, 42) [@@immediate] (* rejected *)
                            ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 524, characters 21-32:
-524 |   let z = (4, 42) [@@immediate64] (* rejected *)
+File "w53.ml", line 536, characters 21-32:
+536 |   let z = (4, 42) [@@immediate64] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 526, characters 18-27:
-526 |   type t1 = int [@immediate] (* rejected *)
+File "w53.ml", line 538, characters 18-27:
+538 |   type t1 = int [@immediate] (* rejected *)
                         ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 530, characters 6-15:
-530 |   [@@@immediate] (* rejected *)
+File "w53.ml", line 542, characters 6-15:
+542 |   [@@@immediate] (* rejected *)
             ^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate" attribute cannot appear in this context
 
-File "w53.ml", line 531, characters 6-17:
-531 |   [@@@immediate64] (* rejected *)
+File "w53.ml", line 543, characters 6-17:
+543 |   [@@@immediate64] (* rejected *)
             ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "immediate64" attribute cannot appear in this context
 
-File "w53.ml", line 536, characters 25-31:
-536 |   type t1 = int -> int [@inline] (* rejected *)
+File "w53.ml", line 548, characters 25-31:
+548 |   type t1 = int -> int [@inline] (* rejected *)
                                ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 537, characters 26-32:
-537 |   type t2 = int -> int [@@inline] (* rejected *)
+File "w53.ml", line 549, characters 26-32:
+549 |   type t2 = int -> int [@@inline] (* rejected *)
                                 ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 538, characters 25-32:
-538 |   type t3 = int -> int [@inlined] (* rejected *)
+File "w53.ml", line 550, characters 25-32:
+550 |   type t3 = int -> int [@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 539, characters 26-33:
-539 |   type t4 = int -> int [@@inlined] (* rejected *)
+File "w53.ml", line 551, characters 26-33:
+551 |   type t4 = int -> int [@@inlined] (* rejected *)
                                 ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 541, characters 24-30:
-541 |   val f1 : int -> int [@inline] (* rejected *)
+File "w53.ml", line 553, characters 24-30:
+553 |   val f1 : int -> int [@inline] (* rejected *)
                               ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 542, characters 25-31:
-542 |   val f2 : int -> int [@@inline] (* rejected *)
+File "w53.ml", line 554, characters 25-31:
+554 |   val f2 : int -> int [@@inline] (* rejected *)
                                ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 543, characters 24-31:
-543 |   val f3 : int -> int [@inlined] (* rejected *)
+File "w53.ml", line 555, characters 24-31:
+555 |   val f3 : int -> int [@inlined] (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 544, characters 25-32:
-544 |   val f4 : int -> int [@@inlined] (* rejected *)
+File "w53.ml", line 556, characters 25-32:
+556 |   val f4 : int -> int [@@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 546, characters 53-59:
-546 |   module type F = functor (X : sig end) -> sig end [@inline] (* rejected *)
+File "w53.ml", line 558, characters 53-59:
+558 |   module type F = functor (X : sig end) -> sig end [@inline] (* rejected *)
                                                            ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 547, characters 54-60:
-547 |   module type G = functor (X : sig end) -> sig end [@@inline] (* rejected *)
+File "w53.ml", line 559, characters 54-60:
+559 |   module type G = functor (X : sig end) -> sig end [@@inline] (* rejected *)
                                                             ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 549, characters 6-12:
-549 |   [@@@inline] (* rejected *)
+File "w53.ml", line 561, characters 6-12:
+561 |   [@@@inline] (* rejected *)
             ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 550, characters 6-13:
-550 |   [@@@inlined] (* rejected *)
+File "w53.ml", line 562, characters 6-13:
+562 |   [@@@inlined] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 554, characters 16-22:
-554 |   let h x = x [@inline] (* rejected *)
+File "w53.ml", line 566, characters 16-22:
+566 |   let h x = x [@inline] (* rejected *)
                       ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 555, characters 16-28:
-555 |   let h x = x [@ocaml.inline] (* rejected *)
+File "w53.ml", line 567, characters 16-28:
+567 |   let h x = x [@ocaml.inline] (* rejected *)
                       ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 557, characters 16-23:
-557 |   let i x = x [@inlined] (* rejected *)
+File "w53.ml", line 569, characters 16-23:
+569 |   let i x = x [@inlined] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 558, characters 16-29:
-558 |   let j x = x [@ocaml.inlined] (* rejected *)
+File "w53.ml", line 570, characters 16-29:
+570 |   let j x = x [@ocaml.inlined] (* rejected *)
                       ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 561, characters 18-25:
-561 |   let l x = h x [@inlined] (* rejected *)
+File "w53.ml", line 573, characters 18-25:
+573 |   let l x = h x [@inlined] (* rejected *)
                         ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 569, characters 27-33:
-569 |   module C = struct end [@@inline] (* rejected *)
+File "w53.ml", line 581, characters 27-33:
+581 |   module C = struct end [@@inline] (* rejected *)
                                  ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 570, characters 28-40:
-570 |   module C' = struct end [@@ocaml.inline] (* rejected *)
+File "w53.ml", line 582, characters 28-40:
+582 |   module C' = struct end [@@ocaml.inline] (* rejected *)
                                   ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 571, characters 27-34:
-571 |   module D = struct end [@@inlined] (* rejected *)
+File "w53.ml", line 583, characters 27-34:
+583 |   module D = struct end [@@inlined] (* rejected *)
                                  ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 572, characters 28-41:
-572 |   module D' = struct end [@@ocaml.inlined] (* rejected *)
+File "w53.ml", line 584, characters 28-41:
+584 |   module D' = struct end [@@ocaml.inlined] (* rejected *)
                                   ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 576, characters 18-24:
-576 |   module G = (A [@inline])(struct end) (* rejected *)
+File "w53.ml", line 588, characters 18-24:
+588 |   module G = (A [@inline])(struct end) (* rejected *)
                         ^^^^^^
 Warning 53 [misplaced-attribute]: the "inline" attribute cannot appear in this context
 
-File "w53.ml", line 577, characters 19-31:
-577 |   module G' = (A [@ocaml.inline])(struct end) (* rejected *)
+File "w53.ml", line 589, characters 19-31:
+589 |   module G' = (A [@ocaml.inline])(struct end) (* rejected *)
                          ^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inline" attribute cannot appear in this context
 
-File "w53.ml", line 581, characters 24-31:
-581 |   module I = Set.Make [@inlined] (* rejected *)
+File "w53.ml", line 593, characters 24-31:
+593 |   module I = Set.Make [@inlined] (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 582, characters 25-38:
-582 |   module I' = Set.Make [@ocaml.inlined] (* rejected *)
+File "w53.ml", line 594, characters 25-38:
+594 |   module I' = Set.Make [@ocaml.inlined] (* rejected *)
                                ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 584, characters 25-32:
-584 |   module J = Set.Make [@@inlined] (* rejected *)
+File "w53.ml", line 596, characters 25-32:
+596 |   module J = Set.Make [@@inlined] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "inlined" attribute cannot appear in this context
 
-File "w53.ml", line 585, characters 26-39:
-585 |   module J' = Set.Make [@@ocaml.inlined] (* rejected *)
+File "w53.ml", line 597, characters 26-39:
+597 |   module J' = Set.Make [@@ocaml.inlined] (* rejected *)
                                 ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.inlined" attribute cannot appear in this context
 
-File "w53.ml", line 590, characters 21-28:
-590 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
+File "w53.ml", line 602, characters 21-28:
+602 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 591, characters 19-26:
-591 |   type s1 = Foo1 [@noalloc] (* rejected *)
+File "w53.ml", line 603, characters 19-26:
+603 |   type s1 = Foo1 [@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 592, characters 19-26:
-592 |   val x : int64 [@@noalloc] (* rejected *)
+File "w53.ml", line 604, characters 19-26:
+604 |   val x : int64 [@@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 594, characters 24-31:
-594 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 606, characters 24-31:
+606 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 594, characters 46-53:
-594 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 606, characters 46-53:
+606 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                                                     ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 599, characters 21-28:
-599 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
+File "w53.ml", line 611, characters 21-28:
+611 |   type 'a t1 = 'a [@@noalloc] (* rejected *)
                            ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 600, characters 19-26:
-600 |   type s1 = Foo1 [@noalloc] (* rejected *)
+File "w53.ml", line 612, characters 19-26:
+612 |   type s1 = Foo1 [@noalloc] (* rejected *)
                          ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 601, characters 25-32:
-601 |   let x : int64 = 42L [@@noalloc] (* rejected *)
+File "w53.ml", line 613, characters 25-32:
+613 |   let x : int64 = 42L [@@noalloc] (* rejected *)
                                ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 603, characters 24-31:
-603 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 615, characters 24-31:
+615 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 603, characters 46-53:
-603 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
+File "w53.ml", line 615, characters 46-53:
+615 |   external y : (int64 [@noalloc]) -> (int64 [@noalloc]) = "x" (* rejected *)
                                                     ^^^^^^^
 Warning 53 [misplaced-attribute]: the "noalloc" attribute cannot appear in this context
 
-File "w53.ml", line 632, characters 21-29:
-632 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
+File "w53.ml", line 644, characters 21-29:
+644 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 633, characters 19-27:
-633 |   type s1 = Foo1 [@tailcall] (* rejected *)
+File "w53.ml", line 645, characters 19-27:
+645 |   type s1 = Foo1 [@tailcall] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 634, characters 16-24:
-634 |   val x : int [@tailcall] (* rejected *)
+File "w53.ml", line 646, characters 16-24:
+646 |   val x : int [@tailcall] (* rejected *)
                       ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 636, characters 35-43:
-636 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
+File "w53.ml", line 648, characters 35-43:
+648 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
                                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 638, characters 6-14:
-638 |   [@@@tailcall] (* rejected *)
+File "w53.ml", line 650, characters 6-14:
+650 |   [@@@tailcall] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 642, characters 21-29:
-642 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
+File "w53.ml", line 654, characters 21-29:
+654 |   type 'a t1 = 'a [@@tailcall] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 643, characters 19-27:
-643 |   type s1 = Foo1 [@tailcall] (* rejected *)
+File "w53.ml", line 655, characters 19-27:
+655 |   type s1 = Foo1 [@tailcall] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 645, characters 16-24:
-645 |   let m x = x [@tailcall] (* rejected *)
+File "w53.ml", line 657, characters 16-24:
+657 |   let m x = x [@tailcall] (* rejected *)
                       ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 646, characters 16-30:
-646 |   let n x = x [@ocaml.tailcall] (* rejected *)
+File "w53.ml", line 658, characters 16-30:
+658 |   let n x = x [@ocaml.tailcall] (* rejected *)
                       ^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "ocaml.tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 649, characters 18-26:
-649 |   let q x = m x [@tailcall] (* rejected *)
+File "w53.ml", line 661, characters 18-26:
+661 |   let q x = m x [@tailcall] (* rejected *)
                         ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 651, characters 35-43:
-651 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
+File "w53.ml", line 663, characters 35-43:
+663 |   external z : int -> int = "x" [@@tailcall] (* rejected *)
                                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 653, characters 6-14:
-653 |   [@@@tailcall] (* rejected *)
+File "w53.ml", line 665, characters 6-14:
+665 |   [@@@tailcall] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tailcall" attribute cannot appear in this context
 
-File "w53.ml", line 658, characters 24-31:
-658 |   type t1 = { x : int [@unboxed] } (* rejected *)
+File "w53.ml", line 670, characters 24-31:
+670 |   type t1 = { x : int [@unboxed] } (* rejected *)
                               ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 660, characters 16-23:
-660 |   val x : int [@unboxed] (* rejected *)
+File "w53.ml", line 672, characters 16-23:
+672 |   val x : int [@unboxed] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 664, characters 17-24:
-664 |   val y : int [@@unboxed] (* rejected *)
+File "w53.ml", line 676, characters 17-24:
+676 |   val y : int [@@unboxed] (* rejected *)
                        ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 668, characters 6-13:
-668 |   [@@@unboxed] (* rejected *)
+File "w53.ml", line 680, characters 6-13:
+680 |   [@@@unboxed] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 672, characters 16-23:
-672 |   let x = (42 [@unboxed], 84) (* rejected *)
+File "w53.ml", line 684, characters 16-23:
+684 |   let x = (42 [@unboxed], 84) (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 674, characters 16-23:
-674 |   let y = 10 [@@unboxed] (* rejected *)
+File "w53.ml", line 686, characters 16-23:
+686 |   let y = 10 [@@unboxed] (* rejected *)
                       ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 678, characters 6-13:
-678 |   [@@@unboxed] (* rejected *)
+File "w53.ml", line 690, characters 6-13:
+690 |   [@@@unboxed] (* rejected *)
             ^^^^^^^
 Warning 53 [misplaced-attribute]: the "unboxed" attribute cannot appear in this context
 
-File "w53.ml", line 683, characters 21-29:
-683 |   type 'a t1 = 'a [@@untagged] (* rejected *)
+File "w53.ml", line 695, characters 21-29:
+695 |   type 'a t1 = 'a [@@untagged] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 684, characters 19-27:
-684 |   type s1 = Foo1 [@untagged] (* rejected *)
+File "w53.ml", line 696, characters 19-27:
+696 |   type s1 = Foo1 [@untagged] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 685, characters 17-25:
-685 |   val x : int [@@untagged] (* rejected *)
+File "w53.ml", line 697, characters 17-25:
+697 |   val x : int [@@untagged] (* rejected *)
                        ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 692, characters 21-29:
-692 |   type 'a t1 = 'a [@@untagged] (* rejected *)
+File "w53.ml", line 704, characters 21-29:
+704 |   type 'a t1 = 'a [@@untagged] (* rejected *)
                            ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 693, characters 19-27:
-693 |   type s1 = Foo1 [@untagged] (* rejected *)
+File "w53.ml", line 705, characters 19-27:
+705 |   type s1 = Foo1 [@untagged] (* rejected *)
                          ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 694, characters 22-30:
-694 |   let x : int = 42 [@@untagged] (* rejected *)
+File "w53.ml", line 706, characters 22-30:
+706 |   let x : int = 42 [@@untagged] (* rejected *)
                             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "untagged" attribute cannot appear in this context
 
-File "w53.ml", line 702, characters 24-32:
-702 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
+File "w53.ml", line 714, characters 24-32:
+714 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 703, characters 27-35:
-703 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
+File "w53.ml", line 715, characters 27-35:
+715 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
                                  ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 705, characters 23-31:
-705 |   val f : int -> int [@unrolled 42] (* rejected *)
+File "w53.ml", line 717, characters 23-31:
+717 |   val f : int -> int [@unrolled 42] (* rejected *)
                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 706, characters 24-32:
-706 |   val g : int -> int [@@unrolled 42] (* rejected *)
+File "w53.ml", line 718, characters 24-32:
+718 |   val g : int -> int [@@unrolled 42] (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 708, characters 39-47:
-708 |   external z : float -> float = "x" [@@unrolled 42] (* rejected *)
+File "w53.ml", line 720, characters 39-47:
+720 |   external z : float -> float = "x" [@@unrolled 42] (* rejected *)
                                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 710, characters 6-14:
-710 |   [@@@unrolled 42] (* rejected *)
+File "w53.ml", line 722, characters 6-14:
+722 |   [@@@unrolled 42] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 714, characters 8-16:
-714 |   let [@unrolled 42] rec test_unrolled x = (* rejected *)
+File "w53.ml", line 726, characters 8-16:
+726 |   let [@unrolled 42] rec test_unrolled x = (* rejected *)
               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 721, characters 24-32:
-721 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
+File "w53.ml", line 733, characters 24-32:
+733 |   type t1 = { x : int [@unrolled 42] } (* rejected *)
                               ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 722, characters 27-35:
-722 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
+File "w53.ml", line 734, characters 27-35:
+734 |   type t2 = { x : int } [@@unrolled 42] (* rejected *)
                                  ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 724, characters 22-30:
-724 |   let rec f x = f x [@unrolled 42] (* rejected *)
+File "w53.ml", line 736, characters 22-30:
+736 |   let rec f x = f x [@unrolled 42] (* rejected *)
                             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 725, characters 23-31:
-725 |   let rec f x = f x [@@unrolled 42] (* rejected *)
+File "w53.ml", line 737, characters 23-31:
+737 |   let rec f x = f x [@@unrolled 42] (* rejected *)
                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 727, characters 39-47:
-727 |   external z : int -> int = "x" "y" [@@unrolled 42] (* rejected *)
+File "w53.ml", line 739, characters 39-47:
+739 |   external z : int -> int = "x" "y" [@@unrolled 42] (* rejected *)
                                              ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 729, characters 6-14:
-729 |   [@@@unrolled 42] (* rejected *)
+File "w53.ml", line 741, characters 6-14:
+741 |   [@@@unrolled 42] (* rejected *)
             ^^^^^^^^
 Warning 53 [misplaced-attribute]: the "unrolled" attribute cannot appear in this context
 
-File "w53.ml", line 778, characters 25-48:
-778 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 790, characters 25-48:
+790 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
                                ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 782, characters 16-39:
-782 |   val x : int [@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 794, characters 16-39:
+794 |   val x : int [@warn_on_literal_pattern] (* rejected *)
                       ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 784, characters 21-44:
-784 |   type 'a t2 = 'a [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 796, characters 21-44:
+796 |   type 'a t2 = 'a [@@warn_on_literal_pattern] (* rejected *)
                            ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 786, characters 17-40:
-786 |   val y : int [@@warn_on_literal_pattern] (* rejected *)
+File "w53.ml", line 798, characters 17-40:
+798 |   val y : int [@@warn_on_literal_pattern] (* rejected *)
                        ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
-
-File "w53.ml", line 788, characters 6-29:
-788 |   [@@@warn_on_literal_pattern] (* rejected *)
-            ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
-
-File "w53.ml", line 794, characters 25-48:
-794 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
-                               ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
-
-File "w53.ml", line 796, characters 14-37:
-796 |   let x = 5 [@warn_on_literal_pattern] (* rejected *)
-                    ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
-
-File "w53.ml", line 798, characters 16-39:
-798 |   let y = 10 [@@warn_on_literal_pattern] (* rejected *)
-                      ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
 File "w53.ml", line 800, characters 6-29:
@@ -1558,114 +1548,99 @@ File "w53.ml", line 800, characters 6-29:
             ^^^^^^^^^^^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
 
-File "w53.ml", line 809, characters 21-25:
-809 |   type 'a t1 = 'a [@@poll error] (* rejected *)
+File "w53.ml", line 806, characters 25-48:
+806 |     | Lit_pat2 of int [@@warn_on_literal_pattern] (* rejected *)
+                               ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+
+File "w53.ml", line 808, characters 14-37:
+808 |   let x = 5 [@warn_on_literal_pattern] (* rejected *)
+                    ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+
+File "w53.ml", line 810, characters 16-39:
+810 |   let y = 10 [@@warn_on_literal_pattern] (* rejected *)
+                      ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+
+File "w53.ml", line 812, characters 6-29:
+812 |   [@@@warn_on_literal_pattern] (* rejected *)
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "warn_on_literal_pattern" attribute cannot appear in this context
+
+File "w53.ml", line 821, characters 21-25:
+821 |   type 'a t1 = 'a [@@poll error] (* rejected *)
                            ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 810, characters 19-23:
-810 |   type s1 = Foo1 [@poll error] (* rejected *)
+File "w53.ml", line 822, characters 19-23:
+822 |   type s1 = Foo1 [@poll error] (* rejected *)
                          ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 811, characters 19-23:
-811 |   val x : int64 [@@poll error] (* rejected *)
+File "w53.ml", line 823, characters 19-23:
+823 |   val x : int64 [@@poll error] (* rejected *)
                          ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 813, characters 24-28:
-813 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+File "w53.ml", line 825, characters 24-28:
+825 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
                               ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 813, characters 49-53:
-813 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
+File "w53.ml", line 825, characters 49-53:
+825 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) = (* rejected *)
                                                        ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 815, characters 39-43:
-815 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
+File "w53.ml", line 827, characters 39-43:
+827 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
                                              ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 819, characters 21-25:
-819 |   type 'a t1 = 'a [@@poll error] (* rejected *)
+File "w53.ml", line 831, characters 21-25:
+831 |   type 'a t1 = 'a [@@poll error] (* rejected *)
                            ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 820, characters 19-23:
-820 |   type s1 = Foo1 [@poll error] (* rejected *)
+File "w53.ml", line 832, characters 19-23:
+832 |   type s1 = Foo1 [@poll error] (* rejected *)
                          ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 821, characters 25-29:
-821 |   let x : int64 = 42L [@@poll error] (* rejected *)
+File "w53.ml", line 833, characters 25-29:
+833 |   let x : int64 = 42L [@@poll error] (* rejected *)
                                ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 824, characters 24-28:
-824 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
+File "w53.ml", line 836, characters 24-28:
+836 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
                               ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 824, characters 49-53:
-824 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
+File "w53.ml", line 836, characters 49-53:
+836 |   external y : (int64 [@poll error]) -> (int64 [@poll error]) =  (* rejected *)
                                                        ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 826, characters 39-43:
-826 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
+File "w53.ml", line 838, characters 39-43:
+838 |   external z : int64 -> int64 = "x" [@@poll error] (* rejected *)
                                              ^^^^
 Warning 53 [misplaced-attribute]: the "poll" attribute cannot appear in this context
 
-File "w53.ml", line 831, characters 21-31:
-831 |   type 'a t1 = 'a [@@specialise] (* rejected *)
+File "w53.ml", line 843, characters 21-31:
+843 |   type 'a t1 = 'a [@@specialise] (* rejected *)
                            ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 832, characters 19-29:
-832 |   type s1 = Foo1 [@specialise] (* rejected *)
+File "w53.ml", line 844, characters 19-29:
+844 |   type s1 = Foo1 [@specialise] (* rejected *)
                          ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 833, characters 19-29:
-833 |   val x : int64 [@@specialise] (* rejected *)
+File "w53.ml", line 845, characters 19-29:
+845 |   val x : int64 [@@specialise] (* rejected *)
                          ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
-
-File "w53.ml", line 835, characters 24-34:
-835 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
-                              ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
-
-File "w53.ml", line 835, characters 49-59:
-835 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
-                                                       ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
-
-File "w53.ml", line 837, characters 39-49:
-837 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
-                                             ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
-
-File "w53.ml", line 841, characters 21-31:
-841 |   type 'a t1 = 'a [@@specialise] (* rejected *)
-                           ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
-
-File "w53.ml", line 842, characters 19-29:
-842 |   type s1 = Foo1 [@specialise] (* rejected *)
-                         ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
-
-File "w53.ml", line 843, characters 25-35:
-843 |   let x : int64 = 42L [@@specialise] (* rejected *)
-                               ^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
-
-File "w53.ml", line 845, characters 16-26:
-845 |   let g x = (f[@specialise]) x (* rejected *)
-                      ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
 File "w53.ml", line 847, characters 24-34:
@@ -1683,54 +1658,54 @@ File "w53.ml", line 849, characters 39-49:
                                              ^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
 
-File "w53.ml", line 854, characters 21-32:
-854 |   type 'a t1 = 'a [@@specialised] (* rejected *)
+File "w53.ml", line 853, characters 21-31:
+853 |   type 'a t1 = 'a [@@specialise] (* rejected *)
+                           ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+
+File "w53.ml", line 854, characters 19-29:
+854 |   type s1 = Foo1 [@specialise] (* rejected *)
+                         ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+
+File "w53.ml", line 855, characters 25-35:
+855 |   let x : int64 = 42L [@@specialise] (* rejected *)
+                               ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+
+File "w53.ml", line 857, characters 16-26:
+857 |   let g x = (f[@specialise]) x (* rejected *)
+                      ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+
+File "w53.ml", line 859, characters 24-34:
+859 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+                              ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+
+File "w53.ml", line 859, characters 49-59:
+859 |   external y : (int64 [@specialise]) -> (int64 [@specialise]) = (* rejected *)
+                                                       ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+
+File "w53.ml", line 861, characters 39-49:
+861 |   external z : int64 -> int64 = "x" [@@specialise] (* rejected *)
+                                             ^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialise" attribute cannot appear in this context
+
+File "w53.ml", line 866, characters 21-32:
+866 |   type 'a t1 = 'a [@@specialised] (* rejected *)
                            ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 855, characters 19-30:
-855 |   type s1 = Foo1 [@specialised] (* rejected *)
+File "w53.ml", line 867, characters 19-30:
+867 |   type s1 = Foo1 [@specialised] (* rejected *)
                          ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 856, characters 19-30:
-856 |   val x : int64 [@@specialised] (* rejected *)
+File "w53.ml", line 868, characters 19-30:
+868 |   val x : int64 [@@specialised] (* rejected *)
                          ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
-
-File "w53.ml", line 858, characters 24-35:
-858 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
-                              ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
-
-File "w53.ml", line 858, characters 50-61:
-858 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
-                                                        ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
-
-File "w53.ml", line 860, characters 39-50:
-860 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
-                                             ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
-
-File "w53.ml", line 864, characters 21-32:
-864 |   type 'a t1 = 'a [@@specialised] (* rejected *)
-                           ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
-
-File "w53.ml", line 865, characters 19-30:
-865 |   type s1 = Foo1 [@specialised] (* rejected *)
-                         ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
-
-File "w53.ml", line 866, characters 25-36:
-866 |   let x : int64 = 42L [@@specialised] (* rejected *)
-                               ^^^^^^^^^^^
-Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
-
-File "w53.ml", line 867, characters 8-19:
-867 |   let [@specialised] f x = x (* rejected *)
-              ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
 File "w53.ml", line 870, characters 24-35:
@@ -1748,72 +1723,107 @@ File "w53.ml", line 872, characters 39-50:
                                              ^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
 
-File "w53.ml", line 877, characters 21-34:
-877 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 876, characters 21-32:
+876 |   type 'a t1 = 'a [@@specialised] (* rejected *)
+                           ^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+
+File "w53.ml", line 877, characters 19-30:
+877 |   type s1 = Foo1 [@specialised] (* rejected *)
+                         ^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+
+File "w53.ml", line 878, characters 25-36:
+878 |   let x : int64 = 42L [@@specialised] (* rejected *)
+                               ^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+
+File "w53.ml", line 879, characters 8-19:
+879 |   let [@specialised] f x = x (* rejected *)
+              ^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+
+File "w53.ml", line 882, characters 24-35:
+882 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+                              ^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+
+File "w53.ml", line 882, characters 50-61:
+882 |   external y : (int64 [@specialised]) -> (int64 [@specialised]) = (* rejected *)
+                                                        ^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+
+File "w53.ml", line 884, characters 39-50:
+884 |   external z : int64 -> int64 = "x" [@@specialised] (* rejected *)
+                                             ^^^^^^^^^^^
+Warning 53 [misplaced-attribute]: the "specialised" attribute cannot appear in this context
+
+File "w53.ml", line 889, characters 21-34:
+889 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
                            ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 878, characters 19-32:
-878 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
+File "w53.ml", line 890, characters 19-32:
+890 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 879, characters 19-32:
-879 |   val x : int64 [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 891, characters 19-32:
+891 |   val x : int64 [@@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 881, characters 24-37:
-881 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 893, characters 24-37:
+893 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                               ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 881, characters 52-65:
-881 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 893, characters 52-65:
+893 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                                                           ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 884, characters 39-52:
-884 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 896, characters 39-52:
+896 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
                                              ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 888, characters 21-34:
-888 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 900, characters 21-34:
+900 |   type 'a t1 = 'a [@@tail_mod_cons] (* rejected *)
                            ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 889, characters 19-32:
-889 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
+File "w53.ml", line 901, characters 19-32:
+901 |   type s1 = Foo1 [@tail_mod_cons] (* rejected *)
                          ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 890, characters 25-38:
-890 |   let x : int64 = 42L [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 902, characters 25-38:
+902 |   let x : int64 = 42L [@@tail_mod_cons] (* rejected *)
                                ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 892, characters 16-29:
-892 |   let g x = (f[@tail_mod_cons]) x (* rejected *)
+File "w53.ml", line 904, characters 16-29:
+904 |   let g x = (f[@tail_mod_cons]) x (* rejected *)
                       ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 894, characters 24-37:
-894 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 906, characters 24-37:
+906 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                               ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 894, characters 52-65:
-894 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
+File "w53.ml", line 906, characters 52-65:
+906 |   external y : (int64 [@tail_mod_cons]) -> (int64 [@tail_mod_cons]) =
                                                           ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 897, characters 39-52:
-897 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
+File "w53.ml", line 909, characters 39-52:
+909 |   external z : int64 -> int64 = "x" [@@tail_mod_cons] (* rejected *)
                                              ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context
 
-File "w53.ml", line 903, characters 10-15:
-903 |       [@@@alert foo "foo"] (* rejected *)
+File "w53.ml", line 915, characters 10-15:
+915 |       [@@@alert foo "foo"] (* rejected *)
                 ^^^^^
 Warning 53 [misplaced-attribute]: the "alert" attribute cannot appear in this context

--- a/testsuite/tests/warnings/w53.ml
+++ b/testsuite/tests/warnings/w53.ml
@@ -108,6 +108,18 @@ module TestFlambdaStruct = struct
   [@@@flambda_oclassic] (* accepted *)
 end
 
+module type TestInferSig = sig
+  type 'a t = { x : 'a } [@@infer_with_bounds] (* rejected *)
+
+  [@@@infer_with_bounds] (* accepted *)
+end
+
+module TestInferStruct = struct
+  type 'a t = { x : 'a } [@@infer_with_bounds] (* rejected *)
+
+  [@@@infer_with_bounds] (* accepted *)
+end
+
 module type TestAflInstRatioSig = sig
   type 'a t1 = 'a [@@afl_inst_ratio 42] (* rejected *)
 


### PR DESCRIPTION
This is an idea from @mshinwell to deal with older dunes. To really finish the job, we also need to add the attribute to a bunch of the stdlib. But @glittershark wonders about just removing `-infer-with-bounds` instead, so we'll wait to check perf numbers tonight before proceeding.