### PR TITLE
Strip jkind_axis functions out of modules

### DIFF
--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -405,7 +405,7 @@ module Mod_bounds = struct
       Nullability.print nullability
 
   let min =
-    Create.f
+    create
       { f =
           (fun (type axis) ~(axis : axis Axis.t) ->
             let (module Bound_ops) = Axis.get axis in
@@ -413,7 +413,7 @@ module Mod_bounds = struct
       }
 
   let max =
-    Create.f
+    create
       { f =
           (fun (type axis) ~(axis : axis Axis.t) ->
             let (module Bound_ops) = Axis.get axis in
@@ -433,7 +433,7 @@ module Mod_bounds = struct
     }
 
   let join =
-    Map2.f
+    map2
       { f =
           (fun (type axis) ~(axis : axis Axis.t) ->
             let (module Bound_ops) = Axis.get axis in
@@ -441,7 +441,7 @@ module Mod_bounds = struct
       }
 
   let meet =
-    Map2.f
+    map2
       { f =
           (fun (type axis) ~(axis : axis Axis.t) ->
             let (module Bound_ops) = Axis.get axis in
@@ -449,7 +449,7 @@ module Mod_bounds = struct
       }
 
   let less_or_equal =
-    Fold2.f
+    fold2
       { f =
           (fun (type axis) ~(axis : axis Axis.t) b1 b2 ->
             let (module Bound_ops) = Axis.get axis in
@@ -459,7 +459,7 @@ module Mod_bounds = struct
       ~combine:Sub_result.combine
 
   let equal =
-    Fold2.f
+    fold2
       { f =
           (fun (type axis) ~(axis : axis Axis.t) ->
             let (module Bound_ops) = Axis.get axis in
@@ -1264,7 +1264,7 @@ module Const = struct
       (* for each mode, lower the corresponding modal bound to be that mode *)
       let parsed_modifiers = Typemode.transl_modifier_annots modifiers in
       let mod_bounds =
-        Mod_bounds.Create.f
+        Mod_bounds.create
           { f =
               (fun (type a) ~(axis : a Axis.t) ->
                 let (module A) = Axis.get axis in
@@ -1538,7 +1538,7 @@ module Jkind_desc = struct
           loop ctl bounds_so_far bs
         | false -> (
           let join_bounds b1 b2 ~relevant_axes =
-            Mod_bounds.Map2.f
+            Mod_bounds.map2
               { f =
                   (fun (type a) ~(axis : a Axis.t) b1 b2 ->
                     if Axis_set.mem relevant_axes axis

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -115,7 +115,7 @@ let transl_modifier_annots annots =
     Transled_modifiers.set ~axis modifiers_so_far (Some { txt = mode; loc })
   in
   let empty_modifiers =
-    Transled_modifiers.Create.f { f = (fun ~axis:_ -> None) }
+    Transled_modifiers.create { f = (fun ~axis:_ -> None) }
   in
   List.fold_left step empty_modifiers annots
 
@@ -135,7 +135,7 @@ let transl_mode_annots annots : Alloc.Const.Option.t =
     Transled_modifiers.set ~axis modifiers_so_far (Some { txt = mode; loc })
   in
   let empty_modifiers =
-    Transled_modifiers.Create.f { f = (fun ~axis:_ -> None) }
+    Transled_modifiers.create { f = (fun ~axis:_ -> None) }
   in
   let modes = List.fold_left step empty_modifiers annots in
   { areality = Transled_modifier.drop_loc modes.locality;


### PR DESCRIPTION
This is a small change that I believe makes `Axis_collection` a bit less cryptic. Rather than writing `.Create.f`, you now write `.create`.