### PR TITLE
Add fast-path to get_nullability

### DIFF
--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -568,9 +568,10 @@ module With_bounds = struct
     | No_with_bounds -> With_bounds_types.empty
     | With_bounds bounds -> bounds
 
-  let to_seq : type d. d with_bounds -> _ = function
-    | No_with_bounds -> Seq.empty
-    | With_bounds tys -> With_bounds_types.to_seq tys
+  let for_all (type l r) f (t : (l * r) t) =
+    match t with
+    | No_with_bounds -> true
+    | With_bounds tys -> With_bounds_types.for_all f tys
 
   let to_list : type d. d with_bounds -> _ = function
     | No_with_bounds -> []
@@ -2253,8 +2254,9 @@ let get_nullability ~jkind_of_type jk =
   (* Optimization: Usually, no with-bounds are relevant to nullability. If we check for
      this case, we can avoid calling normalize. *)
   let all_with_bounds_are_irrelevant =
-    jk.jkind.with_bounds |> With_bounds.to_seq
-    |> Seq.for_all (fun (_, ({ relevant_axes } : With_bounds_type_info.t)) ->
+    jk.jkind.with_bounds
+    |> With_bounds.for_all
+         (fun _ ({ relevant_axes } : With_bounds_type_info.t) ->
            not (Axis_set.mem relevant_axes (Nonmodal Nullability)))
   in
   if all_with_bounds_are_irrelevant

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2250,12 +2250,14 @@ let set_externality_upper_bound jk externality_upper_bound =
 let only_nullability = Axis_set.singleton (Nonmodal Nullability)
 
 let get_nullability ~jkind_of_type jk =
-  let all_irrelevant =
+  (* Optimization: Usually, no with-bounds are relevant to nullability. If we check for
+     this case, we can avoid calling normalize. *)
+  let all_with_bounds_are_irrelevant =
     jk.jkind.with_bounds |> With_bounds.to_seq
     |> Seq.for_all (fun (_, ({ relevant_axes } : With_bounds_type_info.t)) ->
            not (Axis_set.mem relevant_axes (Nonmodal Nullability)))
   in
-  if all_irrelevant
+  if all_with_bounds_are_irrelevant
   then Mod_bounds.nullability jk.jkind.mod_bounds
   else
     let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -609,10 +609,7 @@ module With_bounds = struct
   let map_type_expr (type l r) f : (l * r) t -> (l * r) t = function
     | No_with_bounds -> No_with_bounds
     | With_bounds tys ->
-      With_bounds
-        (tys |> With_bounds_types.to_seq
-        |> Seq.map (fun (ty, ti) -> f ty, ti)
-        |> With_bounds_types.of_seq)
+      With_bounds (With_bounds_types.map_with_key (fun ty ti -> f ty, ti) tys)
 
   let debug_print (type l r) ~print_type_expr ppf : (l * r) t -> _ =
     let open Format in

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -1154,6 +1154,7 @@ module With_bounds_types : sig
   val of_seq : (type_expr * info) Seq.t -> t
   val singleton : type_expr -> info -> t
   val map : (info -> info) -> t -> t
+  val map_with_key : (type_expr -> info -> type_expr * info) -> t -> t
   val merge
     : (type_expr -> info option -> info option -> info option) ->
     t -> t -> t
@@ -1185,6 +1186,10 @@ end = struct
   let update te f t = update te f (to_map t) |> of_map
   let find_opt te t = find_opt te (to_map t)
   let for_all f t = for_all f (to_map t)
+  let map_with_key f t =
+    fold (fun key value acc ->
+      let key, value = f key value in
+      M.add key value acc) (to_map t) M.empty |> of_map
 end
 
 (* Constructor and accessors for [row_desc] *)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -1159,6 +1159,7 @@ module With_bounds_types : sig
     t -> t -> t
   val update : type_expr -> (info option -> info option) -> t -> t
   val find_opt : type_expr -> t -> info option
+  val for_all : (type_expr -> info -> bool) -> t -> bool
 end = struct
   module M = Map.Make(struct
       type t = type_expr
@@ -1183,6 +1184,7 @@ end = struct
   let merge f t1 t2 = merge f (to_map t1) (to_map t2) |> of_map
   let update te f t = update te f (to_map t) |> of_map
   let find_opt te t = find_opt te (to_map t)
+  let for_all f t = for_all f (to_map t)
 end
 
 (* Constructor and accessors for [row_desc] *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -367,6 +367,7 @@ module With_bounds_types : sig
   val update : type_expr -> (info option -> info option) -> t -> t
   val find_opt : type_expr -> t -> info option
   val for_all : (type_expr -> info -> bool) -> t -> bool
+  val map_with_key : (type_expr -> info -> type_expr * info) -> t -> t
 end
 
 val is_commu_ok: commutable -> bool

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -366,6 +366,7 @@ module With_bounds_types : sig
     t -> t -> t
   val update : type_expr -> (info option -> info option) -> t -> t
   val find_opt : type_expr -> t -> info option
+  val for_all : (type_expr -> info -> bool) -> t -> bool
 end
 
 val is_commu_ok: commutable -> bool


### PR DESCRIPTION
When `-infer-with-bounds` is on, we currently spend a lot of time in `get_externality` and `get_nullability`, even though usually none of the with-bounds are relevant.

The branch https://github.com/goldfirere/flambda-backend/tree/rae/optimize-normalize fixes this for the `get_externality` case by adding a fast-path to `normalize` for when all relevant axes are max. But this doesn't work for `get_nullability` because most types are `Non_null`, which is not max.

One way to speed this up would be to add a fast-path to `normalize` (ie, avoid calling `loop`) for when none of the with-bounds are relevant. But this actually seems to slow things down. Empirically, the time overall spent in `normalize` ticked up slightly by adding this check.

Rather, this PR simply adds a special case to nullability where it avoids calling `normalize` when no with-bounds are relevant. When this patch is applied to https://github.com/goldfirere/flambda-backend/tree/rae/optimize-normalize (as of time of writing this), it drops the share of time spent in `get_nullability` when compiling `typecore.ml` from 5.8% to 0.8% (on main, it drops from 3.8% to 0.5%).