### PR TITLE
Add EV_MINOR_EPHE_CLEAN to runtime_events

### DIFF
--- a/otherlibs/runtime_events/runtime_events.ml
+++ b/otherlibs/runtime_events/runtime_events.ml
@@ -83,6 +83,7 @@ type runtime_phase =
 | EV_COMPACT_EVACUATE
 | EV_COMPACT_FORWARD
 | EV_COMPACT_RELEASE
+| EV_MINOR_EPHE_CLEAN
 
 type lifecycle =
   EV_RING_START
@@ -172,6 +173,7 @@ let runtime_phase_name phase =
   | EV_COMPACT_EVACUATE -> "compaction_evacuate"
   | EV_COMPACT_FORWARD -> "compaction_forward"
   | EV_COMPACT_RELEASE -> "compaction_release"
+  | EV_MINOR_EPHE_CLEAN -> "minor_ephe_clean"
 
 let lifecycle_name lifecycle =
   match lifecycle with

--- a/otherlibs/runtime_events/runtime_events.mli
+++ b/otherlibs/runtime_events/runtime_events.mli
@@ -138,6 +138,7 @@ type runtime_phase =
 | EV_COMPACT_EVACUATE
 | EV_COMPACT_FORWARD
 | EV_COMPACT_RELEASE
+| EV_MINOR_EPHE_CLEAN
 
 (** Lifecycle events for the ring itself. *)
 type lifecycle =


### PR DESCRIPTION
This fixes a bug in the recently-merged #3376, which incorrectly added a new runtime event without updating `otherlibs/runtime_events`.