### PR TITLE
Add `Mode.Crossing`

### DIFF
--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -89,7 +89,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
-          value_mode global,many,portable,unyielding;join(aliased,contended)(modevar#1[aliased,contended .. unique,uncontended])
+          value_mode global,many,portable,unyielding;imply(unique,uncontended)(modevar#1[aliased,contended .. unique,uncontended])
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
           alloc_mode global,many,portable,unyielding;id(modevar#7[aliased,contended .. unique,uncontended])

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -89,7 +89,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern 
           Tpat_var "fib"
-          value_mode global,many,portable,unyielding;join(aliased,contended)(modevar#1[aliased,contended .. unique,uncontended])
+          value_mode global,many,portable,unyielding;imply(unique,uncontended)(modevar#1[aliased,contended .. unique,uncontended])
         expression 
           Texp_function
           alloc_mode global,many,portable,unyielding;id(modevar#7[aliased,contended .. unique,uncontended])

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -298,8 +298,8 @@ Error: Signature mismatch:
        [@@unsafe_allow_any_mode_crossing]
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their mod-bounds are not equal:
-         the first has mod-bounds: portable unique
-         but the second has mod-bounds: unique
+         the first has mod-bounds: portable contended
+         but the second has mod-bounds: contended
 |}]
 
 module A : sig

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4974,18 +4974,10 @@ let mode_cross_left_alloc env ty mode =
   if not (is_principal ty) then Alloc.disallow_right mode else begin
     let jkind = type_jkind_purely env ty in
     let jkind_of_type = type_jkind_purely_if_principal env in
-    let Jkind.{ upper_bounds; lower_bounds } =
-      Jkind.get_modal_bounds ~jkind_of_type jkind
-    in
-    let upper_bounds =
-      Alloc.Const.merge
-        { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
-    in
-    let lower_bounds =
-      Alloc.Const.merge
-        { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }
-    in
-    Alloc.subtract lower_bounds (Alloc.meet_const upper_bounds mode)
+    let crossing = Jkind.get_mode_crossing ~jkind_of_type jkind in
+    mode
+    |> Alloc.disallow_right
+    |> Crossing.apply_left_alloc crossing
   end
 
 (* This is very similar to Typecore.expect_mode_cross. Any bugs here
@@ -4994,18 +4986,10 @@ let mode_cross_right env ty mode =
   if not (is_principal ty) then Alloc.disallow_left mode else
   let jkind = type_jkind_purely env ty in
   let jkind_of_type = type_jkind_purely_if_principal env in
-  let Jkind.{ upper_bounds; lower_bounds } =
-    Jkind.get_modal_bounds ~jkind_of_type jkind
-  in
-  let upper_bounds =
-    Alloc.Const.merge
-      { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
-  in
-  let lower_bounds =
-    Alloc.Const.merge
-      { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }
-  in
-  Alloc.imply upper_bounds (Alloc.join_const lower_bounds mode)
+  let crossing = Jkind.get_mode_crossing ~jkind_of_type jkind in
+  mode
+  |> Alloc.disallow_left
+  |> Crossing.apply_right_alloc crossing
 
 let submode_with_cross env ~is_ret ty l r =
   let r' = mode_cross_right env ty r in

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -628,34 +628,12 @@ let report_unsafe_mode_crossing_mismatch first second ppf e =
   | Mode_crossing_not_equal (first_mb, second_mb) ->
     (* CR layouts v2.8: It'd be nice to specifically highlight the offending axis,
        rather than printing all axes here. *)
-    let umc_to_mod_bound_list
-          { modal_upper_bounds = { areality; linearity; portability; yielding };
-            modal_lower_bounds = { uniqueness; contention } }
-      =
-      let value_for_axis (type a) (module Ax : Mode_intf.Lattice with type t = a) (ax : a) =
-        if Ax.equal Ax.max ax
-        then None
-        else Some (Format.asprintf "%a" Ax.print ax)
-      in
-      List.filter_map Fun.id
-        [ value_for_axis (module Mode.Locality.Const) areality
-        ; value_for_axis (module Mode.Linearity.Const) linearity
-        ; value_for_axis (module Mode.Portability.Const) portability
-        ; value_for_axis (module Mode.Yielding.Const) yielding
-        ; value_for_axis (module Mode.Uniqueness.Const) uniqueness
-        ; value_for_axis (module Mode.Contention.Const) contention
-        ]
-    in
     pr "Both specify [%@%@unsafe_allow_any_mode_crossing], but their \
         mod-bounds are not equal:@ \
         %s has mod-bounds:@ @[<h 4>%a@]@ \
         but %s has mod-bounds:@ @[<h 4>%a@]"
-      first
-      (Format.pp_print_list ~pp_sep:Format.pp_print_space Format.pp_print_string)
-      (umc_to_mod_bound_list first_mb)
-      second
-      (Format.pp_print_list ~pp_sep:Format.pp_print_space Format.pp_print_string)
-      (umc_to_mod_bound_list second_mb)
+      first Mode.Crossing.print first_mb
+      second Mode.Crossing.print second_mb
 
 let report_type_mismatch first second decl env ppf err =
   let pr fmt = Format.fprintf ppf fmt in

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -56,20 +56,8 @@ type mmodes =
    there, too. *)
 let right_mode_cross_jkind env jkind mode =
   let jkind_of_type = Ctype.type_jkind_purely_if_principal env in
-  let Jkind.{ upper_bounds; lower_bounds } =
-    Jkind.get_modal_bounds ~jkind_of_type jkind
-  in
-  let upper_bounds =
-    Alloc.Const.merge
-      { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
-  in
-  let upper_bounds = Const.alloc_as_value upper_bounds in
-  let lower_bounds =
-    Alloc.Const.merge
-      { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }
-  in
-  let lower_bounds = Const.alloc_as_value lower_bounds in
-  Value.imply upper_bounds (Value.join_const lower_bounds mode)
+  let crossing = Jkind.get_mode_crossing ~jkind_of_type jkind in
+  Crossing.apply_right crossing mode
 
 let right_mode_cross env ty mode =
   if not (Ctype.is_principal ty) then mode else
@@ -78,20 +66,8 @@ let right_mode_cross env ty mode =
 
 let left_mode_cross_jkind env jkind mode =
   let jkind_of_type = Ctype.type_jkind_purely_if_principal env in
-  let Jkind.{ upper_bounds; lower_bounds } =
-    Jkind.get_modal_bounds ~jkind_of_type jkind
-  in
-  let upper_bounds =
-    Alloc.Const.merge
-      { comonadic = upper_bounds; monadic = Alloc.Monadic.Const.max }
-  in
-  let upper_bounds = Const.alloc_as_value upper_bounds in
-  let lower_bounds =
-    Alloc.Const.merge
-      { comonadic = Alloc.Comonadic.Const.min; monadic = lower_bounds }
-  in
-  let lower_bounds = Const.alloc_as_value lower_bounds in
-  Value.subtract lower_bounds (Value.meet_const upper_bounds mode)
+  let crossing = Jkind.get_mode_crossing ~jkind_of_type jkind in
+  Crossing.apply_left crossing mode
 
 let left_mode_cross env ty mode=
   if not (Ctype.is_principal ty) then mode else

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2212,6 +2212,10 @@ let get_modal_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) =
         }
     }
 
+let get_mode_crossing (type l r) ~jkind_of_type (jk : (l * r) jkind) =
+  let { upper_bounds; lower_bounds } = get_modal_bounds ~jkind_of_type jk in
+  Mode.Crossing.of_bounds { monadic = lower_bounds; comonadic = upper_bounds }
+
 let all_except_externality =
   Axis_set.singleton (Nonmodal Externality) |> Axis_set.complement
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2187,11 +2187,6 @@ let get_layout jk : Layout.Const.t option = Layout.get_const jk.jkind.layout
 
 let extract_layout jk = jk.jkind.layout
 
-type modal_bounds =
-  { upper_bounds : Mode.Alloc.Comonadic.Const.t;
-    lower_bounds : Mode.Alloc.Monadic.Const.t
-  }
-
 let get_modal_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) =
   let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
           (_ * allowed) jkind_desc),
@@ -2200,21 +2195,21 @@ let get_modal_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) =
       ~skip_axes:Axis_set.all_nonmodal_axes ~jkind_of_type jk.jkind
   in
   Mod_bounds.
-    { upper_bounds =
+    { comonadic =
         { areality = locality mod_bounds;
           linearity = linearity mod_bounds;
           portability = portability mod_bounds;
           yielding = yielding mod_bounds
         };
-      lower_bounds =
+      monadic =
         { uniqueness = uniqueness mod_bounds;
           contention = contention mod_bounds
         }
     }
 
 let get_mode_crossing (type l r) ~jkind_of_type (jk : (l * r) jkind) =
-  let { upper_bounds; lower_bounds } = get_modal_bounds ~jkind_of_type jk in
-  Mode.Crossing.of_bounds { monadic = lower_bounds; comonadic = upper_bounds }
+  let bounds = get_modal_bounds ~jkind_of_type jk in
+  Mode.Crossing.of_bounds bounds
 
 let all_except_externality =
   Axis_set.singleton (Nonmodal Externality) |> Axis_set.complement

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -527,20 +527,6 @@ val get_layout : 'd Types.jkind -> Layout.Const.t option
 (** Gets the layout of a jkind, without looking through sort variables. *)
 val extract_layout : 'd Types.jkind -> Sort.t Layout.t
 
-(** This could be [Mode.monadic_comonadic], but redefining here makes the
-    upper-bound/lower-bound distinction more obvious. *)
-type modal_bounds =
-  { upper_bounds : Mode.Alloc.Comonadic.Const.t;
-    lower_bounds : Mode.Alloc.Monadic.Const.t
-  }
-
-(** Gets the maximum comonadic modes and the minimum monadic modes for types
-    of this jkind. *)
-val get_modal_bounds :
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
-  'd Types.jkind ->
-  modal_bounds
-
 (** Gets the mode crossing for types of this jkind. *)
 val get_mode_crossing :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -541,6 +541,12 @@ val get_modal_bounds :
   'd Types.jkind ->
   modal_bounds
 
+(** Gets the mode crossing for types of this jkind. *)
+val get_mode_crossing :
+  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  'd Types.jkind ->
+  Mode.Crossing.t
+
 val get_externality_upper_bound :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
   'd Types.jkind ->

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3086,13 +3086,24 @@ module Crossing = struct
     let comonadic = Comonadic.apply_right t.comonadic comonadic in
     { monadic; comonadic }
 
+  (* Our mode crossing is for [Value] modes, but can be extended to [Alloc]
+     modes via [alloc_as_value], defined as follows:
+
+     Given a mode crossing [f] for [Value], and we are to check [Alloc] submoding
+     [m0 <= m1], we will instead check
+     [f (alloc_as_value m0) <= f (alloc_as_value m1)].
+
+     By adjunction tricks, this is equivalent to
+     - [ m0 <= regional_to_global ∘ fr ∘ f ∘ alloc_as_value m1 ]
+     - [ regional_to_local ∘ fl ∘ f ∘ alloc_as_value m0 <= m1 ]
+     where [regional_to_global] is the right adjoint of [alloc_as_value], and
+     [regional_to_local] the left adjoint. *)
+
   let apply_left_alloc t m =
-    m |> alloc_as_value |> apply_left t
-    |> value_to_alloc_r2l (* the left adjoint of [alloc_as_value] *)
+    m |> alloc_as_value |> apply_left t |> value_to_alloc_r2l
 
   let apply_right_alloc t m =
-    m |> alloc_as_value |> apply_right t
-    |> value_to_alloc_r2g (* the right adjoint of [alloc_as_value] *)
+    m |> alloc_as_value |> apply_right t |> value_to_alloc_r2g
 
   let apply_left_right_alloc t { monadic; comonadic } =
     let monadic = Monadic.apply_right t.monadic monadic in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3024,7 +3024,7 @@ module Crossing = struct
 
     let of_bounds c : t = Join_const c
 
-    let modality m t = Modality.concat ~then_:m t
+    let modality m t = Modality.concat ~then_:t m
 
     let apply_left : t -> _ -> _ = function
       | Join_const c -> fun m -> Mode.subtract c (Mode.join_const c m)
@@ -3049,7 +3049,7 @@ module Crossing = struct
       let c = C.apply Mode.Obj.obj (Map_comonadic Locality_as_regionality) c in
       Meet_const c
 
-    let modality m t = Modality.concat ~then_:m t
+    let modality m t = Modality.concat ~then_:t m
 
     let apply_left : t -> _ -> _ = function
       | Meet_const c ->

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3119,5 +3119,14 @@ module Crossing = struct
   let le t0 t1 =
     Monadic.le t0.monadic t1.monadic && Comonadic.le t0.comonadic t1.comonadic
 
-  let print ppf t = Modality.Value.Const.print ppf t
+  let print ppf t =
+    let print_atom ppf = function
+      | Modality.Atom (ax, Join_with c) -> C.print (Value.proj_obj ax) ppf c
+      | Modality.Atom (ax, Meet_with c) -> C.print (Value.proj_obj ax) ppf c
+    in
+    let l =
+      t |> Modality.Value.Const.to_list
+      |> List.filter (fun t -> not @@ Modality.is_id t)
+    in
+    Format.(pp_print_list ~pp_sep:pp_print_space print_atom ppf l)
 end

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3013,7 +3013,8 @@ module Crossing = struct
      Mode crossing forms a lattice: [f0 <= f1] iff [f0] allows more mode
      crossing than [f1]. Concretely:
 
-     For any [m0, m1], if [f1 m0 <= f1 m1], then [f0 m0 <= f0 m1].
+     [f0 <= f1] iff, for any [m0, m1], if [f1 m0 <= f1 m1],
+     then [f0 m0 <= f0 m1].
   *)
 
   module Monadic = struct

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -722,5 +722,11 @@ module type S = sig
 
     (** Similar to [apply_right] but for [Alloc] *)
     val apply_right_alloc : t -> Alloc.r -> Alloc.r
+
+    (** [le t0 t1] returns [true] if [t0] allows more mode crossing than [t1]. *)
+    val le : t -> t -> bool
+
+    (** Print the mode crossing by axis. Omit axes that do not cross. *)
+    val print : Format.formatter -> t -> unit
   end
 end

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -717,10 +717,10 @@ module type S = sig
        [alloc_as_value] are indistinguishable. Currently types cross locality
        either fully or fully not, and therefore [alloc_as_value] seems sufficient. *)
 
-    (** Similar to [apply_left] but for [Alloc] *)
+    (** Similar to [apply_left] but for [Alloc] via [alloc_as_value] *)
     val apply_left_alloc : t -> Alloc.l -> Alloc.l
 
-    (** Similar to [apply_right] but for [Alloc] *)
+    (** Similar to [apply_right] but for [Alloc] via [alloc_as_value] *)
     val apply_right_alloc : t -> Alloc.r -> Alloc.r
 
     (** Apply mode crossong on the left comonadic fragment, and the right

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -723,6 +723,13 @@ module type S = sig
     (** Similar to [apply_right] but for [Alloc] *)
     val apply_right_alloc : t -> Alloc.r -> Alloc.r
 
+    (** Apply mode crossong on the left comonadic fragment, and the right
+        monadic fragment. *)
+    val apply_left_right_alloc :
+      t ->
+      (Alloc.Monadic.r, Alloc.Comonadic.l) monadic_comonadic ->
+      (Alloc.Monadic.r, Alloc.Comonadic.l) monadic_comonadic
+
     (** [le t0 t1] returns [true] if [t0] allows more mode crossing than [t1]. *)
     val le : t -> t -> bool
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -682,4 +682,45 @@ module type S = sig
       val max : t
     end
   end
+
+  module Crossing : sig
+    (** The mode crossing capability pertaining to a type.
+
+    Some modes might be indistinguishable for values of some type, in which case
+    the actual/expected mode of values can be adjusted accordingly to make more
+    programs mode-check. The adjustment is called mode crossing. *)
+    type t
+
+    (* CR zqian: Complete the lattice structure of mode crossing. *)
+
+    (* CR zqian: jkind modal bounds should just be our [t]. In particular, jkind
+       should infer the modal bounds of a type in the form of [Value] instead of
+       [Alloc]. For example, a type could have [regional] modality, in which case
+       it can cross to [regional] but not [global]. *)
+
+    (** Convert from jkind modal bounds. *)
+    val of_bounds :
+      (Alloc.Monadic.Const.t, Alloc.Comonadic.Const.t) monadic_comonadic -> t
+
+    (** [modality m t] gives the mode crossing of type [T] wrapped in modality
+    [m] where [T] has mode crossing [t]. *)
+    val modality : Modality.Value.Const.t -> t -> t
+
+    (** Apply mode crossing on a left mode, making it stronger. *)
+    val apply_left : t -> Value.l -> Value.l
+
+    (** Apply mode crossing on a right mode, making it more permissive. *)
+    val apply_right : t -> Value.r -> Value.r
+
+    (* We extend mode crossing on [Value] to [Alloc] via [alloc_as_value].
+       Concretely, two [Alloc] modes are indistinguishable if their image under
+       [alloc_as_value] are indistinguishable. Currently types cross locality
+       either fully or fully not, and therefore [alloc_as_value] seems sufficient. *)
+
+    (** Similar to [apply_left] but for [Alloc] *)
+    val apply_left_alloc : t -> Alloc.l -> Alloc.l
+
+    (** Similar to [apply_right] but for [Alloc] *)
+    val apply_right_alloc : t -> Alloc.r -> Alloc.r
+  end
 end

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -713,7 +713,7 @@ module type S = sig
     val apply_right : t -> Value.r -> Value.r
 
     (* We extend mode crossing on [Value] to [Alloc] via [alloc_as_value].
-       Concretely, two [Alloc] modes are indistinguishable if their image under
+       Concretely, two [Alloc] modes are indistinguishable if their images under
        [alloc_as_value] are indistinguishable. Currently types cross locality
        either fully or fully not, and therefore [alloc_as_value] seems sufficient. *)
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -958,12 +958,8 @@ let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
   if not (is_principal ty) then { monadic; comonadic } else
   let jkind = type_jkind_purely env ty in
   let jkind_of_type = type_jkind_purely_if_principal env in
-  let Jkind.{ upper_bounds; lower_bounds } =
-    Jkind.get_modal_bounds ~jkind_of_type jkind
-  in
-  let comonadic = Alloc.Comonadic.meet_const upper_bounds comonadic in
-  let monadic = Alloc.Monadic.join_const lower_bounds monadic in
-  { monadic; comonadic }
+  let crossing = Jkind.get_mode_crossing ~jkind_of_type jkind in
+  Crossing.apply_left_right_alloc crossing { monadic; comonadic }
 
 (** Mode cross a right mode *)
 (* This is very similar to Ctype.mode_cross_right. Any bugs here are likely bugs

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2592,11 +2592,7 @@ let normalize_decl_jkinds env shapes decls =
             | Error () ->
               raise(Error(decl.type_loc, Unsafe_mode_crossing_with_with_bounds))
           in
-          let bounds = Jkind.get_modal_bounds ~jkind_of_type type_jkind in
-          let umc =
-            Some { modal_upper_bounds = bounds.upper_bounds
-                  ; modal_lower_bounds = bounds.lower_bounds }
-          in
+          let umc = Some (Jkind.get_mode_crossing ~jkind_of_type type_jkind) in
           let type_kind =
             match decl.type_kind with
             | Type_abstract _ | Type_open -> assert false (* Checked above *)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -537,9 +537,7 @@ type type_declaration =
 and type_decl_kind =
   (label_declaration, label_declaration, constructor_declaration) type_kind
 
-and unsafe_mode_crossing =
-  { modal_upper_bounds : Mode.Alloc.Comonadic.Const.t;
-    modal_lower_bounds : Mode.Alloc.Monadic.Const.t }
+and unsafe_mode_crossing = Mode.Crossing.t
 
 and ('lbl, 'lbl_flat, 'cstr) type_kind =
     Type_abstract of type_origin
@@ -1076,14 +1074,7 @@ let mixed_block_element_to_lowercase_string = function
   | Word -> "word"
 
 let equal_unsafe_mode_crossing umc1 umc2 =
-    let { modal_upper_bounds = mub1;
-          modal_lower_bounds = mlb1 } = umc1 in
-    let { modal_upper_bounds = mub2;
-          modal_lower_bounds = mlb2 } = umc2 in
-    Mode.Alloc.Comonadic.Const.le mub1 mub2
-    && Mode.Alloc.Comonadic.Const.le mub2 mub1
-    && Mode.Alloc.Monadic.Const.le mlb1 mlb2
-    && Mode.Alloc.Monadic.Const.le mlb2 mlb1
+  Misc.Le_result.equal ~le:Mode.Crossing.le umc1 umc2
 
 (**** Definitions for backtracking ****)
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -706,9 +706,7 @@ type type_declaration =
 
 and type_decl_kind = (label_declaration, label_declaration, constructor_declaration) type_kind
 
-and unsafe_mode_crossing =
-  { modal_upper_bounds : Mode.Alloc.Comonadic.Const.t;
-    modal_lower_bounds : Mode.Alloc.Monadic.Const.t }
+and unsafe_mode_crossing = Mode.Crossing.t
 
 and ('lbl, 'lbl_flat, 'cstr) type_kind =
     Type_abstract of type_origin


### PR DESCRIPTION
This is a reduced version of #2527 so we can merge it sooner.

This PR adds `Mode.Crossing.t`, which describes the mode crossing capability of a type. The main benefit is to have a single place describing and implementing mode crossing, which involves subtleties around adjunction and specific mode system details.

Jkind modal bounds are not touched since @glittershark is doing some performance tuning that are incompatible with this PR. Conversion from jkind modal bounds are provided. In the future we will do similiar performance tuning for `Mode.Crossing.t` so they can be used directly in jkind.

Please review by commits.