### PR TITLE
Fix uniqueness error of variables bound internal to a module

### DIFF
--- a/testsuite/tests/typing-unique/unique_mod_class.ml
+++ b/testsuite/tests/typing-unique/unique_mod_class.ml
@@ -173,9 +173,4 @@ let () =
         end
     in ()
 [%%expect{|
-Line 6, characters 28-29:
-6 |           let _ = unique_id x in
-                                ^
-Error: This value is aliased but used as unique.
-Hint: This value comes from outside the current module or class.
 |}]

--- a/testsuite/tests/typing-unique/unique_mod_class.ml
+++ b/testsuite/tests/typing-unique/unique_mod_class.ml
@@ -162,3 +162,20 @@ let foo (local_ x : string ref) =
 [%%expect{|
 val foo : local_ string ref -> (unit -> < m : string >) = <fun>
 |}]
+
+let () =
+    let module M =
+        struct
+        let () =
+          let x = "hello" in
+          let _ = unique_id x in
+          ()
+        end
+    in ()
+[%%expect{|
+Line 6, characters 28-29:
+6 |           let _ = unique_id x in
+                                ^
+Error: This value is aliased but used as unique.
+Hint: This value comes from outside the current module or class.
+|}]

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2023,14 +2023,15 @@ let comp_pattern_match pat value =
   | Some pat' -> pattern_match pat' value
   | None -> Ienv.Extension.empty, UF.unused
 
-let value_of_ident ienv unique_use occ path =
+let value_of_ident ienv ?(force_missing = true) unique_use occ path =
   match path with
   | Path.Pident id -> (
     match Ienv.find_opt id ienv with
     (* TODO: for better error message, we should record in ienv why some
        variables are not in it. *)
     | None ->
-      force_aliased_boundary ~reason:Out_of_mod_class unique_use occ;
+      if force_missing
+      then force_aliased_boundary ~reason:Out_of_mod_class unique_use occ;
       None
     | Some paths ->
       let value = Value.existing paths unique_use occ in
@@ -2062,7 +2063,9 @@ let open_variables ienv f =
           (match e.exp_desc with
           | Texp_ident (path, _, _, _, unique_use) -> (
             let occ = Occurrence.mk e.exp_loc in
-            match value_of_ident ienv unique_use occ path with
+            match
+              value_of_ident ienv ~force_missing:false unique_use occ path
+            with
             | None -> ()
             | Some value -> ll := value :: !ll)
           | _ -> ());


### PR DESCRIPTION
Currently we treat the boundary between a module and its surrouding environment coarsely: references in both directions are always `aliased`.

To do that, we find all open variables in the module and mark them as `aliased`. We rely on `ienv` (containing only the surrouding variables, but not variables internal to the module) to decide if a variable is bound. If the variable is not found in `ienv`, then we think it's bound locally, and shouldn't be forced to `aliased`.

However, a subtle bug makes it not behaving properly. This PR fixes that.