### PR TITLE
Remove base kind mode crossing and add `mod everything`

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -79,8 +79,8 @@ type t2 : bits64 mod once external64 aliased
 type t3 : immediate mod local aliased
 
 [%%expect {|
-type t1 : float32
-type t2 : bits64
+type t1 : float32 mod many
+type t2 : bits64 mod aliased external64
 type t3 : immediate
 |}]
 
@@ -330,8 +330,8 @@ type (_ : float64) t2_float64'
 type t3 = float# t2_float64
 type ('a : value mod global) t2_global
 type (_ : value mod global) t2_global'
-type ('a : word) t2_complex
-type (_ : word) t2_complex'
+type ('a : word mod aliased many external_) t2_complex
+type (_ : word mod aliased many external_) t2_complex'
 |}]
 
 module M1 : sig
@@ -398,8 +398,8 @@ end = struct
 end
 
 [%%expect {|
-module M1 : sig type ('a : word) t end
-module M2 : sig type (_ : word) t end
+module M1 : sig type ('a : word mod aliased many external_) t end
+module M2 : sig type (_ : word mod aliased many external_) t end
 |}]
 
 type t = string t2_imm
@@ -428,11 +428,11 @@ Error: This type "string" should be an instance of type "('a : value mod global)
          because of the definition of t2_global at line 8, characters 0-38.
 |}]
 
-type u : word
+type u : word mod aliased many external_
 type t = u t2_complex
 ;;
 [%%expect {|
-type u : word
+type u : word mod aliased many external_
 type t = u t2_complex
 |}]
 
@@ -442,7 +442,9 @@ let f : 'a t2_complex -> 'a t2_complex = fun x -> x
 [%%expect {|
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
-val f : ('a : word). 'a t2_complex -> 'a t2_complex = <fun>
+val f :
+  ('a : word mod aliased many external_). 'a t2_complex -> 'a t2_complex =
+  <fun>
 |}]
 
 let f : ('a : immediate) t2_imm -> ('a : value) t2_imm = fun x -> x
@@ -451,7 +453,9 @@ let f : ('a : word mod external_ many aliased) t2_complex -> ('a : word) t2_comp
 [%%expect {|
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
-val f : ('a : word). 'a t2_complex -> 'a t2_complex = <fun>
+val f :
+  ('a : word mod aliased many external_). 'a t2_complex -> 'a t2_complex =
+  <fun>
 |}]
 
 let f : ('a : value) t2_imm -> ('a : value) t2_imm = fun x -> x
@@ -460,7 +464,9 @@ let f : ('a : word) t2_complex -> ('a : word) t2_complex = fun x -> x
 [%%expect {|
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
-val f : ('a : word). 'a t2_complex -> 'a t2_complex = <fun>
+val f :
+  ('a : word mod aliased many external_). 'a t2_complex -> 'a t2_complex =
+  <fun>
 |}]
 
 let f : ('a : immediate). 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -469,7 +475,9 @@ let f : ('a : word mod external_ many aliased). 'a t2_complex -> 'a t2_complex =
 [%%expect {|
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
-val f : ('a : word). 'a t2_complex -> 'a t2_complex = <fun>
+val f :
+  ('a : word mod aliased many external_). 'a t2_complex -> 'a t2_complex =
+  <fun>
 |}]
 
 let f : ('a : value). 'a t2_imm -> 'a t2_imm = fun x -> x
@@ -494,10 +502,14 @@ Error: The universal type variable 'a was declared to have kind value.
          because of the definition of t2_global at line 8, characters 0-38.
 |}]
 
-let f : ('a : word). 'a t2_complex -> 'a t2_complex = fun x -> x
+let f :
+  ('a : word mod external_ many aliased). 'a t2_complex -> 'a t2_complex
+  = fun x -> x
 ;;
 [%%expect {|
-val f : ('a : word). 'a t2_complex -> 'a t2_complex = <fun>
+val f :
+  ('a : word mod aliased many external_). 'a t2_complex -> 'a t2_complex =
+  <fun>
 |}]
 
 type 'a t = 'a t2_imm
@@ -506,7 +518,7 @@ type 'a t = 'a t2_complex
 [%%expect {|
 type ('a : immediate) t = 'a t2_imm
 type ('a : value mod global) t = 'a t2_global
-type ('a : word) t = 'a t2_complex
+type ('a : word mod aliased many external_) t = 'a t2_complex
 |}]
 
 type ('a : value) t = 'a t2_imm
@@ -515,7 +527,7 @@ type ('a : word) t = 'a t2_complex
 [%%expect {|
 type ('a : immediate) t = 'a t2_imm
 type ('a : value mod global) t = 'a t2_global
-type ('a : word) t = 'a t2_complex
+type ('a : word mod aliased many external_) t = 'a t2_complex
 |}]
 
 type ('a : immediate) t = 'a t2_imm
@@ -524,7 +536,7 @@ type ('a : word mod external_ many aliased) t = 'a t2_complex
 [%%expect {|
 type ('a : immediate) t = 'a t2_imm
 type ('a : value mod global) t = 'a t2_global
-type ('a : word) t = 'a t2_complex
+type ('a : word mod aliased many external_) t = 'a t2_complex
 |}]
 
 let f : (_ : value) t2_imm -> unit = fun _ -> ()
@@ -541,8 +553,8 @@ val f : ('a : immediate). 'a t2_imm -> unit = <fun>
 val g : ('a : immediate). 'a t2_imm -> unit = <fun>
 val f : ('a : value mod global). 'a t2_global -> unit = <fun>
 val g : ('a : value mod global). 'a t2_global -> unit = <fun>
-val f : ('a : word). 'a t2_complex -> unit = <fun>
-val g : ('a : word). 'a t2_complex -> unit = <fun>
+val f : ('a : word mod aliased many external_). 'a t2_complex -> unit = <fun>
+val g : ('a : word mod aliased many external_). 'a t2_complex -> unit = <fun>
 |}]
 
 let f : (_ : immediate) -> unit = fun _ -> ()
@@ -553,7 +565,7 @@ let g : (_ : value) -> unit = fun _ -> ()
 [%%expect {|
 val f : ('a : immediate). 'a -> unit = <fun>
 val f : ('a : value mod global). 'a -> unit = <fun>
-val f : ('a : word). 'a -> unit = <fun>
+val f : ('a : word mod aliased many external_). 'a -> unit = <fun>
 val g : 'a -> unit = <fun>
 |}]
 
@@ -571,8 +583,8 @@ val f : ('a : immediate) 'b. 'a -> 'b = <fun>
 val g : 'a ('b : immediate). 'a -> 'b = <fun>
 val f : ('a : value mod global) 'b. 'a -> 'b = <fun>
 val g : 'a ('b : value mod global). 'a -> 'b = <fun>
-val f : ('a : word) 'b. 'a -> 'b = <fun>
-val g : 'a ('b : word). 'a -> 'b = <fun>
+val f : ('a : word mod aliased many external_) 'b. 'a -> 'b = <fun>
+val g : 'a ('b : word mod aliased many external_). 'a -> 'b = <fun>
 |}]
 
 (********************************************)
@@ -636,8 +648,8 @@ let f { fieldc } =
   let x : _ as (_ : word mod external_ many aliased) = assert false in
   fieldc x;;
 [%%expect {|
-type rc = { fieldc : ('a : word). 'a -> 'a; }
-val f : ('a : word). rc -> 'a = <fun>
+type rc = { fieldc : ('a : word mod aliased many external_). 'a -> 'a; }
+val f : ('a : word mod aliased many external_). rc -> 'a = <fun>
 |}]
 
 let f { field } = field "hello"
@@ -675,7 +687,7 @@ Line 1, characters 26-33:
 1 | let f { fieldc } = fieldc "hello"
                               ^^^^^^^
 Error: This expression has type "string" but an expression was expected of type
-         "('a : word)"
+         "('a : word mod aliased many external_)"
        The layout of string is value
          because it is the primitive type string.
        But the layout of string must be a sublayout of word
@@ -786,12 +798,12 @@ Error: Layout mismatch in final type declaration consistency check.
 
 type ('a : word mod external_ many aliased) t_complex
 
-type s = { f : ('a : word). 'a -> 'a u }
+type s = { f : ('a : word mod external_ many aliased). 'a -> 'a u }
 and 'a u = 'a t_complex
 [%%expect {|
-type ('a : word) t_complex
-type s = { f : ('a : word). 'a -> 'a u; }
-and ('a : word) u = 'a t_complex
+type ('a : word mod aliased many external_) t_complex
+type s = { f : ('a : word mod aliased many external_). 'a -> 'a u; }
+and ('a : word mod aliased many external_) u = 'a t_complex
 |}]
 
 (********************)
@@ -824,7 +836,7 @@ val f : ('a : value mod global). 'a -> 'a = <fun>
 let f = fun (type (a : word mod external_ many aliased)) (x : a) -> x
 ;;
 [%%expect {|
-val f : ('a : word). 'a -> 'a = <fun>
+val f : ('a : word mod aliased many external_). 'a -> 'a = <fun>
 |}]
 
 let f = fun (type (a : any)) (x : a) -> x
@@ -872,7 +884,7 @@ val f : ('a : value mod global). 'a -> 'a = <fun>
 let f : type (a : word mod external_ many aliased). a -> a = fun x -> x
 ;;
 [%%expect {|
-val f : ('a : word). 'a -> 'a = <fun>
+val f : ('a : word mod aliased many external_). 'a -> 'a = <fun>
 |}]
 
 let f : type (a : any). a -> a = fun x -> x
@@ -960,7 +972,8 @@ end
 Line 2, characters 24-26:
 2 |   val f : ('a : value). 'a t2_complex -> 'a t2_complex
                             ^^
-Error: This type "('a : value)" should be an instance of type "('b : word)"
+Error: This type "('a : value)" should be an instance of type
+         "('b : word mod aliased many external_)"
        The layout of 'a is value
          because of the annotation on the universal variable 'a.
        But the layout of 'a must overlap with word
@@ -968,11 +981,15 @@ Error: This type "('a : value)" should be an instance of type "('b : word)"
 |}]
 
 module type S = sig
-  val f : ('a : word). 'a t2_complex -> 'a t2_complex
+  val f : ('a : word mod aliased many external_). 'a t2_complex -> 'a t2_complex
 end
 ;;
 [%%expect {|
-module type S = sig val f : ('a : word). 'a t2_complex -> 'a t2_complex end
+module type S =
+  sig
+    val f :
+      ('a : word mod aliased many external_). 'a t2_complex -> 'a t2_complex
+  end
 |}]
 
 module type S = sig
@@ -1015,17 +1032,20 @@ module type S =
 |}]
 
 module type S = sig
-  val f : 'a t2_complex -> 'a t2_complex
+  val f : ('a : word mod external_ many aliased) t2_complex -> 'a t2_complex
   val g : ('a : word mod external_ many aliased). 'a t2_complex -> 'a t2_complex
-  val h : ('a : word mod external_ many). 'a t2_complex -> 'a t2_complex
+  val h : ('a : word mod external_ many aliased). 'a t2_complex -> 'a t2_complex
 end
 ;;
 [%%expect {|
 module type S =
   sig
-    val f : ('a : word). 'a t2_complex -> 'a t2_complex
-    val g : ('a : word). 'a t2_complex -> 'a t2_complex
-    val h : ('a : word). 'a t2_complex -> 'a t2_complex
+    val f :
+      ('a : word mod aliased many external_). 'a t2_complex -> 'a t2_complex
+    val g :
+      ('a : word mod aliased many external_). 'a t2_complex -> 'a t2_complex
+    val h :
+      ('a : word mod aliased many external_). 'a t2_complex -> 'a t2_complex
   end
 |}]
 
@@ -1043,7 +1063,8 @@ let f (x : ('a : word mod external_ many aliased). 'a -> 'a) =
   x native_int
 
 [%%expect {|
-val f : (('a : word). 'a -> 'a) -> nativeint# = <fun>
+val f : (('a : word mod aliased many external_). 'a -> 'a) -> nativeint# =
+  <fun>
 |}]
 
 let f (x : ('a : immediate). 'a -> 'a) = x "string"
@@ -1365,7 +1386,7 @@ type t : bits64 mod portable aliased
 type u = private t
 let f (x : t) : _ as (_ : bits64 mod portable aliased) = x
 [%%expect {|
-type t : bits64
+type t : bits64 mod aliased portable
 type u = private t
 val f : t -> t = <fun>
 |}]
@@ -1374,7 +1395,7 @@ type t : bits64 mod portable aliased
 type u : bits64 = private t
 let f (x : t) : _ as (_ : bits64 mod portable aliased) = x
 [%%expect {|
-type t : bits64
+type t : bits64 mod aliased portable
 type u = private t
 val f : t -> t = <fun>
 |}]
@@ -1384,7 +1405,7 @@ type t : bits64 mod portable aliased
 type u : bits64 mod portable aliased = private t
 let f (x : t) : _ as (_ : bits64 mod portable aliased) = x
 [%%expect {|
-type t : bits64
+type t : bits64 mod aliased portable
 type u = private t
 val f : t -> t = <fun>
 |}]
@@ -1392,7 +1413,7 @@ val f : t -> t = <fun>
 type t : float64 mod global portable
 type u : bits64 mod global portable = private t
 [%%expect {|
-type t : float64
+type t : float64 mod global portable
 Line 2, characters 0-47:
 2 | type u : bits64 mod global portable = private t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1494,7 +1515,7 @@ val f : 'a -> 'a = <fun>
 val f : ('a : immediate). 'a -> 'a = <fun>
 val f : ('a : value mod global). 'a -> 'a = <fun>
 val f : ('a : immediate). 'a -> 'a = <fun>
-val f : ('a : word). 'a -> 'a = <fun>
+val f : ('a : word mod aliased many external_). 'a -> 'a = <fun>
 |}]
 
 let f = fun (type a : value) (x : a) -> x
@@ -1508,7 +1529,7 @@ val f : 'a -> 'a = <fun>
 val f : ('a : immediate). 'a -> 'a = <fun>
 val f : ('a : value mod global). 'a -> 'a = <fun>
 val f : ('a : immediate). 'a -> 'a = <fun>
-val f : ('a : word). 'a -> 'a = <fun>
+val f : ('a : word mod aliased many external_). 'a -> 'a = <fun>
 |}]
 
 let o = object
@@ -1532,7 +1553,7 @@ val o : < m : 'a. 'a -> 'a > = <obj>
 val o : < m : ('a : immediate). 'a -> 'a > = <obj>
 val o : < m : ('a : value mod global). 'a -> 'a > = <obj>
 val o : < m : ('a : immediate). 'a -> 'a > = <obj>
-val o : < m : ('a : word). 'a -> 'a > = <obj>
+val o : < m : ('a : word mod aliased many external_). 'a -> 'a > = <obj>
 |}]
 
 let f : type (a : value). a -> a = fun x -> x
@@ -1546,7 +1567,7 @@ val f : 'a -> 'a = <fun>
 val f : ('a : immediate). 'a -> 'a = <fun>
 val f : ('a : value mod global). 'a -> 'a = <fun>
 val f : ('a : immediate). 'a -> 'a = <fun>
-val f : ('a : word). 'a -> 'a = <fun>
+val f : ('a : word mod aliased many external_). 'a -> 'a = <fun>
 |}]
 
 let f x =
@@ -1574,7 +1595,7 @@ val f : 'a -> 'a = <fun>
 val f : ('a : immediate). 'a -> 'a = <fun>
 val f : ('a : value mod global). 'a -> 'a = <fun>
 val f : ('a : immediate). 'a -> 'a = <fun>
-val f : ('a : word). 'a -> 'a = <fun>
+val f : ('a : word mod aliased many external_). 'a -> 'a = <fun>
 |}]
 
 let f = fun x y (type (a : value)) (z : a) -> z
@@ -1588,7 +1609,8 @@ val f : 'b -> 'c -> 'a -> 'a = <fun>
 val f : 'b 'c ('a : immediate). 'b -> 'c -> 'a -> 'a = <fun>
 val f : 'b 'c ('a : value mod global). 'b -> 'c -> 'a -> 'a = <fun>
 val f : 'b 'c ('a : immediate). 'b -> 'c -> 'a -> 'a = <fun>
-val f : 'b 'c ('a : word). 'b -> 'c -> 'a -> 'a = <fun>
+val f : 'b 'c ('a : word mod aliased many external_). 'b -> 'c -> 'a -> 'a =
+  <fun>
 |}]
 
 let f = fun x y (type a : value) (z : a) -> z
@@ -1602,7 +1624,8 @@ val f : 'b -> 'c -> 'a -> 'a = <fun>
 val f : 'b 'c ('a : immediate). 'b -> 'c -> 'a -> 'a = <fun>
 val f : 'b 'c ('a : value mod global). 'b -> 'c -> 'a -> 'a = <fun>
 val f : 'b 'c ('a : immediate). 'b -> 'c -> 'a -> 'a = <fun>
-val f : 'b 'c ('a : word). 'b -> 'c -> 'a -> 'a = <fun>
+val f : 'b 'c ('a : word mod aliased many external_). 'b -> 'c -> 'a -> 'a =
+  <fun>
 |}]
 (* CR layouts: canonicalizing the order of quantification here
    would reduce wibbles in error messages *)
@@ -1618,7 +1641,7 @@ external f : 'a -> 'a = "%identity"
 external f : ('a : immediate). 'a -> 'a = "%identity"
 external f : ('a : value mod global). 'a -> 'a = "%identity"
 external f : ('a : immediate). 'a -> 'a = "%identity"
-external f : ('a : word). 'a -> 'a = "%identity"
+external f : ('a : word mod aliased many external_). 'a -> 'a = "%identity"
 |}]
 
 

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -294,25 +294,25 @@ type c : immediate64
 type d = c
 |}]
 
-type a : float64
+type a : float64 = float#
 type b : float64 mod global aliased many contended portable external_ = a
 type c : float64 mod global aliased many contended portable external_
 type d : float64 = c
 [%%expect{|
-type a : float64
+type a = float#
 type b = a
-type c : float64
+type c : float64 mod everything
 type d = c
 |}]
 
-type a : float32
+type a : float32 = float32#
 type b : float32 mod global aliased many contended portable external_ = a
 type c : float32 mod global aliased many contended portable external_
 type d : float32 = c
 [%%expect{|
-type a : float32
+type a = float32#
 type b = a
-type c : float32
+type c : float32 mod everything
 type d = c
 |}]
 
@@ -1282,7 +1282,7 @@ type ('a : immediate) t = 'a
 type ('a : immediate) t = 'a
 type 'a t = 'a
 type 'a t = 'a
-type ('a : bits32) t = 'a
+type ('a : bits32 mod global aliased) t = 'a
 |}]
 
 type ('a : bits32) t = ('a : word)

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -1101,11 +1101,11 @@ Error: This value escapes its region.
 (****************************************************)
 (* Test 8: modal kinds for product kind annotations *)
 
-type t : float64 & float64
+type t : float64 & float64 mod global
 let f_external_kind_annot_mode_crosses_local_1
   : local_ t -> t = fun x -> x
 [%%expect{|
-type t : float64 & float64
+type t : float64 mod global & float64 mod global
 val f_external_kind_annot_mode_crosses_local_1 : local_ t -> t = <fun>
 |}]
 
@@ -1120,11 +1120,11 @@ Line 3, characters 29-30:
 Error: This value escapes its region.
 |}]
 
-type t : immediate & (float64 & immediate)
+type t : immediate & ((float64 mod global) & immediate)
 let f_external_kind_annot_mode_crosses_local_2
   : local_ t -> t = fun x -> x
 [%%expect{|
-type t : immediate & (float64 & immediate)
+type t : value mod global & (float64 mod global & value mod global)
 val f_external_kind_annot_mode_crosses_local_2 : local_ t -> t = <fun>
 |}]
 

--- a/testsuite/tests/typing-layouts-products/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-products/basics_alpha.ml
@@ -67,10 +67,8 @@ Line 3, characters 0-39:
 3 | type t3 : any mod non_null = #(t1 * t2);;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "#(t1 * t2)" is
-         any_non_null mod global aliased many contended portable external_
-         with t1 with t2
-         & any_non_null mod global aliased many contended portable external_
-         with t1 with t2
+         any_non_null mod everything with t1 with t2
+         & any_non_null mod everything with t1 with t2
          because it is an unboxed tuple.
        But the kind of type "#(t1 * t2)" must be a subkind of any_non_null
          because of the definition of t3 at line 3, characters 0-39.
@@ -86,10 +84,8 @@ Line 3, characters 0-45:
 3 | type t3 : any & any mod non_null = #(t1 * t2);;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "#(t1 * t2)" is
-         any_non_null mod global aliased many contended portable external_
-         with t1 with t2
-         & any_non_null mod global aliased many contended portable external_
-         with t1 with t2
+         any_non_null mod everything with t1 with t2
+         & any_non_null mod everything with t1 with t2
          because it is an unboxed tuple.
        But the kind of type "#(t1 * t2)" must be a subkind of
          any_non_null & any_non_null
@@ -106,10 +102,8 @@ Line 3, characters 0-62:
 3 | type t3 : (any mod non_null) & (any mod non_null) = #(t1 * t2);;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "#(t1 * t2)" is
-         any_non_null mod global aliased many contended portable external_
-         with t1 with t2
-         & any_non_null mod global aliased many contended portable external_
-         with t1 with t2
+         any_non_null mod everything with t1 with t2
+         & any_non_null mod everything with t1 with t2
          because it is an unboxed tuple.
        But the kind of type "#(t1 * t2)" must be a subkind of
          any_non_null & any_non_null

--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -61,9 +61,9 @@ type t2 = #(int * float#) array
 type t3 = #(float# * int * int64# * bool) array
 type t4 : immediate & immediate
 type t4a = t4 array
-type t5 : immediate & float64
+type t5 : value & float64
 type t5a = t5 array
-type t6 : bits64 & immediate & float64 & immediate
+type t6 : bits64 & value & float64 & value
 type t6a = t6 array
 |}]
 

--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -19,7 +19,7 @@ end = struct
 end
 
 module Hidden_float_u : sig
-  type t : float64
+  type t : float64 mod global many aliased
   val hide : float# -> t
 end = struct
   type t = float#
@@ -28,7 +28,7 @@ end
 
 (* CR layouts v2.8: Change this to be layout bits64, not kind bits64 *)
 module Hidden_int64_u : sig
-  type t : bits64
+  type t : bits64 mod global many aliased
   val hide : int64# -> t
 end = struct
   type t = int64#
@@ -38,8 +38,10 @@ end
 [%%expect{|
 module Hidden_string : sig type t val hide : string -> t end
 module Hidden_int : sig type t : immediate val hide : int -> t end
-module Hidden_float_u : sig type t : float64 val hide : float# -> t end
-module Hidden_int64_u : sig type t : bits64 val hide : int64# -> t end
+module Hidden_float_u :
+  sig type t : float64 mod global aliased many val hide : float# -> t end
+module Hidden_int64_u :
+  sig type t : bits64 mod global aliased many val hide : int64# -> t end
 |}]
 
 module Immediate : sig
@@ -526,8 +528,6 @@ argument kind is known to cross mode. *)
 let float_u_unshare () = let x : float# = #3.14 in Float_u.ignore x; Float_u.unique x
 
 [%%expect{|
-val float_u_unshare : unit -> float# = <fun>
-|}, Principal{|
 Line 1, characters 84-85:
 1 | let float_u_unshare () = let x : float# = #3.14 in Float_u.ignore x; Float_u.unique x
                                                                                         ^
@@ -542,8 +542,6 @@ let int64_u_unshare () = let x : int64# = #314L in Int64_u.ignore x; Int64_u.uni
 
 (* CR layouts v2.8: this should succeed in principal mode, too *)
 [%%expect{|
-val int64_u_unshare : unit -> int64# = <fun>
-|}, Principal{|
 Line 1, characters 84-85:
 1 | let int64_u_unshare () = let x : int64# = #314L in Int64_u.ignore x; Int64_u.unique x
                                                                                         ^
@@ -570,8 +568,6 @@ let hidden_float_u_unshare () =
   Float_u.ignore x; Float_u.unique x
 
 [%%expect{|
-val hidden_float_u_unshare : unit -> Hidden_float_u.t = <fun>
-|}, Principal{|
 Line 3, characters 35-36:
 3 |   Float_u.ignore x; Float_u.unique x
                                        ^
@@ -588,8 +584,6 @@ let hidden_int64_u_unshare () =
 
 (* CR layouts v2.8: This should fail when we use layout bits64 with hidden_int64 *)
 [%%expect{|
-val hidden_int64_u_unshare : unit -> Hidden_int64_u.t = <fun>
-|}, Principal{|
 Line 3, characters 35-36:
 3 |   Int64_u.ignore x; Int64_u.unique x
                                        ^

--- a/testsuite/tests/typing-modal-kinds/everything.ml
+++ b/testsuite/tests/typing-modal-kinds/everything.ml
@@ -285,3 +285,20 @@ Line 1, characters 22-32:
                           ^^^^^^^^^^
 Error: Unrecognized modality everything.
 |}]
+
+(* Printing *)
+type t : immediate & immediate
+[%%expect{|
+type t : immediate & immediate
+|}]
+
+type t : value & float64 mod everything
+[%%expect{|
+type t : immediate & float64 mod everything
+|}]
+
+type t : value & (immediate & bits64) & float32 mod everything
+[%%expect{|
+type t
+  : immediate & (immediate & bits64 mod everything) & float32 mod everything
+|}]

--- a/testsuite/tests/typing-modal-kinds/everything.ml
+++ b/testsuite/tests/typing-modal-kinds/everything.ml
@@ -1,0 +1,287 @@
+(* TEST
+   expect;
+*)
+
+(* The kinds [value] and [float64] don't mode cross, but the kinds [value mod
+   everything] and [float64 mod everything] cross everything (ignoring
+   nullability) *)
+type t_value : value
+type t_value_mod_e : value mod everything
+type t_float64 : float64
+type t_float64_mod_e : float64 mod everything
+[%%expect{|
+type t_value
+type t_value_mod_e : immediate
+type t_float64 : float64
+type t_float64_mod_e : float64 mod everything
+|}]
+
+(*** locality ***)
+type bad : value mod global = t_value
+[%%expect{|
+Line 1, characters 0-37:
+1 | type bad : value mod global = t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_value" is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type "t_value" must be a subkind of value mod global
+         because of the definition of bad at line 1, characters 0-37.
+|}]
+
+type good : value mod global = t_value_mod_e
+[%%expect{|
+type good = t_value_mod_e
+|}]
+
+type bad : float64 mod global = t_float64
+[%%expect{|
+Line 1, characters 0-41:
+1 | type bad : float64 mod global = t_float64
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_float64" is float64
+         because of the definition of t_float64 at line 3, characters 0-24.
+       But the kind of type "t_float64" must be a subkind of float64 mod global
+         because of the definition of bad at line 1, characters 0-41.
+|}]
+
+type good : float64 mod global = t_float64_mod_e
+[%%expect{|
+type good = t_float64_mod_e
+|}]
+
+(*** linearity ***)
+type bad : value mod many = t_value
+[%%expect{|
+Line 1, characters 0-35:
+1 | type bad : value mod many = t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_value" is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type "t_value" must be a subkind of value mod many
+         because of the definition of bad at line 1, characters 0-35.
+|}]
+
+type good : value mod many = t_value_mod_e
+[%%expect{|
+type good = t_value_mod_e
+|}]
+
+type bad : float64 mod many = t_float64
+[%%expect{|
+Line 1, characters 0-39:
+1 | type bad : float64 mod many = t_float64
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_float64" is float64
+         because of the definition of t_float64 at line 3, characters 0-24.
+       But the kind of type "t_float64" must be a subkind of float64 mod many
+         because of the definition of bad at line 1, characters 0-39.
+|}]
+
+type good : float64 mod many = t_float64_mod_e
+[%%expect{|
+type good = t_float64_mod_e
+|}]
+
+(*** uniqueness ***)
+type bad : value mod aliased = t_value
+[%%expect{|
+Line 1, characters 0-38:
+1 | type bad : value mod aliased = t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_value" is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type "t_value" must be a subkind of value mod aliased
+         because of the definition of bad at line 1, characters 0-38.
+|}]
+
+type good : value mod aliased = t_value_mod_e
+[%%expect{|
+type good = t_value_mod_e
+|}]
+
+type bad : float64 mod aliased = t_float64
+[%%expect{|
+Line 1, characters 0-42:
+1 | type bad : float64 mod aliased = t_float64
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_float64" is float64
+         because of the definition of t_float64 at line 3, characters 0-24.
+       But the kind of type "t_float64" must be a subkind of
+         float64 mod aliased
+         because of the definition of bad at line 1, characters 0-42.
+|}]
+
+type good : float64 mod aliased = t_float64_mod_e
+[%%expect{|
+type good = t_float64_mod_e
+|}]
+
+(*** portability ***)
+type bad : value mod portable = t_value
+[%%expect{|
+Line 1, characters 0-39:
+1 | type bad : value mod portable = t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_value" is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type "t_value" must be a subkind of value mod portable
+         because of the definition of bad at line 1, characters 0-39.
+|}]
+
+type good : value mod portable = t_value_mod_e
+[%%expect{|
+type good = t_value_mod_e
+|}]
+
+type bad : float64 mod portable = t_float64
+[%%expect{|
+Line 1, characters 0-43:
+1 | type bad : float64 mod portable = t_float64
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_float64" is float64
+         because of the definition of t_float64 at line 3, characters 0-24.
+       But the kind of type "t_float64" must be a subkind of
+         float64 mod portable
+         because of the definition of bad at line 1, characters 0-43.
+|}]
+
+type good : float64 mod portable = t_float64_mod_e
+[%%expect{|
+type good = t_float64_mod_e
+|}]
+
+(*** contention ***)
+type bad : value mod contended = t_value
+[%%expect{|
+Line 1, characters 0-40:
+1 | type bad : value mod contended = t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_value" is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type "t_value" must be a subkind of value mod contended
+         because of the definition of bad at line 1, characters 0-40.
+|}]
+
+type good : value mod contended = t_value_mod_e
+[%%expect{|
+type good = t_value_mod_e
+|}]
+
+type bad : float64 mod contended = t_float64
+[%%expect{|
+Line 1, characters 0-44:
+1 | type bad : float64 mod contended = t_float64
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_float64" is float64
+         because of the definition of t_float64 at line 3, characters 0-24.
+       But the kind of type "t_float64" must be a subkind of
+         float64 mod contended
+         because of the definition of bad at line 1, characters 0-44.
+|}]
+
+type good : float64 mod contended = t_float64_mod_e
+[%%expect{|
+type good = t_float64_mod_e
+|}]
+
+(*** yielding ***)
+type bad : value mod unyielding = t_value
+[%%expect{|
+Line 1, characters 0-41:
+1 | type bad : value mod unyielding = t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_value" is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type "t_value" must be a subkind of value mod unyielding
+         because of the definition of bad at line 1, characters 0-41.
+|}]
+
+type good : value mod unyielding = t_value_mod_e
+[%%expect{|
+type good = t_value_mod_e
+|}]
+
+type bad : float64 mod unyielding = t_float64
+[%%expect{|
+Line 1, characters 0-45:
+1 | type bad : float64 mod unyielding = t_float64
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_float64" is float64
+         because of the definition of t_float64 at line 3, characters 0-24.
+       But the kind of type "t_float64" must be a subkind of
+         float64 mod unyielding
+         because of the definition of bad at line 1, characters 0-45.
+|}]
+
+type good : float64 mod unyielding = t_float64_mod_e
+[%%expect{|
+type good = t_float64_mod_e
+|}]
+
+(*** external ***)
+type bad : value mod external_ = t_value
+[%%expect{|
+Line 1, characters 0-40:
+1 | type bad : value mod external_ = t_value
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_value" is value
+         because of the definition of t_value at line 1, characters 0-20.
+       But the kind of type "t_value" must be a subkind of value mod external_
+         because of the definition of bad at line 1, characters 0-40.
+|}]
+
+type good : value mod external_ = t_value_mod_e
+[%%expect{|
+type good = t_value_mod_e
+|}]
+
+type bad : float64 mod external_ = t_float64
+[%%expect{|
+Line 1, characters 0-44:
+1 | type bad : float64 mod external_ = t_float64
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t_float64" is float64
+         because of the definition of t_float64 at line 3, characters 0-24.
+       But the kind of type "t_float64" must be a subkind of
+         float64 mod external_
+         because of the definition of bad at line 1, characters 0-44.
+|}]
+
+type good : float64 mod external_ = t_float64_mod_e
+[%%expect{|
+type good = t_float64_mod_e
+|}]
+
+(* mod everything does not affect nullability *)
+type t : value_or_null mod everything
+type bad : value = t
+
+[%%expect{|
+type t : immediate_or_null
+Line 2, characters 0-20:
+2 | type bad : value = t
+    ^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immediate_or_null
+         because of the definition of t at line 1, characters 0-37.
+       But the kind of type "t" must be a subkind of value
+         because of the definition of bad at line 2, characters 0-20.
+|}]
+
+(* everything can not be written as a mode or modality *)
+type t = int @ everything -> int
+
+[%%expect{|
+Line 1, characters 15-25:
+1 | type t = int @ everything -> int
+                   ^^^^^^^^^^
+Error: Unrecognized mode everything.
+|}]
+
+type t = { x : int @@ everything }
+
+[%%expect{|
+Line 1, characters 22-32:
+1 | type t = { x : int @@ everything }
+                          ^^^^^^^^^^
+Error: Unrecognized modality everything.
+|}]

--- a/testsuite/tests/typing-modal-kinds/expected_mode.ml
+++ b/testsuite/tests/typing-modal-kinds/expected_mode.ml
@@ -19,7 +19,7 @@ end = struct
 end
 
 module Hidden_float_u : sig
-  type t : float64
+  type t : float64 mod global many aliased
   val hide : float# -> t
 end = struct
   type t = float#
@@ -37,14 +37,17 @@ end
 [%%expect{|
 module Hidden_string : sig type t val hide : string -> t end
 module Hidden_int : sig type t : immediate val hide : int -> t end
-module Hidden_float_u : sig type t : float64 val hide : float# -> t end
+module Hidden_float_u :
+  sig type t : float64 mod global aliased many val hide : float# -> t end
 module Hidden_function :
   sig type (-'a, +'b) t val hide : ('a -> 'b) -> ('a, 'b) t end
 |}]
 
 module Float_u : sig
   type ('a : float64, 'b : float64) pair
-  val mk_pair : ('a : float64) ('b : float64). 'a -> 'b -> ('a, 'b) pair
+  val mk_pair :
+    ('a : float64 mod global) ('b : float64 mod global).
+    'a -> 'b -> ('a, 'b) pair
 end = struct
   type ('a : float64, 'b : float64) pair = { fst : 'a; snd : 'b }
   let mk_pair fst snd = { fst; snd }
@@ -54,7 +57,9 @@ end
 module Float_u :
   sig
     type ('a : float64, 'b : float64) pair
-    val mk_pair : ('a : float64) ('b : float64). 'a -> 'b -> ('a, 'b) pair
+    val mk_pair :
+      ('a : float64 mod global) ('b : float64 mod global).
+        'a -> 'b -> ('a, 'b) pair
   end
 |}]
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1231,15 +1231,31 @@ module Const = struct
         name = "any"
       }
 
+    let any_mod_everything =
+      { jkind = mk_jkind Any ~mode_crossing:true ~nullability:Maybe_null;
+        name = "any mod everything"
+      }
+
     let any_non_null =
       { jkind = mk_jkind Any ~mode_crossing:false ~nullability:Non_null;
         name = "any_non_null"
+      }
+
+    let any_non_null_mod_everything =
+      { jkind = mk_jkind Any ~mode_crossing:true ~nullability:Non_null;
+        name = "any_non_null mod everything"
       }
 
     let value_or_null =
       { jkind =
           mk_jkind (Base Value) ~mode_crossing:false ~nullability:Maybe_null;
         name = "value_or_null"
+      }
+
+    let value_or_null_mod_everything =
+      { jkind =
+          mk_jkind (Base Value) ~mode_crossing:true ~nullability:Maybe_null;
+        name = "value_or_null mod everything"
       }
 
     let value =
@@ -1415,8 +1431,11 @@ module Const = struct
 
     let all =
       [ any;
+        any_mod_everything;
         any_non_null;
+        any_non_null_mod_everything;
         value_or_null;
+        value_or_null_mod_everything;
         value;
         immutable_data;
         mutable_data;

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1337,39 +1337,80 @@ module Const = struct
     (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
     let float64 =
       { jkind =
-          mk_jkind (Base Float64) ~mode_crossing:true ~nullability:Non_null;
+          mk_jkind (Base Float64) ~mode_crossing:false ~nullability:Non_null;
         name = "float64"
+      }
+
+    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    let kind_of_unboxed_float =
+      { jkind =
+          mk_jkind (Base Float64) ~mode_crossing:true ~nullability:Non_null;
+        name = "float64 mod everything"
       }
 
     (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
     let float32 =
       { jkind =
-          mk_jkind (Base Float32) ~mode_crossing:true ~nullability:Non_null;
+          mk_jkind (Base Float32) ~mode_crossing:false ~nullability:Non_null;
         name = "float32"
       }
 
     (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    let kind_of_unboxed_float32 =
+      { jkind =
+          mk_jkind (Base Float32) ~mode_crossing:true ~nullability:Non_null;
+        name = "float32 mod everything"
+      }
+
+    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
     let word =
-      { jkind = mk_jkind (Base Word) ~mode_crossing:true ~nullability:Non_null;
+      { jkind = mk_jkind (Base Word) ~mode_crossing:false ~nullability:Non_null;
         name = "word"
       }
 
     (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    let kind_of_unboxed_nativeint =
+      { jkind = mk_jkind (Base Word) ~mode_crossing:true ~nullability:Non_null;
+        name = "word mod everything"
+      }
+
+    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
     let bits32 =
-      { jkind = mk_jkind (Base Bits32) ~mode_crossing:true ~nullability:Non_null;
+      { jkind =
+          mk_jkind (Base Bits32) ~mode_crossing:false ~nullability:Non_null;
         name = "bits32"
       }
 
     (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    let kind_of_unboxed_int32 =
+      { jkind = mk_jkind (Base Bits32) ~mode_crossing:true ~nullability:Non_null;
+        name = "bits32 mod everything"
+      }
+
+    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
     let bits64 =
-      { jkind = mk_jkind (Base Bits64) ~mode_crossing:true ~nullability:Non_null;
+      { jkind =
+          mk_jkind (Base Bits64) ~mode_crossing:false ~nullability:Non_null;
         name = "bits64"
       }
 
     (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    let kind_of_unboxed_int64 =
+      { jkind = mk_jkind (Base Bits64) ~mode_crossing:true ~nullability:Non_null;
+        name = "bits64 mod everything"
+      }
+
+    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
     let vec128 =
-      { jkind = mk_jkind (Base Vec128) ~mode_crossing:true ~nullability:Non_null;
+      { jkind =
+          mk_jkind (Base Vec128) ~mode_crossing:false ~nullability:Non_null;
         name = "vec128"
+      }
+
+    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    let kind_of_unboxed_128bit_vectors =
+      { jkind = mk_jkind (Base Vec128) ~mode_crossing:true ~nullability:Non_null;
+        name = "vec128 mod everything"
       }
 
     let all =
@@ -1384,11 +1425,17 @@ module Const = struct
         immediate_or_null;
         immediate64;
         float64;
+        kind_of_unboxed_float;
         float32;
+        kind_of_unboxed_float32;
         word;
+        kind_of_unboxed_nativeint;
         bits32;
+        kind_of_unboxed_int32;
         bits64;
-        vec128 ]
+        kind_of_unboxed_int64;
+        vec128;
+        kind_of_unboxed_128bit_vectors ]
 
     let of_attribute : Builtin_attributes.jkind_attribute -> t = function
       | Immediate -> immediate

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -289,29 +289,41 @@ module Const : sig
     (** Values of types of this jkind are either immediate or null pointers *)
     val immediate_or_null : t
 
-    (** This is the jkind of unboxed 64-bit floats.  They have sort
-    Float64. Mode-crosses. *)
+    (** The jkind of unboxed 64-bit floats with no mode crossing. *)
     val float64 : t
 
-    (** This is the jkind of unboxed 32-bit floats.  They have sort
-    Float32. Mode-crosses. *)
+    (** The jkind of unboxed 64-bit floats with mode crossing. *)
+    val kind_of_unboxed_float : t
+
+    (** The jkind of unboxed 32-bit floats with no mode crossing. *)
     val float32 : t
 
-    (** This is the jkind of unboxed native-sized integers. They have sort
-    Word. Does not mode-cross. *)
+    (** The jkind of unboxed 32-bit floats with mode crossing. *)
+    val kind_of_unboxed_float32 : t
+
+    (** The jkind of unboxed 32-bit native-sized integers with no mode crossing. *)
     val word : t
 
-    (** This is the jkind of unboxed 32-bit integers. They have sort Bits32. Does
-    not mode-cross. *)
+    (** The jkind of unboxed 32-bit native-sized integers with mode crossing. *)
+    val kind_of_unboxed_nativeint : t
+
+    (** The jkind of unboxed 32-bit integers with no mode crossing. *)
     val bits32 : t
 
-    (** This is the jkind of unboxed 64-bit integers. They have sort Bits64. Does
-    not mode-cross. *)
+    (** The jkind of unboxed 32-bit integers with mode crossing. *)
+    val kind_of_unboxed_int32 : t
+
+    (** The jkind of unboxed 64-bit integers with no mode crossing. *)
     val bits64 : t
 
-    (** This is the jkind of unboxed 128-bit simd vectors. They have sort Vec128. Does
-    not mode-cross. *)
+    (** The jkind of unboxed 64-bit integers with mode crossing. *)
+    val kind_of_unboxed_int64 : t
+
+    (** The jkind of unboxed 128-bit vectors with no mode crossing. *)
     val vec128 : t
+
+    (** The jkind of unboxed 128-bit vectors with mode crossing. *)
+    val kind_of_unboxed_128bit_vectors : t
 
     (** A list of all Builtin jkinds *)
     val all : t list

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -413,13 +413,13 @@ let build_initial_env add_type add_extension empty_env =
   |> add_type ident_exn ~kind:Type_open ~jkind:Jkind.Const.Builtin.value
   |> add_type ident_extension_constructor ~jkind:Jkind.Const.Builtin.value
   |> add_type ident_float ~jkind:Jkind.Const.Builtin.immutable_data
-      ~unboxed_jkind:Jkind.Const.Builtin.float64
+      ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_float
   |> add_type ident_floatarray ~jkind:Jkind.Const.Builtin.mutable_data
   |> add_type ident_int ~jkind:Jkind.Const.Builtin.immediate
   |> add_type ident_int32 ~jkind:Jkind.Const.Builtin.immutable_data
-      ~unboxed_jkind:Jkind.Const.Builtin.bits32
+      ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_int32
   |> add_type ident_int64 ~jkind:Jkind.Const.Builtin.immutable_data
-      ~unboxed_jkind:Jkind.Const.Builtin.bits64
+      ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_int64
   |> add_type1 ident_lazy_t
        ~variance:Variance.covariant
        ~separability:Separability.Ind
@@ -440,7 +440,7 @@ let build_initial_env add_type add_extension empty_env =
        ~jkind:list_jkind
   |> add_type ident_nativeint
       ~jkind:Jkind.Const.Builtin.immutable_data
-      ~unboxed_jkind:Jkind.Const.Builtin.word
+      ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_nativeint
   |> add_type1 ident_option
        ~variance:Variance.covariant
        ~separability:Separability.Ind
@@ -521,23 +521,23 @@ let add_simd_stable_extension_types add_type env =
   let _, add_type = mk_add_type add_type in
   env
   |> add_type ident_int8x16 ~jkind:Jkind.Const.Builtin.immutable_data
-      ~unboxed_jkind:Jkind.Const.Builtin.vec128
+      ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_128bit_vectors
   |> add_type ident_int16x8 ~jkind:Jkind.Const.Builtin.immutable_data
-      ~unboxed_jkind:Jkind.Const.Builtin.vec128
+      ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_128bit_vectors
   |> add_type ident_int32x4 ~jkind:Jkind.Const.Builtin.immutable_data
-      ~unboxed_jkind:Jkind.Const.Builtin.vec128
+      ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_128bit_vectors
   |> add_type ident_int64x2 ~jkind:Jkind.Const.Builtin.immutable_data
-      ~unboxed_jkind:Jkind.Const.Builtin.vec128
+      ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_128bit_vectors
   |> add_type ident_float32x4 ~jkind:Jkind.Const.Builtin.immutable_data
-      ~unboxed_jkind:Jkind.Const.Builtin.vec128
+      ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_128bit_vectors
   |> add_type ident_float64x2 ~jkind:Jkind.Const.Builtin.immutable_data
-      ~unboxed_jkind:Jkind.Const.Builtin.vec128
+      ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_128bit_vectors
 
 let add_small_number_extension_types add_type env =
   let _, add_type = mk_add_type add_type in
   env
   |> add_type ident_float32 ~jkind:Jkind.Const.Builtin.immutable_data
-       ~unboxed_jkind:Jkind.Const.Builtin.float32
+       ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_float32
 
 let add_small_number_beta_extension_types add_type env =
   let _, add_type = mk_add_type add_type in

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -159,9 +159,9 @@ let transl_modifier_annots annots =
       Transled_modifiers.
         { locality = Some { txt = Locality.Const.min; loc };
           linearity = Some { txt = Linearity.Const.min; loc };
-          uniqueness = Some { txt = Uniqueness.Const.max; loc };
+          uniqueness = Some { txt = Uniqueness.Const_op.min; loc };
           portability = Some { txt = Portability.Const.min; loc };
-          contention = Some { txt = Contention.Const.max; loc };
+          contention = Some { txt = Contention.Const_op.min; loc };
           yielding = Some { txt = Yielding.Const.min; loc };
           externality = Some { txt = Externality.min; loc };
           nullability =

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -27,6 +27,7 @@ module Axis_pair = struct
   type 'm t =
     | Modal_axis_pair : ('m, 'a, 'd) Mode.Alloc.axis * 'a -> modal t
     | Any_axis_pair : 'a Axis.t * 'a -> maybe_nonmodal t
+    | Everything_but_nullability : maybe_nonmodal t
 
   let of_string s =
     let open Mode in
@@ -62,6 +63,7 @@ module Axis_pair = struct
       Any_axis_pair (Modal (Comonadic Yielding), Yielding.Const.Yielding)
     | "unyielding" ->
       Any_axis_pair (Modal (Comonadic Yielding), Yielding.Const.Unyielding)
+    | "everything" -> Everything_but_nullability
     | _ -> raise Not_found
 end
 
@@ -73,8 +75,9 @@ let transl_annot (type m) ~(annot_type : m annot_type) ~required_mode_maturity
     required_mode_maturity;
   let pair : m Axis_pair.t =
     match Axis_pair.of_string annot.txt, annot_type with
-    | Any_axis_pair (Nonmodal _, _), (Mode | Modality) | (exception Not_found)
-      ->
+    | Any_axis_pair (Nonmodal _, _), (Mode | Modality)
+    | Everything_but_nullability, (Mode | Modality)
+    | (exception Not_found) ->
       raise (Error (annot.loc, Unrecognized_modifier (annot_type, annot.txt)))
     | Any_axis_pair (Modal axis, mode), Mode -> Modal_axis_pair (axis, mode)
     | Any_axis_pair (Modal axis, mode), Modality -> Modal_axis_pair (axis, mode)
@@ -133,24 +136,37 @@ end
 
 let transl_modifier_annots annots =
   let step modifiers_so_far annot =
-    let { txt = Any_axis_pair (type a) ((axis, mode) : a Axis.t * a); loc } =
+    match
       transl_annot ~annot_type:Modifier ~required_mode_maturity:None
       @@ unpack_mode_annot annot
-    in
-    let (module A) = Axis.get axis in
-    let is_top = A.le A.max mode in
-    if is_top
-    then
-      (* CR layouts v2.8: This warning is disabled for now because transl_type_decl
-         results in 3 calls to transl_annots per user-written annotation. This results
-         in the warning being reported 3 times. *)
-      (* Location.prerr_warning new_raw.loc (Warnings.Mod_by_top new_raw.txt) *)
-      ();
-    let is_dup =
-      Option.is_some (Transled_modifiers.get ~axis modifiers_so_far)
-    in
-    if is_dup then raise (Error (annot.loc, Duplicated_axis axis));
-    Transled_modifiers.set ~axis modifiers_so_far (Some { txt = mode; loc })
+    with
+    | { txt = Any_axis_pair (type a) ((axis, mode) : a Axis.t * a); loc } ->
+      let (module A) = Axis.get axis in
+      let is_top = A.le A.max mode in
+      if is_top
+      then
+        (* CR layouts v2.8: This warning is disabled for now because transl_type_decl
+           results in 3 calls to transl_annots per user-written annotation. This results
+           in the warning being reported 3 times. *)
+        (* Location.prerr_warning new_raw.loc (Warnings.Mod_by_top new_raw.txt) *)
+        ();
+      let is_dup =
+        Option.is_some (Transled_modifiers.get ~axis modifiers_so_far)
+      in
+      if is_dup then raise (Error (annot.loc, Duplicated_axis axis));
+      Transled_modifiers.set ~axis modifiers_so_far (Some { txt = mode; loc })
+    | { txt = Everything_but_nullability; loc } ->
+      Transled_modifiers.
+        { locality = Some { txt = Locality.Const.min; loc };
+          linearity = Some { txt = Linearity.Const.min; loc };
+          uniqueness = Some { txt = Uniqueness.Const.max; loc };
+          portability = Some { txt = Portability.Const.min; loc };
+          contention = Some { txt = Contention.Const.max; loc };
+          yielding = Some { txt = Yielding.Const.min; loc };
+          externality = Some { txt = Externality.min; loc };
+          nullability =
+            Transled_modifiers.get ~axis:(Nonmodal Nullability) modifiers_so_far
+        }
   in
   let empty_modifiers = Transled_modifiers.empty in
   let modifiers = List.fold_left step empty_modifiers annots in


### PR DESCRIPTION
Two commits, best reviewed individually.
- The first makes it so kinds like `bits64`, when written in the source program, no longer imply mode crossing.
- The second adds the ability to write "`mod everything`" to conveniently get the full mode crossing kinds of the built-in types like `int64#`.

I think the only surprise is that there are a couple tests that used to pass only in non-principal mode that now always fail.  I think these are just standard cases where we expect type annotations to be needed for mode crossing to work (even if we are sad about it).

Review: @glittershark or @liam923 ?