### PR TITLE
Normalize before printing

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -247,7 +247,7 @@ Line 1, characters 21-23:
                          ^^
 Error: This alias is bound to type "int list"
        but is used as an instance of type "('a : immediate)"
-       The kind of int list is immutable_data
+       The kind of int list is value
          because it's a boxed variant type.
        But the kind of int list must be a subkind of immediate
          because of the annotation on the type variable 'a.
@@ -261,7 +261,7 @@ Line 1, characters 21-23:
                          ^^
 Error: This alias is bound to type "int list"
        but is used as an instance of type "('a : value mod global)"
-       The kind of int list is immutable_data
+       The kind of int list is value
          because it's a boxed variant type.
        But the kind of int list must be a subkind of value mod global
          because of the annotation on the type variable 'a.
@@ -1117,7 +1117,7 @@ type t : value mod global = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod global
          because of the annotation on the declaration of the type t.
@@ -1128,7 +1128,7 @@ type t : value mod aliased = { x : t_value }
 Line 1, characters 0-44:
 1 | type t : value mod aliased = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
@@ -1139,7 +1139,7 @@ type t : value mod many = { x : t_value }
 Line 1, characters 0-41:
 1 | type t : value mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod many
          because of the annotation on the declaration of the type t.
@@ -1150,7 +1150,7 @@ type t : value mod portable = { x : t_value }
 Line 1, characters 0-45:
 1 | type t : value mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod portable
          because of the annotation on the declaration of the type t.
@@ -1161,7 +1161,7 @@ type t : value mod contended = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod contended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod contended
          because of the annotation on the declaration of the type t.
@@ -1172,7 +1172,7 @@ type t : value mod external_ = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod external_ = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod external_
          because of the annotation on the declaration of the type t.
@@ -1256,7 +1256,7 @@ type t : value mod global = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod global = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod global
          because of the annotation on the declaration of the type t.
@@ -1267,7 +1267,7 @@ type t : value mod aliased = Foo of t_value
 Line 1, characters 0-43:
 1 | type t : value mod aliased = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
@@ -1278,7 +1278,7 @@ type t : value mod many = Foo of t_value
 Line 1, characters 0-40:
 1 | type t : value mod many = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod many
          because of the annotation on the declaration of the type t.
@@ -1289,7 +1289,7 @@ type t : value mod portable = Foo of t_value
 Line 1, characters 0-44:
 1 | type t : value mod portable = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod portable
          because of the annotation on the declaration of the type t.
@@ -1300,7 +1300,7 @@ type t : value mod contended = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod contended = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod contended
          because of the annotation on the declaration of the type t.
@@ -1311,7 +1311,7 @@ type t : value mod external_ = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod external_ = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod external_
          because of the annotation on the declaration of the type t.

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -9,13 +9,13 @@
 type 'a list : immutable_data with 'a
 
 [%%expect{|
-type 'a list : immutable_data
+type 'a list : immutable_data with 'a
 |}]
 
 type ('a, 'b) either : immutable_data with 'a * 'b
 
 [%%expect{|
-type ('a, 'b) either : immutable_data
+type ('a, 'b) either : immutable_data with 'a * 'b
 |}]
 
 type 'a gel : kind_of_ 'a mod global
@@ -762,7 +762,7 @@ type t : any mod many = { x : t_value }
 Line 1, characters 0-39:
 1 | type t : any mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of any mod many
          because of the annotation on the declaration of the type t.
@@ -773,7 +773,7 @@ type t : any mod contended = { x : t_value }
 Line 1, characters 0-44:
 1 | type t : any mod contended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of any mod contended
          because of the annotation on the declaration of the type t.
@@ -784,7 +784,7 @@ type t : any mod portable = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : any mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of any mod portable
          because of the annotation on the declaration of the type t.
@@ -795,7 +795,7 @@ type t : any mod many contended portable global = { x : t_value }
 Line 1, characters 0-65:
 1 | type t : any mod many contended portable global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of
          any mod global many contended portable
@@ -1234,7 +1234,7 @@ type 'a t : value mod aliased = { x : 'a @@ aliased }
 Line 1, characters 0-53:
 1 | type 'a t : value mod aliased = { x : 'a @@ aliased }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
@@ -1245,7 +1245,7 @@ type 'a t : value mod global = { x : 'a @@ global }
 Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod global
          because of the annotation on the declaration of the type t.
@@ -1547,7 +1547,7 @@ type 'a t : value mod global = { x : 'a }
 Line 1, characters 0-41:
 1 | type 'a t : value mod global = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod global
          because of the annotation on the declaration of the type t.
@@ -1558,7 +1558,7 @@ type 'a t : value mod many = { x : 'a }
 Line 1, characters 0-39:
 1 | type 'a t : value mod many = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod many
          because of the annotation on the declaration of the type t.

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -182,7 +182,7 @@ Line 1, characters 13-20:
 1 | let foo (t : int ref t @@ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
-       The kind of int ref is mutable_data.
+       The kind of int ref is value mod many unyielding.
        But the kind of int ref must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-46.
 |}]
@@ -320,7 +320,7 @@ Line 1, characters 13-20:
 1 | let foo (t : int ref t @@ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
-       The kind of int ref is mutable_data.
+       The kind of int ref is value mod many unyielding.
        But the kind of int ref must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-73.
 |}]
@@ -500,7 +500,7 @@ Line 1, characters 0-149:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "int list list list list list list list list list list
                         list list list list list list list list list list
-                        list list list list" is immutable_data
+                        list list list list" is value
          because it's a boxed variant type.
        But the kind of type "int list list list list list list list list list
                             list list list list list list list list list list
@@ -568,7 +568,7 @@ type 'a t : immutable_data = Flat | Nested of 'a t t
 Line 1, characters 0-52:
 1 | type 'a t : immutable_data = Flat | Nested of 'a t t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -611,7 +611,7 @@ type ('a : immutable_data) t : immutable_data = Flat | Nested of 'a t t
 Line 1, characters 0-71:
 1 | type ('a : immutable_data) t : immutable_data = Flat | Nested of 'a t t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -647,7 +647,7 @@ Error: This value is "aliased" but expected to be "unique".
 type 'a u : immutable_data with 'a
 type t = { x : int u; y : string u }
 [%%expect {|
-type 'a u : immutable_data
+type 'a u : immutable_data with 'a
 type t = { x : int u; y : string u; }
 |}]
 
@@ -688,7 +688,7 @@ type 'a t =
   | None
   | Some of ('a * 'a) t u
 [%%expect {|
-type 'a u : immutable_data
+type 'a u : immutable_data with 'a
 type 'a t = None | Some of ('a * 'a) t u
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -146,7 +146,10 @@ type (_ : any, _ : any) eq = Refl : ('a : any). ('a, 'a) eq
 val use_portable : 'a @ portable -> unit = <fun>
 module F :
   functor (X : S) ->
-    sig type t3 : value mod portable type t4 : value mod portable end
+    sig
+      type t3 : value mod portable with X.t1
+      type t4 : value mod portable with X.t2
+    end
 module Arg1 : sig type t1 = int -> int type t2 = string end
 module M1 : sig type t3 = F(Arg1).t3 type t4 = F(Arg1).t4 end
 >> Fatal error: Abstract kind with [with]: value mod portable

--- a/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
+++ b/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
@@ -48,7 +48,7 @@ Line 1, characters 20-31:
                         ^^^^^^^^^^^
 Error: This type "int Define_with_kinds.my_list" should be an instance of type
          "('a : value mod portable)"
-       The kind of int Define_with_kinds.my_list is immutable_data.
+       The kind of int Define_with_kinds.my_list is value.
        But the kind of int Define_with_kinds.my_list must be a subkind of
          value mod portable
          because of the definition of require_portable at line 12, characters 0-47.
@@ -63,7 +63,8 @@ Line 1, characters 20-35:
                         ^^^^^^^^^^^^^^^
 Error: This type "int ref Define_with_kinds.my_list"
        should be an instance of type "('a : value mod portable)"
-       The kind of int ref Define_with_kinds.my_list is immutable_data.
+       The kind of int ref Define_with_kinds.my_list is
+         value mod many unyielding.
        But the kind of int ref Define_with_kinds.my_list must be a subkind of
          value mod portable
          because of the definition of require_portable at line 12, characters 0-47.
@@ -76,7 +77,8 @@ Line 1, characters 20-40:
                         ^^^^^^^^^^^^^^^^^^^^
 Error: This type "(int -> int) Define_with_kinds.my_list"
        should be an instance of type "('a : value mod portable)"
-       The kind of (int -> int) Define_with_kinds.my_list is immutable_data.
+       The kind of (int -> int) Define_with_kinds.my_list is
+         value mod contended.
        But the kind of (int -> int) Define_with_kinds.my_list must be a subkind of
          value mod portable
          because of the definition of require_portable at line 12, characters 0-47.
@@ -89,7 +91,7 @@ Line 1, characters 14-25:
                   ^^^^^^^^^^^
 Error: This type "int Define_with_kinds.my_list" should be an instance of type
          "('a : value mod global)"
-       The kind of int Define_with_kinds.my_list is immutable_data.
+       The kind of int Define_with_kinds.my_list is value.
        But the kind of int Define_with_kinds.my_list must be a subkind of
          value mod global
          because of the definition of require_global at line 9, characters 0-43.
@@ -102,7 +104,8 @@ Line 1, characters 20-35:
                         ^^^^^^^^^^^^^^^
 Error: This type "int ref Define_with_kinds.my_list"
        should be an instance of type "('a : value mod contended)"
-       The kind of int ref Define_with_kinds.my_list is immutable_data.
+       The kind of int ref Define_with_kinds.my_list is
+         value mod many unyielding.
        But the kind of int ref Define_with_kinds.my_list must be a subkind of
          value mod contended
          because of the definition of require_contended at line 11, characters 0-49.
@@ -116,7 +119,7 @@ Line 1, characters 20-38:
 Error: This type "int Define_with_kinds.my_ref Define_with_kinds.my_list"
        should be an instance of type "('a : value mod contended)"
        The kind of int Define_with_kinds.my_ref Define_with_kinds.my_list is
-         immutable_data.
+         value mod many unyielding.
        But the kind of int Define_with_kinds.my_ref Define_with_kinds.my_list must be a subkind of
          value mod contended
          because of the definition of require_contended at line 11, characters 0-49.
@@ -134,7 +137,7 @@ Line 1, characters 20-38:
 Error: This type "int Define_with_kinds.my_ref Define_with_kinds.my_list"
        should be an instance of type "('a : value mod portable)"
        The kind of int Define_with_kinds.my_ref Define_with_kinds.my_list is
-         immutable_data.
+         value mod many unyielding.
        But the kind of int Define_with_kinds.my_ref Define_with_kinds.my_list must be a subkind of
          value mod portable
          because of the definition of require_portable at line 12, characters 0-47.
@@ -248,7 +251,7 @@ Error: This expression has type
          "#((int -> int) * int) Define_with_kinds.unboxed_record"
        but an expression was expected of type "('a : (value & value) & value)"
        The kind of #((int -> int) * int) Define_with_kinds.unboxed_record is
-         (immutable_data & immutable_data) & immutable_data.
+         (value mod contended & value mod contended) & value mod contended.
        But the kind of #((int -> int) * int) Define_with_kinds.unboxed_record must be a subkind of
          (value & value) & value
          because of the definition of use_portable_three_values at line 2, characters 84-95.

--- a/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
+++ b/testsuite/tests/typing-jkind-bounds/no-infer-across-modules/test.ml
@@ -256,6 +256,7 @@ Error: This expression has type
          (value & value) & value
          because of the definition of use_portable_three_values at line 2, characters 84-95.
 |}]
+(* CR layouts v2.8: Lift bounds outside of products *)
 
 (******)
 

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -48,7 +48,7 @@ type 'a t : immutable_data = 'a option
 Line 1, characters 0-38:
 1 | type 'a t : immutable_data = 'a option
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a option" is immutable_data
+Error: The kind of type "'a option" is value
          because it's a boxed variant type.
        But the kind of type "'a option" must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-38.
@@ -59,7 +59,7 @@ type t : immutable_data = int ref option
 Line 1, characters 0-40:
 1 | type t : immutable_data = int ref option
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int ref option" is immutable_data
+Error: The kind of type "int ref option" is mutable_data
          because it's a boxed variant type.
        But the kind of type "int ref option" must be a subkind of
          immutable_data
@@ -82,7 +82,7 @@ Line 1, characters 14-24:
                   ^^^^^^^^^^
 Error: This type "int option" should be an instance of type
          "('a : value mod portable)"
-       The kind of int option is immutable_data
+       The kind of int option is value
          because it's a boxed variant type.
        But the kind of int option must be a subkind of value mod portable
          because of the definition of require_portable at line 10, characters 0-47.
@@ -95,7 +95,7 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) option" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) option is immutable_data
+       The kind of (unit -> unit) option is value mod contended
          because it's a boxed variant type.
        But the kind of (unit -> unit) option must be a subkind of
          value mod portable
@@ -109,7 +109,7 @@ Line 1, characters 14-24:
                   ^^^^^^^^^^
 Error: This type "int option" should be an instance of type
          "('a : value mod global)"
-       The kind of int option is immutable_data
+       The kind of int option is value
          because it's a boxed variant type.
        But the kind of int option must be a subkind of value mod global
          because of the definition of require_global at line 7, characters 0-43.
@@ -156,7 +156,7 @@ type 'a t : mutable_data = 'a ref
 Line 1, characters 0-33:
 1 | type 'a t : mutable_data = 'a ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a ref" is mutable_data.
+Error: The kind of type "'a ref" is value mod many unyielding.
        But the kind of type "'a ref" must be a subkind of mutable_data
          because of the definition of t at line 1, characters 0-33.
 |}]
@@ -175,7 +175,7 @@ Line 1, characters 14-21:
                   ^^^^^^^
 Error: This type "int ref" should be an instance of type
          "('a : value mod portable)"
-       The kind of int ref is mutable_data.
+       The kind of int ref is value mod many unyielding.
        But the kind of int ref must be a subkind of value mod portable
          because of the definition of require_portable at line 10, characters 0-47.
 |}]
@@ -187,7 +187,7 @@ Line 1, characters 14-21:
                   ^^^^^^^
 Error: This type "int ref" should be an instance of type
          "('a : value mod contended)"
-       The kind of int ref is mutable_data.
+       The kind of int ref is value mod many unyielding.
        But the kind of int ref must be a subkind of value mod contended
          because of the definition of require_contended at line 9, characters 0-49.
 |}]
@@ -227,7 +227,7 @@ type 'a t : immutable_data = 'a list
 Line 1, characters 0-36:
 1 | type 'a t : immutable_data = 'a list
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a list" is immutable_data
+Error: The kind of type "'a list" is value
          because it's a boxed variant type.
        But the kind of type "'a list" must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-36.
@@ -238,7 +238,7 @@ type t : immutable_data = int ref list
 Line 1, characters 0-38:
 1 | type t : immutable_data = int ref list
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int ref list" is immutable_data
+Error: The kind of type "int ref list" is mutable_data
          because it's a boxed variant type.
        But the kind of type "int ref list" must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-38.
@@ -260,7 +260,7 @@ Line 1, characters 14-22:
                   ^^^^^^^^
 Error: This type "int list" should be an instance of type
          "('a : value mod portable)"
-       The kind of int list is immutable_data
+       The kind of int list is value
          because it's a boxed variant type.
        But the kind of int list must be a subkind of value mod portable
          because of the definition of require_portable at line 10, characters 0-47.
@@ -273,7 +273,7 @@ Line 1, characters 14-33:
                   ^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) list" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) list is immutable_data
+       The kind of (unit -> unit) list is value mod contended
          because it's a boxed variant type.
        But the kind of (unit -> unit) list must be a subkind of
          value mod portable
@@ -287,7 +287,7 @@ Line 1, characters 14-22:
                   ^^^^^^^^
 Error: This type "int list" should be an instance of type
          "('a : value mod global)"
-       The kind of int list is immutable_data
+       The kind of int list is value
          because it's a boxed variant type.
        But the kind of int list must be a subkind of value mod global
          because of the definition of require_global at line 7, characters 0-43.
@@ -335,7 +335,7 @@ type 'a t : mutable_data = 'a array
 Line 1, characters 0-35:
 1 | type 'a t : mutable_data = 'a array
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a array" is mutable_data
+Error: The kind of type "'a array" is value
          because it is the primitive value type array.
        But the kind of type "'a array" must be a subkind of mutable_data
          because of the definition of t at line 1, characters 0-35.
@@ -355,7 +355,7 @@ Line 1, characters 14-23:
                   ^^^^^^^^^
 Error: This type "int array" should be an instance of type
          "('a : value mod portable)"
-       The kind of int array is mutable_data
+       The kind of int array is value
          because it is the primitive value type array.
        But the kind of int array must be a subkind of value mod portable
          because of the definition of require_portable at line 10, characters 0-47.
@@ -368,7 +368,7 @@ Line 1, characters 14-23:
                   ^^^^^^^^^
 Error: This type "int array" should be an instance of type
          "('a : value mod contended)"
-       The kind of int array is mutable_data
+       The kind of int array is value
          because it is the primitive value type array.
        But the kind of int array must be a subkind of value mod contended
          because of the definition of require_contended at line 9, characters 0-49.
@@ -406,7 +406,7 @@ type 'a t : immutable_data = 'a iarray
 Line 1, characters 0-38:
 1 | type 'a t : immutable_data = 'a iarray
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a iarray" is immutable_data
+Error: The kind of type "'a iarray" is value
          because it is the primitive value type iarray.
        But the kind of type "'a iarray" must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-38.
@@ -417,7 +417,7 @@ type t : immutable_data = int ref iarray
 Line 1, characters 0-40:
 1 | type t : immutable_data = int ref iarray
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int ref iarray" is immutable_data
+Error: The kind of type "int ref iarray" is mutable_data
          because it is the primitive value type iarray.
        But the kind of type "int ref iarray" must be a subkind of
          immutable_data
@@ -440,7 +440,7 @@ Line 1, characters 14-24:
                   ^^^^^^^^^^
 Error: This type "int iarray" should be an instance of type
          "('a : value mod portable)"
-       The kind of int iarray is immutable_data
+       The kind of int iarray is value
          because it is the primitive value type iarray.
        But the kind of int iarray must be a subkind of value mod portable
          because of the definition of require_portable at line 10, characters 0-47.
@@ -453,7 +453,7 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) iarray" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) iarray is immutable_data
+       The kind of (unit -> unit) iarray is value mod contended
          because it is the primitive value type iarray.
        But the kind of (unit -> unit) iarray must be a subkind of
          value mod portable
@@ -467,7 +467,7 @@ Line 1, characters 14-24:
                   ^^^^^^^^^^
 Error: This type "int iarray" should be an instance of type
          "('a : value mod global)"
-       The kind of int iarray is immutable_data
+       The kind of int iarray is value
          because it is the primitive value type iarray.
        But the kind of int iarray must be a subkind of value mod global
          because of the definition of require_global at line 7, characters 0-43.

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -118,7 +118,7 @@ type 'a t : immutable_data = { x : 'a }
 Line 1, characters 0-39:
 1 | type 'a t : immutable_data = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -129,7 +129,7 @@ type 'a t : immutable_data = { mutable x : 'a }
 Line 1, characters 0-47:
 1 | type 'a t : immutable_data = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
+Error: The kind of type "t" is value mod many unyielding
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -162,7 +162,7 @@ type 'a t : immutable_data = { x : 'a option }
 Line 1, characters 0-46:
 1 | type 'a t : immutable_data = { x : 'a option }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -195,7 +195,7 @@ type ('a : value mod portable) t : value mod many = { x : 'a }
 Line 1, characters 0-62:
 1 | type ('a : value mod portable) t : value mod many = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value mod portable
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod many
          because of the annotation on the declaration of the type t.
@@ -206,7 +206,7 @@ type ('a : value mod global) t : value mod global = { x : 'a }
 Line 1, characters 0-62:
 1 | type ('a : value mod global) t : value mod global = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod global
          because of the annotation on the declaration of the type t.
@@ -217,7 +217,7 @@ type ('a : value mod aliased) t : value mod aliased = { x : 'a }
 Line 1, characters 0-64:
 1 | type ('a : value mod aliased) t : value mod aliased = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
@@ -228,7 +228,7 @@ type ('a : value mod external_) t : value mod external_ = { x : 'a }
 Line 1, characters 0-68:
 1 | type ('a : value mod external_) t : value mod external_ = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod external_
          because of the annotation on the declaration of the type t.
@@ -265,9 +265,9 @@ type 'a t : immutable_data with 'a = { mutable x : 'a }
 Line 1, characters 0-55:
 1 | type 'a t : immutable_data with 'a = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
+Error: The kind of type "t" is value mod many unyielding
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data
+       But the kind of type "t" must be a subkind of value
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -278,7 +278,7 @@ Line 1, characters 0-53:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is value mod contended
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data
+       But the kind of type "t" must be a subkind of value
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -287,9 +287,9 @@ type 'a t : value mod global with 'a = { x : 'a }
 Line 1, characters 0-49:
 1 | type 'a t : value mod global with 'a = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
+       But the kind of type "t" must be a subkind of value
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -298,9 +298,9 @@ type 'a t : value mod aliased with 'a = { x : 'a }
 Line 1, characters 0-50:
 1 | type 'a t : value mod aliased with 'a = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod aliased
+       But the kind of type "t" must be a subkind of value
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -309,9 +309,9 @@ type 'a t : value mod external_ with 'a = { x : 'a }
 Line 1, characters 0-52:
 1 | type 'a t : value mod external_ with 'a = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod external_
+       But the kind of type "t" must be a subkind of value
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -605,7 +605,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is immutable_data
+       The kind of (unit -> unit) t is value mod contended
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable
@@ -619,7 +619,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is immutable_data
+       The kind of (unit -> unit) t is value mod contended
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod external_
@@ -648,7 +648,7 @@ Line 2, characters 14-19:
 2 | type t_test = int t require_many
                   ^^^^^
 Error: This type "int t" should be an instance of type "('a : value mod many)"
-       The kind of int t is immutable_data
+       The kind of int t is value
          because of the definition of t at line 1, characters 0-22.
        But the kind of int t must be a subkind of value mod many
          because of the definition of require_many at line 19, characters 0-39.
@@ -660,7 +660,7 @@ Line 1, characters 14-19:
 1 | type t_test = int t require_global
                   ^^^^^
 Error: This type "int t" should be an instance of type "('a : value mod global)"
-       The kind of int t is immutable_data
+       The kind of int t is value
          because of the definition of t at line 1, characters 0-22.
        But the kind of int t must be a subkind of value mod global
          because of the definition of require_global at line 15, characters 0-43.
@@ -672,7 +672,7 @@ Line 1, characters 14-19:
 1 | type t_test = int t require_aliased
                   ^^^^^
 Error: This type "int t" should be an instance of type "('a : value mod aliased)"
-       The kind of int t is immutable_data
+       The kind of int t is value
          because of the definition of t at line 1, characters 0-22.
        But the kind of int t must be a subkind of value mod aliased
          because of the definition of require_aliased at line 16, characters 0-45.
@@ -685,7 +685,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is immutable_data
+       The kind of (unit -> unit) t is value mod contended
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable
@@ -698,7 +698,7 @@ Line 1, characters 41-45:
 1 | type ('a : value mod contended) t_test = 'a t require_portable
                                              ^^^^
 Error: This type "'a t" should be an instance of type "('b : value mod portable)"
-       The kind of 'a t is immutable_data
+       The kind of 'a t is value mod contended
          because of the definition of t at line 1, characters 0-22.
        But the kind of 'a t must be a subkind of value mod portable
          because of the definition of require_portable at line 18, characters 0-47.
@@ -711,7 +711,7 @@ Line 1, characters 41-45:
                                              ^^^^
 Error: This type "'a t" should be an instance of type
          "('b : value mod external_)"
-       The kind of 'a t is immutable_data
+       The kind of 'a t is value
          because of the definition of t at line 1, characters 0-22.
        But the kind of 'a t must be a subkind of value mod external_
          because of the definition of require_external at line 21, characters 0-48.
@@ -761,7 +761,7 @@ end = struct
   type 'a t = { x : 'a }
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data end
+module M : sig type 'a t : immutable_data with 'a end
 |}]
 
 module M : sig
@@ -770,7 +770,7 @@ end = struct
   type 'a t = { x : 'a; y : int }
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data end
+module M : sig type 'a t : immutable_data with 'a end
 |}]
 
 module M : sig
@@ -779,7 +779,7 @@ end = struct
   type 'a t = { x : 'a; y : int }
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data end
+module M : sig type 'a t : immutable_data with 'a end
 |}]
 
 module M : sig
@@ -864,7 +864,7 @@ Error: Signature mismatch:
          type 'a t = { x : 'a; y : string; }
        is not included in
          type 'a t : immutable_data
-       The kind of the first is immutable_data
+       The kind of the first is value
          because of the definition of t at line 4, characters 2-36.
        But the kind of the first must be a subkind of immutable_data
          because of the definition of t at line 2, characters 2-28.

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -122,7 +122,7 @@ type 'a t : immutable_data = Foo of 'a
 Line 1, characters 0-38:
 1 | type 'a t : immutable_data = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -133,7 +133,7 @@ type 'a t : immutable_data = Foo of { mutable x : 'a }
 Line 1, characters 0-54:
 1 | type 'a t : immutable_data = Foo of { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
+Error: The kind of type "t" is value mod many unyielding
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -166,7 +166,7 @@ type 'a t : immutable_data = Foo of 'a option
 Line 1, characters 0-45:
 1 | type 'a t : immutable_data = Foo of 'a option
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -199,7 +199,7 @@ type ('a : value mod portable) t : value mod many = Foo of 'a
 Line 1, characters 0-61:
 1 | type ('a : value mod portable) t : value mod many = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value mod portable
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod many
          because of the annotation on the declaration of the type t.
@@ -210,7 +210,7 @@ type ('a : value mod global) t : value mod global = Foo of 'a
 Line 1, characters 0-61:
 1 | type ('a : value mod global) t : value mod global = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod global
          because of the annotation on the declaration of the type t.
@@ -221,7 +221,7 @@ type ('a : value mod aliased) t : value mod aliased = Foo of 'a
 Line 1, characters 0-63:
 1 | type ('a : value mod aliased) t : value mod aliased = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
@@ -232,7 +232,7 @@ type ('a : value mod external_) t : value mod external_ = Foo of 'a
 Line 1, characters 0-67:
 1 | type ('a : value mod external_) t : value mod external_ = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of value mod external_
          because of the annotation on the declaration of the type t.
@@ -269,9 +269,9 @@ type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
 Line 1, characters 0-62:
 1 | type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
+Error: The kind of type "t" is value mod many unyielding
          because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data
+       But the kind of type "t" must be a subkind of value
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -282,7 +282,7 @@ Line 1, characters 0-60:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "t" is value mod contended
          because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data
+       But the kind of type "t" must be a subkind of value
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -291,9 +291,9 @@ type 'a t : value mod global with 'a = Foo of 'a
 Line 1, characters 0-48:
 1 | type 'a t : value mod global with 'a = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod global
+       But the kind of type "t" must be a subkind of value
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -302,9 +302,9 @@ type 'a t : value mod aliased with 'a = Foo of 'a
 Line 1, characters 0-49:
 1 | type 'a t : value mod aliased with 'a = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod aliased
+       But the kind of type "t" must be a subkind of value
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -313,9 +313,9 @@ type 'a t : value mod external_ with 'a = Foo of 'a
 Line 1, characters 0-51:
 1 | type 'a t : value mod external_ with 'a = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod external_
+       But the kind of type "t" must be a subkind of value
          because of the annotation on the declaration of the type t.
 |}]
 
@@ -608,7 +608,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is immutable_data
+       The kind of (unit -> unit) t is value mod contended
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable
@@ -622,7 +622,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is immutable_data
+       The kind of (unit -> unit) t is value mod contended
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod external_
@@ -651,7 +651,7 @@ Line 2, characters 14-19:
 2 | type t_test = int t require_many
                   ^^^^^
 Error: This type "int t" should be an instance of type "('a : value mod many)"
-       The kind of int t is immutable_data
+       The kind of int t is value
          because of the definition of t at line 1, characters 0-21.
        But the kind of int t must be a subkind of value mod many
          because of the definition of require_many at line 19, characters 0-39.
@@ -663,7 +663,7 @@ Line 1, characters 14-19:
 1 | type t_test = int t require_global
                   ^^^^^
 Error: This type "int t" should be an instance of type "('a : value mod global)"
-       The kind of int t is immutable_data
+       The kind of int t is value
          because of the definition of t at line 1, characters 0-21.
        But the kind of int t must be a subkind of value mod global
          because of the definition of require_global at line 15, characters 0-43.
@@ -675,7 +675,7 @@ Line 1, characters 14-19:
 1 | type t_test = int t require_aliased
                   ^^^^^
 Error: This type "int t" should be an instance of type "('a : value mod aliased)"
-       The kind of int t is immutable_data
+       The kind of int t is value
          because of the definition of t at line 1, characters 0-21.
        But the kind of int t must be a subkind of value mod aliased
          because of the definition of require_aliased at line 16, characters 0-45.
@@ -688,7 +688,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is immutable_data
+       The kind of (unit -> unit) t is value mod contended
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable
@@ -701,7 +701,7 @@ Line 1, characters 41-45:
 1 | type ('a : value mod contended) t_test = 'a t require_portable
                                              ^^^^
 Error: This type "'a t" should be an instance of type "('b : value mod portable)"
-       The kind of 'a t is immutable_data
+       The kind of 'a t is value mod contended
          because of the definition of t at line 1, characters 0-21.
        But the kind of 'a t must be a subkind of value mod portable
          because of the definition of require_portable at line 18, characters 0-47.
@@ -714,7 +714,7 @@ Line 1, characters 41-45:
                                              ^^^^
 Error: This type "'a t" should be an instance of type
          "('b : value mod external_)"
-       The kind of 'a t is immutable_data
+       The kind of 'a t is value
          because of the definition of t at line 1, characters 0-21.
        But the kind of 'a t must be a subkind of value mod external_
          because of the definition of require_external at line 21, characters 0-48.
@@ -764,7 +764,7 @@ end = struct
   type 'a t = Foo of 'a
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data end
+module M : sig type 'a t : immutable_data with 'a end
 |}]
 
 module M : sig
@@ -773,7 +773,7 @@ end = struct
   type 'a t = Foo of 'a * int
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data end
+module M : sig type 'a t : immutable_data with 'a end
 |}]
 
 module M : sig
@@ -782,7 +782,7 @@ end = struct
   type 'a t = Foo of 'a * int | Bar of string
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data end
+module M : sig type 'a t : immutable_data with 'a end
 |}]
 
 module M : sig
@@ -867,7 +867,7 @@ Error: Signature mismatch:
          type 'a t = Foo of 'a | Bar of string
        is not included in
          type 'a t : immutable_data
-       The kind of the first is immutable_data
+       The kind of the first is value
          because of the definition of t at line 4, characters 2-39.
        But the kind of the first must be a subkind of immutable_data
          because of the definition of t at line 2, characters 2-28.

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -587,7 +587,7 @@ type ('a : mutable_data) t : immutable_data = { x : 'a }
 Line 1, characters 0-56:
 1 | type ('a : mutable_data) t : immutable_data = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is mutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -616,7 +616,7 @@ type 'a contended_with : value mod contended with 'a
 type _ t =
   | Foo : ('a : value mod contended) t
 [%%expect {|
-type 'a contended_with : value mod contended
+type 'a contended_with : value mod contended with 'a
 type _ t = Foo : ('a : value mod contended). 'a t
 |}]
 
@@ -647,7 +647,8 @@ end = struct
   type t : immutable_data with T.t
 end
 [%%expect {|
-module F : functor (T : sig type t end) -> sig type t : immutable_data end
+module F :
+  functor (T : sig type t end) -> sig type t : immutable_data with T.t end
 |}]
 
 module Immutable = F(struct type t : immutable_data end)
@@ -731,7 +732,7 @@ Error: This value is "nonportable" but expected to be "portable".
 (*********************)
 type 'a t : value mod contended with 'a
 [%%expect {|
-type 'a t : value mod contended
+type 'a t : value mod contended with 'a
 |}]
 
 let foo (t : int t @@ contended) = use_uncontended t
@@ -758,7 +759,7 @@ Error: This value is "nonportable" but expected to be "portable".
 (*********************)
 type ('a : immutable_data) t : value mod contended with 'a
 [%%expect {|
-type ('a : immutable_data) t : value mod contended
+type ('a : immutable_data) t : value mod contended with 'a
 |}]
 
 type 'a t_test = 'a t require_contended
@@ -804,7 +805,7 @@ Error: This value is "nonportable" but expected to be "portable".
 (*********************)
 type ('a, 'b) t : value mod contended with 'a with 'b
 [%%expect {|
-type ('a, 'b) t : value mod contended
+type ('a, 'b) t : value mod contended with 'a with 'b
 |}]
 
 type t_test = (int, int) t require_contended
@@ -817,7 +818,7 @@ Line 1, characters 14-26:
                   ^^^^^^^^^^^^
 Error: This type "(int, int) t" should be an instance of type
          "('a : value mod contended)"
-       The kind of (int, int) t is value mod contended
+       The kind of (int, int) t is value
          because of the definition of t at line 1, characters 0-53.
        But the kind of (int, int) t must be a subkind of value mod contended
          because of the definition of require_contended at line 6, characters 0-49.
@@ -830,7 +831,7 @@ Line 1, characters 23-33:
                            ^^^^^^^^^^
 Error: This type "('a, 'b) t" should be an instance of type
          "('c : value mod contended)"
-       The kind of ('a, 'b) t is value mod contended
+       The kind of ('a, 'b) t is value
          because of the definition of t at line 1, characters 0-53.
        But the kind of ('a, 'b) t must be a subkind of value mod contended
          because of the definition of require_contended at line 6, characters 0-49.
@@ -889,7 +890,7 @@ end = struct
   type 'a t = { x : 'a }
 end
 [%%expect {|
-module T : sig type 'a t : value mod contended end
+module T : sig type 'a t : value mod contended with 'a end
 |}]
 
 let foo (t : int T.t @@ contended) = use_uncontended t
@@ -1020,7 +1021,7 @@ type 'a u = Foo of { x : 'a; }
 Line 2, characters 0-53:
 2 | type 'a t : immutable_data = 'a u = Foo of { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3478,7 +3478,7 @@ let add_gadt_equation uenv source destination =
     let jkind = jkind_of_abstract_type_declaration env source in
     let jkind = match Jkind.try_allow_r jkind with
       | None -> Misc.fatal_errorf "Abstract kind with [with]: %a"
-                  (Jkind.format ~jkind_of_type:(type_jkind_purely env))
+                  (Jkind.format ~jkind_of_type:(Some (type_jkind_purely env)))
                   jkind
       | Some jkind -> jkind
     in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3478,7 +3478,8 @@ let add_gadt_equation uenv source destination =
     let jkind = jkind_of_abstract_type_declaration env source in
     let jkind = match Jkind.try_allow_r jkind with
       | None -> Misc.fatal_errorf "Abstract kind with [with]: %a"
-                  Jkind.format jkind
+                  (Jkind.format ~jkind_of_type:(type_jkind_purely env))
+                  jkind
       | Some jkind -> jkind
     in
     add_jkind_equation ~reason:(Gadt_equation source)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -4469,6 +4469,7 @@ let report_lookup_error _loc env ppf = function
                    captured by an object.@ %a@]"
         (Style.as_inline_code !print_longident) lid
         (fun v -> Jkind.Violation.report_with_offender
+                    ~jkind_of_type:None
            ~offender:(fun ppf -> !print_type_expr ppf typ) v) err
   | Error_from_persistent_env err ->
       Persistent_env.report_error ppf err

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -4468,8 +4468,8 @@ let report_lookup_error _loc env ppf = function
       fprintf ppf "@[%a must have a type of layout value because it is \
                    captured by an object.@ %a@]"
         (Style.as_inline_code !print_longident) lid
-        (Jkind.Violation.report_with_offender
-           ~offender:(fun ppf -> !print_type_expr ppf typ)) err
+        (fun v -> Jkind.Violation.report_with_offender
+           ~offender:(fun ppf -> !print_type_expr ppf typ) v) err
   | Error_from_persistent_env err ->
       Persistent_env.report_error ppf err
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -671,6 +671,7 @@ let report_type_mismatch first second decl env ppf err =
   | Parameter_jkind (ty, v) ->
       pr "The problem is in the kinds of a parameter:@,";
       Jkind.Violation.report_with_offender
+        ~jkind_of_type:(Ctype.type_jkind_purely env)
         ~offender:(fun pp -> Printtyp.type_expr pp ty) ppf v
   | Private_variant (_ty1, _ty2, mismatch) ->
       report_private_variant_mismatch first second decl env ppf mismatch
@@ -698,7 +699,8 @@ let report_type_mismatch first second decl env ppf err =
          (choose ord first second) decl
          "has a null constructor"
   | Jkind v ->
-      Jkind.Violation.report_with_name ~name:first ppf v
+      Jkind.Violation.report_with_name
+        ~jkind_of_type:(Ctype.type_jkind_purely env) ~name:first ppf v
   | Unsafe_mode_crossing mismatch ->
     pr "They have different unsafe mode crossing behavior:@,";
     report_unsafe_mode_crossing_mismatch first second ppf mismatch

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -671,7 +671,7 @@ let report_type_mismatch first second decl env ppf err =
   | Parameter_jkind (ty, v) ->
       pr "The problem is in the kinds of a parameter:@,";
       Jkind.Violation.report_with_offender
-        ~jkind_of_type:(Ctype.type_jkind_purely env)
+        ~jkind_of_type:(Some (Ctype.type_jkind_purely env))
         ~offender:(fun pp -> Printtyp.type_expr pp ty) ppf v
   | Private_variant (_ty1, _ty2, mismatch) ->
       report_private_variant_mismatch first second decl env ppf mismatch
@@ -700,7 +700,7 @@ let report_type_mismatch first second decl env ppf err =
          "has a null constructor"
   | Jkind v ->
       Jkind.Violation.report_with_name
-        ~jkind_of_type:(Ctype.type_jkind_purely env) ~name:first ppf v
+        ~jkind_of_type:(Some (Ctype.type_jkind_purely env)) ~name:first ppf v
   | Unsafe_mode_crossing mismatch ->
     pr "They have different unsafe mode crossing behavior:@,";
     report_unsafe_mode_crossing_mismatch first second ppf mismatch

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2209,7 +2209,7 @@ let decompose_product ({ jkind; _ } as jk) =
    doing so, because it teaches the user that e.g. [value mod local] is better
    off spelled [value]. Possibly remove [jkind.annotation], but only after
    we have a proper printing story. *)
-let format ?jkind_of_type ppf jkind =
+let format ~jkind_of_type ppf jkind =
   Desc.format ~jkind_of_type ppf (Jkind_desc.get jkind.jkind)
 
 let printtyp_path = ref (fun _ _ -> assert false)
@@ -2525,7 +2525,7 @@ module Format_history = struct
         match reason, Desc.get_const jkind_desc with
         | Concrete_legacy_creation _, Some _ ->
           fprintf ppf ",@ chosen to have %s %a" layout_or_kind
-            (format ?jkind_of_type) t
+            (format ~jkind_of_type) t
         | _ -> ())
     | Interact _ ->
       Misc.fatal_error "Non-flat history in format_flattened_history");
@@ -2555,7 +2555,7 @@ module Format_history = struct
       else format_history_tree ~intro ~layout_or_kind ppf t
 end
 
-let format_history ?jkind_of_type ~intro ppf t =
+let format_history ~jkind_of_type ~intro ppf t =
   Format_history.format_history ~jkind_of_type ~intro ~layout_or_kind:"kind" ppf
     t
 
@@ -2688,7 +2688,7 @@ module Violation = struct
     in
     let format_layout_or_kind ppf jkind =
       match mismatch_type with
-      | Mode -> Format.fprintf ppf "@,%a" (format ?jkind_of_type) jkind
+      | Mode -> Format.fprintf ppf "@,%a" (format ~jkind_of_type) jkind
       | Layout -> Layout.format ppf jkind.jkind.layout
     in
     let subjkind_format verb k2 =
@@ -2761,14 +2761,14 @@ module Violation = struct
 
   let pp_t ppf x = fprintf ppf "%t" x
 
-  let report_with_offender ?jkind_of_type ~offender =
+  let report_with_offender ~jkind_of_type ~offender =
     report_general ~jkind_of_type "" pp_t offender
 
-  let report_with_offender_sort ?jkind_of_type ~offender =
+  let report_with_offender_sort ~jkind_of_type ~offender =
     report_general ~jkind_of_type "A representable layout was expected, but "
       pp_t offender
 
-  let report_with_name ?jkind_of_type ~name =
+  let report_with_name ~jkind_of_type ~name =
     report_general ~jkind_of_type "" pp_print_string name
 end
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1255,8 +1255,16 @@ module Const = struct
         unique portable uncontended external_ non_null] could be written in
         terms of [value] (as it appears above), or in terms of [immediate]
         (which would just be [immediate]). Since the latter requires less modes
-        to be printed, it is chosen. *)
-    val convert : 'd t -> Outcometree.out_jkind_const
+        to be printed, it is chosen.
+
+        The [jkind_of_type] function is used to normalize when we don't wish
+        to print with-bounds. If it's not supplied, we unconditionally print
+        the with-bounds.
+    *)
+    val convert :
+      jkind_of_type:(type_expr -> jkind_l) option ->
+      'd t ->
+      Outcometree.out_jkind_const
   end = struct
     type printable_jkind =
       { base : string;
@@ -1356,11 +1364,21 @@ module Const = struct
       | [out] -> Some out
       | [] -> None
 
-    let convert jkind =
+    let convert ~jkind_of_type jkind =
       let jkind =
-        if should_print_with_bounds ()
-        then jkind
-        else { jkind with with_bounds = No_with_bounds }
+        match jkind_of_type with
+        | None ->
+          jkind
+          (* if we can't normalize, then print the with-bounds unconditionally *)
+        | Some jkind_of_type ->
+          if should_print_with_bounds ()
+          then jkind
+          else
+            (* We never care about principality in printing, so the functions
+               passed in don't have the [option] in the right spot. *)
+            let jkind_of_type ty = Some (jkind_of_type ty) in
+            fst
+              (Layout_and_axes.normalize ~jkind_of_type ~mode:Ignore_best jkind)
       in
       (* For each primitive jkind, we try to print the jkind in terms of it (this is
          possible if the primitive is a subjkind of it). We then choose the "simplest". The
@@ -1431,9 +1449,12 @@ module Const = struct
         base with_tys
   end
 
-  let to_out_jkind_const jkind = To_out_jkind_const.convert jkind
+  let to_out_jkind_const jkind =
+    To_out_jkind_const.convert ~jkind_of_type:None jkind
 
-  let format ppf jkind = to_out_jkind_const jkind |> !Oprint.out_jkind_const ppf
+  let format ~jkind_of_type ppf jkind =
+    To_out_jkind_const.convert ~jkind_of_type jkind
+    |> !Oprint.out_jkind_const ppf
 
   (*******************************)
   (* converting user annotations *)
@@ -1561,7 +1582,7 @@ module Desc = struct
   (* CR layouts v2.8: This will probably need to be overhauled with
      [with]-types. See also [Printtyp.out_jkind_of_desc], which uses the same
      algorithm. *)
-  let format ppf t =
+  let format ~jkind_of_type ppf t =
     let open Format in
     let rec format_desc ~nested ppf (desc : _ t) =
       match desc.layout with
@@ -1574,7 +1595,7 @@ module Desc = struct
           (List.map (fun layout -> { desc with layout }) lays)
       | _ -> (
         match get_const desc with
-        | Some c -> Const.format ppf c
+        | Some c -> Const.format ~jkind_of_type ppf c
         | None -> assert false (* handled above *))
     in
     format_desc ~nested:false ppf t
@@ -2188,7 +2209,8 @@ let decompose_product ({ jkind; _ } as jk) =
    doing so, because it teaches the user that e.g. [value mod local] is better
    off spelled [value]. Possibly remove [jkind.annotation], but only after
    we have a proper printing story. *)
-let format ppf jkind = Desc.format ppf (Jkind_desc.get jkind.jkind)
+let format ?jkind_of_type ppf jkind =
+  Desc.format ~jkind_of_type ppf (Jkind_desc.get jkind.jkind)
 
 let printtyp_path = ref (fun _ _ -> assert false)
 
@@ -2490,7 +2512,7 @@ module Format_history = struct
 
       Consider revisiting that if the current implementation becomes insufficient. *)
 
-  let format_flattened_history ~intro ~layout_or_kind ppf t =
+  let format_flattened_history ~jkind_of_type ~intro ~layout_or_kind ppf t =
     let jkind_desc = Jkind_desc.get t.jkind in
     fprintf ppf "@[<v 2>%t" intro;
     (match t.history with
@@ -2502,7 +2524,8 @@ module Format_history = struct
           reason;
         match reason, Desc.get_const jkind_desc with
         | Concrete_legacy_creation _, Some _ ->
-          fprintf ppf ",@ chosen to have %s %a" layout_or_kind format t
+          fprintf ppf ",@ chosen to have %s %a" layout_or_kind
+            (format ?jkind_of_type) t
         | _ -> ())
     | Interact _ ->
       Misc.fatal_error "Non-flat history in format_flattened_history");
@@ -2524,16 +2547,17 @@ module Format_history = struct
     fprintf ppf "@;%t has this %s history:@;@[<v 2>  %a@]" intro layout_or_kind
       in_order t.history
 
-  let format_history ~intro ~layout_or_kind ppf t =
+  let format_history ~jkind_of_type ~intro ~layout_or_kind ppf t =
     if display_histories
     then
       if flattened_histories
-      then format_flattened_history ~intro ~layout_or_kind ppf t
+      then format_flattened_history ~jkind_of_type ~intro ~layout_or_kind ppf t
       else format_history_tree ~intro ~layout_or_kind ppf t
 end
 
-let format_history ~intro ppf t =
-  Format_history.format_history ~intro ~layout_or_kind:"kind" ppf t
+let format_history ?jkind_of_type ~intro ppf t =
+  Format_history.format_history ~jkind_of_type ~intro ~layout_or_kind:"kind" ppf
+    t
 
 (******************************)
 (* errors *)
@@ -2645,7 +2669,7 @@ module Violation = struct
                    pp_bound sub.jkind pp_bound super.jkind))
     | No_intersection _ -> ()
 
-  let report_general preamble pp_former former ppf t =
+  let report_general ~jkind_of_type preamble pp_former former ppf t =
     let mismatch_type =
       match t.violation with
       | Not_a_subjkind (k1, k2, _) ->
@@ -2664,7 +2688,7 @@ module Violation = struct
     in
     let format_layout_or_kind ppf jkind =
       match mismatch_type with
-      | Mode -> Format.fprintf ppf "@,%a" format jkind
+      | Mode -> Format.fprintf ppf "@,%a" (format ?jkind_of_type) jkind
       | Layout -> Layout.format ppf jkind.jkind.layout
     in
     let subjkind_format verb k2 =
@@ -2717,13 +2741,13 @@ module Violation = struct
         | _, true -> dprintf "be representable"
       in
       fprintf ppf "@[<v>%a@;%a@]"
-        (Format_history.format_history
+        (Format_history.format_history ~jkind_of_type
            ~intro:
              (dprintf "@[<hov 2>The %s of %a is %a@]" layout_or_kind pp_former
                 former format_layout_or_kind k1)
            ~layout_or_kind)
         k1
-        (Format_history.format_history
+        (Format_history.format_history ~jkind_of_type
            ~intro:
              (dprintf "@[<hov 2>But the %s of %a must %t@]" layout_or_kind
                 pp_former former connective)
@@ -2737,12 +2761,15 @@ module Violation = struct
 
   let pp_t ppf x = fprintf ppf "%t" x
 
-  let report_with_offender ~offender = report_general "" pp_t offender
+  let report_with_offender ?jkind_of_type ~offender =
+    report_general ~jkind_of_type "" pp_t offender
 
-  let report_with_offender_sort ~offender =
-    report_general "A representable layout was expected, but " pp_t offender
+  let report_with_offender_sort ?jkind_of_type ~offender =
+    report_general ~jkind_of_type "A representable layout was expected, but "
+      pp_t offender
 
-  let report_with_name ~name = report_general "" pp_print_string name
+  let report_with_name ?jkind_of_type ~name =
+    report_general ~jkind_of_type "" pp_print_string name
 end
 
 (******************************)

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -701,6 +701,225 @@ module Layout_and_axes = struct
       format_layout layout Mod_bounds.debug_print mod_bounds
       (With_bounds.debug_print ~print_type_expr)
       with_bounds
+
+  type 'd normalize_mode =
+    | Require_best : ('l * disallowed) normalize_mode
+    | Ignore_best : ('l * 'r) normalize_mode
+
+  module Fuel_status = struct
+    type t =
+      | Ran_out_of_fuel
+      | Sufficient_fuel
+
+    let both a b =
+      match a, b with
+      | Ran_out_of_fuel, _ | _, Ran_out_of_fuel -> Ran_out_of_fuel
+      | Sufficient_fuel, Sufficient_fuel -> Sufficient_fuel
+  end
+
+  (* Normalize the jkind. If mode is Require_best, only jkinds that are best will be used.
+     If mode is Ignore_best, then Not_best will be used. Since Ignore_best can use
+     Not_best, the result is guaranteed to have no with-bounds.
+
+     At each step during normalization, before expanding a type, [map_type_info] is used
+     to map the type-info for the type being expanded. The type can be prevented from
+     being expanded by mapping the relevant axes to an empty set. [map_type_info] is used
+     by sub_jkind_l to remove irrelevant axes. *)
+  let normalize (type l1 r1 l2 r2) ~jkind_of_type
+      ~(mode : (l2 * r2) normalize_mode)
+      ?(map_type_info :
+         (type_expr -> With_bounds_type_info.t -> With_bounds_type_info.t)
+         option) (t : (l1 * r1) jkind_desc) :
+      (l2 * r2) jkind_desc * Fuel_status.t =
+    (* Sadly, it seems hard (impossible?) to be sure to expand all types
+       here without using a fuel parameter to stop infinite regress. Here
+       is a nasty case:
+
+       {[
+         type zero
+         type 'n succ
+
+         type 'n loopy = Mk of 'n succ loopy list [@@unboxed]
+       ]}
+
+       First off: this type *is* inhabited, because of the [list] intervening
+       type (which can be empty). It's also inhabited by various circular
+       structures.
+
+       But what's the jkind of ['n loopy]? It must be the jkind of
+       ['n succ loopy list], which is [immutable_data with 'n succ loopy].
+       In order to see if we shouldn't mode-cross, we have to expand the
+       ['n succ loopy] in the jkind, but expanding that just yields the need
+       to expand ['n succ succ loopy], and around we go.
+
+       It seems hard to avoid this problem. And so we use fuel. Yet we want
+       both a small amount of fuel (a type like [type t = K of (t * t) list]
+       gets big very quickly) and a lot of fuel (we can imagine using a unit
+       of fuel for each level of a deeply nested record structure). The
+       compromise is to track fuel per type head, where a type head is either
+       the path to a type constructor (like [t] or [loopy]) or a tuple.
+       (We need to include tuples because of the possibility of recursive
+       types and the fact that tuples track their element types in their
+       jkind's with_bounds.)
+
+       The initial fuel per type head is 10, as it seems hard to imagine that
+       we're going to make meaningful progress if we've seen the same type
+       head 10 times in one line of recursive descent. (This "one line of
+       recursive descent" bit is why we recur separately down one type before
+       iterating down the list.)
+    *)
+    (* CR reisenberg: document seen_args *)
+    let module Loop_control = struct
+      type t =
+        { tuple_fuel : int;
+          constr : (int * type_expr list) Path.Map.t;
+          fuel_status : Fuel_status.t
+        }
+
+      type result =
+        | Stop of t (* give up, returning [max] *)
+        | Skip (* skip reducing this type, but otherwise continue *)
+        | Continue of t (* continue, with a new [t] *)
+
+      let initial_fuel_per_ty = 2
+
+      let starting =
+        { tuple_fuel = initial_fuel_per_ty;
+          constr = Path.Map.empty;
+          fuel_status = Sufficient_fuel
+        }
+
+      let rec check ({ tuple_fuel; constr; fuel_status = _ } as t) ty =
+        match Types.get_desc ty with
+        | Tpoly (ty, _) -> check t ty
+        | Ttuple _ ->
+          if tuple_fuel > 0
+          then Continue { t with tuple_fuel = tuple_fuel - 1 }
+          else Stop { t with fuel_status = Ran_out_of_fuel }
+        | Tconstr (p, args, _) -> (
+          match Path.Map.find_opt p constr with
+          | None ->
+            Continue
+              { t with
+                constr = Path.Map.add p (initial_fuel_per_ty, args) constr
+              }
+          | Some (fuel, seen_args) ->
+            if List.for_all2
+                 (fun ty1 ty2 ->
+                   TransientTypeOps.equal (Transient_expr.repr ty1)
+                     (Transient_expr.repr ty2))
+                 seen_args args
+            then Skip
+            else if fuel > 0
+            then
+              Continue
+                { t with constr = Path.Map.add p (fuel - 1, args) constr }
+            else Stop { t with fuel_status = Ran_out_of_fuel })
+        | Tvar _ | Tarrow _ | Tunboxed_tuple _ | Tobject _ | Tfield _ | Tnil
+        | Tvariant _ | Tunivar _ | Tpackage _ ->
+          (* these cases either cannot be infinitely recursive or their jkinds
+             do not have with_bounds *)
+          (* CR layouts v2.8: Some of these might get with-bounds someday. We
+             should double-check before we're done that they haven't. *)
+          Continue t
+        | Tlink _ | Tsubst _ -> Misc.fatal_error "Tlink or Tsubst in normalize"
+    end in
+    let rec loop (ctl : Loop_control.t) bounds_so_far :
+        (type_expr * With_bounds_type_info.t) list ->
+        Mod_bounds.t * (l2 * r2) with_bounds * Fuel_status.t = function
+      (* early cutoff *)
+      | _
+        when Sub_result.is_le
+               (Mod_bounds.less_or_equal Mod_bounds.max bounds_so_far) ->
+        (* CR layouts v2.8: we can do better by early-terminating on a per-axis basis *)
+        bounds_so_far, No_with_bounds, Sufficient_fuel
+      | [] -> bounds_so_far, No_with_bounds, ctl.fuel_status
+      | (ty, ti) :: bs -> (
+        (* Map the type's info before expanding the type *)
+        let ti =
+          match map_type_info with
+          | None -> ti
+          | Some map_type_info -> map_type_info ty ti
+        in
+        (* We don't care about axes that are already max because they can't get any
+           better or worse. By ignoring them, we may be able to terminate early *)
+        let ti : With_bounds_type_info.t =
+          { relevant_axes =
+              Axis_set.diff ti.relevant_axes
+                (Mod_bounds.get_max_axes bounds_so_far)
+          }
+        in
+        match Axis_set.is_empty ti.relevant_axes with
+        | true ->
+          (* If [ty] is not relevant to any axes, then we can safely drop it and thereby
+             avoid doing the work of expanding it. *)
+          loop ctl bounds_so_far bs
+        | false -> (
+          let join_bounds b1 b2 ~relevant_axes =
+            Mod_bounds.Map2.f
+              { f =
+                  (fun (type a) ~(axis : a Axis.t) b1 b2 ->
+                    if Axis_set.mem relevant_axes axis
+                    then
+                      let (module Bound_ops) = Axis.get axis in
+                      Bound_ops.join b1 b2
+                    else b1)
+              }
+              b1 b2
+          in
+          let found_jkind_for_ty new_ctl b_upper_bounds b_with_bounds quality :
+              Mod_bounds.t * (l2 * r2) with_bounds * Fuel_status.t =
+            match quality, mode with
+            | Best, _ | Not_best, Ignore_best ->
+              let bounds_so_far =
+                join_bounds bounds_so_far b_upper_bounds
+                  ~relevant_axes:ti.relevant_axes
+              in
+              (* Descend into the with-bounds of each of our with-bounds types'
+                  with-bounds *)
+              let bounds_so_far, nested_with_bounds, fuel_result1 =
+                loop new_ctl bounds_so_far (With_bounds.to_list b_with_bounds)
+              in
+              (* CR layouts v2.8: we use [new_ctl] here, not [ctl], to avoid big quadratic
+                 stack growth for very widely recursive types. This is sad, since it
+                 prevents us from mode crossing a record with 20 lists with different
+                 payloads, but less sad than a stack overflow of the compiler during type
+                 declaration checking.
+
+                 Ideally, this whole problem goes away once we rethink fuel.
+              *)
+              let bounds, bs', fuel_result2 = loop new_ctl bounds_so_far bs in
+              ( bounds,
+                With_bounds.join nested_with_bounds bs',
+                Fuel_status.both fuel_result1 fuel_result2 )
+            | Not_best, Require_best ->
+              let bounds_so_far, bs', fuel_result =
+                loop new_ctl bounds_so_far bs
+              in
+              bounds_so_far, With_bounds.add ty ti bs', fuel_result
+          in
+          match Loop_control.check ctl ty with
+          | Stop ctl_after_stop ->
+            (* out of fuel, so assume [ty] has the worst possible bounds. *)
+            found_jkind_for_ty ctl_after_stop Mod_bounds.max No_with_bounds
+              Not_best
+          | Skip -> loop ctl bounds_so_far bs (* skip [b] *)
+          | Continue ctl_after_unpacking_b -> (
+            match jkind_of_type ty with
+            | Some b_jkind ->
+              found_jkind_for_ty ctl_after_unpacking_b b_jkind.jkind.mod_bounds
+                b_jkind.jkind.with_bounds b_jkind.quality
+            | None ->
+              (* kind of b is not principally known, so we treat it as having the max
+                 bound (only along the axes we care about for this type!) *)
+              found_jkind_for_ty ctl_after_unpacking_b Mod_bounds.max
+                No_with_bounds Not_best)))
+    in
+    let mod_bounds, with_bounds, fuel_status =
+      loop Loop_control.starting t.mod_bounds
+        (With_bounds.to_list t.with_bounds)
+    in
+    { t with mod_bounds; with_bounds }, fuel_status
 end
 
 (*********************************)
@@ -1388,225 +1607,6 @@ module Jkind_desc = struct
 
   let equate_or_equal ~allow_mutation t1 t2 =
     Layout_and_axes.equal (Layout.equate_or_equal ~allow_mutation) t1 t2
-
-  type 'd normalize_mode =
-    | Require_best : ('l * disallowed) normalize_mode
-    | Ignore_best : ('l * 'r) normalize_mode
-
-  module Fuel_status = struct
-    type t =
-      | Ran_out_of_fuel
-      | Sufficient_fuel
-
-    let both a b =
-      match a, b with
-      | Ran_out_of_fuel, _ | _, Ran_out_of_fuel -> Ran_out_of_fuel
-      | Sufficient_fuel, Sufficient_fuel -> Sufficient_fuel
-  end
-
-  (* Normalize the jkind. If mode is Require_best, only jkinds that are best will be used.
-     If mode is Ignore_best, then Not_best will be used. Since Ignore_best can use
-     Not_best, the result is guaranteed to have no with-bounds.
-
-     At each step during normalization, before expanding a type, [map_type_info] is used
-     to map the type-info for the type being expanded. The type can be prevented from
-     being expanded by mapping the relevant axes to an empty set. [map_type_info] is used
-     by sub_jkind_l to remove irrelevant axes. *)
-  let normalize (type l1 r1 l2 r2) ~jkind_of_type
-      ~(mode : (l2 * r2) normalize_mode)
-      ?(map_type_info :
-         (type_expr -> With_bounds_type_info.t -> With_bounds_type_info.t)
-         option) (t : (l1 * r1) jkind_desc) :
-      (l2 * r2) jkind_desc * Fuel_status.t =
-    (* Sadly, it seems hard (impossible?) to be sure to expand all types
-       here without using a fuel parameter to stop infinite regress. Here
-       is a nasty case:
-
-       {[
-         type zero
-         type 'n succ
-
-         type 'n loopy = Mk of 'n succ loopy list [@@unboxed]
-       ]}
-
-       First off: this type *is* inhabited, because of the [list] intervening
-       type (which can be empty). It's also inhabited by various circular
-       structures.
-
-       But what's the jkind of ['n loopy]? It must be the jkind of
-       ['n succ loopy list], which is [immutable_data with 'n succ loopy].
-       In order to see if we shouldn't mode-cross, we have to expand the
-       ['n succ loopy] in the jkind, but expanding that just yields the need
-       to expand ['n succ succ loopy], and around we go.
-
-       It seems hard to avoid this problem. And so we use fuel. Yet we want
-       both a small amount of fuel (a type like [type t = K of (t * t) list]
-       gets big very quickly) and a lot of fuel (we can imagine using a unit
-       of fuel for each level of a deeply nested record structure). The
-       compromise is to track fuel per type head, where a type head is either
-       the path to a type constructor (like [t] or [loopy]) or a tuple.
-       (We need to include tuples because of the possibility of recursive
-       types and the fact that tuples track their element types in their
-       jkind's with_bounds.)
-
-       The initial fuel per type head is 10, as it seems hard to imagine that
-       we're going to make meaningful progress if we've seen the same type
-       head 10 times in one line of recursive descent. (This "one line of
-       recursive descent" bit is why we recur separately down one type before
-       iterating down the list.)
-    *)
-    (* CR reisenberg: document seen_args *)
-    let module Loop_control = struct
-      type t =
-        { tuple_fuel : int;
-          constr : (int * type_expr list) Path.Map.t;
-          fuel_status : Fuel_status.t
-        }
-
-      type result =
-        | Stop of t (* give up, returning [max] *)
-        | Skip (* skip reducing this type, but otherwise continue *)
-        | Continue of t (* continue, with a new [t] *)
-
-      let initial_fuel_per_ty = 2
-
-      let starting =
-        { tuple_fuel = initial_fuel_per_ty;
-          constr = Path.Map.empty;
-          fuel_status = Sufficient_fuel
-        }
-
-      let rec check ({ tuple_fuel; constr; fuel_status = _ } as t) ty =
-        match Types.get_desc ty with
-        | Tpoly (ty, _) -> check t ty
-        | Ttuple _ ->
-          if tuple_fuel > 0
-          then Continue { t with tuple_fuel = tuple_fuel - 1 }
-          else Stop { t with fuel_status = Ran_out_of_fuel }
-        | Tconstr (p, args, _) -> (
-          match Path.Map.find_opt p constr with
-          | None ->
-            Continue
-              { t with
-                constr = Path.Map.add p (initial_fuel_per_ty, args) constr
-              }
-          | Some (fuel, seen_args) ->
-            if List.for_all2
-                 (fun ty1 ty2 ->
-                   TransientTypeOps.equal (Transient_expr.repr ty1)
-                     (Transient_expr.repr ty2))
-                 seen_args args
-            then Skip
-            else if fuel > 0
-            then
-              Continue
-                { t with constr = Path.Map.add p (fuel - 1, args) constr }
-            else Stop { t with fuel_status = Ran_out_of_fuel })
-        | Tvar _ | Tarrow _ | Tunboxed_tuple _ | Tobject _ | Tfield _ | Tnil
-        | Tvariant _ | Tunivar _ | Tpackage _ ->
-          (* these cases either cannot be infinitely recursive or their jkinds
-             do not have with_bounds *)
-          (* CR layouts v2.8: Some of these might get with-bounds someday. We
-             should double-check before we're done that they haven't. *)
-          Continue t
-        | Tlink _ | Tsubst _ -> Misc.fatal_error "Tlink or Tsubst in normalize"
-    end in
-    let rec loop (ctl : Loop_control.t) bounds_so_far :
-        (type_expr * With_bounds_type_info.t) list ->
-        Mod_bounds.t * (l2 * r2) with_bounds * Fuel_status.t = function
-      (* early cutoff *)
-      | _
-        when Sub_result.is_le
-               (Mod_bounds.less_or_equal Mod_bounds.max bounds_so_far) ->
-        (* CR layouts v2.8: we can do better by early-terminating on a per-axis basis *)
-        bounds_so_far, No_with_bounds, Sufficient_fuel
-      | [] -> bounds_so_far, No_with_bounds, ctl.fuel_status
-      | (ty, ti) :: bs -> (
-        (* Map the type's info before expanding the type *)
-        let ti =
-          match map_type_info with
-          | None -> ti
-          | Some map_type_info -> map_type_info ty ti
-        in
-        (* We don't care about axes that are already max because they can't get any
-           better or worse. By ignoring them, we may be able to terminate early *)
-        let ti : With_bounds_type_info.t =
-          { relevant_axes =
-              Axis_set.diff ti.relevant_axes
-                (Mod_bounds.get_max_axes bounds_so_far)
-          }
-        in
-        match Axis_set.is_empty ti.relevant_axes with
-        | true ->
-          (* If [ty] is not relevant to any axes, then we can safely drop it and thereby
-             avoid doing the work of expanding it. *)
-          loop ctl bounds_so_far bs
-        | false -> (
-          let join_bounds b1 b2 ~relevant_axes =
-            Mod_bounds.Map2.f
-              { f =
-                  (fun (type a) ~(axis : a Axis.t) b1 b2 ->
-                    if Axis_set.mem relevant_axes axis
-                    then
-                      let (module Bound_ops) = Axis.get axis in
-                      Bound_ops.join b1 b2
-                    else b1)
-              }
-              b1 b2
-          in
-          let found_jkind_for_ty new_ctl b_upper_bounds b_with_bounds quality :
-              Mod_bounds.t * (l2 * r2) with_bounds * Fuel_status.t =
-            match quality, mode with
-            | Best, _ | Not_best, Ignore_best ->
-              let bounds_so_far =
-                join_bounds bounds_so_far b_upper_bounds
-                  ~relevant_axes:ti.relevant_axes
-              in
-              (* Descend into the with-bounds of each of our with-bounds types'
-                  with-bounds *)
-              let bounds_so_far, nested_with_bounds, fuel_result1 =
-                loop new_ctl bounds_so_far (With_bounds.to_list b_with_bounds)
-              in
-              (* CR layouts v2.8: we use [new_ctl] here, not [ctl], to avoid big quadratic
-                 stack growth for very widely recursive types. This is sad, since it
-                 prevents us from mode crossing a record with 20 lists with different
-                 payloads, but less sad than a stack overflow of the compiler during type
-                 declaration checking.
-
-                 Ideally, this whole problem goes away once we rethink fuel.
-              *)
-              let bounds, bs', fuel_result2 = loop new_ctl bounds_so_far bs in
-              ( bounds,
-                With_bounds.join nested_with_bounds bs',
-                Fuel_status.both fuel_result1 fuel_result2 )
-            | Not_best, Require_best ->
-              let bounds_so_far, bs', fuel_result =
-                loop new_ctl bounds_so_far bs
-              in
-              bounds_so_far, With_bounds.add ty ti bs', fuel_result
-          in
-          match Loop_control.check ctl ty with
-          | Stop ctl_after_stop ->
-            (* out of fuel, so assume [ty] has the worst possible bounds. *)
-            found_jkind_for_ty ctl_after_stop Mod_bounds.max No_with_bounds
-              Not_best
-          | Skip -> loop ctl bounds_so_far bs (* skip [b] *)
-          | Continue ctl_after_unpacking_b -> (
-            match jkind_of_type ty with
-            | Some b_jkind ->
-              found_jkind_for_ty ctl_after_unpacking_b b_jkind.jkind.mod_bounds
-                b_jkind.jkind.with_bounds b_jkind.quality
-            | None ->
-              (* kind of b is not principally known, so we treat it as having the max
-                 bound (only along the axes we care about for this type!) *)
-              found_jkind_for_ty ctl_after_unpacking_b Mod_bounds.max
-                No_with_bounds Not_best)))
-    in
-    let mod_bounds, with_bounds, fuel_status =
-      loop Loop_control.starting t.mod_bounds
-        (With_bounds.to_list t.with_bounds)
-    in
-    { t with mod_bounds; with_bounds }, fuel_status
 
   let sub (type l r) ~type_equal:_ ~jkind_of_type
       (sub : (allowed * r) jkind_desc)

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -186,16 +186,29 @@ module Violation : sig
   (** Prints a violation and the thing that had an unexpected jkind
       ([offender], which you supply an arbitrary printer for). *)
   val report_with_offender :
-    offender:(Format.formatter -> unit) -> Format.formatter -> t -> unit
+    ?jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
+    offender:(Format.formatter -> unit) ->
+    Format.formatter ->
+    t ->
+    unit
 
   (** Like [report_with_offender], but additionally prints that the issue is
       that a representable jkind was expected. *)
   val report_with_offender_sort :
-    offender:(Format.formatter -> unit) -> Format.formatter -> t -> unit
+    ?jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
+    offender:(Format.formatter -> unit) ->
+    Format.formatter ->
+    t ->
+    unit
 
   (** Simpler version of [report_with_offender] for when the thing that had an
       unexpected jkind is available as a string. *)
-  val report_with_name : name:string -> Format.formatter -> t -> unit
+  val report_with_name :
+    ?jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
+    name:string ->
+    Format.formatter ->
+    t ->
+    unit
 end
 
 (******************************)
@@ -474,7 +487,11 @@ module Desc : sig
 
   val get_const : 'd t -> 'd Const.t option
 
-  val format : Format.formatter -> 'd t -> unit
+  val format :
+    jkind_of_type:(Types.type_expr -> Types.jkind_l) option ->
+    Format.formatter ->
+    'd t ->
+    unit
 end
 
 (** Get a description of a jkind. *)
@@ -580,7 +597,11 @@ val set_outcometree_of_modalities_new :
   Outcometree.out_mode_new list) ->
   unit
 
-val format : Format.formatter -> 'd Types.jkind -> unit
+val format :
+  ?jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
+  Format.formatter ->
+  'd Types.jkind ->
+  unit
 
 (** Format the history of this jkind: what interactions it has had and why
     it is the jkind that it is. Might be a no-op: see [display_histories]
@@ -588,7 +609,11 @@ val format : Format.formatter -> 'd Types.jkind -> unit
 
     The [intro] is something like "The jkind of t is". *)
 val format_history :
-  intro:(Format.formatter -> unit) -> Format.formatter -> 'd Types.jkind -> unit
+  ?jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
+  intro:(Format.formatter -> unit) ->
+  Format.formatter ->
+  'd Types.jkind ->
+  unit
 
 (** Provides the [Printtyp.path] formatter back up the dependency chain to
     this module. *)

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -184,9 +184,19 @@ module Violation : sig
      probably should be rethought at some point. *)
 
   (** Prints a violation and the thing that had an unexpected jkind
-      ([offender], which you supply an arbitrary printer for). *)
+      ([offender], which you supply an arbitrary printer for).
+
+      The [jkind_of_type] allows the printer to normalize with-bounds.  If none
+      is supplied (because you don't have an [env], say), then all with-bounds
+      are printed as-is. If a [jkind_of_type] is supplied, and we're trying to
+      avoid printing with-bounds (because we're not in alpha), then we'll
+      normalize the with-bounds before printing.  Unlike other [jkind_of_type]s,
+      this one does not return a [jkind_l option]; the optionality there is to
+      allow the callback to fail in the case that the type is not principally
+      known. For printing, we do not need to care about principality in this
+      way, so we just unconditionally succeed with a [jkind_l].  *)
   val report_with_offender :
-    ?jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
+    jkind_of_type:(Types.type_expr -> Types.jkind_l) option ->
     offender:(Format.formatter -> unit) ->
     Format.formatter ->
     t ->
@@ -195,7 +205,7 @@ module Violation : sig
   (** Like [report_with_offender], but additionally prints that the issue is
       that a representable jkind was expected. *)
   val report_with_offender_sort :
-    ?jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
+    jkind_of_type:(Types.type_expr -> Types.jkind_l) option ->
     offender:(Format.formatter -> unit) ->
     Format.formatter ->
     t ->
@@ -204,7 +214,7 @@ module Violation : sig
   (** Simpler version of [report_with_offender] for when the thing that had an
       unexpected jkind is available as a string. *)
   val report_with_name :
-    ?jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
+    jkind_of_type:(Types.type_expr -> Types.jkind_l) option ->
     name:string ->
     Format.formatter ->
     t ->
@@ -487,6 +497,8 @@ module Desc : sig
 
   val get_const : 'd t -> 'd Const.t option
 
+  (* See [Violation.report_with_offender] for comments on the [jkind_of_type]
+     argument. *)
   val format :
     jkind_of_type:(Types.type_expr -> Types.jkind_l) option ->
     Format.formatter ->
@@ -597,8 +609,10 @@ val set_outcometree_of_modalities_new :
   Outcometree.out_mode_new list) ->
   unit
 
+(* See [Violation.report_with_offender] for comments on the [jkind_of_type]
+   argument. *)
 val format :
-  ?jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
+  jkind_of_type:(Types.type_expr -> Types.jkind_l) option ->
   Format.formatter ->
   'd Types.jkind ->
   unit
@@ -607,9 +621,13 @@ val format :
     it is the jkind that it is. Might be a no-op: see [display_histories]
     in the implementation of the [Jkind] module.
 
-    The [intro] is something like "The jkind of t is". *)
+    The [intro] is something like "The jkind of t is".
+
+    See [Violation.report_with_offender] for comments on the [jkind_of_type]
+    argument.
+*)
 val format_history :
-  ?jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
+  jkind_of_type:(Types.type_expr -> Types.jkind_l) option ->
   intro:(Format.formatter -> unit) ->
   Format.formatter ->
   'd Types.jkind ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -662,7 +662,7 @@ and raw_lid_type_list tl =
 and raw_type_desc ppf = function
     Tvar { name; jkind } ->
       fprintf ppf "Tvar (@,%a,@,%a)"
-        print_name name (fun k -> Jkind.format k) jkind
+        print_name name (Jkind.format ~jkind_of_type:None) jkind
   | Tarrow((l,arg,ret),t1,t2,c) ->
       fprintf ppf "@[<hov1>Tarrow((\"%s\",%a,%a),@,%a,@,%a,@,%s)@]"
         (string_of_label l)
@@ -695,7 +695,7 @@ and raw_type_desc ppf = function
       fprintf ppf "@[<1>Tsubst@,(%a,@ Some%a)@]" raw_type t raw_type t'
   | Tunivar { name; jkind } ->
       fprintf ppf "Tunivar (@,%a,@,%a)"
-        print_name name (fun k -> Jkind.format k) jkind
+        print_name name (Jkind.format ~jkind_of_type:None) jkind
   | Tpoly (t, tl) ->
       fprintf ppf "@[<hov1>Tpoly(@,%a,@,%a)@]"
         raw_type t
@@ -3132,18 +3132,18 @@ let explanation (type variety) intro prev env
   | Errortrace.Bad_jkind (t,e) ->
       Some (dprintf "@ @[<hov>%a@]"
               (Jkind.Violation.report_with_offender
-                 ~jkind_of_type:(Ctype.type_jkind_purely env)
+                 ~jkind_of_type:(Some (Ctype.type_jkind_purely env))
                  ~offender:(fun ppf -> type_expr ppf t)) e)
   | Errortrace.Bad_jkind_sort (t,e) ->
       Some (dprintf "@ @[<hov>%a@]"
               (Jkind.Violation.report_with_offender_sort
-                 ~jkind_of_type:(Ctype.type_jkind_purely env)
+                 ~jkind_of_type:(Some (Ctype.type_jkind_purely env))
                  ~offender:(fun ppf -> type_expr ppf t)) e)
   | Errortrace.Unequal_var_jkinds (t1,l1,t2,l2) ->
       let fmt_history t l ppf =
-        Jkind.(format_history ~intro:(
+        Jkind.(format_history ~jkind_of_type:None ~intro:(
           dprintf "The layout of %a is %a" prepared_type_expr t
-            (fun k -> format k) l) ppf l)
+            (format ~jkind_of_type:None) l) ppf l)
       in
       Some (dprintf "@ because the layouts of their variables are different.\
                      @ @[<v>%t@;%t@]"

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -661,7 +661,8 @@ and raw_lid_type_list tl =
     tl
 and raw_type_desc ppf = function
     Tvar { name; jkind } ->
-      fprintf ppf "Tvar (@,%a,@,%a)" print_name name Jkind.format jkind
+      fprintf ppf "Tvar (@,%a,@,%a)"
+        print_name name (fun k -> Jkind.format k) jkind
   | Tarrow((l,arg,ret),t1,t2,c) ->
       fprintf ppf "@[<hov1>Tarrow((\"%s\",%a,%a),@,%a,@,%a,@,%s)@]"
         (string_of_label l)
@@ -693,7 +694,8 @@ and raw_type_desc ppf = function
   | Tsubst (t, Some t') ->
       fprintf ppf "@[<1>Tsubst@,(%a,@ Some%a)@]" raw_type t raw_type t'
   | Tunivar { name; jkind } ->
-      fprintf ppf "Tunivar (@,%a,@,%a)" print_name name Jkind.format jkind
+      fprintf ppf "Tunivar (@,%a,@,%a)"
+        print_name name (fun k -> Jkind.format k) jkind
   | Tpoly (t, tl) ->
       fprintf ppf "@[<hov1>Tpoly(@,%a,@,%a)@]"
         raw_type t
@@ -3130,15 +3132,18 @@ let explanation (type variety) intro prev env
   | Errortrace.Bad_jkind (t,e) ->
       Some (dprintf "@ @[<hov>%a@]"
               (Jkind.Violation.report_with_offender
+                 ~jkind_of_type:(Ctype.type_jkind_purely env)
                  ~offender:(fun ppf -> type_expr ppf t)) e)
   | Errortrace.Bad_jkind_sort (t,e) ->
       Some (dprintf "@ @[<hov>%a@]"
               (Jkind.Violation.report_with_offender_sort
+                 ~jkind_of_type:(Ctype.type_jkind_purely env)
                  ~offender:(fun ppf -> type_expr ppf t)) e)
   | Errortrace.Unequal_var_jkinds (t1,l1,t2,l2) ->
       let fmt_history t l ppf =
         Jkind.(format_history ~intro:(
-          dprintf "The layout of %a is %a" prepared_type_expr t format l) ppf l)
+          dprintf "The layout of %a is %a" prepared_type_expr t
+            (fun k -> format k) l) ppf l)
       in
       Some (dprintf "@ because the layouts of their variables are different.\
                      @ @[<v>%t@;%t@]"

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2368,7 +2368,7 @@ let report_error env ppf =
     fprintf ppf
       "@[Variables bound in a class must have layout value.@ %a@]"
       (Jkind.Violation.report_with_name
-         ~jkind_of_type:(Ctype.type_jkind_purely env) ~name:nm) err
+         ~jkind_of_type:(Some (Ctype.type_jkind_purely env)) ~name:nm) err
   | Non_value_let_binding (nm, sort) ->
     fprintf ppf
       "@[The types of variables bound by a 'let' in a class function@ \

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2367,7 +2367,8 @@ let report_error env ppf =
   | Non_value_binding (nm, err) ->
     fprintf ppf
       "@[Variables bound in a class must have layout value.@ %a@]"
-      (Jkind.Violation.report_with_name ~name:nm) err
+      (Jkind.Violation.report_with_name
+         ~jkind_of_type:(Ctype.type_jkind_purely env) ~name:nm) err
   | Non_value_let_binding (nm, sort) ->
     fprintf ppf
       "@[The types of variables bound by a 'let' in a class function@ \

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -10312,7 +10312,7 @@ let report_too_many_arg_error ~funct ~func_ty ~previous_arg_loc
     report_this_function funct Printtyp.type_expr func_ty
 
 let report_error ~loc env =
-  let jkind_of_type = Ctype.type_jkind_purely env in
+  let jkind_of_type = Some (Ctype.type_jkind_purely env) in
   function
   | Constructor_arity_mismatch(lid, expected, provided) ->
       Location.errorf ~loc
@@ -10542,6 +10542,7 @@ let report_error ~loc env =
     Location.error_of_printer ~loc (fun ppf () ->
       fprintf ppf "Variables bound in a \"let rec\" must have layout value.@ %a"
         (fun v -> Jkind.Violation.report_with_offender
+           ~jkind_of_type:None
            ~offender:(fun ppf -> Printtyp.type_expr ppf ty) v) err)
       ()
   | Undefined_method (ty, me, valid_methods) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -10311,7 +10311,9 @@ let report_too_many_arg_error ~funct ~func_ty ~previous_arg_loc
      @ It is applied to too many arguments@]"
     report_this_function funct Printtyp.type_expr func_ty
 
-let report_error ~loc env = function
+let report_error ~loc env =
+  let jkind_of_type = Ctype.type_jkind_purely env in
+  function
   | Constructor_arity_mismatch(lid, expected, provided) ->
       Location.errorf ~loc
        "@[The constructor %a@ expects %i argument(s),@ \
@@ -10531,15 +10533,16 @@ let report_error ~loc env = function
   | Non_value_object (err, explanation) ->
     Location.error_of_printer ~loc (fun ppf () ->
       fprintf ppf "Object types must have layout value.@ %a"
-        (Jkind.Violation.report_with_name ~name:"the type of this expression")
+        (Jkind.Violation.report_with_name
+           ~jkind_of_type ~name:"the type of this expression")
         err;
       report_type_expected_explanation_opt explanation ppf)
       ()
   | Non_value_let_rec (err, ty) ->
     Location.error_of_printer ~loc (fun ppf () ->
       fprintf ppf "Variables bound in a \"let rec\" must have layout value.@ %a"
-        (Jkind.Violation.report_with_offender
-           ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) err)
+        (fun v -> Jkind.Violation.report_with_offender
+           ~offender:(fun ppf -> Printtyp.type_expr ppf ty) v) err)
       ()
   | Undefined_method (ty, me, valid_methods) ->
       Location.error_of_printer ~loc (fun ppf () ->
@@ -10990,17 +10993,17 @@ let report_error ~loc env = function
   | Function_type_not_rep (ty,violation) ->
       Location.errorf ~loc
         "@[Function arguments and returns must be representable.@]@ %a"
-        (Jkind.Violation.report_with_offender
+        (Jkind.Violation.report_with_offender ~jkind_of_type
            ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) violation
   | Record_projection_not_rep (ty,violation) ->
       Location.errorf ~loc
         "@[Records being projected from must be representable.@]@ %a"
-        (Jkind.Violation.report_with_offender
+        (Jkind.Violation.report_with_offender ~jkind_of_type
            ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) violation
   | Record_not_rep (ty,violation) ->
       Location.errorf ~loc
         "@[Record expressions must be representable.@]@ %a"
-        (Jkind.Violation.report_with_offender
+        (Jkind.Violation.report_with_offender ~jkind_of_type
            ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) violation
   | Invalid_label_for_src_pos arg_label ->
       Location.errorf ~loc
@@ -11029,8 +11032,8 @@ let report_error ~loc env = function
          has kind %a, which cannot be the kind of a function.@ \
          (Functions always have kind %a.)@]"
         (Style.as_inline_code Printtyp.type_expr) ty
-        (Style.as_inline_code Jkind.format) jkind
-        (Style.as_inline_code Jkind.format) Jkind.for_arrow
+        (Style.as_inline_code (Jkind.format ~jkind_of_type)) jkind
+        (Style.as_inline_code (Jkind.format ~jkind_of_type)) Jkind.for_arrow
   | Overwrite_of_invalid_term ->
       Location.errorf ~loc
         "Overwriting is only supported on tuples, constructors and boxed records."

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3948,7 +3948,7 @@ let report_jkind_mismatch_due_to_bad_inference ppf env ty violation loc =
      the declaration where this error is reported.@]"
     loc
     (Jkind.Violation.report_with_offender
-       ~jkind_of_type:(Ctype.type_jkind_purely env)
+       ~jkind_of_type:(Some (Ctype.type_jkind_purely env))
        ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) violation
 
 let report_error ppf = function
@@ -4224,12 +4224,12 @@ let report_error ppf = function
       fprintf ppf "type %a" Style.inline_code (Ident.name (Path.head dpath))
     in
     Jkind.Violation.report_with_offender
-      ~jkind_of_type:(Ctype.type_jkind_purely env) ~offender ppf v
+      ~jkind_of_type:(Some (Ctype.type_jkind_purely env)) ~offender ppf v
   | Jkind_mismatch_of_type (ty,env,v) ->
     let offender ppf = fprintf ppf "type %a"
         (Style.as_inline_code Printtyp.type_expr) ty in
     Jkind.Violation.report_with_offender
-      ~jkind_of_type:(Ctype.type_jkind_purely env) ~offender ppf v
+      ~jkind_of_type:(Some (Ctype.type_jkind_purely env)) ~offender ppf v
   | Jkind_sort {kloc; typ; env; err} ->
     let s =
       match kloc with
@@ -4255,12 +4255,12 @@ let report_error ppf = function
     fprintf ppf "@[%s must have a representable layout%t.@ %a@]" s
       extra
       (Jkind.Violation.report_with_offender
-         ~jkind_of_type:(Ctype.type_jkind_purely env)
+         ~jkind_of_type:(Some (Ctype.type_jkind_purely env))
          ~offender:(fun ppf -> Printtyp.type_expr ppf typ)) err
   | Jkind_empty_record ->
     fprintf ppf "@[Records must contain at least one runtime value.@]"
   | Non_value_in_sig (err, val_name, env, ty) ->
-    let jkind_of_type = Ctype.type_jkind_purely env in
+    let jkind_of_type = Some (Ctype.type_jkind_purely env) in
     let offender ppf = fprintf ppf "type %a" Printtyp.type_expr ty in
     fprintf ppf "@[This type signature for %a is not a value type.@ %a@]"
       Style.inline_code val_name
@@ -4417,7 +4417,7 @@ let report_error ppf = function
   | Illegal_baggage jkind ->
     fprintf ppf
       "@[Illegal %a in kind annotation of an abbreviation:@ %a@]"
-      Style.inline_code "with" (fun k -> Jkind.format k) jkind
+      Style.inline_code "with" (Jkind.format ~jkind_of_type:None) jkind
 
 let () =
   Location.register_error_of_exn

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -117,17 +117,18 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Jkind_mismatch_of_type of type_expr * Jkind.Violation.t
-  | Jkind_mismatch_of_path of Path.t * Jkind.Violation.t
+  | Jkind_mismatch_of_type of type_expr * Env.t * Jkind.Violation.t
+  | Jkind_mismatch_of_path of Path.t * Env.t * Jkind.Violation.t
   | Jkind_mismatch_due_to_bad_inference of
-      type_expr * Jkind.Violation.t * bad_jkind_inference_location
+      type_expr * Env.t * Jkind.Violation.t * bad_jkind_inference_location
   | Jkind_sort of
       { kloc : jkind_sort_loc
       ; typ : type_expr
+      ; env : Env.t
       ; err : Jkind.Violation.t
       }
   | Jkind_empty_record
-  | Non_value_in_sig of Jkind.Violation.t * string * type_expr
+  | Non_value_in_sig of Jkind.Violation.t * string * Env.t * type_expr
   | Invalid_jkind_in_block of type_expr * Jkind.Sort.Const.t * jkind_sort_loc
   | Illegal_mixed_product of mixed_product_violation
   | Separability of Typedecl_separability.error
@@ -437,7 +438,7 @@ let set_private_row env loc p decl =
 let check_representable ~why env loc kloc typ =
   match Ctype.type_sort ~why ~fixed:false env typ with
   | Ok _ -> ()
-  | Error err -> raise (Error (loc,Jkind_sort {kloc; typ; err}))
+  | Error err -> raise (Error (loc,Jkind_sort {kloc; typ; env; err}))
 
 let transl_labels (type rep) ~(record_form : rep record_form) ~new_var_jkind
       env univars closed lbls kloc =
@@ -1106,7 +1107,7 @@ let rec check_constraints_rec env loc visited ty =
                                []))
           in
           raise (Error(loc, Jkind_mismatch_due_to_bad_inference
-                            (ty, violation, Check_constraints)))
+                            (ty, env, violation, Check_constraints)))
         | All_good -> ()
       end;
       List.iter (check_constraints_rec env loc visited) args
@@ -1278,12 +1279,12 @@ let narrow_to_manifest_jkind env loc decl =
             manifest_jkind decl.type_jkind
         with
         | Ok () -> ()
-        | Error v -> raise (Error (loc, Jkind_mismatch_of_type (ty,v)))
+        | Error v -> raise (Error (loc, Jkind_mismatch_of_type (ty,env,v)))
       end
     | Some type_jkind -> begin
         match Ctype.constrain_type_jkind env ty type_jkind with
         | Ok () -> ()
-        | Error v -> raise (Error (loc, Jkind_mismatch_of_type (ty,v)))
+        | Error v -> raise (Error (loc, Jkind_mismatch_of_type (ty,env,v)))
       end
     end;
     { decl with type_jkind = manifest_jkind }
@@ -1898,6 +1899,7 @@ let update_decl_jkind env id decl =
       decl.type_loc,
       Jkind_mismatch_of_path (
         Pident id,
+        env,
         Jkind.Violation.of_ (
           Not_a_subjkind (
             new_decl.type_jkind, decl.type_jkind, Nonempty_list.to_list reason)))))
@@ -2545,7 +2547,8 @@ let normalize_decl_jkinds env shapes decls =
               env, (id, { decl with type_jkind; type_kind; })
             else env, (id, decl)
          | Error err ->
-           raise(Error(decl.type_loc, Jkind_mismatch_of_path (Pident id, err)))
+           raise(Error(decl.type_loc,
+                       Jkind_mismatch_of_path (Pident id, env, err)))
        end
        else env, (id, decl))
     env
@@ -2705,7 +2708,7 @@ let transl_type_decl env rec_flag sdecl_list =
           raise (Error (loc, Type_clash (new_env, err)))
         | Ok _ ->
           raise (Error (loc, Jkind_mismatch_due_to_bad_inference
-                               (ty, err, Delayed_checks)))
+                               (ty, env, err, Delayed_checks)))
         end)
       checks)
     delayed_jkind_checks;
@@ -3181,7 +3184,7 @@ let type_sort_external ~is_layout_poly ~why env loc typ =
     let kloc =
       if is_layout_poly then External_with_layout_poly else External
     in
-    raise(Error (loc, Jkind_sort {kloc; typ; err}))
+    raise(Error (loc, Jkind_sort {kloc; typ; env; err}))
 
 let make_native_repr env core_type ty ~global_repr ~is_layout_poly ~why =
   error_if_has_deep_native_repr_attributes core_type;
@@ -3464,7 +3467,8 @@ let transl_value_decl env loc ~sig_modalities valdecl =
                 (Jkind.Builtin.value_or_null ~why:Structure_element) with
   | Ok () -> ()
   | Error err ->
-    raise(Error(cty.ctyp_loc, Non_value_in_sig(err,valdecl.pval_name.txt,cty.ctyp_type)))
+    raise(Error(cty.ctyp_loc,
+                Non_value_in_sig(err,valdecl.pval_name.txt,env,cty.ctyp_type)))
   end;
   let ty = cty.ctyp_type in
   let v =
@@ -3926,7 +3930,7 @@ module Reaching_path = struct
     pp path
 end
 
-let report_jkind_mismatch_due_to_bad_inference ppf ty violation loc =
+let report_jkind_mismatch_due_to_bad_inference ppf env ty violation loc =
   let loc =
     match loc with
     | Check_constraints ->
@@ -3944,6 +3948,7 @@ let report_jkind_mismatch_due_to_bad_inference ppf ty violation loc =
      the declaration where this error is reported.@]"
     loc
     (Jkind.Violation.report_with_offender
+       ~jkind_of_type:(Ctype.type_jkind_purely env)
        ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) violation
 
 let report_error ppf = function
@@ -4003,7 +4008,7 @@ let report_error ppf = function
       in
       begin match List.find_map get_jkind_error err.trace with
       | Some (ty, violation) ->
-        report_jkind_mismatch_due_to_bad_inference ppf ty violation
+        report_jkind_mismatch_due_to_bad_inference ppf env ty violation
           Check_constraints
       | None ->
       fprintf ppf "@[<v>Constraints are not satisfied in this type.@ ";
@@ -4012,8 +4017,8 @@ let report_error ppf = function
         (fun ppf -> fprintf ppf "should be an instance of");
       fprintf ppf "@]"
       end
-  | Jkind_mismatch_due_to_bad_inference (ty, violation, loc) ->
-      report_jkind_mismatch_due_to_bad_inference ppf ty violation loc
+  | Jkind_mismatch_due_to_bad_inference (ty, env, violation, loc) ->
+      report_jkind_mismatch_due_to_bad_inference ppf env ty violation loc
   | Non_regular { definition; used_as; defined_as; reaching_path } ->
       let reaching_path = Reaching_path.simplify reaching_path in
       let pp_type ppf ty = Style.as_inline_code !Oprint.out_type ppf ty in
@@ -4212,18 +4217,20 @@ let report_error ppf = function
          it should not occur deeply into its type.@]"
         Style.inline_code
         (match kind with Unboxed -> "@unboxed" | Untagged -> "@untagged")
-  | Jkind_mismatch_of_path (dpath,v) ->
+  | Jkind_mismatch_of_path (dpath,env,v) ->
     (* the type is always printed just above, so print out just the head of the
        path instead of something like [t/3] *)
     let offender ppf =
       fprintf ppf "type %a" Style.inline_code (Ident.name (Path.head dpath))
     in
-    Jkind.Violation.report_with_offender ~offender ppf v
-  | Jkind_mismatch_of_type (ty,v) ->
+    Jkind.Violation.report_with_offender
+      ~jkind_of_type:(Ctype.type_jkind_purely env) ~offender ppf v
+  | Jkind_mismatch_of_type (ty,env,v) ->
     let offender ppf = fprintf ppf "type %a"
         (Style.as_inline_code Printtyp.type_expr) ty in
-    Jkind.Violation.report_with_offender ~offender ppf v
-  | Jkind_sort {kloc; typ; err} ->
+    Jkind.Violation.report_with_offender
+      ~jkind_of_type:(Ctype.type_jkind_purely env) ~offender ppf v
+  | Jkind_sort {kloc; typ; env; err} ->
     let s =
       match kloc with
       | Mixed_product -> "Structures with non-value elements"
@@ -4248,14 +4255,16 @@ let report_error ppf = function
     fprintf ppf "@[%s must have a representable layout%t.@ %a@]" s
       extra
       (Jkind.Violation.report_with_offender
+         ~jkind_of_type:(Ctype.type_jkind_purely env)
          ~offender:(fun ppf -> Printtyp.type_expr ppf typ)) err
   | Jkind_empty_record ->
     fprintf ppf "@[Records must contain at least one runtime value.@]"
-  | Non_value_in_sig (err, val_name, ty) ->
+  | Non_value_in_sig (err, val_name, env, ty) ->
+    let jkind_of_type = Ctype.type_jkind_purely env in
     let offender ppf = fprintf ppf "type %a" Printtyp.type_expr ty in
     fprintf ppf "@[This type signature for %a is not a value type.@ %a@]"
       Style.inline_code val_name
-      (Jkind.Violation.report_with_offender ~offender) err
+      (Jkind.Violation.report_with_offender ~jkind_of_type ~offender) err
   | Invalid_jkind_in_block (typ, sort_const, lloc) ->
     let struct_desc =
       match lloc with
@@ -4408,7 +4417,7 @@ let report_error ppf = function
   | Illegal_baggage jkind ->
     fprintf ppf
       "@[Illegal %a in kind annotation of an abbreviation:@ %a@]"
-      Style.inline_code "with" Jkind.format jkind
+      Style.inline_code "with" (fun k -> Jkind.format k) jkind
 
 let () =
   Location.register_error_of_exn

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -153,17 +153,18 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Jkind_mismatch_of_type of type_expr * Jkind.Violation.t
-  | Jkind_mismatch_of_path of Path.t * Jkind.Violation.t
+  | Jkind_mismatch_of_type of type_expr * Env.t * Jkind.Violation.t
+  | Jkind_mismatch_of_path of Path.t * Env.t * Jkind.Violation.t
   | Jkind_mismatch_due_to_bad_inference of
-      type_expr * Jkind.Violation.t * bad_jkind_inference_location
+      type_expr * Env.t * Jkind.Violation.t * bad_jkind_inference_location
   | Jkind_sort of
       { kloc : jkind_sort_loc
       ; typ : type_expr
+      ; env : Env.t
       ; err : Jkind.Violation.t
       }
   | Jkind_empty_record
-  | Non_value_in_sig of Jkind.Violation.t * string * type_expr
+  | Non_value_in_sig of Jkind.Violation.t * string * Env.t * type_expr
   | Invalid_jkind_in_block of type_expr * Jkind.Sort.Const.t * jkind_sort_loc
   | Illegal_mixed_product of mixed_product_violation
   | Separability of Typedecl_separability.error

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -21,14 +21,14 @@ open Typedtree
 open Lambda
 
 type error =
-    Non_value_layout of type_expr * Jkind.Violation.t option
+    Non_value_layout of type_expr * Env.t * Jkind.Violation.t option
   | Non_value_sort of Jkind.Sort.t * type_expr
   | Sort_without_extension of
       Jkind.Sort.t * Language_extension.maturity * type_expr option
   | Non_value_sort_unknown_ty of Jkind.Sort.t
   | Small_number_sort_without_extension of Jkind.Sort.t * type_expr option
   | Simd_sort_without_extension of Jkind.Sort.t * type_expr option
-  | Not_a_sort of type_expr * Jkind.Violation.t
+  | Not_a_sort of type_expr * Env.t * Jkind.Violation.t
   | Unsupported_sort of Jkind.Sort.Const.t
   | Unsupported_product_in_lazy of Jkind.Sort.Const.t
   | Unsupported_vector_in_product_array
@@ -114,7 +114,7 @@ let maybe_pointer exp = maybe_pointer_type exp.exp_env exp.exp_type
 let type_legacy_sort ~why env loc ty =
   match Ctype.type_legacy_sort ~why env ty with
   | Ok sort -> sort
-  | Error err -> raise (Error (loc, Not_a_sort (ty, err)))
+  | Error err -> raise (Error (loc, Not_a_sort (ty, env, err)))
 
 (* [classification]s are used for two things: things in arrays, and things in
    lazys. In the former case, we need detailed information about unboxed
@@ -459,7 +459,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
       | Error violation ->
         if (Jkind.Violation.is_missing_cmi violation)
         then raise Missing_cmi_fallback
-        else raise (Error (loc, Non_value_layout (ty, Some violation)))
+        else raise (Error (loc, Non_value_layout (ty, env, Some violation)))
   end;
   match get_desc scty with
   | Tconstr(p, _, _) when Path.same p Predef.path_int ->
@@ -806,7 +806,7 @@ let value_kind env loc ty =
     in
     value_kind
   with
-  | Missing_cmi_fallback -> raise (Error (loc, Non_value_layout (ty, None)))
+  | Missing_cmi_fallback -> raise (Error (loc, Non_value_layout (ty, env, None)))
 
 let[@inline always] rec layout_of_const_sort_generic ~value_kind ~error
   : Jkind.Sort.Const.t -> _ = function
@@ -972,7 +972,7 @@ let rec layout_union l1 l2 =
 open Format
 
 let report_error ppf = function
-  | Non_value_layout (ty, err) ->
+  | Non_value_layout (ty, env, err) ->
       fprintf ppf
         "Non-value detected in [value_kind].@ Please report this error to \
          the Jane Street compilers team.";
@@ -982,6 +982,7 @@ let report_error ppf = function
       | Some err ->
         fprintf ppf "@ %a"
         (Jkind.Violation.report_with_offender
+           ~jkind_of_type:(Ctype.type_jkind_purely env)
            ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) err
       end
   | Non_value_sort (sort, ty) ->
@@ -1046,9 +1047,10 @@ let report_error ppf = function
          build file.@ \
          Otherwise, please report this error to the Jane Street compilers team."
         extension verb flags
-  | Not_a_sort (ty, err) ->
+  | Not_a_sort (ty, env, err) ->
       fprintf ppf "A representable layout is required here.@ %a"
         (Jkind.Violation.report_with_offender
+           ~jkind_of_type:(Ctype.type_jkind_purely env)
            ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) err
   | Unsupported_sort const ->
       fprintf ppf "Layout %a is not supported yet."

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -982,7 +982,7 @@ let report_error ppf = function
       | Some err ->
         fprintf ppf "@ %a"
         (Jkind.Violation.report_with_offender
-           ~jkind_of_type:(Ctype.type_jkind_purely env)
+           ~jkind_of_type:(Some (Ctype.type_jkind_purely env))
            ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) err
       end
   | Non_value_sort (sort, ty) ->
@@ -1050,7 +1050,7 @@ let report_error ppf = function
   | Not_a_sort (ty, env, err) ->
       fprintf ppf "A representable layout is required here.@ %a"
         (Jkind.Violation.report_with_offender
-           ~jkind_of_type:(Ctype.type_jkind_purely env)
+           ~jkind_of_type:(Some (Ctype.type_jkind_purely env))
            ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) err
   | Unsupported_sort const ->
       fprintf ppf "Layout %a is not supported yet."

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1433,7 +1433,7 @@ let pp_tag ppf t = Format.fprintf ppf "`%s" t
 
 
 let report_error env ppf =
-  let jkind_of_type = Ctype.type_jkind_purely env in
+  let jkind_of_type = Some (Ctype.type_jkind_purely env) in
   function
   | Unbound_type_variable (name, in_scope_names) ->
     fprintf ppf "The type variable %a is unbound in this type declaration.@ %a"


### PR DESCRIPTION
Looking at the changes in output when we enable `-infer-with-bounds` everywhere, it's clear that the current "drop with-bounds" approach to hiding them is not going to fly. So I have us normalize instead.

This has the effect of rounding up. So this is good for left kinds, but not so good for right kinds. Happily, it's rare for a with-bound to exist on a right-kind -- it can happen only in typedecl (or I suppose module inclusion) and when the user has written a with-bound. A few messages have gotten worse, but a vast number have gotten better. And the ones that are worse are very proximate to the with-bound in question, so it's easier to see what's going on.

I also made a design choice here to print with-bounds in the few places we are unable to normalize (because we don't have an `env`) -- even if we normally wouldn't want to print. These places are few. One interesting one is in the outcometree -- but of course we'll only print a with-bound there if the user has written one, so I think this is an improvement.

Review by commit: the first two commits just move the `normalize` function above the printing code; the last commit is the payload. I nominate @liam923 as the reviewer.