### PR TITLE
Some `value_or_null` support in Stdlib

### DIFF
--- a/flambda-backend/tests/backend/zero_alloc_checker/test_custom_error_msg.opt.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_custom_error_msg.opt.output
@@ -22,7 +22,7 @@ Error: Annotation check for zero_alloc strict failed on function Test_custom_err
 This annotation is for testing custom error messages.
 
 File "test_custom_error_msg.ml", line 8, characters 22-39:
-Error: called function may allocate on a path to exceptional return (external call to caml_format_int) (test_custom_error_msg.ml:8,22--39;stdlib.ml:273,2--19)
+Error: called function may allocate on a path to exceptional return (external call to caml_format_int) (test_custom_error_msg.ml:8,22--39;stdlib.ml:275,2--19)
 
 File "test_custom_error_msg.ml", line 8, characters 13-40:
 Error: allocation of 24 bytes on a path to exceptional return

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_custom_error_msg.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_custom_error_msg.output
@@ -22,7 +22,7 @@ Error: Annotation check for zero_alloc strict failed on function Test_custom_err
 This annotation is for testing custom error messages.
 
 File "test_custom_error_msg.ml", line 8, characters 22-39:
-Error: called function may allocate on a path to exceptional return (external call to caml_format_int) (test_custom_error_msg.ml:8,22--39;stdlib.ml:273,2--19)
+Error: called function may allocate on a path to exceptional return (external call to caml_format_int) (test_custom_error_msg.ml:8,22--39;stdlib.ml:275,2--19)
 
 File "test_custom_error_msg.ml", line 8, characters 13-40:
 Error: allocation of 24 bytes on a path to exceptional return

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -187,13 +187,15 @@ val mapi : (int -> char -> char) -> bytes -> bytes
     index (in increasing index order) and stores the resulting bytes
     in a new sequence that is returned as the result. *)
 
-val fold_left : ('acc -> char -> 'acc) -> 'acc -> bytes -> 'acc
+val fold_left : ('acc : value_or_null)
+  . ('acc -> char -> 'acc) -> 'acc -> bytes -> 'acc
 (** [fold_left f x s] computes
     [f (... (f (f x (get s 0)) (get s 1)) ...) (get s (n-1))],
     where [n] is the length of [s].
     @since 4.13 *)
 
-val fold_right : (char -> 'acc -> 'acc) -> bytes -> 'acc -> 'acc
+val fold_right : ('acc : value_or_null)
+  . (char -> 'acc -> 'acc) -> bytes -> 'acc -> 'acc
 (** [fold_right f s x] computes
     [f (get s 0) (f (get s 1) ( ... (f (get s (n-1)) x) ...))],
     where [n] is the length of [s].

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -189,13 +189,15 @@ val mapi : f:(int -> char -> char) -> bytes -> bytes
     index (in increasing index order) and stores the resulting bytes
     in a new sequence that is returned as the result. *)
 
-val fold_left : f:('acc -> char -> 'acc) -> init:'acc -> bytes -> 'acc
+val fold_left : ('acc : value_or_null)
+  . f:('acc -> char -> 'acc) -> init:'acc -> bytes -> 'acc
 (** [fold_left f x s] computes
     [f (... (f (f x (get s 0)) (get s 1)) ...) (get s (n-1))],
     where [n] is the length of [s].
     @since 4.13 *)
 
-val fold_right : f:(char -> 'acc -> 'acc) -> bytes -> init:'acc -> 'acc
+val fold_right : ('acc : value_or_null)
+  . f:(char -> 'acc -> 'acc) -> bytes -> init:'acc -> 'acc
 (** [fold_right f s x] computes
     [f (get s 0) (f (get s 1) ( ... (f (get s (n-1)) x) ...))],
     where [n] is the length of [s].

--- a/stdlib/either.ml
+++ b/stdlib/either.ml
@@ -15,7 +15,7 @@
 
 [@@@ocaml.flambda_o3]
 
-type ('a, 'b) t = Left of 'a | Right of 'b
+type ('a : value_or_null, 'b : value_or_null) t = Left of 'a | Right of 'b
 
 let left v = Left v
 let right v = Right v

--- a/stdlib/either.mli
+++ b/stdlib/either.mli
@@ -55,62 +55,76 @@
    revisit this choice.
 *)
 
-type ('a, 'b) t = Left of 'a | Right of 'b (**)
+type ('a : value_or_null, 'b : value_or_null) t = Left of 'a | Right of 'b (**)
 (** A value of [('a, 'b) Either.t] contains
     either a value of ['a]  or a value of ['b] *)
 
-val left : 'a -> ('a, 'b) t
+val left : ('a : value_or_null) ('b : value_or_null)
+  . 'a -> ('a, 'b) t
 (** [left v] is [Left v]. *)
 
-val right : 'b -> ('a, 'b) t
+val right : ('a : value_or_null) ('b : value_or_null)
+  . 'b -> ('a, 'b) t
 (** [right v] is [Right v]. *)
 
-val is_left : ('a, 'b) t -> bool
+val is_left : ('a : value_or_null) ('b : value_or_null)
+  . ('a, 'b) t -> bool
 (** [is_left (Left v)] is [true], [is_left (Right v)] is [false]. *)
 
-val is_right : ('a, 'b) t -> bool
+val is_right : ('a : value_or_null) ('b : value_or_null)
+  . ('a, 'b) t -> bool
 (** [is_right (Left v)] is [false], [is_right (Right v)] is [true]. *)
 
-val find_left : ('a, 'b) t -> 'a option
+val find_left : ('a : value_or_null) ('b : value_or_null)
+  . ('a, 'b) t -> 'a option
 (** [find_left (Left v)] is [Some v], [find_left (Right _)] is [None] *)
 
-val find_right : ('a, 'b) t -> 'b option
+val find_right : ('a : value_or_null) ('b : value_or_null)
+  . ('a, 'b) t -> 'b option
 (** [find_right (Right v)] is [Some v], [find_right (Left _)] is [None] *)
 
-val map_left : ('a1 -> 'a2) -> ('a1, 'b) t -> ('a2, 'b) t
+val map_left : ('a1 : value_or_null) ('a2 : value_or_null) 
+  ('b : value_or_null).
+  ('a1 -> 'a2) -> ('a1, 'b) t -> ('a2, 'b) t
 (** [map_left f e] is [Left (f v)] if [e] is [Left v]
     and [e] if [e] is [Right _]. *)
 
-val map_right : ('b1 -> 'b2) -> ('a, 'b1) t -> ('a, 'b2) t
+val map_right : ('a : value_or_null) ('b1 : value_or_null) 
+  ('b2 : value_or_null).
+  ('b1 -> 'b2) -> ('a, 'b1) t -> ('a, 'b2) t
 (** [map_right f e] is [Right (f v)] if [e] is [Right v]
     and [e] if [e] is [Left _]. *)
 
-val map :
-  left:('a1 -> 'a2) -> right:('b1 -> 'b2) -> ('a1, 'b1) t -> ('a2, 'b2) t
+val map : ('a1 : value_or_null) ('a2 : value_or_null) 
+  ('b1 : value_or_null) ('b2 : value_or_null)
+  . left:('a1 -> 'a2) -> right:('b1 -> 'b2) -> ('a1, 'b1) t -> ('a2, 'b2) t
 (** [map ~left ~right (Left v)] is [Left (left v)],
     [map ~left ~right (Right v)] is [Right (right v)]. *)
 
-val fold : left:('a -> 'c) -> right:('b -> 'c) -> ('a, 'b) t -> 'c
+val fold : ('a : value_or_null) ('b : value_or_null) ('c : value_or_null).
+  left:('a -> 'c) -> right:('b -> 'c) -> ('a, 'b) t -> 'c
 (** [fold ~left ~right (Left v)] is [left v], and
     [fold ~left ~right (Right v)] is [right v]. *)
 
-val iter : left:('a -> unit) -> right:('b -> unit) -> ('a, 'b) t -> unit
+val iter : ('a : value_or_null) ('b : value_or_null)
+  . left:('a -> unit) -> right:('b -> unit) -> ('a, 'b) t -> unit
 (** [iter ~left ~right (Left v)] is [left v], and
     [iter ~left ~right (Right v)] is [right v]. *)
 
-val for_all : left:('a -> bool) -> right:('b -> bool) -> ('a, 'b) t -> bool
+val for_all : ('a : value_or_null) ('b : value_or_null)
+  . left:('a -> bool) -> right:('b -> bool) -> ('a, 'b) t -> bool
 (** [for_all ~left ~right (Left v)] is [left v], and
     [for_all ~left ~right (Right v)] is [right v]. *)
 
-val equal :
-  left:('a -> 'a -> bool) -> right:('b -> 'b -> bool) ->
+val equal : ('a : value_or_null) ('b : value_or_null)
+  . left:('a -> 'a -> bool) -> right:('b -> 'b -> bool) ->
   ('a, 'b) t -> ('a, 'b) t -> bool
 (** [equal ~left ~right e0 e1] tests equality of [e0] and [e1] using [left]
     and [right] to respectively compare values wrapped by [Left _] and
     [Right _]. *)
 
-val compare :
-  left:('a -> 'a -> int) -> right:('b -> 'b -> int) ->
+val compare : ('a : value_or_null) ('b : value_or_null)
+  . left:('a -> 'a -> int) -> right:('b -> 'b -> int) ->
   ('a, 'b) t -> ('a, 'b) t -> int
 (** [compare ~left ~right e0 e1] totally orders [e0] and [e1] using [left] and
     [right] to respectively compare values wrapped by [Left _ ] and [Right _].

--- a/stdlib/fun.ml
+++ b/stdlib/fun.ml
@@ -18,7 +18,7 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
-external id : 'a -> 'a @@ portable = "%identity"
+external id : ('a : value_or_null) . 'a -> 'a @@ portable = "%identity"
 let const c _ = c
 let compose f g x = f (g x)
 let flip f x y = f y x

--- a/stdlib/fun.mli
+++ b/stdlib/fun.mli
@@ -24,30 +24,36 @@ open! Stdlib
 
 (** {1:combinators Combinators} *)
 
-external id : 'a -> 'a = "%identity"
+external id : ('a : value_or_null) . 'a -> 'a = "%identity"
 (** [id] is the identity function. For any argument [x], [id x] is [x]. *)
 
-val const : 'a -> (_ -> 'a)
+val const : ('a : value_or_null) ('b : value_or_null)
+  . 'a -> ('b -> 'a)
 (** [const c] is a function that always returns the value [c]. For any
     argument [x], [(const c) x] is [c]. *)
 
-val compose : ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c
+val compose : ('a : value_or_null) ('b : value_or_null) 
+  ('c : value_or_null).
+  ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c
 (** [compose f g] is a function composition of applying [g] then [f].
     For any arguments [f], [g], and [x], [compose f g x] is [f (g x)].
 
     @since 5.2 *)
 
-val flip : ('a -> 'b -> 'c) -> ('b -> 'a -> 'c)
+val flip : ('a : value_or_null) ('b : value_or_null) 
+  ('c : value_or_null).
+  ('a -> 'b -> 'c) -> ('b -> 'a -> 'c)
 (** [flip f] reverses the argument order of the binary function
     [f]. For any arguments [x] and [y], [(flip f) x y] is [f y x]. *)
 
-val negate : ('a -> bool) -> ('a -> bool)
+val negate : ('a : value_or_null) . ('a -> bool) -> ('a -> bool)
 (** [negate p] is the negation of the predicate function [p]. For any
     argument [x], [(negate p) x] is [not (p x)]. *)
 
 (** {1:exception Exception handling} *)
 
-val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
+val protect : ('a : value_or_null).
+  finally:(unit -> unit) -> (unit -> 'a) -> 'a
 (** [protect ~finally work] invokes [work ()] and then [finally ()]
     before [work ()] returns with its value or an exception. In the
     latter case the exception is re-raised after [finally ()]. If

--- a/stdlib/list.ml
+++ b/stdlib/list.ml
@@ -19,7 +19,7 @@ open! Stdlib
 [@@@ocaml.flambda_o3]
 
 (* An alias for the type of lists. *)
-type 'a t = 'a list = [] | (::) of 'a * 'a list
+type ('a : value_or_null) t = 'a list = [] | (::) of 'a * 'a list
 
 (* List operations *)
 

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -42,55 +42,56 @@ open! Stdlib
    {!StdLabels} module.
  *)
 
-type 'a t = 'a list = [] | (::) of 'a * 'a list (**)
+type ('a : value_or_null) t = 'a list = [] | (::) of 'a * 'a list (**)
 (** An alias for the type of lists. *)
 
-val length : 'a list -> int
+val length : ('a : value_or_null). 'a list -> int
 (** Return the length (number of elements) of the given list. *)
 
-val compare_lengths : 'a list -> 'b list -> int
+val compare_lengths : ('a : value_or_null) ('b : value_or_null)
+  . 'a list -> 'b list -> int
 (** Compare the lengths of two lists. [compare_lengths l1 l2] is
    equivalent to [compare (length l1) (length l2)], except that
    the computation stops after reaching the end of the shortest list.
    @since 4.05
  *)
 
-val compare_length_with : 'a list -> int -> int
+val compare_length_with : ('a : value_or_null). 'a list -> int -> int
 (** Compare the length of a list to an integer. [compare_length_with l len] is
    equivalent to [compare (length l) len], except that the computation stops
    after at most [len] iterations on the list.
    @since 4.05
  *)
 
-val is_empty : 'a list -> bool
+val is_empty : ('a : value_or_null). 'a list -> bool
 (** [is_empty l] is true if and only if [l] has no elements. It is equivalent to
     [compare_length_with l 0 = 0].
     @since 5.1
  *)
 
-val cons : 'a -> 'a list -> 'a list
+val cons : ('a : value_or_null). 'a -> 'a list -> 'a list
 (** [cons x xs] is [x :: xs]
     @since 4.03 (4.05 in ListLabels)
  *)
 
-val hd : 'a list -> 'a
+val hd : ('a : value_or_null). 'a list -> 'a
 (** Return the first element of the given list.
    @raise Failure if the list is empty.
  *)
 
-val tl : 'a list -> 'a list
+val tl : ('a : value_or_null). 'a list -> 'a list
 (** Return the given list without its first element.
    @raise Failure if the list is empty.
  *)
 
-val nth : 'a list -> int -> 'a
+val nth : ('a : value_or_null). 'a list -> int -> 'a
 (** Return the [n]-th element of the given list.
    The first element (head of the list) is at position 0.
    @raise Failure if the list is too short.
    @raise Invalid_argument if [n] is negative.
  *)
 
-val nth_opt : 'a list -> int -> 'a option
+val nth_opt : ('a : value_or_null). 'a list -> int -> 'a option
 (** Return the [n]-th element of the given list.
     The first element (head of the list) is at position 0.
     Return [None] if the list is too short.
@@ -98,34 +99,34 @@ val nth_opt : 'a list -> int -> 'a option
     @since 4.05
  *)
 
-val rev : 'a list -> 'a list
+val rev : ('a : value_or_null). 'a list -> 'a list
 (** List reversal. *)
 
-val init : int -> (int -> 'a) -> 'a list
+val init : ('a : value_or_null). int -> (int -> 'a) -> 'a list
 (** [init len f] is [[f 0; f 1; ...; f (len-1)]], evaluated left to right.
     @raise Invalid_argument if [len < 0].
     @since 4.06
  *)
 
-val append : 'a list -> 'a list -> 'a list
+val append : ('a : value_or_null). 'a list -> 'a list -> 'a list
 (** [append l0 l1] appends [l1] to [l0].
      Same function as the infix operator [@].
      @since 5.1 this function is tail-recursive.
  *)
 
-val rev_append : 'a list -> 'a list -> 'a list
+val rev_append : ('a : value_or_null). 'a list -> 'a list -> 'a list
 (** [rev_append l1 l2] reverses [l1] and concatenates it with [l2].
    This is equivalent to [(]{!rev}[ l1) @ l2].
  *)
 
-val concat : 'a list list -> 'a list
+val concat : ('a : value_or_null). 'a list list -> 'a list
 (** Concatenate a list of lists. The elements of the argument are all
    concatenated together (in the same order) to give the result.
    Not tail-recursive
    (length of the argument + length of the longest sub-list).
  *)
 
-val flatten : 'a list list -> 'a list
+val flatten : ('a : value_or_null). 'a list list -> 'a list
 (** Same as {!concat}. Not tail-recursive
    (length of the argument + length of the longest sub-list).
  *)
@@ -133,7 +134,8 @@ val flatten : 'a list list -> 'a list
 
 (** {1 Comparison} *)
 
-val equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
+val equal : ('a : value_or_null). 
+  ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
 (** [equal eq [a1; ...; an] [b1; ..; bm]] holds when
     the two input lists have the same length, and for each
     pair of elements [ai], [bi] at the same position we have
@@ -147,7 +149,8 @@ val equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
     @since 4.12
 *)
 
-val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
+val compare : ('a : value_or_null). 
+  ('a -> 'a -> int) -> 'a list -> 'a list -> int
 (** [compare cmp [a1; ...; an] [b1; ...; bm]] performs
     a lexicographic comparison of the two input lists,
     using the same ['a -> 'a -> int] interface as {!Stdlib.compare}:
@@ -166,63 +169,71 @@ val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
 (** {1 Iterators} *)
 
 
-val iter : ('a -> unit) -> 'a list -> unit
+val iter : ('a : value_or_null). ('a -> unit) -> 'a list -> unit
 (** [iter f [a1; ...; an]] applies function [f] in turn to
    [[a1; ...; an]]. It is equivalent to
    [f a1; f a2; ...; f an].
  *)
 
-val iteri : (int -> 'a -> unit) -> 'a list -> unit
+val iteri : ('a : value_or_null). (int -> 'a -> unit) -> 'a list -> unit
 (** Same as {!iter}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
    @since 4.00
  *)
 
-val map : ('a -> 'b) -> 'a list -> 'b list
+val map : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b) -> 'a list -> 'b list
 (** [map f [a1; ...; an]] applies function [f] to [a1, ..., an],
    and builds the list [[f a1; ...; f an]]
    with the results returned by [f].
  *)
 
-val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
+val mapi : ('a : value_or_null) ('b : value_or_null)
+  . (int -> 'a -> 'b) -> 'a list -> 'b list
 (** Same as {!map}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
    @since 4.00
  *)
 
-val rev_map : ('a -> 'b) -> 'a list -> 'b list
+val rev_map : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b) -> 'a list -> 'b list
 (** [rev_map f l] gives the same result as
    {!rev}[ (]{!map}[ f l)], but is more efficient.
  *)
 
-val filter_map : ('a -> 'b option) -> 'a list -> 'b list
+val filter_map : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b option) -> 'a list -> 'b list
 (** [filter_map f l] applies [f] to every element of [l], filters
     out the [None] elements and returns the list of the arguments of
     the [Some] elements.
     @since 4.08
  *)
 
-val concat_map : ('a -> 'b list) -> 'a list -> 'b list
+val concat_map : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b list) -> 'a list -> 'b list
 (** [concat_map f l] gives the same result as
     {!concat}[ (]{!map}[ f l)]. Tail-recursive.
     @since 4.10
 *)
 
 val fold_left_map :
-  ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
+   ('a : value_or_null) ('acc : value_or_null) ('b : value_or_null).
+   ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
 (** [fold_left_map] is  a combination of [fold_left] and [map] that threads an
     accumulator through calls to [f].
     @since 4.11
 *)
 
-val fold_left : ('acc -> 'a -> 'acc) -> 'acc -> 'a list -> 'acc
+val fold_left : ('a : value_or_null) ('acc : value_or_null).
+   ('acc -> 'a -> 'acc) -> 'acc -> 'a list -> 'acc
 (** [fold_left f init [b1; ...; bn]] is
    [f (... (f (f init b1) b2) ...) bn].
  *)
 
-val fold_right : ('a -> 'acc -> 'acc) -> 'a list -> 'acc -> 'acc
+val fold_right : ('a : value_or_null) ('acc : value_or_null).
+   ('a -> 'acc -> 'acc) -> 'a list -> 'acc -> 'acc
 (** [fold_right f [a1; ...; an] init] is
    [f a1 (f a2 (... (f an init) ...))]. Not tail-recursive.
  *)
@@ -231,26 +242,30 @@ val fold_right : ('a -> 'acc -> 'acc) -> 'a list -> 'acc -> 'acc
 (** {1 Iterators on two lists} *)
 
 
-val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
+val iter2 : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
 (** [iter2 f [a1; ...; an] [b1; ...; bn]] calls in turn
    [f a1 b1; ...; f an bn].
    @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
-val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+val map2 : ('a : value_or_null) ('b : value_or_null) ('c : value_or_null)
+  . ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [map2 f [a1; ...; an] [b1; ...; bn]] is
    [[f a1 b1; ...; f an bn]].
    @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
-val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+val rev_map2 : ('a : value_or_null) ('b : value_or_null) ('c : value_or_null)
+  . ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [rev_map2 f l1 l2] gives the same result as
    {!rev}[ (]{!map2}[ f l1 l2)], but is more efficient.
  *)
 
 val fold_left2 :
+  ('a : value_or_null) ('b : value_or_null) ('acc : value_or_null).
   ('acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a list -> 'b list -> 'acc
 (** [fold_left2 f init [a1; ...; an] [b1; ...; bn]] is
    [f (... (f (f init a1 b1) a2 b2) ...) an bn].
@@ -259,6 +274,7 @@ val fold_left2 :
  *)
 
 val fold_right2 :
+  ('a : value_or_null) ('b : value_or_null) ('acc : value_or_null).
   ('a -> 'b -> 'acc -> 'acc) -> 'a list -> 'b list -> 'acc -> 'acc
 (** [fold_right2 f [a1; ...; an] [b1; ...; bn] init] is
    [f a1 b1 (f a2 b2 (... (f an bn init) ...))].
@@ -270,38 +286,40 @@ val fold_right2 :
 (** {1 List scanning} *)
 
 
-val for_all : ('a -> bool) -> 'a list -> bool
+val for_all : ('a : value_or_null). ('a -> bool) -> 'a list -> bool
 (** [for_all f [a1; ...; an]] checks if all elements of the list
    satisfy the predicate [f]. That is, it returns
    [(f a1) && (f a2) && ... && (f an)] for a non-empty list and
    [true] if the list is empty.
  *)
 
-val exists : ('a -> bool) -> 'a list -> bool
+val exists : ('a : value_or_null). ('a -> bool) -> 'a list -> bool
 (** [exists f [a1; ...; an]] checks if at least one element of
    the list satisfies the predicate [f]. That is, it returns
    [(f a1) || (f a2) || ... || (f an)] for a non-empty list and
    [false] if the list is empty.
  *)
 
-val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+val for_all2 : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!for_all}, but for a two-argument predicate.
    @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
-val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+val exists2 : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!exists}, but for a two-argument predicate.
    @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
-val mem : 'a -> 'a list -> bool
+val mem : ('a : value_or_null). 'a -> 'a list -> bool
 (** [mem a set] is true if and only if [a] is equal
    to an element of [set].
  *)
 
-val memq : 'a -> 'a list -> bool
+val memq : ('a : value_or_null). 'a -> 'a list -> bool
 (** Same as {!mem}, but uses physical equality instead of structural
    equality to compare list elements.
  *)
@@ -310,14 +328,14 @@ val memq : 'a -> 'a list -> bool
 (** {1 List searching} *)
 
 
-val find : ('a -> bool) -> 'a list -> 'a
+val find : ('a : value_or_null). ('a -> bool) -> 'a list -> 'a
 (** [find f l] returns the first element of the list [l]
    that satisfies the predicate [f].
    @raise Not_found if there is no value that satisfies [f] in the
    list [l].
  *)
 
-val find_opt : ('a -> bool) -> 'a list -> 'a option
+val find_opt : ('a : value_or_null). ('a -> bool) -> 'a list -> 'a option
 (** [find f l] returns the first element of the list [l]
    that satisfies the predicate [f].
    Returns [None] if there is no value that satisfies [f] in the
@@ -325,7 +343,7 @@ val find_opt : ('a -> bool) -> 'a list -> 'a option
    @since 4.05
  *)
 
-val find_index : ('a -> bool) -> 'a list -> int option
+val find_index : ('a : value_or_null). ('a -> bool) -> 'a list -> int option
 (** [find_index f xs] returns [Some i], where [i] is the index of the first
    element of the list [xs] that satisfies [f x], if there is such an element.
 
@@ -333,38 +351,41 @@ val find_index : ('a -> bool) -> 'a list -> int option
 
    @since 5.1 *)
 
-val find_map : ('a -> 'b option) -> 'a list -> 'b option
+val find_map : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b option) -> 'a list -> 'b option
 (** [find_map f l] applies [f] to the elements of [l] in order,
     and returns the first result of the form [Some v], or [None]
     if none exist.
     @since 4.10
 *)
 
-val find_mapi : (int -> 'a -> 'b option) -> 'a list -> 'b option
+val find_mapi : ('a : value_or_null) ('b : value_or_null)
+  . (int -> 'a -> 'b option) -> 'a list -> 'b option
 (** Same as [find_map], but the predicate is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
 
    @since 5.1 *)
 
-val filter : ('a -> bool) -> 'a list -> 'a list
+val filter : ('a : value_or_null). ('a -> bool) -> 'a list -> 'a list
 (** [filter f l] returns all the elements of the list [l]
    that satisfy the predicate [f]. The order of the elements
    in the input list is preserved.
  *)
 
-val find_all : ('a -> bool) -> 'a list -> 'a list
+val find_all : ('a : value_or_null). ('a -> bool) -> 'a list -> 'a list
 (** [find_all] is another name for {!filter}.
  *)
 
-val filteri : (int -> 'a -> bool) -> 'a list -> 'a list
+val filteri : ('a : value_or_null). (int -> 'a -> bool) -> 'a list -> 'a list
 (** Same as {!filter}, but the predicate is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
    @since 4.11
 *)
 
-val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
+val partition : ('a : value_or_null). 
+  ('a -> bool) -> 'a list -> 'a list * 'a list
 (** [partition f l] returns a pair of lists [(l1, l2)], where
    [l1] is the list of all the elements of [l] that
    satisfy the predicate [f], and [l2] is the list of all the
@@ -372,7 +393,9 @@ val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
    The order of the elements in the input list is preserved.
  *)
 
-val partition_map : ('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
+val partition_map : 
+  ('a : value_or_null) ('b : value_or_null) ('c : value_or_null)
+  . ('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
 (** [partition_map f l] returns a pair of lists [(l1, l2)] such that,
     for each element [x] of the input list [l]:
     - if [f x] is [Left y1], then [y1] is in [l1], and
@@ -391,7 +414,8 @@ val partition_map : ('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
 (** {1 Association lists} *)
 
 
-val assoc : 'a -> ('a * 'b) list -> 'b
+val assoc : ('a : value_or_null) ('b : value_or_null). 
+  'a -> ('a * 'b) list -> 'b
 (** [assoc a l] returns the value associated with key [a] in the list of
    pairs [l]. That is,
    [assoc a [ ...; (a,b); ...] = b]
@@ -400,7 +424,8 @@ val assoc : 'a -> ('a * 'b) list -> 'b
    list [l].
  *)
 
-val assoc_opt : 'a -> ('a * 'b) list -> 'b option
+val assoc_opt : ('a : value_or_null) ('b : value_or_null). 
+  'a -> ('a * 'b) list -> 'b option
 (** [assoc_opt a l] returns the value associated with key [a] in the list of
     pairs [l]. That is,
     [assoc_opt a [ ...; (a,b); ...] = Some b]
@@ -410,34 +435,39 @@ val assoc_opt : 'a -> ('a * 'b) list -> 'b option
     @since 4.05
  *)
 
-val assq : 'a -> ('a * 'b) list -> 'b
+val assq : ('a : value_or_null) ('b : value_or_null). 'a -> ('a * 'b) list -> 'b
 (** Same as {!assoc}, but uses physical equality instead of
    structural equality to compare keys.
  *)
 
-val assq_opt : 'a -> ('a * 'b) list -> 'b option
+val assq_opt : ('a : value_or_null) ('b : value_or_null). 
+  'a -> ('a * 'b) list -> 'b option
 (** Same as {!assoc_opt}, but uses physical equality instead of
    structural equality to compare keys.
    @since 4.05
  *)
 
-val mem_assoc : 'a -> ('a * 'b) list -> bool
+val mem_assoc : ('a : value_or_null) ('b : value_or_null). 
+  'a -> ('a * 'b) list -> bool
 (** Same as {!assoc}, but simply return [true] if a binding exists,
    and [false] if no bindings exist for the given key.
  *)
 
-val mem_assq : 'a -> ('a * 'b) list -> bool
+val mem_assq : ('a : value_or_null) ('b : value_or_null). 
+  'a -> ('a * 'b) list -> bool
 (** Same as {!mem_assoc}, but uses physical equality instead of
    structural equality to compare keys.
  *)
 
-val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
+val remove_assoc : ('a : value_or_null) ('b : value_or_null). 
+  'a -> ('a * 'b) list -> ('a * 'b) list
 (** [remove_assoc a l] returns the list of
    pairs [l] without the first pair with key [a], if any.
    Not tail-recursive.
  *)
 
-val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
+val remove_assq : ('a : value_or_null) ('b : value_or_null). 
+  'a -> ('a * 'b) list -> ('a * 'b) list
 (** Same as {!remove_assoc}, but uses physical equality instead
    of structural equality to compare keys. Not tail-recursive.
  *)
@@ -446,13 +476,15 @@ val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
 (** {1 Lists of pairs} *)
 
 
-val split : ('a * 'b) list -> 'a list * 'b list
+val split : ('a : value_or_null) ('b : value_or_null). 
+  ('a * 'b) list -> 'a list * 'b list
 (** Transform a list of pairs into a pair of lists:
    [split [(a1,b1); ...; (an,bn)]] is [([a1; ...; an], [b1; ...; bn])].
    Not tail-recursive.
  *)
 
-val combine : 'a list -> 'b list -> ('a * 'b) list
+val combine : ('a : value_or_null) ('b : value_or_null). 
+  'a list -> 'b list -> ('a * 'b) list
 (** Transform a pair of lists into a list of pairs:
    [combine [a1; ...; an] [b1; ...; bn]] is
    [[(a1,b1); ...; (an,bn)]].
@@ -464,7 +496,7 @@ val combine : 'a list -> 'b list -> ('a * 'b) list
 (** {1 Sorting} *)
 
 
-val sort : ('a -> 'a -> int) -> 'a list -> 'a list
+val sort : ('a : value_or_null). ('a -> 'a -> int) -> 'a list -> 'a list
 (** Sort a list in increasing order according to a comparison
    function. The comparison function must return 0 if its arguments
    compare as equal, a positive integer if the first is greater,
@@ -480,7 +512,7 @@ val sort : ('a -> 'a -> int) -> 'a list -> 'a list
    heap space and logarithmic stack space.
  *)
 
-val stable_sort : ('a -> 'a -> int) -> 'a list -> 'a list
+val stable_sort : ('a : value_or_null). ('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!sort}, but the sorting algorithm is guaranteed to
    be stable (i.e. elements that compare equal are kept in their
    original order).
@@ -489,17 +521,18 @@ val stable_sort : ('a -> 'a -> int) -> 'a list -> 'a list
    heap space and logarithmic stack space.
  *)
 
-val fast_sort : ('a -> 'a -> int) -> 'a list -> 'a list
+val fast_sort : ('a : value_or_null). ('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!sort} or {!stable_sort}, whichever is
     faster on typical input.
  *)
 
-val sort_uniq : ('a -> 'a -> int) -> 'a list -> 'a list
+val sort_uniq : ('a : value_or_null). ('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!sort}, but also remove duplicates.
     @since 4.02 (4.03 in ListLabels)
  *)
 
-val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
+val merge : ('a : value_or_null). 
+  ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
 (** Merge two lists:
     Assuming that [l1] and [l2] are sorted according to the
     comparison function [cmp], [merge cmp l1 l2] will return a
@@ -511,12 +544,12 @@ val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
 
 (** {1 Lists and Sequences} *)
 
-val to_seq : 'a list -> 'a Seq.t
+val to_seq : ('a : value_or_null) . 'a list -> 'a Seq.t
 (** Iterate on the list.
     @since 4.07
  *)
 
-val of_seq : 'a Seq.t -> 'a list
+val of_seq : ('a : value_or_null) . 'a Seq.t -> 'a list
 (** Create a list from a sequence.
     @since 4.07
  *)

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -44,55 +44,56 @@ open! Stdlib
    {!StdLabels} module.
  *)
 
-type 'a t = 'a list = [] | (::) of 'a * 'a list (**)
+type ('a : value_or_null) t = 'a list = [] | (::) of 'a * 'a list (**)
 (** An alias for the type of lists. *)
 
-val length : 'a list -> int
+val length : ('a : value_or_null). 'a list -> int
 (** Return the length (number of elements) of the given list. *)
 
-val compare_lengths : 'a list -> 'b list -> int
+val compare_lengths : ('a : value_or_null) ('b : value_or_null)
+  . 'a list -> 'b list -> int
 (** Compare the lengths of two lists. [compare_lengths l1 l2] is
    equivalent to [compare (length l1) (length l2)], except that
    the computation stops after reaching the end of the shortest list.
    @since 4.05
  *)
 
-val compare_length_with : 'a list -> len:int -> int
+val compare_length_with : ('a : value_or_null). 'a list -> len:int -> int
 (** Compare the length of a list to an integer. [compare_length_with l len] is
    equivalent to [compare (length l) len], except that the computation stops
    after at most [len] iterations on the list.
    @since 4.05
  *)
 
-val is_empty : 'a list -> bool
+val is_empty : ('a : value_or_null). 'a list -> bool
 (** [is_empty l] is true if and only if [l] has no elements. It is equivalent to
     [compare_length_with l 0 = 0].
     @since 5.1
  *)
 
-val cons : 'a -> 'a list -> 'a list
+val cons : ('a : value_or_null). 'a -> 'a list -> 'a list
 (** [cons x xs] is [x :: xs]
     @since 4.03 (4.05 in ListLabels)
  *)
 
-val hd : 'a list -> 'a
+val hd : ('a : value_or_null). 'a list -> 'a
 (** Return the first element of the given list.
    @raise Failure if the list is empty.
  *)
 
-val tl : 'a list -> 'a list
+val tl : ('a : value_or_null). 'a list -> 'a list
 (** Return the given list without its first element.
    @raise Failure if the list is empty.
  *)
 
-val nth : 'a list -> int -> 'a
+val nth : ('a : value_or_null). 'a list -> int -> 'a
 (** Return the [n]-th element of the given list.
    The first element (head of the list) is at position 0.
    @raise Failure if the list is too short.
    @raise Invalid_argument if [n] is negative.
  *)
 
-val nth_opt : 'a list -> int -> 'a option
+val nth_opt : ('a : value_or_null). 'a list -> int -> 'a option
 (** Return the [n]-th element of the given list.
     The first element (head of the list) is at position 0.
     Return [None] if the list is too short.
@@ -100,34 +101,34 @@ val nth_opt : 'a list -> int -> 'a option
     @since 4.05
  *)
 
-val rev : 'a list -> 'a list
+val rev : ('a : value_or_null). 'a list -> 'a list
 (** List reversal. *)
 
-val init : len:int -> f:(int -> 'a) -> 'a list
+val init : ('a : value_or_null). len:int -> f:(int -> 'a) -> 'a list
 (** [init ~len ~f] is [[f 0; f 1; ...; f (len-1)]], evaluated left to right.
     @raise Invalid_argument if [len < 0].
     @since 4.06
  *)
 
-val append : 'a list -> 'a list -> 'a list
+val append : ('a : value_or_null). 'a list -> 'a list -> 'a list
 (** [append l0 l1] appends [l1] to [l0].
      Same function as the infix operator [@].
      @since 5.1 this function is tail-recursive.
  *)
 
-val rev_append : 'a list -> 'a list -> 'a list
+val rev_append : ('a : value_or_null). 'a list -> 'a list -> 'a list
 (** [rev_append l1 l2] reverses [l1] and concatenates it with [l2].
    This is equivalent to [(]{!rev}[ l1) @ l2].
  *)
 
-val concat : 'a list list -> 'a list
+val concat : ('a : value_or_null). 'a list list -> 'a list
 (** Concatenate a list of lists. The elements of the argument are all
    concatenated together (in the same order) to give the result.
    Not tail-recursive
    (length of the argument + length of the longest sub-list).
  *)
 
-val flatten : 'a list list -> 'a list
+val flatten : ('a : value_or_null). 'a list list -> 'a list
 (** Same as {!concat}. Not tail-recursive
    (length of the argument + length of the longest sub-list).
  *)
@@ -135,7 +136,8 @@ val flatten : 'a list list -> 'a list
 
 (** {1 Comparison} *)
 
-val equal : eq:('a -> 'a -> bool) -> 'a list -> 'a list -> bool
+val equal : ('a : value_or_null). 
+  eq:('a -> 'a -> bool) -> 'a list -> 'a list -> bool
 (** [equal eq [a1; ...; an] [b1; ..; bm]] holds when
     the two input lists have the same length, and for each
     pair of elements [ai], [bi] at the same position we have
@@ -149,7 +151,8 @@ val equal : eq:('a -> 'a -> bool) -> 'a list -> 'a list -> bool
     @since 4.12
 *)
 
-val compare : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> int
+val compare : ('a : value_or_null). 
+  cmp:('a -> 'a -> int) -> 'a list -> 'a list -> int
 (** [compare cmp [a1; ...; an] [b1; ...; bm]] performs
     a lexicographic comparison of the two input lists,
     using the same ['a -> 'a -> int] interface as {!Stdlib.compare}:
@@ -168,63 +171,71 @@ val compare : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> int
 (** {1 Iterators} *)
 
 
-val iter : f:('a -> unit) -> 'a list -> unit
+val iter : ('a : value_or_null). f:('a -> unit) -> 'a list -> unit
 (** [iter ~f [a1; ...; an]] applies function [f] in turn to
    [[a1; ...; an]]. It is equivalent to
    [f a1; f a2; ...; f an].
  *)
 
-val iteri : f:(int -> 'a -> unit) -> 'a list -> unit
+val iteri : ('a : value_or_null). f:(int -> 'a -> unit) -> 'a list -> unit
 (** Same as {!iter}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
    @since 4.00
  *)
 
-val map : f:('a -> 'b) -> 'a list -> 'b list
+val map : ('a : value_or_null) ('b : value_or_null)
+  . f:('a -> 'b) -> 'a list -> 'b list
 (** [map ~f [a1; ...; an]] applies function [f] to [a1, ..., an],
    and builds the list [[f a1; ...; f an]]
    with the results returned by [f].
  *)
 
-val mapi : f:(int -> 'a -> 'b) -> 'a list -> 'b list
+val mapi : ('a : value_or_null) ('b : value_or_null)
+  . f:(int -> 'a -> 'b) -> 'a list -> 'b list
 (** Same as {!map}, but the function is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
    @since 4.00
  *)
 
-val rev_map : f:('a -> 'b) -> 'a list -> 'b list
+val rev_map : ('a : value_or_null) ('b : value_or_null)
+  . f:('a -> 'b) -> 'a list -> 'b list
 (** [rev_map ~f l] gives the same result as
    {!rev}[ (]{!map}[ f l)], but is more efficient.
  *)
 
-val filter_map : f:('a -> 'b option) -> 'a list -> 'b list
+val filter_map : ('a : value_or_null) ('b : value_or_null)
+  . f:('a -> 'b option) -> 'a list -> 'b list
 (** [filter_map ~f l] applies [f] to every element of [l], filters
     out the [None] elements and returns the list of the arguments of
     the [Some] elements.
     @since 4.08
  *)
 
-val concat_map : f:('a -> 'b list) -> 'a list -> 'b list
+val concat_map : ('a : value_or_null) ('b : value_or_null)
+  . f:('a -> 'b list) -> 'a list -> 'b list
 (** [concat_map ~f l] gives the same result as
     {!concat}[ (]{!map}[ f l)]. Tail-recursive.
     @since 4.10
 *)
 
 val fold_left_map :
-  f:('acc -> 'a -> 'acc * 'b) -> init:'acc -> 'a list -> 'acc * 'b list
+  ('acc : value_or_null) ('a : value_or_null) ('b : value_or_null)
+  . f:('acc -> 'a -> 'acc * 'b) -> init:'acc -> 'a list -> 'acc * 'b list
 (** [fold_left_map] is  a combination of [fold_left] and [map] that threads an
     accumulator through calls to [f].
     @since 4.11
 *)
 
-val fold_left : f:('acc -> 'a -> 'acc) -> init:'acc -> 'a list -> 'acc
+val fold_left : ('acc : value_or_null) ('a : value_or_null). 
+  f:('acc -> 'a -> 'acc) -> init:'acc -> 'a list -> 'acc
 (** [fold_left ~f ~init [b1; ...; bn]] is
    [f (... (f (f init b1) b2) ...) bn].
  *)
 
-val fold_right : f:('a -> 'acc -> 'acc) -> 'a list -> init:'acc -> 'acc
+val fold_right : ('a : value_or_null) ('acc : value_or_null). 
+  f:('a -> 'acc -> 'acc) -> 'a list -> init:'acc -> 'acc
 (** [fold_right ~f [a1; ...; an] ~init] is
    [f a1 (f a2 (... (f an init) ...))]. Not tail-recursive.
  *)
@@ -233,27 +244,31 @@ val fold_right : f:('a -> 'acc -> 'acc) -> 'a list -> init:'acc -> 'acc
 (** {1 Iterators on two lists} *)
 
 
-val iter2 : f:('a -> 'b -> unit) -> 'a list -> 'b list -> unit
+val iter2 : ('a : value_or_null) ('b : value_or_null)
+  . f:('a -> 'b -> unit) -> 'a list -> 'b list -> unit
 (** [iter2 ~f [a1; ...; an] [b1; ...; bn]] calls in turn
    [f a1 b1; ...; f an bn].
    @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
-val map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+val map2 : ('a : value_or_null) ('b : value_or_null) ('c : value_or_null)
+  . f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [map2 ~f [a1; ...; an] [b1; ...; bn]] is
    [[f a1 b1; ...; f an bn]].
    @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
-val rev_map2 : f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+val rev_map2 : ('a : value_or_null) ('b : value_or_null) ('c : value_or_null)
+  . f:('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
 (** [rev_map2 ~f l1 l2] gives the same result as
    {!rev}[ (]{!map2}[ f l1 l2)], but is more efficient.
  *)
 
 val fold_left2 :
-  f:('acc -> 'a -> 'b -> 'acc) -> init:'acc -> 'a list -> 'b list -> 'acc
+  ('acc : value_or_null) ('a : value_or_null) ('b : value_or_null)
+  . f:('acc -> 'a -> 'b -> 'acc) -> init:'acc -> 'a list -> 'b list -> 'acc
 (** [fold_left2 ~f ~init [a1; ...; an] [b1; ...; bn]] is
    [f (... (f (f init a1 b1) a2 b2) ...) an bn].
    @raise Invalid_argument if the two lists are determined
@@ -261,7 +276,8 @@ val fold_left2 :
  *)
 
 val fold_right2 :
-  f:('a -> 'b -> 'acc -> 'acc) -> 'a list -> 'b list -> init:'acc -> 'acc
+  ('a : value_or_null) ('b : value_or_null) ('acc : value_or_null)
+  . f:('a -> 'b -> 'acc -> 'acc) -> 'a list -> 'b list -> init:'acc -> 'acc
 (** [fold_right2 ~f [a1; ...; an] [b1; ...; bn] ~init] is
    [f a1 b1 (f a2 b2 (... (f an bn init) ...))].
    @raise Invalid_argument if the two lists are determined
@@ -272,38 +288,40 @@ val fold_right2 :
 (** {1 List scanning} *)
 
 
-val for_all : f:('a -> bool) -> 'a list -> bool
+val for_all : ('a : value_or_null). f:('a -> bool) -> 'a list -> bool
 (** [for_all ~f [a1; ...; an]] checks if all elements of the list
    satisfy the predicate [f]. That is, it returns
    [(f a1) && (f a2) && ... && (f an)] for a non-empty list and
    [true] if the list is empty.
  *)
 
-val exists : f:('a -> bool) -> 'a list -> bool
+val exists : ('a : value_or_null). f:('a -> bool) -> 'a list -> bool
 (** [exists ~f [a1; ...; an]] checks if at least one element of
    the list satisfies the predicate [f]. That is, it returns
    [(f a1) || (f a2) || ... || (f an)] for a non-empty list and
    [false] if the list is empty.
  *)
 
-val for_all2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+val for_all2 : ('a : value_or_null) ('b : value_or_null)
+  . f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!for_all}, but for a two-argument predicate.
    @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
-val exists2 : f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+val exists2 : ('a : value_or_null) ('b : value_or_null)
+  . f:('a -> 'b -> bool) -> 'a list -> 'b list -> bool
 (** Same as {!exists}, but for a two-argument predicate.
    @raise Invalid_argument if the two lists are determined
    to have different lengths.
  *)
 
-val mem : 'a -> set:'a list -> bool
+val mem : ('a : value_or_null). 'a -> set:'a list -> bool
 (** [mem a ~set] is true if and only if [a] is equal
    to an element of [set].
  *)
 
-val memq : 'a -> set:'a list -> bool
+val memq : ('a : value_or_null). 'a -> set:'a list -> bool
 (** Same as {!mem}, but uses physical equality instead of structural
    equality to compare list elements.
  *)
@@ -312,14 +330,14 @@ val memq : 'a -> set:'a list -> bool
 (** {1 List searching} *)
 
 
-val find : f:('a -> bool) -> 'a list -> 'a
+val find : ('a : value_or_null). f:('a -> bool) -> 'a list -> 'a
 (** [find ~f l] returns the first element of the list [l]
    that satisfies the predicate [f].
    @raise Not_found if there is no value that satisfies [f] in the
    list [l].
  *)
 
-val find_opt : f:('a -> bool) -> 'a list -> 'a option
+val find_opt : ('a : value_or_null). f:('a -> bool) -> 'a list -> 'a option
 (** [find ~f l] returns the first element of the list [l]
    that satisfies the predicate [f].
    Returns [None] if there is no value that satisfies [f] in the
@@ -327,7 +345,7 @@ val find_opt : f:('a -> bool) -> 'a list -> 'a option
    @since 4.05
  *)
 
-val find_index : f:('a -> bool) -> 'a list -> int option
+val find_index : ('a : value_or_null). f:('a -> bool) -> 'a list -> int option
 (** [find_index ~f xs] returns [Some i], where [i] is the index of the first
    element of the list [xs] that satisfies [f x], if there is such an element.
 
@@ -335,38 +353,41 @@ val find_index : f:('a -> bool) -> 'a list -> int option
 
    @since 5.1 *)
 
-val find_map : f:('a -> 'b option) -> 'a list -> 'b option
+val find_map : ('a : value_or_null) ('b : value_or_null)
+  . f:('a -> 'b option) -> 'a list -> 'b option
 (** [find_map ~f l] applies [f] to the elements of [l] in order,
     and returns the first result of the form [Some v], or [None]
     if none exist.
     @since 4.10
 *)
 
-val find_mapi : f:(int -> 'a -> 'b option) -> 'a list -> 'b option
+val find_mapi : ('a : value_or_null) ('b : value_or_null)
+  . f:(int -> 'a -> 'b option) -> 'a list -> 'b option
 (** Same as [find_map], but the predicate is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
 
    @since 5.1 *)
 
-val filter : f:('a -> bool) -> 'a list -> 'a list
+val filter : ('a : value_or_null). f:('a -> bool) -> 'a list -> 'a list
 (** [filter ~f l] returns all the elements of the list [l]
    that satisfy the predicate [f]. The order of the elements
    in the input list is preserved.
  *)
 
-val find_all : f:('a -> bool) -> 'a list -> 'a list
+val find_all : ('a : value_or_null). f:('a -> bool) -> 'a list -> 'a list
 (** [find_all] is another name for {!filter}.
  *)
 
-val filteri : f:(int -> 'a -> bool) -> 'a list -> 'a list
+val filteri : ('a : value_or_null). f:(int -> 'a -> bool) -> 'a list -> 'a list
 (** Same as {!filter}, but the predicate is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
    @since 4.11
 *)
 
-val partition : f:('a -> bool) -> 'a list -> 'a list * 'a list
+val partition : ('a : value_or_null). 
+  f:('a -> bool) -> 'a list -> 'a list * 'a list
 (** [partition ~f l] returns a pair of lists [(l1, l2)], where
    [l1] is the list of all the elements of [l] that
    satisfy the predicate [f], and [l2] is the list of all the
@@ -374,7 +395,9 @@ val partition : f:('a -> bool) -> 'a list -> 'a list * 'a list
    The order of the elements in the input list is preserved.
  *)
 
-val partition_map : f:('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
+val partition_map : 
+  ('a : value_or_null) ('b : value_or_null) ('c : value_or_null)
+  . f:('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
 (** [partition_map f l] returns a pair of lists [(l1, l2)] such that,
     for each element [x] of the input list [l]:
     - if [f x] is [Left y1], then [y1] is in [l1], and
@@ -393,7 +416,8 @@ val partition_map : f:('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
 (** {1 Association lists} *)
 
 
-val assoc : 'a -> ('a * 'b) list -> 'b
+val assoc : ('a : value_or_null) ('b : value_or_null)
+  . 'a -> ('a * 'b) list -> 'b
 (** [assoc a l] returns the value associated with key [a] in the list of
    pairs [l]. That is,
    [assoc a [ ...; (a,b); ...] = b]
@@ -402,7 +426,8 @@ val assoc : 'a -> ('a * 'b) list -> 'b
    list [l].
  *)
 
-val assoc_opt : 'a -> ('a * 'b) list -> 'b option
+val assoc_opt : ('a : value_or_null) ('b : value_or_null)
+  . 'a -> ('a * 'b) list -> 'b option
 (** [assoc_opt a l] returns the value associated with key [a] in the list of
     pairs [l]. That is,
     [assoc_opt a [ ...; (a,b); ...] = Some b]
@@ -412,34 +437,39 @@ val assoc_opt : 'a -> ('a * 'b) list -> 'b option
     @since 4.05
  *)
 
-val assq : 'a -> ('a * 'b) list -> 'b
+val assq : ('a : value_or_null) ('b : value_or_null). 'a -> ('a * 'b) list -> 'b
 (** Same as {!assoc}, but uses physical equality instead of
    structural equality to compare keys.
  *)
 
-val assq_opt : 'a -> ('a * 'b) list -> 'b option
+val assq_opt : ('a : value_or_null) ('b : value_or_null). 
+  'a -> ('a * 'b) list -> 'b option
 (** Same as {!assoc_opt}, but uses physical equality instead of
    structural equality to compare keys.
    @since 4.05
  *)
 
-val mem_assoc : 'a -> map:('a * 'b) list -> bool
+val mem_assoc : ('a : value_or_null) ('b : value_or_null). 
+  'a -> map:('a * 'b) list -> bool
 (** Same as {!assoc}, but simply return [true] if a binding exists,
    and [false] if no bindings exist for the given key.
  *)
 
-val mem_assq : 'a -> map:('a * 'b) list -> bool
+val mem_assq : ('a : value_or_null) ('b : value_or_null). 
+  'a -> map:('a * 'b) list -> bool
 (** Same as {!mem_assoc}, but uses physical equality instead of
    structural equality to compare keys.
  *)
 
-val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
+val remove_assoc : ('a : value_or_null) ('b : value_or_null). 
+  'a -> ('a * 'b) list -> ('a * 'b) list
 (** [remove_assoc a l] returns the list of
    pairs [l] without the first pair with key [a], if any.
    Not tail-recursive.
  *)
 
-val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
+val remove_assq : ('a : value_or_null) ('b : value_or_null). 
+  'a -> ('a * 'b) list -> ('a * 'b) list
 (** Same as {!remove_assoc}, but uses physical equality instead
    of structural equality to compare keys. Not tail-recursive.
  *)
@@ -448,13 +478,15 @@ val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
 (** {1 Lists of pairs} *)
 
 
-val split : ('a * 'b) list -> 'a list * 'b list
+val split : ('a : value_or_null) ('b : value_or_null)
+  . ('a * 'b) list -> 'a list * 'b list
 (** Transform a list of pairs into a pair of lists:
    [split [(a1,b1); ...; (an,bn)]] is [([a1; ...; an], [b1; ...; bn])].
    Not tail-recursive.
  *)
 
-val combine : 'a list -> 'b list -> ('a * 'b) list
+val combine : ('a : value_or_null) ('b : value_or_null). 
+  'a list -> 'b list -> ('a * 'b) list
 (** Transform a pair of lists into a list of pairs:
    [combine [a1; ...; an] [b1; ...; bn]] is
    [[(a1,b1); ...; (an,bn)]].
@@ -466,7 +498,7 @@ val combine : 'a list -> 'b list -> ('a * 'b) list
 (** {1 Sorting} *)
 
 
-val sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
+val sort : ('a : value_or_null). cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Sort a list in increasing order according to a comparison
    function. The comparison function must return 0 if its arguments
    compare as equal, a positive integer if the first is greater,
@@ -482,7 +514,8 @@ val sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
    heap space and logarithmic stack space.
  *)
 
-val stable_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
+val stable_sort : ('a : value_or_null). 
+  cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!sort}, but the sorting algorithm is guaranteed to
    be stable (i.e. elements that compare equal are kept in their
    original order).
@@ -491,17 +524,20 @@ val stable_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
    heap space and logarithmic stack space.
  *)
 
-val fast_sort : cmp:('a -> 'a -> int) -> 'a list -> 'a list
+val fast_sort : ('a : value_or_null). 
+  cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!sort} or {!stable_sort}, whichever is
     faster on typical input.
  *)
 
-val sort_uniq : cmp:('a -> 'a -> int) -> 'a list -> 'a list
+val sort_uniq : ('a : value_or_null). 
+  cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!sort}, but also remove duplicates.
     @since 4.02 (4.03 in ListLabels)
  *)
 
-val merge : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
+val merge : ('a : value_or_null). 
+  cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
 (** Merge two lists:
     Assuming that [l1] and [l2] are sorted according to the
     comparison function [cmp], [merge ~cmp l1 l2] will return a
@@ -513,12 +549,12 @@ val merge : cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
 
 (** {1 Lists and Sequences} *)
 
-val to_seq : 'a list -> 'a Seq.t
+val to_seq : ('a : value_or_null). 'a list -> 'a Seq.t
 (** Iterate on the list.
     @since 4.07
  *)
 
-val of_seq : 'a Seq.t -> 'a list
+val of_seq : ('a : value_or_null). 'a Seq.t -> 'a list
 (** Create a list from a sequence.
     @since 4.07
  *)

--- a/stdlib/marshal.ml
+++ b/stdlib/marshal.ml
@@ -25,14 +25,18 @@ type extern_flags =
 
 (* note: this type definition is used in 'runtime/debugger.c' *)
 
-external to_channel: out_channel -> 'a -> extern_flags list -> unit @@ portable
-    = "caml_output_value"
-external to_bytes: 'a -> extern_flags list -> bytes @@ portable
-    = "caml_output_value_to_bytes"
-external to_string: 'a -> extern_flags list -> string @@ portable
-    = "caml_output_value_to_string"
+external to_channel: ('a : value_or_null)
+  . out_channel -> 'a -> extern_flags list -> unit @@ portable
+  = "caml_output_value"
+external to_bytes: ('a : value_or_null)
+  . 'a -> extern_flags list -> bytes @@ portable
+  = "caml_output_value_to_bytes"
+external to_string: ('a : value_or_null)
+  . 'a -> extern_flags list -> string @@ portable
+  = "caml_output_value_to_string"
 external to_buffer_unsafe:
-      bytes -> int -> int -> 'a -> extern_flags list -> int @@ portable
+      ('a : value_or_null)
+      . bytes -> int -> int -> 'a -> extern_flags list -> int @@ portable
     = "caml_output_value_to_buffer"
 
 let to_buffer buff ofs len v flags =
@@ -46,9 +50,15 @@ let to_buffer buff ofs len v flags =
    a text representation.
 *)
 
-external from_channel: in_channel -> 'a @@ portable = "caml_input_value"
-external from_bytes_unsafe: bytes -> int -> 'a @@ portable = "caml_input_value_from_bytes"
-external data_size_unsafe: bytes -> int -> int @@ portable = "caml_marshal_data_size"
+external from_channel: ('a : value_or_null)
+  . in_channel -> 'a @@ portable
+  = "caml_input_value"
+external from_bytes_unsafe: ('a : value_or_null)
+  . bytes -> int -> 'a @@ portable
+  = "caml_input_value_from_bytes"
+external data_size_unsafe: ('a : value_or_null)
+  . bytes -> int -> int @@ portable
+  = "caml_marshal_data_size"
 
 let header_size = 16
 

--- a/stdlib/marshal.mli
+++ b/stdlib/marshal.mli
@@ -64,7 +64,8 @@ type extern_flags =
 
 (** The flags to the [Marshal.to_*] functions below. *)
 
-val to_channel : out_channel -> 'a -> extern_flags list -> unit
+val to_channel : ('a : value_or_null)
+  . out_channel -> 'a -> extern_flags list -> unit
 (** [Marshal.to_channel chan v flags] writes the representation
    of [v] on channel [chan]. The [flags] argument is a
    possibly empty list of flags that governs the marshaling
@@ -119,7 +120,8 @@ val to_channel : out_channel -> 'a -> extern_flags list -> unit
  *)
 
 external to_bytes :
-  'a -> extern_flags list -> bytes = "caml_output_value_to_bytes"
+  ('a : value_or_null)
+  . 'a -> extern_flags list -> bytes = "caml_output_value_to_bytes"
 (** [Marshal.to_bytes v flags] returns a byte sequence containing
    the representation of [v].
    The [flags] argument has the same meaning as for
@@ -127,11 +129,13 @@ external to_bytes :
    @since 4.02 *)
 
 external to_string :
-  'a -> extern_flags list -> string = "caml_output_value_to_string"
+  ('a : value_or_null)
+  . 'a -> extern_flags list -> string = "caml_output_value_to_string"
 (** Same as [to_bytes] but return the result as a string instead of
     a byte sequence. *)
 
-val to_buffer : bytes -> int -> int -> 'a -> extern_flags list -> int
+val to_buffer : ('a : value_or_null)
+  . bytes -> int -> int -> 'a -> extern_flags list -> int
 (** [Marshal.to_buffer buff ofs len v flags] marshals the value [v],
    storing its byte representation in the sequence [buff],
    starting at index [ofs], and writing at most
@@ -140,7 +144,8 @@ val to_buffer : bytes -> int -> int -> 'a -> extern_flags list -> int
    of [v] does not fit in [len] characters, the exception [Failure]
    is raised. *)
 
-val from_channel : in_channel -> 'a
+val from_channel : ('a : value_or_null)
+  . in_channel -> 'a
 (** [Marshal.from_channel chan] reads from channel [chan] the
    byte representation of a structured value, as produced by
    one of the [Marshal.to_*] functions, and reconstructs and
@@ -151,7 +156,8 @@ val from_channel : in_channel -> 'a
    @raise Failure if the end of the file is reached during
    unmarshalling itself or if [chan] is not in binary mode.*)
 
-val from_bytes : bytes -> int -> 'a
+val from_bytes : ('a : value_or_null)
+  . bytes -> int -> 'a
 (** [Marshal.from_bytes buff ofs] unmarshals a structured value
    like {!Marshal.from_channel} does, except that the byte
    representation is not read from a channel, but taken from
@@ -159,7 +165,8 @@ val from_bytes : bytes -> int -> 'a
    The byte sequence is not mutated.
    @since 4.02 *)
 
-val from_string : string -> int -> 'a
+val from_string : ('a : value_or_null)
+  . string -> int -> 'a
 (** Same as [from_bytes] but take a string as argument instead of a
     byte sequence. *)
 

--- a/stdlib/option.ml
+++ b/stdlib/option.ml
@@ -18,7 +18,7 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
-type 'a t = 'a option = None | Some of 'a
+type ('a : value_or_null) t = 'a option = None | Some of 'a
 
 let none = None
 let some v = Some v

--- a/stdlib/option.mli
+++ b/stdlib/option.mli
@@ -26,64 +26,70 @@ open! Stdlib
 
 (** {1:options Options} *)
 
-type 'a t = 'a option = None | Some of 'a (**)
+type ('a : value_or_null) t = 'a option = None | Some of 'a (**)
 (** The type for option values. Either [None] or a value [Some v]. *)
 
-val none : 'a option
+val none : ('a : value_or_null). 'a option
 (** [none] is [None]. *)
 
-val some : 'a -> 'a option
+val some : ('a : value_or_null). 'a -> 'a option
 (** [some v] is [Some v]. *)
 
-val value : 'a option -> default:'a -> 'a
+val value : ('a : value_or_null). 'a option -> default:'a -> 'a
 (** [value o ~default] is [v] if [o] is [Some v] and [default] otherwise. *)
 
-val get : 'a option -> 'a
+val get : ('a : value_or_null). 'a option -> 'a
 (** [get o] is [v] if [o] is [Some v] and raise otherwise.
 
     @raise Invalid_argument if [o] is [None]. *)
 
-val bind : 'a option -> ('a -> 'b option) -> 'b option
+val bind : ('a : value_or_null) ('b : value_or_null)
+  . 'a option -> ('a -> 'b option) -> 'b option
 (** [bind o f] is [f v] if [o] is [Some v] and [None] if [o] is [None]. *)
 
-val join : 'a option option -> 'a option
+val join : ('a : value_or_null). 'a option option -> 'a option
 (** [join oo] is [Some v] if [oo] is [Some (Some v)] and [None] otherwise. *)
 
-val map : ('a -> 'b) -> 'a option -> 'b option
+val map : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b) -> 'a option -> 'b option
 (** [map f o] is [None] if [o] is [None] and [Some (f v)] if [o] is [Some v]. *)
 
-val fold : none:'a -> some:('b -> 'a) -> 'b option -> 'a
+val fold : ('a : value_or_null) ('b : value_or_null)
+  . none:'a -> some:('b -> 'a) -> 'b option -> 'a
 (** [fold ~none ~some o] is [none] if [o] is [None] and [some v] if [o] is
     [Some v]. *)
 
-val iter : ('a -> unit) -> 'a option -> unit
+val iter : ('a : value_or_null). ('a -> unit) -> 'a option -> unit
 (** [iter f o] is [f v] if [o] is [Some v] and [()] otherwise. *)
 
 (** {1:preds Predicates and comparisons} *)
 
-val is_none : 'a option -> bool
+val is_none : ('a : value_or_null). 'a option -> bool
 (** [is_none o] is [true] if and only if [o] is [None]. *)
 
-val is_some : 'a option -> bool
+val is_some : ('a : value_or_null). 'a option -> bool
 (** [is_some o] is [true] if and only if [o] is [Some o]. *)
 
-val equal : ('a -> 'a -> bool) -> 'a option -> 'a option -> bool
+val equal : ('a : value_or_null)
+  . ('a -> 'a -> bool) -> 'a option -> 'a option -> bool
 (** [equal eq o0 o1] is [true] if and only if [o0] and [o1] are both [None]
     or if they are [Some v0] and [Some v1] and [eq v0 v1] is [true]. *)
 
-val compare : ('a -> 'a -> int) -> 'a option -> 'a option -> int
+val compare : ('a : value_or_null)
+  . ('a -> 'a -> int) -> 'a option -> 'a option -> int
 (** [compare cmp o0 o1] is a total order on options using [cmp] to compare
     values wrapped by [Some _]. [None] is smaller than [Some _] values. *)
 
 (** {1:convert Converting} *)
 
-val to_result : none:'e -> 'a option -> ('a, 'e) result
+val to_result : ('a : value_or_null) ('e : value_or_null)
+  . none:'e -> 'a option -> ('a, 'e) result
 (** [to_result ~none o] is [Ok v] if [o] is [Some v] and [Error none]
     otherwise. *)
 
-val to_list : 'a option -> 'a list
+val to_list : ('a : value_or_null) . 'a option -> 'a list
 (** [to_list o] is [[]] if [o] is [None] and [[v]] if [o] is [Some v]. *)
 
-val to_seq : 'a option -> 'a Seq.t
+val to_seq : ('a : value_or_null) . 'a option -> 'a Seq.t
 (** [to_seq o] is [o] as a sequence. [None] is the empty sequence and
     [Some v] is the singleton sequence containing [v]. *)

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -115,7 +115,8 @@ let raw_backtrace_entries bt = bt
 external get_raw_backtrace:
   unit -> raw_backtrace @@ portable = "caml_get_exception_raw_backtrace"
 
-external raise_with_backtrace: exn -> raw_backtrace -> 'a @ portable @@ portable
+external raise_with_backtrace: ('a : value_or_null)
+  . exn -> raw_backtrace -> 'a @ portable @@ portable
   = "%raise_with_backtrace"
 
 (* Disable warning 37: values are constructed in the runtime *)

--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -178,7 +178,8 @@ val raw_backtrace_to_string: raw_backtrace -> string
     @since 4.01
 *)
 
-external raise_with_backtrace: exn -> raw_backtrace -> 'a @ portable
+external raise_with_backtrace: ('a : value_or_null)
+  . exn -> raw_backtrace -> 'a @ portable
   = "%raise_with_backtrace"
 (** Reraise the exception using the given raw_backtrace for the
     origin of the exception

--- a/stdlib/queue.ml
+++ b/stdlib/queue.ml
@@ -21,11 +21,11 @@ open! Stdlib
 
 exception Empty
 
-type 'a cell =
+type ('a : value_or_null) cell =
   | Nil
   | Cons of { content: 'a; mutable next: 'a cell }
 
-type 'a t = {
+type ('a : value_or_null) t = {
   mutable length: int;
   mutable first: 'a cell;
   mutable last: 'a cell

--- a/stdlib/queue.mli
+++ b/stdlib/queue.mli
@@ -36,7 +36,7 @@ open! Stdlib
     with a {!Mutex.t}).
 *)
 
-type !'a t
+type (!'a : value_or_null) t
 (** The type of queues containing elements of type ['a]. *)
 
 
@@ -44,62 +44,63 @@ exception Empty
 (** Raised when {!Queue.take} or {!Queue.peek} is applied to an empty queue. *)
 
 
-val create : unit -> 'a t
+val create : ('a : value_or_null) .unit -> 'a t
 (** Return a new queue, initially empty. *)
 
-val add : 'a -> 'a t -> unit
+val add : ('a : value_or_null) . 'a -> 'a t -> unit
 (** [add x q] adds the element [x] at the end of the queue [q]. *)
 
-val push : 'a -> 'a t -> unit
+val push : ('a : value_or_null) . 'a -> 'a t -> unit
 (** [push] is a synonym for [add]. *)
 
-val take : 'a t -> 'a
+val take : ('a : value_or_null) . 'a t -> 'a
 (** [take q] removes and returns the first element in queue [q],
    or raises {!Empty} if the queue is empty. *)
 
-val take_opt : 'a t -> 'a option
+val take_opt : ('a : value_or_null) . 'a t -> 'a option
 (** [take_opt q] removes and returns the first element in queue [q],
    or returns [None] if the queue is empty.
    @since 4.08 *)
 
-val pop : 'a t -> 'a
+val pop : ('a : value_or_null) . 'a t -> 'a
 (** [pop] is a synonym for [take]. *)
 
-val peek : 'a t -> 'a
+val peek : ('a : value_or_null) . 'a t -> 'a
 (** [peek q] returns the first element in queue [q], without removing
    it from the queue, or raises {!Empty} if the queue is empty. *)
 
-val peek_opt : 'a t -> 'a option
+val peek_opt : ('a : value_or_null) . 'a t -> 'a option
 (** [peek_opt q] returns the first element in queue [q], without removing
    it from the queue, or returns [None] if the queue is empty.
    @since 4.08 *)
 
-val top : 'a t -> 'a
+val top : ('a : value_or_null) . 'a t -> 'a
 (** [top] is a synonym for [peek]. *)
 
-val clear : 'a t -> unit
+val clear : ('a : value_or_null) . 'a t -> unit
 (** Discard all elements from a queue. *)
 
-val copy : 'a t -> 'a t
+val copy : ('a : value_or_null) . 'a t -> 'a t
 (** Return a copy of the given queue. *)
 
-val is_empty : 'a t -> bool
+val is_empty : ('a : value_or_null) . 'a t -> bool
 (** Return [true] if the given queue is empty, [false] otherwise. *)
 
-val length : 'a t -> int
+val length : ('a : value_or_null) . 'a t -> int
 (** Return the number of elements in a queue. *)
 
-val iter : ('a -> unit) -> 'a t -> unit
+val iter : ('a : value_or_null) . ('a -> unit) -> 'a t -> unit
 (** [iter f q] applies [f] in turn to all elements of [q],
    from the least recently entered to the most recently entered.
    The queue itself is unchanged. *)
 
-val fold : ('acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+val fold : ('acc : value_or_null) ('a : value_or_null)
+  . ('acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
 (** [fold f accu q] is equivalent to [List.fold_left f accu l],
    where [l] is the list of [q]'s elements. The queue remains
    unchanged. *)
 
-val transfer : 'a t -> 'a t -> unit
+val transfer : ('a : value_or_null) . 'a t -> 'a t -> unit
 (** [transfer q1 q2] adds all of [q1]'s elements at the end of
    the queue [q2], then clears [q1]. It is equivalent to the
    sequence [iter (fun x -> add x q2) q1; clear q1], but runs
@@ -107,17 +108,17 @@ val transfer : 'a t -> 'a t -> unit
 
 (** {1 Iterators} *)
 
-val to_seq : 'a t -> 'a Seq.t
+val to_seq : ('a : value_or_null) . 'a t -> 'a Seq.t
 (** Iterate on the queue, in front-to-back order.
     The behavior is not specified if the queue is modified
     during the iteration.
     @since 4.07 *)
 
-val add_seq : 'a t -> 'a Seq.t -> unit
+val add_seq : ('a : value_or_null) . 'a t -> 'a Seq.t -> unit
 (** Add the elements from a sequence to the end of the queue.
     @since 4.07 *)
 
-val of_seq : 'a Seq.t -> 'a t
+val of_seq : ('a : value_or_null) . 'a Seq.t -> 'a t
 (** Create a queue from a sequence.
     @since 4.07 *)
 

--- a/stdlib/result.ml
+++ b/stdlib/result.ml
@@ -18,7 +18,7 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
-type ('a, 'e) t = ('a, 'e) result = Ok of 'a | Error of 'e
+type ('a : value_or_null, 'e : value_or_null) t = ('a, 'e) result = Ok of 'a | Error of 'e
 
 let ok v = Ok v
 let error e = Error e

--- a/stdlib/result.mli
+++ b/stdlib/result.mli
@@ -27,60 +27,70 @@ open! Stdlib
 
 (** {1:results Results} *)
 
-type ('a, 'e) t = ('a, 'e) result = Ok of 'a | Error of 'e (**)
+type ('a : value_or_null, 'e : value_or_null) t = ('a, 'e) result = Ok of 'a | Error of 'e (**)
 (** The type for result values. Either a value [Ok v] or an error [Error e]. *)
 
-val ok : 'a -> ('a, 'e) result
+val ok : ('a : value_or_null) ('e : value_or_null). 'a -> ('a, 'e) result
 (** [ok v] is [Ok v]. *)
 
-val error : 'e -> ('a, 'e) result
+val error : ('a : value_or_null) ('e : value_or_null). 'e -> ('a, 'e) result
 (** [error e] is [Error e]. *)
 
-val value : ('a, 'e) result -> default:'a -> 'a
+val value : ('a : value_or_null) ('e : value_or_null). ('a, 'e) result -> default:'a -> 'a
 (** [value r ~default] is [v] if [r] is [Ok v] and [default] otherwise. *)
 
-val get_ok : ('a, 'e) result -> 'a
+val get_ok : ('a : value_or_null) ('e : value_or_null). ('a, 'e) result -> 'a
 (** [get_ok r] is [v] if [r] is [Ok v] and raise otherwise.
 
     @raise Invalid_argument if [r] is [Error _]. *)
 
-val get_error : ('a, 'e) result -> 'e
+val get_error : ('a : value_or_null) ('e : value_or_null). ('a, 'e) result -> 'e
 (** [get_error r] is [e] if [r] is [Error e] and raise otherwise.
 
     @raise Invalid_argument if [r] is [Ok _]. *)
 
-val bind : ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result
+val bind : ('a : value_or_null) ('b : value_or_null) ('e : value_or_null).
+  ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result
 (** [bind r f] is [f v] if [r] is [Ok v] and [r] if [r] is [Error _]. *)
 
-val join : (('a, 'e) result, 'e) result -> ('a, 'e) result
+val join : ('a : value_or_null) ('e : value_or_null)
+  . (('a, 'e) result, 'e) result -> ('a, 'e) result
 (** [join rr] is [r] if [rr] is [Ok r] and [rr] if [rr] is [Error _]. *)
 
-val map : ('a -> 'b) -> ('a, 'e) result -> ('b, 'e) result
+val map : ('a : value_or_null) ('b : value_or_null) ('e : value_or_null).
+  ('a -> 'b) -> ('a, 'e) result -> ('b, 'e) result
 (** [map f r] is [Ok (f v)] if [r] is [Ok v] and [r] if [r] is [Error _]. *)
 
-val map_error : ('e -> 'f) -> ('a, 'e) result -> ('a, 'f) result
+val map_error : ('a : value_or_null) ('e : value_or_null) ('f : value_or_null).
+  ('e -> 'f) -> ('a, 'e) result -> ('a, 'f) result
 (** [map_error f r] is [Error (f e)] if [r] is [Error e] and [r] if
     [r] is [Ok _]. *)
 
-val fold : ok:('a -> 'c) -> error:('e -> 'c) -> ('a, 'e) result -> 'c
+val fold : ('a : value_or_null) ('c : value_or_null) ('e : value_or_null).
+  ok:('a -> 'c) -> error:('e -> 'c) -> ('a, 'e) result -> 'c
 (** [fold ~ok ~error r] is [ok v] if [r] is [Ok v] and [error e] if [r]
     is [Error e]. *)
 
-val iter : ('a -> unit) -> ('a, 'e) result -> unit
+val iter : ('a : value_or_null) ('e : value_or_null)
+  . ('a -> unit) -> ('a, 'e) result -> unit
 (** [iter f r] is [f v] if [r] is [Ok v] and [()] otherwise. *)
 
-val iter_error : ('e -> unit) -> ('a, 'e) result -> unit
+val iter_error : ('a : value_or_null) ('e : value_or_null)
+  . ('e -> unit) -> ('a, 'e) result -> unit
 (** [iter_error f r] is [f e] if [r] is [Error e] and [()] otherwise. *)
 
 (** {1:preds Predicates and comparisons} *)
 
-val is_ok : ('a, 'e) result -> bool
+val is_ok : ('a : value_or_null) ('e : value_or_null)
+  . ('a, 'e) result -> bool
 (** [is_ok r] is [true] if and only if [r] is [Ok _]. *)
 
-val is_error : ('a, 'e) result -> bool
+val is_error : ('a : value_or_null) ('e : value_or_null)
+  . ('a, 'e) result -> bool
 (** [is_error r] is [true] if and only if [r] is [Error _]. *)
 
 val equal :
+  ('a : value_or_null) ('e : value_or_null).
   ok:('a -> 'a -> bool) -> error:('e -> 'e -> bool) -> ('a, 'e) result ->
   ('a, 'e) result -> bool
 (** [equal ~ok ~error r0 r1] tests equality of [r0] and [r1] using [ok]
@@ -88,6 +98,7 @@ val equal :
     [Error _]. *)
 
 val compare :
+  ('a : value_or_null) ('e : value_or_null).
   ok:('a -> 'a -> int) -> error:('e -> 'e -> int) -> ('a, 'e) result ->
   ('a, 'e) result -> int
 (** [compare ~ok ~error r0 r1] totally orders [r0] and [r1] using [ok] and
@@ -96,13 +107,16 @@ val compare :
 
 (** {1:convert Converting} *)
 
-val to_option : ('a, 'e) result -> 'a option
+val to_option : ('a : value_or_null) ('e : value_or_null)
+  . ('a, 'e) result -> 'a option
 (** [to_option r] is [r] as an option, mapping [Ok v] to [Some v] and
     [Error _] to [None]. *)
 
-val to_list : ('a, 'e) result -> 'a list
+val to_list : ('a : value_or_null) ('e : value_or_null)
+  . ('a, 'e) result -> 'a list
 (** [to_list r] is [[v]] if [r] is [Ok v] and [[]] otherwise. *)
 
-val to_seq : ('a, 'e) result -> 'a Seq.t
+val to_seq : ('a : value_or_null) ('e : value_or_null)
+  . ('a, 'e) result -> 'a Seq.t
 (** [to_seq r] is [r] as a sequence. [Ok v] is the singleton sequence
     containing [v] and [Error _] is the empty sequence. *)

--- a/stdlib/seq.ml
+++ b/stdlib/seq.ml
@@ -20,11 +20,11 @@ open! Stdlib
 
 (* Module [Seq]: functional iterators *)
 
-type +'a node =
+type ('a : value_or_null) node =
   | Nil
   | Cons of 'a * 'a t
 
-and 'a t = unit -> 'a node
+and ('a : value_or_null) t = unit -> 'a node
 
 let empty () = Nil
 

--- a/stdlib/seq.mli
+++ b/stdlib/seq.mli
@@ -92,14 +92,14 @@ open! Stdlib
 
     @since 4.07 *)
 
-type 'a t = unit -> 'a node
+type ('a : value_or_null) t = unit -> 'a node
 (** A sequence [xs] of type ['a t] is a delayed list of elements of
     type ['a]. Such a sequence is queried by performing a function
     application [xs()]. This function application returns a node,
     allowing the caller to determine whether the sequence is empty
     or nonempty, and in the latter case, to obtain its head and tail. *)
 
-and +'a node =
+and ('a : value_or_null) node =
   | Nil
   | Cons of 'a * 'a t (**)
 (** A node is either [Nil], which means that the sequence is empty,
@@ -134,7 +134,7 @@ and +'a node =
    None of the functions in this section is lazy. These functions
    are consumers: they force some computation to take place. *)
 
-val is_empty : 'a t -> bool
+val is_empty : ('a : value_or_null). 'a t -> bool
 (** [is_empty xs] determines whether the sequence [xs] is empty.
 
     It is recommended that the sequence [xs] be persistent.
@@ -144,7 +144,7 @@ val is_empty : 'a t -> bool
 
     @since 4.14 *)
 
-val uncons : 'a t -> ('a * 'a t) option
+val uncons : ('a : value_or_null). 'a t -> ('a * 'a t) option
 (** If [xs] is empty, then [uncons xs] is [None].
 
     If [xs] is nonempty, then [uncons xs] is [Some (x, ys)] where [x] is the
@@ -152,21 +152,22 @@ val uncons : 'a t -> ('a * 'a t) option
 
     @since 4.14 *)
 
-val length : 'a t -> int
+val length : ('a : value_or_null). 'a t -> int
 (** [length xs] is the length of the sequence [xs].
 
     The sequence [xs] must be finite.
 
     @since 4.14 *)
 
-val iter : ('a -> unit) -> 'a t -> unit
+val iter : ('a : value_or_null). ('a -> unit) -> 'a t -> unit
 (** [iter f xs] invokes [f x] successively
     for every element [x] of the sequence [xs],
     from left to right.
 
     It terminates only if the sequence [xs] is finite. *)
 
-val fold_left : ('acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+val fold_left : ('acc : value_or_null) ('a : value_or_null)
+  . ('acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
 (** [fold_left f _ xs] invokes [f _ x] successively
     for every element [x] of the sequence [xs],
     from left to right.
@@ -175,7 +176,7 @@ val fold_left : ('acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
 
     It terminates only if the sequence [xs] is finite. *)
 
-val iteri : (int -> 'a -> unit) -> 'a t -> unit
+val iteri : ('a : value_or_null). (int -> 'a -> unit) -> 'a t -> unit
 (** [iteri f xs] invokes [f i x] successively
     for every element [x] located at index [i] in the sequence [xs].
 
@@ -186,7 +187,8 @@ val iteri : (int -> 'a -> unit) -> 'a t -> unit
 
     @since 4.14 *)
 
-val fold_lefti : ('acc -> int -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+val fold_lefti : ('acc : value_or_null) ('a : value_or_null)
+  . ('acc -> int -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
 (** [fold_lefti f _ xs] invokes [f _ i x] successively
     for every element [x] located at index [i] of the sequence [xs].
 
@@ -199,7 +201,7 @@ val fold_lefti : ('acc -> int -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
 
     @since 4.14 *)
 
-val for_all : ('a -> bool) -> 'a t -> bool
+val for_all : ('a : value_or_null). ('a -> bool) -> 'a t -> bool
 (** [for_all p xs] determines whether all elements [x] of the sequence [xs]
     satisfy [p x].
 
@@ -207,7 +209,7 @@ val for_all : ('a -> bool) -> 'a t -> bool
 
     @since 4.14 *)
 
-val exists : ('a -> bool) -> 'a t -> bool
+val exists : ('a : value_or_null). ('a -> bool) -> 'a t -> bool
 (** [exists xs p] determines whether at least one element [x]
     of the sequence [xs] satisfies [p x].
 
@@ -215,7 +217,7 @@ val exists : ('a -> bool) -> 'a t -> bool
 
     @since 4.14 *)
 
-val find : ('a -> bool) -> 'a t -> 'a option
+val find : ('a : value_or_null). ('a -> bool) -> 'a t -> 'a option
 (** [find p xs] returns [Some x], where [x] is the first element of the
     sequence [xs] that satisfies [p x], if there is such an element.
 
@@ -225,7 +227,7 @@ val find : ('a -> bool) -> 'a t -> 'a option
 
     @since 4.14 *)
 
-val find_index : ('a -> bool) -> 'a t -> int option
+val find_index : ('a : value_or_null). ('a -> bool) -> 'a t -> int option
 (** [find_index p xs] returns [Some i], where [i] is the index of the first
     element of the sequence [xs] that satisfies [p x], if there is such an
     element.
@@ -236,7 +238,8 @@ val find_index : ('a -> bool) -> 'a t -> int option
 
     @since 5.1 *)
 
-val find_map : ('a -> 'b option) -> 'a t -> 'b option
+val find_map : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b option) -> 'a t -> 'b option
 (** [find_map f xs] returns [Some y], where [x] is the first element of the
     sequence [xs] such that [f x = Some _], if there is such an element,
     and where [y] is defined by [f x = Some y].
@@ -247,7 +250,8 @@ val find_map : ('a -> 'b option) -> 'a t -> 'b option
 
     @since 4.14 *)
 
-val find_mapi : (int -> 'a -> 'b option) -> 'a t -> 'b option
+val find_mapi : ('a : value_or_null) ('b : value_or_null)
+  . (int -> 'a -> 'b option) -> 'a t -> 'b option
 (** Same as [find_map], but the predicate is applied to the index of
    the element as first argument (counting from 0), and the element
    itself as second argument.
@@ -256,7 +260,8 @@ val find_mapi : (int -> 'a -> 'b option) -> 'a t -> 'b option
 
    @since 5.1 *)
 
-val iter2 : ('a -> 'b -> unit) -> 'a t -> 'b t -> unit
+val iter2 : ('a : value_or_null) ('b : value_or_null).
+  ('a -> 'b -> unit) -> 'a t -> 'b t -> unit
 (** [iter2 f xs ys] invokes [f x y] successively for every pair [(x, y)] of
     elements drawn synchronously from the sequences [xs] and [ys].
 
@@ -272,7 +277,9 @@ val iter2 : ('a -> 'b -> unit) -> 'a t -> 'b t -> unit
 
     @since 4.14 *)
 
-val fold_left2 : ('acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
+val fold_left2 : ('acc : value_or_null) ('a : value_or_null) 
+  ('b : value_or_null).
+  ('acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
 (** [fold_left2 f _ xs ys] invokes [f _ x y] successively
     for every pair [(x, y)] of elements drawn synchronously
     from the sequences [xs] and [ys].
@@ -291,7 +298,8 @@ val fold_left2 : ('acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a t -> 'b t -> 'acc
 
     @since 4.14 *)
 
-val for_all2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+val for_all2 : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
 (** [for_all2 p xs ys] determines whether all pairs [(x, y)] of elements
     drawn synchronously from the sequences [xs] and [ys] satisfy [p x y].
 
@@ -309,7 +317,8 @@ val for_all2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
 
     @since 4.14 *)
 
-val exists2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+val exists2 : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
 (** [exists2 p xs ys] determines whether some pair [(x, y)] of elements
     drawn synchronously from the sequences [xs] and [ys] satisfies [p x y].
 
@@ -323,7 +332,8 @@ val exists2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
 
     @since 4.14 *)
 
-val equal : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+val equal : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
 (** Provided the function [eq] defines an equality on elements,
     [equal eq xs ys] determines whether the sequences [xs] and [ys]
     are pointwise equal.
@@ -332,7 +342,8 @@ val equal : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
 
     @since 4.14 *)
 
-val compare : ('a -> 'b -> int) -> 'a t -> 'b t -> int
+val compare : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b -> int) -> 'a t -> 'b t -> int
 (** Provided the function [cmp] defines a preorder on elements,
     [compare cmp xs ys] compares the sequences [xs] and [ys]
     according to the lexicographic preorder.
@@ -348,15 +359,15 @@ val compare : ('a -> 'b -> int) -> 'a t -> 'b t -> int
 (** The functions in this section are lazy: that is, they return sequences
     whose elements are computed only when demanded. *)
 
-val empty : 'a t
+val empty : ('a : value_or_null) . 'a t
 (** [empty] is the empty sequence.
     It has no elements. Its length is 0. *)
 
-val return : 'a -> 'a t
+val return : ('a : value_or_null) . 'a -> 'a t
 (** [return x] is the sequence whose sole element is [x].
     Its length is 1. *)
 
-val cons : 'a -> 'a t -> 'a t
+val cons : ('a : value_or_null). 'a -> 'a t -> 'a t
 (** [cons x xs] is the sequence that begins with the element [x],
     followed with the sequence [xs].
 
@@ -367,7 +378,7 @@ val cons : 'a -> 'a t -> 'a t
 
     @since 4.11 *)
 
-val init : int -> (int -> 'a) -> 'a t
+val init : ('a : value_or_null). int -> (int -> 'a) -> 'a t
 (** [init n f] is the sequence [f 0; f 1; ...; f (n-1)].
 
     [n] must be nonnegative.
@@ -379,7 +390,8 @@ val init : int -> (int -> 'a) -> 'a t
 
     @since 4.14 *)
 
-val unfold : ('b -> ('a * 'b) option) -> 'b -> 'a t
+val unfold : ('a : value_or_null) ('b : value_or_null)
+  . ('b -> ('a * 'b) option) -> 'b -> 'a t
 (** [unfold] constructs a sequence
     out of a step function and an initial state.
 
@@ -393,7 +405,7 @@ val unfold : ('b -> ('a * 'b) option) -> 'b -> 'a t
 
     @since 4.11 *)
 
-val repeat : 'a -> 'a t
+val repeat : ('a : value_or_null). 'a -> 'a t
 (** [repeat x] is the infinite sequence
     where the element [x] is repeated indefinitely.
 
@@ -401,7 +413,7 @@ val repeat : 'a -> 'a t
 
     @since 4.14 *)
 
-val forever : (unit -> 'a) -> 'a t
+val forever : ('a : value_or_null). (unit -> 'a) -> 'a t
 (** [forever f] is an infinite sequence where every element is produced
     (on demand) by the function call [f()].
 
@@ -412,7 +424,7 @@ val forever : (unit -> 'a) -> 'a t
 
     @since 4.14 *)
 
-val cycle : 'a t -> 'a t
+val cycle : ('a : value_or_null). 'a t -> 'a t
 (** [cycle xs] is the infinite sequence that consists of an infinite
     number of repetitions of the sequence [xs].
 
@@ -425,7 +437,7 @@ val cycle : 'a t -> 'a t
 
     @since 4.14 *)
 
-val iterate : ('a -> 'a) -> 'a -> 'a t
+val iterate : ('a : value_or_null). ('a -> 'a) -> 'a -> 'a t
 (** [iterate f x] is the infinite sequence whose elements are
     [x], [f x], [f (f x)], and so on.
 
@@ -439,14 +451,16 @@ val iterate : ('a -> 'a) -> 'a -> 'a t
 (** The functions in this section are lazy: that is, they return sequences
     whose elements are computed only when demanded. *)
 
-val map : ('a -> 'b) -> 'a t -> 'b t
+val map : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b) -> 'a t -> 'b t
 (** [map f xs] is the image of the sequence [xs] through the
     transformation [f].
 
     If [xs] is the sequence [x0; x1; ...] then
     [map f xs] is the sequence [f x0; f x1; ...]. *)
 
-val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
+val mapi : ('a : value_or_null) ('b : value_or_null)
+  . (int -> 'a -> 'b) -> 'a t -> 'b t
 (** [mapi] is analogous to [map], but applies the function [f] to
     an index and an element.
 
@@ -454,21 +468,23 @@ val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
 
     @since 4.14 *)
 
-val filter : ('a -> bool) -> 'a t -> 'a t
+val filter : ('a : value_or_null). ('a -> bool) -> 'a t -> 'a t
 (** [filter p xs] is the sequence of the elements [x] of [xs]
     that satisfy [p x].
 
     In other words, [filter p xs] is the sequence [xs],
     deprived of the elements [x] such that [p x] is false. *)
 
-val filter_map : ('a -> 'b option) -> 'a t -> 'b t
+val filter_map : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b option) -> 'a t -> 'b t
 (** [filter_map f xs] is the sequence of the elements [y] such that
     [f x = Some y], where [x] ranges over [xs].
 
     [filter_map f xs] is equivalent to
     [map Option.get (filter Option.is_some (map f xs))]. *)
 
-val scan : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b t
+val scan : ('a : value_or_null) ('b : value_or_null)
+  . ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b t
 (** If [xs] is a sequence [[x0; x1; x2; ...]], then
     [scan f a0 xs] is a sequence of accumulators
     [[a0; a1; a2; ...]]
@@ -487,7 +503,7 @@ val scan : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b t
 
     @since 4.14 *)
 
-val take : int -> 'a t -> 'a t
+val take : ('a : value_or_null). int -> 'a t -> 'a t
 (** [take n xs] is the sequence of the first [n] elements of [xs].
 
     If [xs] has fewer than [n] elements,
@@ -499,7 +515,7 @@ val take : int -> 'a t -> 'a t
 
     @since 4.14 *)
 
-val drop : int -> 'a t -> 'a t
+val drop : ('a : value_or_null). int -> 'a t -> 'a t
 (** [drop n xs] is the sequence [xs], deprived of its first [n] elements.
 
     If [xs] has fewer than [n] elements,
@@ -516,19 +532,19 @@ val drop : int -> 'a t -> 'a t
 
     @since 4.14 *)
 
-val take_while : ('a -> bool) -> 'a t -> 'a t
+val take_while : ('a : value_or_null). ('a -> bool) -> 'a t -> 'a t
 (** [take_while p xs] is the longest prefix of the sequence [xs]
     where every element [x] satisfies [p x].
 
     @since 4.14 *)
 
-val drop_while : ('a -> bool) -> 'a t -> 'a t
+val drop_while : ('a : value_or_null). ('a -> bool) -> 'a t -> 'a t
 (** [drop_while p xs] is the sequence [xs], deprived of the prefix
     [take_while p xs].
 
     @since 4.14 *)
 
-val group : ('a -> 'a -> bool) -> 'a t -> 'a t t
+val group : ('a : value_or_null). ('a -> 'a -> bool) -> 'a t -> 'a t t
 (** Provided the function [eq] defines an equality on elements,
     [group eq xs] is the sequence of the maximal runs
     of adjacent duplicate elements of the sequence [xs].
@@ -543,7 +559,7 @@ val group : ('a -> 'a -> bool) -> 'a t -> 'a t t
 
     @since 4.14 *)
 
-val memoize : 'a t -> 'a t
+val memoize : ('a : value_or_null). 'a t -> 'a t
 (** The sequence [memoize xs] has the same elements as the sequence [xs].
 
     Regardless of whether [xs] is ephemeral or persistent,
@@ -563,7 +579,7 @@ exception Forced_twice
 
     @since 4.14 *)
 
-val once : 'a t -> 'a t
+val once : ('a : value_or_null). 'a t -> 'a t
 (** The sequence [once xs] has the same elements as the sequence [xs].
 
     Regardless of whether [xs] is ephemeral or persistent,
@@ -577,7 +593,7 @@ val once : 'a t -> 'a t
 
     @since 4.14 *)
 
-val transpose : 'a t t -> 'a t t
+val transpose : ('a : value_or_null). 'a t t -> 'a t t
 (** If [xss] is a matrix (a sequence of rows), then [transpose xss] is
     the sequence of the columns of the matrix [xss].
 
@@ -591,14 +607,14 @@ val transpose : 'a t t -> 'a t t
 
 (** {1 Combining sequences} *)
 
-val append : 'a t -> 'a t -> 'a t
+val append : ('a : value_or_null). 'a t -> 'a t -> 'a t
 (** [append xs ys] is the concatenation of the sequences [xs] and [ys].
 
     Its elements are the elements of [xs], followed by the elements of [ys].
 
     @since 4.11 *)
 
-val concat : 'a t t -> 'a t
+val concat : ('a : value_or_null). 'a t t -> 'a t
 (** If [xss] is a sequence of sequences,
     then [concat xss] is its concatenation.
 
@@ -607,17 +623,20 @@ val concat : 'a t t -> 'a t
 
     @since 4.13 *)
 
-val flat_map : ('a -> 'b t) -> 'a t -> 'b t
+val flat_map : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b t) -> 'a t -> 'b t
 (** [flat_map f xs] is equivalent to [concat (map f xs)]. *)
 
-val concat_map : ('a -> 'b t) -> 'a t -> 'b t
+val concat_map : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b t) -> 'a t -> 'b t
 (** [concat_map f xs] is equivalent to [concat (map f xs)].
 
     [concat_map] is an alias for [flat_map].
 
     @since 4.13 *)
 
-val zip : 'a t -> 'b t -> ('a * 'b) t
+val zip : ('a : value_or_null) ('b : value_or_null)
+  . 'a t -> 'b t -> ('a * 'b) t
 (** [zip xs ys] is the sequence of pairs [(x, y)]
     drawn synchronously from the sequences [xs] and [ys].
 
@@ -629,7 +648,8 @@ val zip : 'a t -> 'b t -> ('a * 'b) t
 
     @since 4.14 *)
 
-val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+val map2 : ('a : value_or_null) ('b : value_or_null) ('c : value_or_null)
+  . ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** [map2 f xs ys] is the sequence of the elements [f x y],
     where the pairs [(x, y)] are drawn synchronously from the
     sequences [xs] and [ys].
@@ -642,7 +662,7 @@ val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 
     @since 4.14 *)
 
-val interleave : 'a t -> 'a t -> 'a t
+val interleave : ('a : value_or_null). 'a t -> 'a t -> 'a t
 (** [interleave xs ys] is the sequence that begins with the first element of
     [xs], continues with the first element of [ys], and so on.
 
@@ -651,7 +671,8 @@ val interleave : 'a t -> 'a t -> 'a t
 
     @since 4.14 *)
 
-val sorted_merge : ('a -> 'a -> int) -> 'a t -> 'a t -> 'a t
+val sorted_merge : ('a : value_or_null).
+  ('a -> 'a -> int) -> 'a t -> 'a t -> 'a t
 (** If the sequences [xs] and [ys] are sorted according to the total preorder
     [cmp], then [sorted_merge cmp xs ys] is the sorted sequence obtained by
     merging the sequences [xs] and [ys].
@@ -660,7 +681,8 @@ val sorted_merge : ('a -> 'a -> int) -> 'a t -> 'a t -> 'a t
 
     @since 4.14 *)
 
-val product : 'a t -> 'b t -> ('a * 'b) t
+val product : ('a : value_or_null) ('b : value_or_null).
+  'a t -> 'b t -> ('a * 'b) t
 (** [product xs ys] is the Cartesian product of the sequences [xs] and [ys].
 
     For every element [x] of [xs] and for every element [y] of [ys],
@@ -674,7 +696,9 @@ val product : 'a t -> 'b t -> ('a * 'b) t
 
     @since 4.14 *)
 
-val map_product : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+val map_product : ('a : value_or_null) ('b : value_or_null) 
+  ('c : value_or_null).
+  ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 (** The sequence [map_product f xs ys] is the image through [f]
     of the Cartesian product of the sequences [xs] and [ys].
 
@@ -694,7 +718,8 @@ val map_product : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
 
 (** {1 Splitting a sequence into two sequences} *)
 
-val unzip : ('a * 'b) t -> 'a t * 'b t
+val unzip : ('a : value_or_null) ('b : value_or_null)
+  . ('a * 'b) t -> 'a t * 'b t
 (** [unzip] transforms a sequence of pairs into a pair of sequences.
 
     [unzip xs] is equivalent to [(map fst xs, map snd xs)].
@@ -708,12 +733,15 @@ val unzip : ('a * 'b) t -> 'a t * 'b t
 
     @since 4.14 *)
 
-val split : ('a * 'b) t -> 'a t * 'b t
+val split : ('a : value_or_null) ('b : value_or_null)
+  . ('a * 'b) t -> 'a t * 'b t
 (** [split] is an alias for [unzip].
 
     @since 4.14 *)
 
-val partition_map : ('a -> ('b, 'c) Either.t) -> 'a t -> 'b t * 'c t
+val partition_map : ('a : value_or_null) ('b : value_or_null) 
+  ('c : value_or_null).
+  ('a -> ('b, 'c) Either.t) -> 'a t -> 'b t * 'c t
 (** [partition_map f xs] returns a pair of sequences [(ys, zs)], where:
 
     - [ys] is the sequence of the elements [y] such that
@@ -735,7 +763,7 @@ val partition_map : ('a -> ('b, 'c) Either.t) -> 'a t -> 'b t * 'c t
 
     @since 4.14 *)
 
-val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
+val partition : ('a : value_or_null). ('a -> bool) -> 'a t -> 'a t * 'a t
 (** [partition p xs] returns a pair of the subsequence of the elements
     of [xs] that satisfy [p] and the subsequence of the elements of
     [xs] that do not satisfy [p].
@@ -761,7 +789,7 @@ val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
     is ephemeral: the sequence that it represents can be consumed at most
     once. *)
 
-val of_dispenser : (unit -> 'a option) -> 'a t
+val of_dispenser : ('a : value_or_null). (unit -> 'a option) -> 'a t
 (** [of_dispenser it] is the sequence of the elements produced by the
     dispenser [it]. It is an ephemeral sequence: it can be consumed at most
     once. If a persistent sequence is needed, use
@@ -769,7 +797,7 @@ val of_dispenser : (unit -> 'a option) -> 'a t
 
     @since 4.14 *)
 
-val to_dispenser : 'a t -> (unit -> 'a option)
+val to_dispenser : ('a : value_or_null). 'a t -> (unit -> 'a option)
 (** [to_dispenser xs] is a fresh dispenser on the sequence [xs].
 
     This dispenser has mutable internal state,

--- a/stdlib/stack.ml
+++ b/stdlib/stack.ml
@@ -18,7 +18,7 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
-type 'a t = { mutable c : 'a list; mutable len : int; }
+type ('a : value_or_null) t = { mutable c : 'a list; mutable len : int; }
 
 exception Empty
 

--- a/stdlib/stack.mli
+++ b/stdlib/stack.mli
@@ -35,60 +35,61 @@ open! Stdlib
     with a {!Mutex.t}).
 *)
 
-type !'a t
+type (!'a : value_or_null) t
 (** The type of stacks containing elements of type ['a]. *)
 
 exception Empty
 (** Raised when {!Stack.pop} or {!Stack.top} is applied to an empty stack. *)
 
 
-val create : unit -> 'a t
+val create : ('a : value_or_null) . unit -> 'a t
 (** Return a new stack, initially empty. *)
 
-val push : 'a -> 'a t -> unit
+val push : ('a : value_or_null) . 'a -> 'a t -> unit
 (** [push x s] adds the element [x] at the top of stack [s]. *)
 
-val pop : 'a t -> 'a
+val pop : ('a : value_or_null) . 'a t -> 'a
 (** [pop s] removes and returns the topmost element in stack [s],
    or raises {!Empty} if the stack is empty. *)
 
-val pop_opt : 'a t -> 'a option
+val pop_opt : ('a : value_or_null) . 'a t -> 'a option
 (** [pop_opt s] removes and returns the topmost element in stack [s],
    or returns [None] if the stack is empty.
    @since 4.08 *)
 
-val drop : 'a t -> unit
+val drop : ('a : value_or_null) . 'a t -> unit
 (** [drop s] removes the topmost element in stack [s],
    or raises {!Empty} if the stack is empty.
    @since 5.1 *)
 
-val top : 'a t -> 'a
+val top : ('a : value_or_null) . 'a t -> 'a
 (** [top s] returns the topmost element in stack [s],
    or raises {!Empty} if the stack is empty. *)
 
-val top_opt : 'a t -> 'a option
+val top_opt : ('a : value_or_null) . 'a t -> 'a option
 (** [top_opt s] returns the topmost element in stack [s],
    or [None] if the stack is empty.
    @since 4.08 *)
 
-val clear : 'a t -> unit
+val clear : ('a : value_or_null) . 'a t -> unit
 (** Discard all elements from a stack. *)
 
-val copy : 'a t -> 'a t
+val copy : ('a : value_or_null) . 'a t -> 'a t
 (** Return a copy of the given stack. *)
 
-val is_empty : 'a t -> bool
+val is_empty : ('a : value_or_null) . 'a t -> bool
 (** Return [true] if the given stack is empty, [false] otherwise. *)
 
-val length : 'a t -> int
+val length : ('a : value_or_null) . 'a t -> int
 (** Return the number of elements in a stack. Time complexity O(1) *)
 
-val iter : ('a -> unit) -> 'a t -> unit
+val iter : ('a : value_or_null) . ('a -> unit) -> 'a t -> unit
 (** [iter f s] applies [f] in turn to all elements of [s],
    from the element at the top of the stack to the element at the
    bottom of the stack. The stack itself is unchanged. *)
 
-val fold : ('acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
+val fold : ('acc : value_or_null) ('a : value_or_null)
+  . ('acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
 (** [fold f accu s] is [(f (... (f (f accu x1) x2) ...) xn)]
     where [x1] is the top of the stack, [x2] the second element,
     and [xn] the bottom element. The stack is unchanged.
@@ -96,15 +97,15 @@ val fold : ('acc -> 'a -> 'acc) -> 'acc -> 'a t -> 'acc
 
 (** {1 Stacks and Sequences} *)
 
-val to_seq : 'a t -> 'a Seq.t
+val to_seq : ('a : value_or_null) . 'a t -> 'a Seq.t
 (** Iterate on the stack, top to bottom.
     It is safe to modify the stack during iteration.
     @since 4.07 *)
 
-val add_seq : 'a t -> 'a Seq.t -> unit
+val add_seq : ('a : value_or_null) . 'a t -> 'a Seq.t -> unit
 (** Add the elements from the sequence on the top of the stack.
     @since 4.07 *)
 
-val of_seq : 'a Seq.t -> 'a t
+val of_seq : ('a : value_or_null) . 'a Seq.t -> 'a t
 (** Create a stack from the sequence.
     @since 4.07 *)

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -29,8 +29,8 @@ let () =
   register_named_value "Pervasives.array_align_error"
     (Invalid_argument "address was misaligned")
 
-external raise : exn -> 'a @ portable @@ portable = "%reraise"
-external raise_notrace : exn -> 'a @ portable @@ portable = "%raise_notrace"
+external raise : ('a : value_or_null). exn -> 'a @ portable @@ portable = "%reraise"
+external raise_notrace : ('a : value_or_null). exn -> 'a @ portable @@ portable = "%raise_notrace"
 
 let failwith s = raise(Failure s)
 let invalid_arg s = raise(Invalid_argument s)
@@ -51,8 +51,10 @@ exception Undefined_recursive_module = Undefined_recursive_module
 
 (* Composition operators *)
 
-external ( |> ) : 'a -> ('a -> 'b) -> 'b @@ portable = "%revapply"
-external ( @@ ) : ('a -> 'b) -> 'a -> 'b @@ portable = "%apply"
+external ( |> ) : ('a : value_or_null) ('b : value_or_null)
+  . 'a -> ('a -> 'b) -> 'b @@ portable = "%revapply"
+external ( @@ ) : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b) -> 'a -> 'b @@ portable = "%apply"
 
 (* Debugging *)
 
@@ -63,25 +65,25 @@ external __MODULE__ : string @@ portable = "%loc_MODULE"
 external __POS__ : string * int * int * int @@ portable = "%loc_POS"
 external __FUNCTION__ : string @@ portable = "%loc_FUNCTION"
 
-external __LOC_OF__ : 'a -> string * 'a @@ portable = "%loc_LOC"
-external __LINE_OF__ : 'a -> int * 'a @@ portable = "%loc_LINE"
-external __POS_OF__ : 'a -> (string * int * int * int) * 'a @@ portable = "%loc_POS"
+external __LOC_OF__ : ('a : value_or_null) . 'a -> string * 'a @@ portable = "%loc_LOC"
+external __LINE_OF__ : ('a : value_or_null) . 'a -> int * 'a @@ portable = "%loc_LINE"
+external __POS_OF__ : ('a : value_or_null) . 'a -> (string * int * int * int) * 'a @@ portable = "%loc_POS"
 
 (* Comparisons *)
 
-external ( = ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%equal"
-external ( <> ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%notequal"
-external ( < ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%lessthan"
-external ( > ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%greaterthan"
-external ( <= ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%lessequal"
-external ( >= ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%greaterequal"
-external compare : ('a[@local_opt]) -> ('a[@local_opt]) -> int @@ portable = "%compare"
+external ( = ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%equal"
+external ( <> ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%notequal"
+external ( < ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%lessthan"
+external ( > ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%greaterthan"
+external ( <= ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%lessequal"
+external ( >= ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%greaterequal"
+external compare : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> int @@ portable = "%compare"
 
 let min x y = if x <= y then x else y
 let max x y = if x >= y then x else y
 
-external ( == ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%eq"
-external ( != ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%noteq"
+external ( == ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%eq"
+external ( != ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool @@ portable = "%noteq"
 
 (* Boolean operations *)
 
@@ -231,7 +233,7 @@ let char_of_int n =
 
 (* Unit operations *)
 
-external ignore : 'a -> unit @@ portable = "%ignore"
+external ignore : ('a : value_or_null) . 'a -> unit @@ portable = "%ignore"
 external ignore_contended : 'a @ contended -> unit @@ portable = "%ignore"
 
 (* Pair operations *)
@@ -241,16 +243,16 @@ external snd : ('a * 'b[@local_opt]) -> ('b[@local_opt]) @@ portable = "%field1_
 
 (* References *)
 
-type 'a ref = { mutable contents : 'a }
-external ref : 'a -> ('a ref[@local_opt]) @@ portable = "%makemutable"
-external ( ! ) : ('a ref[@local_opt]) -> 'a @@ portable = "%field0"
-external ( := ) : ('a ref[@local_opt]) -> 'a -> unit @@ portable = "%setfield0"
+type ('a : value_or_null) ref = { mutable contents : 'a }
+external ref : ('a : value_or_null) . 'a -> ('a ref[@local_opt]) @@ portable = "%makemutable"
+external ( ! ) : ('a : value_or_null) . ('a ref[@local_opt]) -> 'a @@ portable = "%field0"
+external ( := ) : ('a : value_or_null) . ('a ref[@local_opt]) -> 'a -> unit @@ portable = "%setfield0"
 external incr : (int ref[@local_opt]) -> unit @@ portable = "%incr"
 external decr : (int ref[@local_opt]) -> unit @@ portable = "%decr"
 
 (* Result type *)
 
-type ('a,'b) result = Ok of 'a | Error of 'b
+type ('a : value_or_null, 'b : value_or_null) result = Ok of 'a | Error of 'b
 
 (* String conversion functions *)
 
@@ -388,7 +390,7 @@ let output_substring oc s ofs len =
 external output_byte : out_channel -> int -> unit @@ portable = "caml_ml_output_char"
 external output_binary_int : out_channel -> int -> unit @@ portable = "caml_ml_output_int"
 
-external marshal_to_channel : out_channel -> 'a -> unit list -> unit @@ portable
+external marshal_to_channel : ('a : value_or_null) . out_channel -> 'a -> unit list -> unit @@ portable
      = "caml_output_value"
 let output_value chan v = marshal_to_channel chan v []
 
@@ -479,7 +481,7 @@ let input_line chan =
 
 external input_byte : in_channel -> int @@ portable = "caml_ml_input_char"
 external input_binary_int : in_channel -> int @@ portable = "caml_ml_input_int"
-external input_value : in_channel -> 'a @@ portable = "caml_input_value"
+external input_value : ('a : value_or_null) . in_channel -> 'a @@ portable = "caml_input_value"
 external seek_in : in_channel -> int -> unit @@ portable = "caml_ml_seek_in"
 external pos_in : in_channel -> int @@ portable = "caml_ml_pos_in"
 external in_channel_length : in_channel -> int @@ portable = "caml_ml_channel_size"

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -32,18 +32,18 @@
 
 (** {1 Exceptions} *)
 
-external raise : exn -> 'a @ portable = "%reraise"
+external raise : ('a : value_or_null). exn -> 'a @ portable = "%reraise"
 (** Raise the given exception value *)
 
-external raise_notrace : exn -> 'a @ portable = "%raise_notrace"
+external raise_notrace : ('a : value_or_null). exn -> 'a @ portable = "%raise_notrace"
 (** A faster version [raise] which does not record the backtrace.
     @since 4.02
 *)
 
-val invalid_arg : string -> 'a @ portable
+val invalid_arg : ('a : value_or_null) . string -> 'a @ portable
 (** Raise exception [Invalid_argument] with the given string. *)
 
-val failwith : string -> 'a @ portable
+val failwith : ('a : value_or_null) . string -> 'a @ portable
 (** Raise exception [Failure] with the given string. *)
 
 exception Exit
@@ -124,7 +124,7 @@ exception Undefined_recursive_module of (string * int * int)
 
 (** {1 Comparisons} *)
 
-external ( = ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%equal"
+external ( = ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%equal"
 (** [e1 = e2] tests for structural equality of [e1] and [e2].
    Mutable structures (e.g. references and arrays) are equal
    if and only if their current contents are structurally equal,
@@ -133,27 +133,27 @@ external ( = ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%equal"
    Equality between cyclic data structures may not terminate.
    Left-associative operator, see {!Ocaml_operators} for more information. *)
 
-external ( <> ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%notequal"
+external ( <> ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%notequal"
 (** Negation of {!Stdlib.( = )}.
     Left-associative operator, see {!Ocaml_operators} for more information.
 *)
 
-external ( < ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%lessthan"
+external ( < ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%lessthan"
 (** See {!Stdlib.( >= )}.
     Left-associative operator, see {!Ocaml_operators} for more information.
 *)
 
-external ( > ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%greaterthan"
+external ( > ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%greaterthan"
 (** See {!Stdlib.( >= )}.
     Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
-external ( <= ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%lessequal"
+external ( <= ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%lessequal"
 (** See {!Stdlib.( >= )}.
     Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
-external ( >= ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%greaterequal"
+external ( >= ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%greaterequal"
 (** Structural ordering functions. These functions coincide with
    the usual orderings over integers, characters, strings, byte sequences
    and floating-point numbers, and extend them to a
@@ -165,7 +165,7 @@ external ( >= ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%greaterequal"
    Left-associative operator, see {!Ocaml_operators} for more information.
 *)
 
-external compare : ('a[@local_opt]) -> ('a[@local_opt]) -> int = "%compare"
+external compare : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> int = "%compare"
 (** [compare x y] returns [0] if [x] is equal to [y],
    a negative integer if [x] is less than [y], and a positive integer
    if [x] is greater than [y].  The ordering implemented by [compare]
@@ -184,17 +184,17 @@ external compare : ('a[@local_opt]) -> ('a[@local_opt]) -> int = "%compare"
    required by the {!Set.Make} and {!Map.Make} functors, as well as
    the {!List.sort} and {!Array.sort} functions. *)
 
-val min : 'a -> 'a -> 'a
+val min : ('a : value_or_null) . 'a -> 'a -> 'a
 (** Return the smaller of the two arguments.
     The result is unspecified if one of the arguments contains
     the float value [nan]. *)
 
-val max : 'a -> 'a -> 'a
+val max : ('a : value_or_null) . 'a -> 'a -> 'a
 (** Return the greater of the two arguments.
     The result is unspecified if one of the arguments contains
     the float value [nan]. *)
 
-external ( == ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%eq"
+external ( == ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%eq"
 (** [e1 == e2] tests for physical equality of [e1] and [e2].
    On mutable types such as references, arrays, byte sequences, records with
    mutable fields and objects with mutable instance variables,
@@ -206,7 +206,7 @@ external ( == ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%eq"
    Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
 
-external ( != ) : ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%noteq"
+external ( != ) : ('a : value_or_null) . ('a[@local_opt]) -> ('a[@local_opt]) -> bool = "%noteq"
 (** Negation of {!Stdlib.( == )}.
     Left-associative operator,  see {!Ocaml_operators} for more information.
 *)
@@ -273,7 +273,7 @@ external __FUNCTION__ : string = "%loc_FUNCTION"
 
     @since 4.12 *)
 
-external __LOC_OF__ : 'a -> string * 'a = "%loc_LOC"
+external __LOC_OF__ : ('a : value_or_null) . 'a -> string * 'a = "%loc_LOC"
 (** [__LOC_OF__ expr] returns a pair [(loc, expr)] where [loc] is the
     location of [expr] in the file currently being parsed by the
     compiler, with the standard error format of OCaml: "File %S, line
@@ -281,14 +281,14 @@ external __LOC_OF__ : 'a -> string * 'a = "%loc_LOC"
     @since 4.02
 *)
 
-external __LINE_OF__ : 'a -> int * 'a = "%loc_LINE"
+external __LINE_OF__ : ('a : value_or_null) . 'a -> int * 'a = "%loc_LINE"
 (** [__LINE_OF__ expr] returns a pair [(line, expr)], where [line] is the
     line number at which the expression [expr] appears in the file
     currently being parsed by the compiler.
     @since 4.02
  *)
 
-external __POS_OF__ : 'a -> (string * int * int * int) * 'a = "%loc_POS"
+external __POS_OF__ : ('a : value_or_null) . 'a -> (string * int * int * int) * 'a = "%loc_POS"
 (** [__POS_OF__ expr] returns a pair [(loc,expr)], where [loc] is a
     tuple [(file,lnum,cnum,enum)] corresponding to the location at
     which the expression [expr] appears in the file currently being
@@ -300,14 +300,16 @@ external __POS_OF__ : 'a -> (string * int * int * int) * 'a = "%loc_POS"
 
 (** {1 Composition operators} *)
 
-external ( |> ) : 'a -> ('a -> 'b) -> 'b = "%revapply"
+external ( |> ) : ('a : value_or_null) ('b : value_or_null)
+  . 'a -> ('a -> 'b) -> 'b = "%revapply"
 (** Reverse-application operator: [x |> f |> g] is exactly equivalent
  to [g (f (x))].
  Left-associative operator, see {!Ocaml_operators} for more information.
  @since 4.01
 *)
 
-external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
+external ( @@ ) : ('a : value_or_null) ('b : value_or_null)
+  . ('a -> 'b) -> 'a -> 'b = "%apply"
 (** Application operator: [g @@ f @@ x] is exactly equivalent to
  [g (f (x))].
  Right-associative operator, see {!Ocaml_operators} for more information.
@@ -717,7 +719,7 @@ val char_of_int : int -> char
 
 (** {1 Unit operations} *)
 
-external ignore : 'a -> unit = "%ignore"
+external ignore : ('a : value_or_null) . 'a -> unit = "%ignore"
 (** Discard the value of its argument and return [()].
    For instance, [ignore(f x)] discards the result of
    the side-effecting function [f].  It is equivalent to
@@ -824,7 +826,7 @@ external snd : ('a * 'b[@local_opt]) -> ('b[@local_opt]) = "%field1_immut"
    More list operations are provided in module {!List}.
 *)
 
-val ( @ ) : 'a list -> 'a list -> 'a list
+val ( @ ) : ('a : value_or_null) . 'a list -> 'a list -> 'a list
 (** [l0 @ l1] appends [l1] to [l0]. Same function as {!List.append}.
   Right-associative operator, see {!Ocaml_operators} for more information.
   @since 5.1 this function is tail-recursive.
@@ -1028,7 +1030,7 @@ val output_binary_int : out_channel -> int -> unit
    {!Stdlib.input_binary_int} function. The format is compatible across
    all machines for a given version of OCaml. *)
 
-val output_value : out_channel -> 'a -> unit
+val output_value :  ('a : value_or_null) . out_channel -> 'a -> unit
 (** Write the representation of a structured value of any type
    to a channel. Circularities and sharing inside the value
    are detected and preserved. The object can be read back,
@@ -1153,7 +1155,7 @@ val input_binary_int : in_channel -> int
    @raise End_of_file if the end of file was reached while reading the
    integer. *)
 
-val input_value : in_channel -> 'a
+val input_value : ('a : value_or_null) . in_channel -> 'a
 (** Read the representation of a structured value, as produced
    by {!Stdlib.output_value}, and return the corresponding value.
    This function is identical to {!Marshal.from_channel};
@@ -1222,20 +1224,20 @@ module LargeFile :
 
 (** {1 References} *)
 
-type 'a ref = { mutable contents : 'a }
+type ('a : value_or_null) ref = { mutable contents : 'a }
 (** The type of references (mutable indirection cells) containing
    a value of type ['a]. *)
 
-external ref : 'a -> ('a ref[@local_opt]) = "%makemutable"
+external ref : ('a : value_or_null) . 'a -> ('a ref[@local_opt]) = "%makemutable"
 (** Return a fresh reference containing the given value. *)
 
-external ( ! ) : ('a ref[@local_opt]) -> 'a = "%field0"
+external ( ! ) : ('a : value_or_null) . ('a ref[@local_opt]) -> 'a = "%field0"
 (** [!r] returns the current contents of reference [r].
    Equivalent to [fun r -> r.contents].
    Unary operator, see {!Ocaml_operators} for more information.
 *)
 
-external ( := ) : ('a ref[@local_opt]) -> 'a -> unit = "%setfield0"
+external ( := ) : ('a : value_or_null) . ('a ref[@local_opt]) -> 'a -> unit = "%setfield0"
 (** [r := a] stores the value of [a] in reference [r].
    Equivalent to [fun r v -> r.contents <- v].
    Right-associative operator, see {!Ocaml_operators} for more information.
@@ -1252,7 +1254,7 @@ external decr : (int ref[@local_opt]) -> unit = "%decr"
 (** {1 Result type} *)
 
 (** @since 4.03 *)
-type ('a,'b) result = Ok of 'a | Error of 'b
+type ('a : value_or_null, 'b : value_or_null) result = Ok of 'a | Error of 'b
 
 (** {1 Operations on format strings} *)
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -226,12 +226,14 @@ val mapi : (int -> char -> char) -> string -> string
 
     @since 4.02 *)
 
-val fold_left : ('acc -> char -> 'acc) -> 'acc -> string -> 'acc
+val fold_left : ('acc : value_or_null)
+  . ('acc -> char -> 'acc) -> 'acc -> string -> 'acc
 (** [fold_left f x s] computes [f (... (f (f x s.[0]) s.[1]) ...) s.[n-1]],
     where [n] is the length of the string [s].
     @since 4.13 *)
 
-val fold_right : (char -> 'acc -> 'acc) -> string -> 'acc -> 'acc
+val fold_right : ('acc : value_or_null)
+  . (char -> 'acc -> 'acc) -> string -> 'acc -> 'acc
 (** [fold_right f s x] computes [f s.[0] (f s.[1] ( ... (f s.[n-1] x) ...))],
     where [n] is the length of the string [s].
     @since 4.13 *)

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -228,12 +228,14 @@ val mapi : f:(int -> char -> char) -> string -> string
 
     @since 4.02 *)
 
-val fold_left : f:('acc -> char -> 'acc) -> init:'acc -> string -> 'acc
+val fold_left : ('acc : value_or_null)
+  . f:('acc -> char -> 'acc) -> init:'acc -> string -> 'acc
 (** [fold_left f x s] computes [f (... (f (f x s.[0]) s.[1]) ...) s.[n-1]],
     where [n] is the length of the string [s].
     @since 4.13 *)
 
-val fold_right : f:(char -> 'acc -> 'acc) -> string -> init:'acc -> 'acc
+val fold_right : ('acc : value_or_null)
+  . f:(char -> 'acc -> 'acc) -> string -> init:'acc -> 'acc
 (** [fold_right f s x] computes [f s.[0] (f s.[1] ( ... (f s.[n-1] x) ...))],
     where [n] is the length of the string [s].
     @since 4.13 *)

--- a/stdlib/type.ml
+++ b/stdlib/type.ml
@@ -17,27 +17,29 @@ open! Stdlib
 
 (* Type equality witness *)
 
-type (_, _) eq = Equal: ('a, 'a) eq
+type (_ : value_or_null, _ : value_or_null) eq = 
+  Equal: ('a : value_or_null) . ('a , 'a) eq
 
 (* Type identifiers *)
 
 module Id = struct
-  type _ id = ..
+  type (_ : value_or_null) id = ..
   module type ID = sig
-    type t
+    type t : value_or_null
     type _ id += Id : t id
   end
 
-  type !'a t = (module ID with type t = 'a)
+  type (!'a : value_or_null) t = (module ID with type t = 'a)
 
-  let make (type a) () : a t =
+  let make (type a : value_or_null) () : a t =
     (module struct type t = a type _ id += Id : t id end)
 
-  let[@inline] uid (type a) ((module A) : a t) =
+  let[@inline] uid (type a : value_or_null) ((module A) : a t) =
     Obj.Extension_constructor.id (Obj.Extension_constructor.of_val A.Id)
 
   let provably_equal
-      (type a b) ((module A) : a t) ((module B) : b t) : (a, b) eq option
+      (type a : value_or_null) (type b : value_or_null)
+      ((module A) : a t) ((module B) : b t) : (a, b) eq option
     =
     match A.Id with B.Id -> Some Equal | _ -> None
 end

--- a/stdlib/type.mli
+++ b/stdlib/type.mli
@@ -21,7 +21,8 @@
 
 (** {1:witness Type equality witness} *)
 
-type (_, _) eq = Equal: ('a, 'a) eq (** *)
+type (_ : value_or_null, _ : value_or_null) eq = 
+  Equal: ('a : value_or_null) . ('a, 'a) eq (** *)
 (** The purpose of [eq] is to represent type equalities that may not otherwise
     be known by the type checker (e.g. because they may depend on dynamic data).
 
@@ -56,16 +57,17 @@ module Id : sig
 
   (** {1:ids Type identifiers} *)
 
-  type !'a t
+  type (!'a : value_or_null) t
   (** The type for identifiers for type ['a]. *)
 
-  val make : unit -> 'a t
+  val make : ('a : value_or_null) . unit -> 'a t
   (** [make ()] is a new type identifier. *)
 
-  val uid : 'a t -> int
+  val uid : ('a : value_or_null) . 'a t -> int
   (** [uid id] is a runtime unique identifier for [id]. *)
 
-  val provably_equal : 'a t -> 'b t -> ('a, 'b) eq option
+  val provably_equal : ('a : value_or_null) ('b : value_or_null)
+    . 'a t -> 'b t -> ('a, 'b) eq option
   (** [provably_equal i0 i1] is [Some Equal] if identifier [i0] is equal
       to [i1] and [None] otherwise. *)
 

--- a/testsuite/tests/backtrace/pr2195-locs.byte.reference
+++ b/testsuite/tests/backtrace/pr2195-locs.byte.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Stdlib.Exit
-Raised at Stdlib.open_in_gen in file "stdlib.ml", line 412, characters 28-54
+Raised at Stdlib.open_in_gen in file "stdlib.ml", line 414, characters 28-54
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/testsuite/tests/backtrace/pr2195.opt.reference
+++ b/testsuite/tests/backtrace/pr2195.opt.reference
@@ -1,5 +1,5 @@
 Fatal error: exception Stdlib.Exit
-Raised at Stdlib.open_in_gen in file "stdlib.ml", line 412, characters 28-54
-Called from Stdlib.open_in in file "stdlib.ml", line 417, characters 2-45
+Raised at Stdlib.open_in_gen in file "stdlib.ml", line 414, characters 28-54
+Called from Stdlib.open_in in file "stdlib.ml", line 419, characters 2-45
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/testsuite/tests/statmemprof/callstacks.flat-float-array.byte.reference
+++ b/testsuite/tests/statmemprof/callstacks.flat-float-array.byte.reference
@@ -56,7 +56,7 @@ Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
 Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
 Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Stdlib__Marshal.from_bytes in file "marshal.ml", line 68, characters 9-35
+Raised by primitive operation at Stdlib__Marshal.from_bytes in file "marshal.ml", line 78, characters 9-35
 Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 63, characters 12-87
 Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
 Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23

--- a/testsuite/tests/statmemprof/callstacks.flat-float-array.opt.reference
+++ b/testsuite/tests/statmemprof/callstacks.flat-float-array.opt.reference
@@ -56,8 +56,8 @@ Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
 Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
 Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Stdlib__Marshal.from_bytes in file "marshal.ml" (inlined), line 68, characters 9-35
-Called from Stdlib__Marshal.from_string in file "marshal.ml", line 74, characters 2-46
+Raised by primitive operation at Stdlib__Marshal.from_bytes in file "marshal.ml" (inlined), line 78, characters 9-35
+Called from Stdlib__Marshal.from_string in file "marshal.ml", line 84, characters 2-46
 Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 63, characters 12-87
 Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
 Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23

--- a/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -719,7 +719,7 @@ Line 1, characters 27-28:
 1 | let f13_1 (x : t_bits32) = x = x;;
                                ^
 Error: This expression has type "t_bits32"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
        But the layout of t_bits32 must be a sublayout of value.
@@ -731,7 +731,7 @@ Line 1, characters 35-36:
 1 | let f13_2 (x : t_bits32) = compare x x;;
                                        ^
 Error: This expression has type "t_bits32"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
        But the layout of t_bits32 must be a sublayout of value.
@@ -743,7 +743,7 @@ Line 1, characters 44-45:
 1 | let f13_3 (x : t_bits32) = Marshal.to_bytes x;;
                                                 ^
 Error: This expression has type "t_bits32"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
        But the layout of t_bits32 must be a sublayout of value.

--- a/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
@@ -712,7 +712,7 @@ Line 1, characters 27-28:
 1 | let f13_1 (x : t_bits32) = x = x;;
                                ^
 Error: This expression has type "t_bits32"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
        But the layout of t_bits32 must be a sublayout of value.
@@ -724,7 +724,7 @@ Line 1, characters 35-36:
 1 | let f13_2 (x : t_bits32) = compare x x;;
                                        ^
 Error: This expression has type "t_bits32"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
        But the layout of t_bits32 must be a sublayout of value.
@@ -736,7 +736,7 @@ Line 1, characters 44-45:
 1 | let f13_3 (x : t_bits32) = Marshal.to_bytes x;;
                                                 ^
 Error: This expression has type "t_bits32"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits32 is bits32
          because of the definition of t_bits32 at line 1, characters 0-22.
        But the layout of t_bits32 must be a sublayout of value.

--- a/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -721,7 +721,7 @@ Line 1, characters 27-28:
 1 | let f13_1 (x : t_bits64) = x = x;;
                                ^
 Error: This expression has type "t_bits64"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
        But the layout of t_bits64 must be a sublayout of value.
@@ -733,7 +733,7 @@ Line 1, characters 35-36:
 1 | let f13_2 (x : t_bits64) = compare x x;;
                                        ^
 Error: This expression has type "t_bits64"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
        But the layout of t_bits64 must be a sublayout of value.
@@ -745,7 +745,7 @@ Line 1, characters 44-45:
 1 | let f13_3 (x : t_bits64) = Marshal.to_bytes x;;
                                                 ^
 Error: This expression has type "t_bits64"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
        But the layout of t_bits64 must be a sublayout of value.

--- a/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
@@ -714,7 +714,7 @@ Line 1, characters 27-28:
 1 | let f13_1 (x : t_bits64) = x = x;;
                                ^
 Error: This expression has type "t_bits64"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
        But the layout of t_bits64 must be a sublayout of value.
@@ -726,7 +726,7 @@ Line 1, characters 35-36:
 1 | let f13_2 (x : t_bits64) = compare x x;;
                                        ^
 Error: This expression has type "t_bits64"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
        But the layout of t_bits64 must be a sublayout of value.
@@ -738,7 +738,7 @@ Line 1, characters 44-45:
 1 | let f13_3 (x : t_bits64) = Marshal.to_bytes x;;
                                                 ^
 Error: This expression has type "t_bits64"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_bits64 is bits64
          because of the definition of t_bits64 at line 1, characters 0-22.
        But the layout of t_bits64 must be a sublayout of value.

--- a/testsuite/tests/typing-layouts-float32/basics.ml
+++ b/testsuite/tests/typing-layouts-float32/basics.ml
@@ -771,7 +771,7 @@ Line 1, characters 28-29:
 1 | let f13_1 (x : t_float32) = x = x;;
                                 ^
 Error: This expression has type "t_float32"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_float32 is float32
          because of the definition of t_float32 at line 1, characters 0-24.
        But the layout of t_float32 must be a sublayout of value.
@@ -783,7 +783,7 @@ Line 1, characters 36-37:
 1 | let f13_2 (x : t_float32) = compare x x;;
                                         ^
 Error: This expression has type "t_float32"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_float32 is float32
          because of the definition of t_float32 at line 1, characters 0-24.
        But the layout of t_float32 must be a sublayout of value.
@@ -795,7 +795,7 @@ Line 1, characters 45-46:
 1 | let f13_3 (x : t_float32) = Marshal.to_bytes x;;
                                                  ^
 Error: This expression has type "t_float32"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_float32 is float32
          because of the definition of t_float32 at line 1, characters 0-24.
        But the layout of t_float32 must be a sublayout of value.

--- a/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/testsuite/tests/typing-layouts-float64/basics.ml
@@ -779,7 +779,7 @@ Line 1, characters 28-29:
 1 | let f13_1 (x : t_float64) = x = x;;
                                 ^
 Error: This expression has type "t_float64"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_float64 is float64
          because of the definition of t_float64 at line 1, characters 0-24.
        But the layout of t_float64 must be a sublayout of value.
@@ -791,7 +791,7 @@ Line 1, characters 36-37:
 1 | let f13_2 (x : t_float64) = compare x x;;
                                         ^
 Error: This expression has type "t_float64"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_float64 is float64
          because of the definition of t_float64 at line 1, characters 0-24.
        But the layout of t_float64 must be a sublayout of value.
@@ -803,7 +803,7 @@ Line 1, characters 45-46:
 1 | let f13_3 (x : t_float64) = Marshal.to_bytes x;;
                                                  ^
 Error: This expression has type "t_float64"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_float64 is float64
          because of the definition of t_float64 at line 1, characters 0-24.
        But the layout of t_float64 must be a sublayout of value.

--- a/testsuite/tests/typing-layouts-or-null/optimized.ml
+++ b/testsuite/tests/typing-layouts-or-null/optimized.ml
@@ -175,8 +175,6 @@ let () = test_higher_order ()
 (************************************************)
 (* Test: Closures capturing or_null values *)
 
-type 'a nref = { mutable v : 'a or_null }
-
 let test_closures () =
   let[@inline never] increment_by offset x =
     match (x, offset) with
@@ -192,14 +190,14 @@ let test_closures () =
   print_int_or_null "Closure Test, increment 10 with null offset" (inc_by_null (This 10));
 
   let[@inline never] make_accumulator initial =
-    let state = { v = initial } in
+    let state = ref initial in
     fun x ->
       match x with
       | This n ->
-          (match state.v with
+          (match !state with
           | This m ->
               let result = This (n + m) in
-              state.v <- result;
+              state := result;
               result
           | Null -> Null)
       | Null -> Null

--- a/testsuite/tests/typing-layouts-or-null/runtime.ml
+++ b/testsuite/tests/typing-layouts-or-null/runtime.ml
@@ -61,23 +61,19 @@ let () =
   | _ -> assert false
 ;;
 
-external to_bytes : ('a : value_or_null) . 'a -> int list -> bytes = "caml_output_value_to_bytes"
-
-external from_bytes_unsafe : ('a : value_or_null) . bytes -> int -> 'a = "caml_input_value_from_bytes"
-
-let z = to_bytes (This "foo") []
+let z = Marshal.to_bytes (This "foo") []
 
 let () =
-  match from_bytes_unsafe z 0 with
+  match Marshal.from_bytes z 0 with
     | This "foo" -> ()
     | This _ -> assert false
     | Null -> assert false
 ;;
 
-let w = to_bytes Null []
+let w = Marshal.to_bytes Null []
 
 let () =
-  match from_bytes_unsafe w 0 with
+  match Marshal.from_bytes w 0 with
     | Null -> ()
     | This _ -> assert false
 ;;
@@ -148,15 +144,12 @@ let () =
   | _ -> assert false
 ;;
 
-external equal : ('a : value_or_null) . 'a -> 'a -> bool = "%eq"
-external compare : ('a : value_or_null) . 'a -> 'a -> int = "%compare"
-
 let () =
-  assert (equal Null Null);
-  assert (equal (This 4) (This 4));
-  assert (not (equal Null (This 4)));
-  assert (not (equal (This 8) Null));
-  assert (not (equal (This 4) (This 5)));
+  assert (Null = Null);
+  assert (This 4 = This 4);
+  assert (Null <> This 4);
+  assert (This 8 <> Null);
+  assert (This 4 <> This 5);
 ;;
 
 let () =

--- a/testsuite/tests/typing-layouts-or-null/runtime.ml
+++ b/testsuite/tests/typing-layouts-or-null/runtime.ml
@@ -118,28 +118,26 @@ let () =
   | _ -> assert false
 ;;
 
-type 'a nref = { mutable v : 'a or_null }
-
-let x : string nref = { v = Null }
+let x = ref Null
 
 let () =
-  match x.v with
+  match !x with
   | Null -> ()
   | _ -> assert false
 ;;
 
-let () = x.v <- This "foo"
+let () = x := This "foo"
 
 let () =
-  match x.v with
+  match !x with
   | This "foo" -> ()
   | _ -> assert false
 ;;
 
-let () = x.v <- Null
+let () = x := Null
 
 let () =
-  match x.v with
+  match !x with
   | Null -> ()
   | _ -> assert false
 ;;

--- a/testsuite/tests/typing-layouts-vec128/basics.ml
+++ b/testsuite/tests/typing-layouts-vec128/basics.ml
@@ -722,7 +722,7 @@ Line 1, characters 27-28:
 1 | let f13_1 (x : t_vec128) = x = x;;
                                ^
 Error: This expression has type "t_vec128"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_vec128 is vec128
          because of the definition of t_vec128 at line 1, characters 0-22.
        But the layout of t_vec128 must be a sublayout of value.
@@ -734,7 +734,7 @@ Line 1, characters 35-36:
 1 | let f13_2 (x : t_vec128) = compare x x;;
                                        ^
 Error: This expression has type "t_vec128"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_vec128 is vec128
          because of the definition of t_vec128 at line 1, characters 0-22.
        But the layout of t_vec128 must be a sublayout of value.
@@ -746,7 +746,7 @@ Line 1, characters 44-45:
 1 | let f13_3 (x : t_vec128) = Marshal.to_bytes x;;
                                                 ^
 Error: This expression has type "t_vec128"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_vec128 is vec128
          because of the definition of t_vec128 at line 1, characters 0-22.
        But the layout of t_vec128 must be a sublayout of value.

--- a/testsuite/tests/typing-layouts-vec128/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-vec128/basics_alpha.ml
@@ -717,7 +717,7 @@ Line 1, characters 27-28:
 1 | let f13_1 (x : t_vec128) = x = x;;
                                ^
 Error: This expression has type "t_vec128"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_vec128 is vec128
          because of the definition of t_vec128 at line 1, characters 0-22.
        But the layout of t_vec128 must be a sublayout of value.
@@ -729,7 +729,7 @@ Line 1, characters 35-36:
 1 | let f13_2 (x : t_vec128) = compare x x;;
                                        ^
 Error: This expression has type "t_vec128"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_vec128 is vec128
          because of the definition of t_vec128 at line 1, characters 0-22.
        But the layout of t_vec128 must be a sublayout of value.
@@ -741,7 +741,7 @@ Line 1, characters 44-45:
 1 | let f13_3 (x : t_vec128) = Marshal.to_bytes x;;
                                                 ^
 Error: This expression has type "t_vec128"
-       but an expression was expected of type "('a : value)"
+       but an expression was expected of type "('a : value_or_null)"
        The layout of t_vec128 is vec128
          because of the definition of t_vec128 at line 1, characters 0-22.
        But the layout of t_vec128 must be a sublayout of value.

--- a/testsuite/tests/typing-layouts-word/basics.ml
+++ b/testsuite/tests/typing-layouts-word/basics.ml
@@ -719,7 +719,7 @@ Line 1, characters 25-26:
 1 | let f13_1 (x : t_word) = x = x;;
                              ^
 Error: This expression has type "t_word" but an expression was expected of type
-         "('a : value)"
+         "('a : value_or_null)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
        But the layout of t_word must be a sublayout of value.
@@ -731,7 +731,7 @@ Line 1, characters 33-34:
 1 | let f13_2 (x : t_word) = compare x x;;
                                      ^
 Error: This expression has type "t_word" but an expression was expected of type
-         "('a : value)"
+         "('a : value_or_null)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
        But the layout of t_word must be a sublayout of value.
@@ -743,7 +743,7 @@ Line 1, characters 42-43:
 1 | let f13_3 (x : t_word) = Marshal.to_bytes x;;
                                               ^
 Error: This expression has type "t_word" but an expression was expected of type
-         "('a : value)"
+         "('a : value_or_null)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
        But the layout of t_word must be a sublayout of value.

--- a/testsuite/tests/typing-layouts-word/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-word/basics_alpha.ml
@@ -712,7 +712,7 @@ Line 1, characters 25-26:
 1 | let f13_1 (x : t_word) = x = x;;
                              ^
 Error: This expression has type "t_word" but an expression was expected of type
-         "('a : value)"
+         "('a : value_or_null)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
        But the layout of t_word must be a sublayout of value.
@@ -724,7 +724,7 @@ Line 1, characters 33-34:
 1 | let f13_2 (x : t_word) = compare x x;;
                                      ^
 Error: This expression has type "t_word" but an expression was expected of type
-         "('a : value)"
+         "('a : value_or_null)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
        But the layout of t_word must be a sublayout of value.
@@ -736,7 +736,7 @@ Line 1, characters 42-43:
 1 | let f13_3 (x : t_word) = Marshal.to_bytes x;;
                                               ^
 Error: This expression has type "t_word" but an expression was expected of type
-         "('a : value)"
+         "('a : value_or_null)"
        The layout of t_word is word
          because of the definition of t_word at line 1, characters 0-18.
        But the layout of t_word must be a sublayout of value.

--- a/testsuite/tests/typing-missing-cmi/test.compilers.reference
+++ b/testsuite/tests/typing-missing-cmi/test.compilers.reference
@@ -2,7 +2,7 @@ File "main.ml", line 1, characters 8-11:
 1 | let _ = A.a = B.b
             ^^^
 Error: This expression has type "M.a" but an expression was expected of type
-         "('a : value)"
+         "('a : value_or_null)"
        The layout of M.a is any
          because the .cmi file for M.a is missing.
        But the layout of M.a must be a sublayout of value.


### PR DESCRIPTION
Annotate modules in `Stdlib` as working with `value_or_null`.

A notable omission are the `Hashtbl`, `Map` and `Set` modules. All of those can be made to work with `or_null`, but the changes to the key interface would be nontrivial.

Another omission is the `Array` module -- supporting `or_null` values in arrays requires separability. `Weak` hash tables also store their data in arrays.

`Atomic` is omitted pending minor changes to the middle end to propagate kind information correctly.