### PR TITLE
Revert "AddressSanitizer build compatibility fixes"

### DIFF
--- a/build_ocaml_compiler.sexp
+++ b/build_ocaml_compiler.sexp
@@ -24,6 +24,5 @@
    stack_allocation
    poll_insertion
    runtime5
-   address_sanitizer
    ))
  )

--- a/configure.ac
+++ b/configure.ac
@@ -2640,7 +2640,7 @@ AS_IF([test x"$enable_frame_pointers" = "xyes" -o x"$enable_address_sanitizer" =
 ## Address Sanitizer
 
 AS_IF([test x"$enable_address_sanitizer" = "xyes"],
-  [AS_CASE(["$host,$ocaml_cc_vendor"],
+  [AS_CASE(["$host,$cc_basename"],
     [x86_64-*-linux*,gcc-*|x86_64-*-linux*,clang-*],
       [common_cflags="$common_cflags -fsanitize=address -fsanitize-recover=address"
        oc_ldflags="$oc_ldflags -fsanitize=address -fsanitize-recover=address"


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#3607

This broke our internal build infrastructure. We'll re-revert once that's fixed.