### PR TITLE
Recognize %identity and %obj_magic as nonexpansive

### DIFF
--- a/testsuite/tests/typing-misc/magic_is_a_value.ml
+++ b/testsuite/tests/typing-misc/magic_is_a_value.ml
@@ -1,0 +1,16 @@
+(* TEST
+ expect;
+*)
+
+(* not really an application, since Obj.magic doesn't do anything *)
+let f : 'a. 'a -> 'a = Obj.magic Fun.id
+[%%expect {|
+val f : 'a -> 'a = <fun>
+|}]
+
+
+(* not a value, since it's actually an application *)
+let g : 'a -> 'a = Obj.magic Fun.id Fun.id
+[%%expect {|
+val g : '_a -> '_a = <fun>
+|}]

--- a/testsuite/tests/typing-misc/magic_is_a_value_upstream.ml
+++ b/testsuite/tests/typing-misc/magic_is_a_value_upstream.ml
@@ -1,0 +1,28 @@
+(* TEST
+ flags = "-extension-universe upstream_compatible";
+ expect;
+*)
+
+(* This file is meant to read in tandem with [magic_is_a_value.ml],
+   showing that our special treatment of [Obj.magic] is internal-only
+   and can't be used in upstream-compatible code.
+ *)
+
+(* not really an application, since Obj.magic doesn't do anything *)
+(* Nonetheless, in upstream-compatible code, we expect the type vars
+   to not be generalized. *)
+let f : 'a. 'a -> 'a = Obj.magic Fun.id
+[%%expect {|
+Line 1, characters 23-39:
+1 | let f : 'a. 'a -> 'a = Obj.magic Fun.id
+                           ^^^^^^^^^^^^^^^^
+Error: This definition has type "'a -> 'a" which is less general than
+         "'a0. 'a0 -> 'a0"
+|}]
+
+
+(* not a value, since it's actually an application *)
+let g : 'a -> 'a = Obj.magic Fun.id Fun.id
+[%%expect {|
+val g : '_a -> '_a = <fun>
+|}]

--- a/testsuite/tests/typing-misc/polyvars.ml
+++ b/testsuite/tests/typing-misc/polyvars.ml
@@ -225,12 +225,12 @@ val inspect : [< `A of a & int ] -> unit = <fun>
 |}]
 
 (** Error messages with weakly polymorphic row variables *)
-let x = Fun.id (function `X -> () | _ -> ())
+let x = !(ref (function `X -> () | _ -> ()))
 [%%expect {|
 val x : ([> `X ] as '_weak1) -> unit = <fun>
 |}]
 
-let x = let rec x = `X (`Y (fun y -> x = y)) in Fun.id x
+let x = let rec x = `X (`Y (fun y -> x = y)) in !(ref x)
 [%%expect {|
 val x : [> `X of [> `Y of '_weak2 -> bool ] as '_weak3 ] as '_weak2 =
   `X (`Y <fun>)

--- a/testsuite/tests/typing-unique/overwriting_lift_constants.ml
+++ b/testsuite/tests/typing-unique/overwriting_lift_constants.ml
@@ -73,7 +73,7 @@ let () =
 
 [%%expect{|
 type point = { mutable dim : int; x : float; y : float; z : float; }
-val unsafe_dup : '_a @ unique -> '_a * '_a @ unique = <fun>
+val unsafe_dup : 'a @ unique -> 'a * 'a @ unique = <fun>
 Line 9, characters 10-66:
 9 |   let p = overwrite_ p with { dim = 4; x = 1.0; y = 2.0; z = 3.0 } in
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This code should not hit the value restriction:
```ocaml
let f = Obj.magic f
```
This change lets the compiler see that `Obj.magic` and similar primitives aren't actually applications, so can't hide a mutable cell allocation, so don't need to be subject to the value restriction. (We already have a similar check for `raise`).