### PR TITLE
Use the same threshold for out-of-cycle work for major and minor dependent allocs

### DIFF
--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -89,9 +89,6 @@ CAMLextern value caml_alloc_custom_dep(const struct custom_operations * ops,
 CAMLextern void
           caml_register_custom_operations(const struct custom_operations * ops);
 
-/* Return the current [max] factor for [caml_alloc_custom_mem] allocations. */
-CAMLextern mlsize_t caml_custom_get_max_major (void);
-
 /* Global variable moved to Caml_state in 4.10 */
 #define caml_compare_unordered (Caml_state_field(compare_unordered))
 

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -36,22 +36,6 @@ uintnat caml_custom_major_ratio = Custom_major_ratio_def;
 uintnat caml_custom_minor_ratio = Custom_minor_ratio_def;
 uintnat caml_custom_minor_max_bsz = Custom_minor_max_bsz_def;
 
-mlsize_t caml_custom_get_max_major (void)
-{
-  /* The major ratio is a percentage relative to the major heap size.
-     A complete GC cycle will be done every time 2/3 of that much
-     memory is allocated for blocks in the major heap.  Assuming
-     constant allocation and deallocation rates, this means there are
-     at most [M/100 * major-heap-size] bytes of floating garbage at
-     any time.  The reason for a factor of 2/3 (or 1.5) is, roughly
-     speaking, because the major GC takes 1.5 cycles (previous cycle +
-     marking phase) before it starts to deallocate dead blocks
-     allocated during the previous cycle.  [heap_size / 150] is really
-     [heap_size * (2/3) / 100] (but faster). */
-  return caml_heap_size(Caml_state->shared_heap) / 150
-         * caml_custom_major_ratio;
-}
-
 static value alloc_custom_gen (const struct custom_operations * ops,
                                uintnat bsz,
                                bool minor_ok,


### PR DESCRIPTION
This replaces the strange `caml_custom_get_max_major` computation with something more sensible. The function `caml_custom_get_max_major` is now inlined into its only callsite (which is about to be replaced)