### PR TITLE
Specialize comparisons in presence of `immediate_or_null` correctly.

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2333,7 +2333,7 @@ let get_expr_args_record ~scopes head (arg, _mut, sort, layout) rem =
     else
       let lbl = all_labels.(pos) in
       sort_check_not_void head.pat_loc lbl.lbl_sort;
-      let ptr = Typeopt.maybe_pointer_type head.pat_env lbl.lbl_arg in
+      let ptr, _ = Typeopt.maybe_pointer_type head.pat_env lbl.lbl_arg in
       let lbl_layout = Typeopt.layout_of_sort lbl.lbl_loc lbl.lbl_sort in
       let sem =
         if Types.is_mutable lbl.lbl_mut then Reads_vary else Reads_agree

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -102,7 +102,8 @@ let transl_meth_list lst =
             (0, List.map (fun lab -> Const_immstring lab) lst))
 
 let set_inst_var ~scopes obj id expr =
-  Lprim(Psetfield_computed (Typeopt.maybe_pointer expr, Assignment modify_heap),
+  let ptr_or_imm, _ = Typeopt.maybe_pointer expr in
+  Lprim(Psetfield_computed (ptr_or_imm, Assignment modify_heap),
     [Lvar obj; Lvar id; transl_exp ~scopes Jkind.Sort.Const.for_instance_var expr],
         Loc_unknown)
 

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1432,7 +1432,9 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       Some (Comparison(comp, Compare_ints))
     end else if (is_base_type env p1 Predef.path_int
         || is_base_type env p1 Predef.path_char
-        || (maybe_pointer_type env p1 = Immediate)) then begin
+        || ((* Non-null external types are always represented by tagged integers. *)
+            maybe_pointer_type env p1 = Immediate
+            && Ctype.check_type_nullability env p1 Non_null)) then begin
       Some (Comparison(comp, Compare_ints))
     end else if is_base_type env p1 Predef.path_float then begin
       Some (Comparison(comp, Compare_floats))

--- a/otherlibs/stdlib_beta/or_null.ml
+++ b/otherlibs/stdlib_beta/or_null.ml
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
+type 'a t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
 
 let null = Null
 let this v = This v

--- a/otherlibs/stdlib_beta/or_null.mli
+++ b/otherlibs/stdlib_beta/or_null.mli
@@ -24,9 +24,9 @@
 (* CR layouts: enable ocamlformat for this module when it starts supporting
    jkind annotations. *)
 
-type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
+type 'a t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
       (** The type of nullable values. Either [Null] or a value [This v].
-          ['a or_null] has a non-standard layout [value_or_null],
+          ['a or_null] has a non-standard [immediate_or_null with 'a] layout,
           preventing the type constructor from being nested. *)
 
 val null : 'a t

--- a/testsuite/tests/typing-layouts-or-null/containers.ml
+++ b/testsuite/tests/typing-layouts-or-null/containers.ml
@@ -64,8 +64,8 @@ Line 1, characters 21-25:
                          ^^^^
 Error: This expression has type "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a or_null must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.
@@ -130,8 +130,8 @@ Line 1, characters 28-32:
                                 ^^^^
 Error: This expression has type "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a or_null must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -1,0 +1,142 @@
+(* TEST
+ flags = "-extension-universe alpha";
+ expect;
+*)
+
+(* Tests for [immediate_or_null]. *)
+
+(* The [immediate_or_null] layout. *)
+type t_immediate_or_null : immediate_or_null
+[%%expect{|
+type t_immediate_or_null : immediate_or_null
+|}]
+
+(* The subkind relation. *)
+
+type ('a : immediate_or_null) accept_immediate_or_null
+[%%expect{|
+type ('a : immediate_or_null) accept_immediate_or_null
+|}]
+
+type should_work = t_immediate_or_null accept_immediate_or_null
+[%%expect{|
+type should_work = t_immediate_or_null accept_immediate_or_null
+|}]
+
+type should_work = int accept_immediate_or_null
+[%%expect{|
+type should_work = int accept_immediate_or_null
+|}]
+
+type ('a : immediate) accept_immediate
+[%%expect{|
+type ('a : immediate) accept_immediate
+|}]
+
+type should_fail = t_immediate_or_null accept_immediate
+[%%expect{|
+Line 1, characters 19-38:
+1 | type should_fail = t_immediate_or_null accept_immediate
+                       ^^^^^^^^^^^^^^^^^^^
+Error: This type "t_immediate_or_null" should be an instance of type
+         "('a : immediate)"
+       The kind of t_immediate_or_null is immediate_or_null
+         because of the definition of t_immediate_or_null at line 1, characters 0-44.
+       But the kind of t_immediate_or_null must be a subkind of immediate
+         because of the definition of accept_immediate at line 1, characters 0-38.
+|}]
+
+type ('a : value) accept_value
+[%%expect{|
+type 'a accept_value
+|}]
+
+type should_fail = t_immediate_or_null accept_value
+[%%expect{|
+Line 1, characters 19-38:
+1 | type should_fail = t_immediate_or_null accept_value
+                       ^^^^^^^^^^^^^^^^^^^
+Error: This type "t_immediate_or_null" should be an instance of type
+         "('a : value)"
+       The kind of t_immediate_or_null is immediate_or_null
+         because of the definition of t_immediate_or_null at line 1, characters 0-44.
+       But the kind of t_immediate_or_null must be a subkind of value
+         because of the definition of accept_value at line 1, characters 0-30.
+|}]
+
+type ('a : value_or_null) accept_value_or_null
+
+type should_work = t_immediate_or_null accept_value_or_null
+[%%expect{|
+type 'a accept_value_or_null
+type should_work = t_immediate_or_null accept_value_or_null
+|}]
+
+(* [int or_null] fits into [immediate_or_null]: *)
+
+
+type int_or_null : immediate_or_null = int or_null
+[%%expect{|
+type int_or_null = int or_null
+|}]
+
+type should_work = int_or_null accept_immediate_or_null
+[%%expect{|
+type should_work = int_or_null accept_immediate_or_null
+|}]
+
+(* CR layouts v2.8: this is a bug in principal inference with with-kinds. *)
+
+type should_work = int or_null accept_immediate_or_null
+[%%expect{|
+type should_work = int or_null accept_immediate_or_null
+|}, Principal{|
+Line 1, characters 19-30:
+1 | type should_work = int or_null accept_immediate_or_null
+                       ^^^^^^^^^^^
+Error: This type "int or_null" should be an instance of type
+         "('a : immediate_or_null)"
+       The kind of int or_null is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of immediate_or_null
+         because of the definition of accept_immediate_or_null at line 1, characters 0-54.
+|}]
+
+(* Values. *)
+
+type ('a : immediate_or_null) myref = { mutable v : 'a }
+
+external read_imm : ('a : immediate_or_null) . 'a myref -> 'a = "%field0"
+external write_imm : ('a : immediate_or_null) . 'a myref -> 'a -> unit = "%setfield0"
+external equal : ('a : immediate_or_null) . 'a -> 'a -> bool = "%equal"
+
+[%%expect{|
+type ('a : immediate_or_null) myref = { mutable v : 'a; }
+external read_imm : ('a : immediate_or_null). 'a myref -> 'a = "%field0"
+external write_imm : ('a : immediate_or_null). 'a myref -> 'a -> unit
+  = "%setfield0"
+external equal : ('a : immediate_or_null). 'a -> 'a -> bool = "%equal"
+|}]
+
+(* CR layouts v2.8: this is a bug in principal inference with with-kinds. *)
+
+let () =
+  let r = { v = (Null : int or_null) } in
+  let x = read_imm r in
+  assert (equal x Null);
+  write_imm r (This 5);
+  assert (equal r.v (This 5))
+;;
+
+[%%expect{|
+|}, Principal{|
+Line 2, characters 16-36:
+2 |   let r = { v = (Null : int or_null) } in
+                    ^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "int or_null"
+       but an expression was expected of type "('a : immediate_or_null)"
+       The kind of int or_null is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of immediate_or_null
+         because of the definition of myref at line 1, characters 0-56.
+|}]

--- a/testsuite/tests/typing-layouts-or-null/immediate_comparison.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate_comparison.ml
@@ -1,0 +1,19 @@
+(* TEST
+ flags = "-extension-universe beta";
+*)
+
+type int_or_null : value_or_null mod external_
+
+external mk : int or_null -> int_or_null = "%identity"
+
+external compare_int_or_null : int_or_null -> int_or_null -> int = "%compare"
+
+let compare x y = compare_int_or_null (mk x) (mk y)
+
+let () =
+  assert (compare Null Null = 0);
+  assert (compare (This 4) (This 4) = 0);
+  assert (compare Null (This 4) < 0);
+  assert (compare (This 8) Null > 0);
+  assert (compare (This 4) (This 5) < 0);
+;;

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -6,23 +6,23 @@
 (* CR layouts v3.5: ['a or_null] can't be re-exported normally,
    because users can't define their own [Null]-like constructors. *)
 module Or_null = struct
-  type ('a : value) t : value_or_null = 'a or_null =
+  type ('a : value) t : immediate_or_null with 'a = 'a or_null =
     | Null
     | This of 'a
 end
 [%%expect{|
 Lines 2-4, characters 2-16:
-2 | ..type ('a : value) t : value_or_null = 'a or_null =
+2 | ..type ('a : value) t : immediate_or_null with 'a = 'a or_null =
 3 |     | Null
 4 |     | This of 'a
-Error: This variant or record definition does not match that of type
-         "'a or_null"
-       Their internal representations differ:
-       the original definition has a null constructor.
+Error: The kind of type "t" is immutable_data with 'a
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of immediate_or_null with 'a
+         because of the annotation on the declaration of the type t.
 |}]
 
 module Or_null = struct
-  type ('a : value) t : value_or_null = 'a or_null
+  type ('a : value) t : immediate_or_null with 'a = 'a or_null
 end
 [%%expect{|
 module Or_null : sig type 'a t = 'a or_null end
@@ -51,7 +51,7 @@ Error: Unbound constructor "Or_null.This"
 (* [@@or_null_reexport] re-exports those constructors. *)
 
 module Or_null = struct
-  type ('a : value) t : value_or_null = 'a or_null [@@or_null_reexport]
+  type ('a : value) t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
 end
 let n = Or_null.Null
 let t v = Or_null.This v
@@ -62,7 +62,7 @@ val n : 'a Or_null.t = Or_null.Null
 val t : 'a -> 'a Or_null.t = <fun>
 |}]
 
-(* The jkind of [Or_null] is still correctly [value_or_null]. *)
+(* The jkind of [Or_null] is still correctly [immediate_or_null with 'a]. *)
 let fail = Or_null.This (Or_null.This 5)
 
 [%%expect{|
@@ -71,10 +71,10 @@ Line 1, characters 24-40:
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a Or_null.t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a Or_null.t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a Or_null.t must be a subkind of value
-         because of the definition of t at line 2, characters 2-71.
+         because of the definition of t at line 2, characters 2-83.
 |}]
 
 (* Type annotations are not required. *)
@@ -92,8 +92,8 @@ Line 4, characters 24-40:
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a Or_null.t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a Or_null.t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a Or_null.t must be a subkind of value
          because of the definition of t at line 2, characters 2-45.
 |}]
@@ -106,8 +106,8 @@ type 'a t : value = 'a or_null [@@or_null_reexport]
 Line 1, characters 0-51:
 1 | type 'a t : value = 'a or_null [@@or_null_reexport]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a or_null" is value_or_null
-         because it is the primitive value_or_null type or_null.
+Error: The kind of type "'a or_null" is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of type "'a or_null" must be a subkind of value
          because of the definition of t at line 1, characters 0-51.
 |}]
@@ -119,7 +119,7 @@ Line 1, characters 0-53:
 1 | type 'a t : float64 = 'a or_null [@@or_null_reexport]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type "'a or_null" is value
-         because it is the primitive value_or_null type or_null.
+         because it is the primitive immediate_or_null type or_null.
        But the layout of type "'a or_null" must be a sublayout of float64
          because of the definition of t at line 1, characters 0-53.
 |}]
@@ -153,8 +153,8 @@ Line 4, characters 24-40:
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a Or_null.t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a Or_null.t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a Or_null.t must be a subkind of value
          because of the definition of t at line 2, characters 2-63.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/stubs.c
+++ b/testsuite/tests/typing-layouts-or-null/stubs.c
@@ -1,0 +1,5 @@
+#include <caml/mlvalues.h>
+
+int caml_add_untagged(int x, int y) {
+    return x + y;
+}

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -3,7 +3,7 @@
  expect;
 *)
 
-type ('a : value) t : value_or_null = 'a or_null [@@or_null_reexport]
+type ('a : value) t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
 
 [%%expect{|
 type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport]
@@ -99,8 +99,17 @@ Line 1, characters 14-25:
 1 | type nested = int or_null or_null
                   ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type "('a : value)"
-       The kind of int or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of int or_null is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of value
+         because the type argument of or_null has kind value.
+|}, Principal{|
+Line 1, characters 14-25:
+1 | type nested = int or_null or_null
+                  ^^^^^^^^^^^
+Error: This type "int or_null" should be an instance of type "('a : value)"
+       The kind of int or_null is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
        But the kind of int or_null must be a subkind of value
          because the type argument of or_null has kind value.
 |}]
@@ -113,10 +122,10 @@ Line 1, characters 23-31:
                            ^^^^^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a t must be a subkind of value
-         because of the definition of t at line 1, characters 0-69.
+         because of the definition of t at line 1, characters 0-81.
 |}]
 
 let should_also_fail = This Null
@@ -127,10 +136,10 @@ Line 1, characters 28-32:
                                 ^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a t must be a subkind of value
-         because of the definition of t at line 1, characters 0-69.
+         because of the definition of t at line 1, characters 0-81.
 |}]
 
 let mk' n = `Foo (This n)
@@ -192,8 +201,8 @@ Line 1, characters 21-25:
                          ^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a t must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.
@@ -207,8 +216,19 @@ Line 1, characters 19-32:
                        ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of float or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of float or_null is
+         value_or_null mod many contended portable unyielding
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 19-32:
+1 | type should_fail = float or_null array
+                       ^^^^^^^^^^^^^
+Error: This type "float or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of float or_null is immediate_or_null with float
+         because it is the primitive immediate_or_null type or_null.
        But the kind of float or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -235,8 +255,8 @@ Line 1, characters 21-25:
                          ^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a t must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.
@@ -250,8 +270,19 @@ Line 1, characters 19-32:
                        ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of float or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of float or_null is
+         value_or_null mod many contended portable unyielding
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 19-32:
+1 | type should_fail = float or_null array
+                       ^^^^^^^^^^^^^
+Error: This type "float or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of float or_null is immediate_or_null with float
+         because it is the primitive immediate_or_null type or_null.
        But the kind of float or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -264,8 +295,17 @@ Line 1, characters 26-42:
 1 | type object_with_null = < x : int or_null; .. >
                               ^^^^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The kind of "int or_null" is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of "int or_null" is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of "int or_null" must be a subkind of value
+         because it's the type of an object field.
+|}, Principal{|
+Line 1, characters 26-42:
+1 | type object_with_null = < x : int or_null; .. >
+                              ^^^^^^^^^^^^^^^^
+Error: Object field types must have layout value.
+       The kind of "int or_null" is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
        But the kind of "int or_null" must be a subkind of value
          because it's the type of an object field.
 |}]
@@ -281,8 +321,8 @@ Line 3, characters 8-9:
 3 |     val x = Null
             ^
 Error: Variables bound in a class must have layout value.
-       The kind of x is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of x is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of x must be a subkind of value
          because it's the type of a class field.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/untagged.compilers.reference
+++ b/testsuite/tests/typing-layouts-or-null/untagged.compilers.reference
@@ -1,0 +1,5 @@
+File "untagged.ml", line 15, characters 8-19:
+15 |     :  (int_or_null [@untagged])
+             ^^^^^^^^^^^
+Error: Don't know how to untag this type. Only "int"
+       and other immediate types can be untagged.

--- a/testsuite/tests/typing-layouts-or-null/untagged.ml
+++ b/testsuite/tests/typing-layouts-or-null/untagged.ml
@@ -1,0 +1,18 @@
+(* TEST
+ flags = "-extension-universe beta";
+ modules = "stubs.c";
+ ocamlopt_opt_exit_status = "2";
+ setup-ocamlopt.opt-build-env;
+ ocamlopt.opt;
+ check-ocamlopt.opt-output;
+*)
+
+(* [@untagged] attributes are disallowed on [maybe_null] arguments. *)
+
+type int_or_null : value_or_null mod external_
+
+external untagged_add
+    :  (int_or_null [@untagged])
+    -> (int_or_null [@untagged])
+    -> (int_or_null [@untagged])
+    =  "caml_untagged_add"

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2524,6 +2524,7 @@ let check_type_nullability env ty nullability =
   let upper_bound =
     Jkind.set_nullability_upper_bound (Jkind.Builtin.any ~why:Dummy_jkind) nullability
   in
+  (* CR layouts v2.8: We should have a better way to check the upper bound of a jkind along a particular relevant axis than this (also for [check_type_externality], above) *)
   match check_type_jkind env ty upper_bound with
   | Ok () -> true
   | Error _ -> false

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2520,6 +2520,14 @@ let check_type_externality env ty ext =
   | Ok () -> true
   | Error _ -> false
 
+let check_type_nullability env ty nullability =
+  let upper_bound =
+    Jkind.set_nullability_upper_bound (Jkind.Builtin.any ~why:Dummy_jkind) nullability
+  in
+  match check_type_jkind env ty upper_bound with
+  | Ok () -> true
+  | Error _ -> false
+
 let check_type_jkind_exn env texn ty jkind =
   match check_type_jkind env ty jkind with
   | Ok _ -> ()

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -653,6 +653,12 @@ val constrain_type_jkind :
 val check_type_externality :
   Env.t -> type_expr -> Jkind_axis.Externality.t -> bool
 
+(* Check whether a type's nullability is less than some target.
+   Uses get_nullability which is potentially cheaper than calling type_jkind
+   if all with-bounds are irrelevant. *)
+val check_type_nullability :
+  Env.t -> type_expr -> Jkind_axis.Nullability.t -> bool
+
 (* This function should get called after a type is generalized.
 
    It does two things:

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1236,6 +1236,12 @@ module Const = struct
         name = "immediate"
       }
 
+    let immediate_or_null =
+      { jkind =
+          mk_jkind (Base Value) ~mode_crossing:true ~nullability:Maybe_null;
+        name = "immediate_or_null"
+      }
+
     (* [immediate64] describes types that are stored directly (no indirection)
        on 64-bit platforms but indirectly on 32-bit platforms. The key question:
        along which modes should a [immediate64] cross? As of today, all of them,
@@ -1323,6 +1329,7 @@ module Const = struct
         mutable_data;
         void;
         immediate;
+        immediate_or_null;
         immediate64;
         float64;
         float32;
@@ -1552,6 +1559,7 @@ module Const = struct
       | "void" -> Builtin.void.jkind
       | "immediate64" -> Builtin.immediate64.jkind
       | "immediate" -> Builtin.immediate.jkind
+      | "immediate_or_null" -> Builtin.immediate_or_null.jkind
       | "float64" -> Builtin.float64.jkind
       | "float32" -> Builtin.float32.jkind
       | "word" -> Builtin.word.jkind
@@ -1757,6 +1765,8 @@ module Jkind_desc = struct
     let void = of_const Const.Builtin.void.jkind
 
     let immediate = of_const Const.Builtin.immediate.jkind
+
+    let immediate_or_null = of_const Const.Builtin.immediate_or_null.jkind
   end
 
   let product ~jkind_of_first_type tys_modalities layouts =
@@ -1859,6 +1869,11 @@ module Builtin = struct
     fresh_jkind Jkind_desc.Builtin.immediate ~annotation:(mk_annot "immediate")
       ~why:(Immediate_creation why)
     |> mark_best
+
+  let immediate_or_null ~why =
+    fresh_jkind Jkind_desc.Builtin.immediate_or_null
+      ~annotation:(mk_annot "immediate_or_null")
+      ~why:(Immediate_or_null_creation why)
 
   let product ~jkind_of_first_type ~why tys_modalities layouts =
     let desc = Jkind_desc.product ~jkind_of_first_type tys_modalities layouts in
@@ -2445,6 +2460,12 @@ module Format_history = struct
       fprintf ppf
         "it's an enumeration variant type (all constructors are constant)"
 
+  let format_immediate_or_null_creation_reason ppf :
+      History.immediate_or_null_creation_reason -> _ = function
+    | Primitive id ->
+      fprintf ppf "it is the primitive immediate_or_null type %s"
+        (Ident.name id)
+
   let format_value_or_null_creation_reason ppf ~layout_or_kind :
       History.value_or_null_creation_reason -> _ = function
     | Primitive id ->
@@ -2536,6 +2557,8 @@ module Format_history = struct
     | Any_creation any -> format_any_creation_reason ppf any
     | Immediate_creation immediate ->
       format_immediate_creation_reason ppf immediate
+    | Immediate_or_null_creation immediate ->
+      format_immediate_or_null_creation_reason ppf immediate
     | Void_creation _ -> .
     | Value_or_null_creation value ->
       format_value_or_null_creation_reason ppf value ~layout_or_kind
@@ -3168,6 +3191,10 @@ module Debug_printers = struct
     | Immediate_polymorphic_variant ->
       fprintf ppf "Immediate_polymorphic_variant"
 
+  let immediate_or_null_creation_reason ppf :
+      History.immediate_or_null_creation_reason -> _ = function
+    | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
+
   let value_or_null_creation_reason ppf :
       History.value_or_null_creation_reason -> _ = function
     | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
@@ -3227,6 +3254,9 @@ module Debug_printers = struct
     | Any_creation any -> fprintf ppf "Any_creation %a" any_creation_reason any
     | Immediate_creation immediate ->
       fprintf ppf "Immediate_creation %a" immediate_creation_reason immediate
+    | Immediate_or_null_creation immediate ->
+      fprintf ppf "Immediate_or_null_creation %a"
+        immediate_or_null_creation_reason immediate
     | Value_or_null_creation value ->
       fprintf ppf "Value_or_null_creation %a" value_or_null_creation_reason
         value

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2204,6 +2204,15 @@ let set_externality_upper_bound jk externality_upper_bound =
       }
   }
 
+let set_nullability_upper_bound jk nullability_upper_bound =
+  { jk with
+    jkind =
+      { jk.jkind with
+        mod_bounds =
+          Mod_bounds.set_nullability nullability_upper_bound jk.jkind.mod_bounds
+      }
+  }
+
 let all_except_nullability =
   Axis_set.singleton (Nonmodal Nullability) |> Axis_set.complement
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -273,6 +273,9 @@ module Const : sig
     (** We know for sure that values of types of this jkind are always immediate *)
     val immediate : t
 
+    (** Values of types of this jkind are either immediate or null pointers *)
+    val immediate_or_null : t
+
     (** This is the jkind of unboxed 64-bit floats.  They have sort
     Float64. Mode-crosses. *)
     val float64 : t
@@ -326,6 +329,10 @@ module Builtin : sig
   (** We know for sure that values of types of this jkind are always immediate *)
   val immediate :
     why:History.immediate_creation_reason -> ('l * disallowed) Types.jkind
+
+  (** Values of types of this jkind are either immediate or null pointers *)
+  val immediate_or_null :
+    why:History.immediate_or_null_creation_reason -> 'd Types.jkind
 
   (** Build a jkind of unboxed products, from a list of types with
       their layouts. Errors if zero inputs are given. If only one input

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -548,6 +548,9 @@ val get_externality_upper_bound :
 val set_externality_upper_bound :
   Types.jkind_r -> Jkind_axis.Externality.t -> Types.jkind_r
 
+val set_nullability_upper_bound :
+  Types.jkind_r -> Jkind_axis.Nullability.t -> Types.jkind_r
+
 (** Gets the nullability from a jkind. *)
 val get_nullability :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -302,6 +302,8 @@ module History = struct
     | Primitive of Ident.t
     | Immediate_polymorphic_variant
 
+  type immediate_or_null_creation_reason = Primitive of Ident.t
+
   (* CR layouts v5: make new void_creation_reasons *)
   type void_creation_reason = |
 
@@ -328,6 +330,7 @@ module History = struct
     | Value_or_null_creation of value_or_null_creation_reason
     | Value_creation of value_creation_reason
     | Immediate_creation of immediate_creation_reason
+    | Immediate_or_null_creation of immediate_or_null_creation_reason
     | Void_creation of void_creation_reason
     | Any_creation of any_creation_reason
     | Product_creation of product_creation_reason

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -159,7 +159,7 @@ val or_null_kind : type_expr -> ('a, 'b, constructor_declaration) type_kind
 (* Construct the [jkind] of [or_null]. For re-exporting [or_null]
    while users can't define their own types with null constructors. *)
 (* CR layouts v3.5: remove this when users can define null constructors. *)
-val or_null_jkind : Types.jkind_l
+val or_null_jkind : Types.type_expr -> Types.jkind_l
 
 (* To initialize linker tables *)
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3114,7 +3114,8 @@ type sort_or_poly = Sort of Jkind.Sort.Const.t | Poly
 let native_repr_of_type env kind ty sort_or_poly =
   match kind, get_desc (Ctype.expand_head_opt env ty) with
   | Untagged, Tconstr (_, _, _) when
-         Typeopt.maybe_pointer_type env ty = Lambda.Immediate
+         Typeopt.maybe_pointer_type env ty
+         = (Lambda.Immediate, Lambda.Non_nullable)
       (* Only allow [@untagged] on immediate values. [maybe_pointer_type]
          currently returns [Immediate] on unboxed number types, which
          do not support [@untagged].

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -846,7 +846,7 @@ let transl_declaration env sdecl (id, uid) =
               { definition = path; expected = Predef.path_or_null }))
           in
           let type_kind = Predef.or_null_kind param in
-          let jkind = Predef.or_null_jkind in
+          let jkind = Predef.or_null_jkind param in
           Ttype_abstract, type_kind, jkind
       | (Ptype_variant _ | Ptype_record _ | Ptype_record_unboxed_product _
         | Ptype_open)

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -100,7 +100,17 @@ let is_always_gc_ignorable env ty =
 
 let maybe_pointer_type env ty =
   let ty = scrape_ty env ty in
-  if is_always_gc_ignorable env ty then Immediate else Pointer
+  let immediate_or_pointer =
+    match is_always_gc_ignorable env ty with
+    | true -> Immediate
+    | false -> Pointer
+  in
+  let nullable =
+    match Ctype.check_type_nullability env ty Non_null with
+    | true -> Non_nullable
+    | false -> Nullable
+  in
+  immediate_or_pointer, nullable
 
 let maybe_pointer exp = maybe_pointer_type exp.exp_env exp.exp_type
 

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -20,8 +20,9 @@ val is_function_type :
 val is_base_type : Env.t -> Types.type_expr -> Path.t -> bool
 
 val maybe_pointer_type : Env.t -> Types.type_expr
-  -> Lambda.immediate_or_pointer
-val maybe_pointer : Typedtree.expression -> Lambda.immediate_or_pointer
+  -> Lambda.immediate_or_pointer * Lambda.nullable
+val maybe_pointer : Typedtree.expression
+  -> Lambda.immediate_or_pointer * Lambda.nullable
 
 (* Supplying [None] for [elt_sort] should be avoided when possible. It
    will result in a call to [Ctype.type_sort] which can be expensive. *)


### PR DESCRIPTION
Code handling comparisons in `translprim.ml` assumes that all immediate values are tagged integers. But, with `or_null`, this is no longer true. Check that a type is both `external` and `non_null` before specializing to `Compare_ints`.

I reviewed other uses of `maybe_pointer_type`, and they seem unproblematic to allow on null pointers.

Add a test. On `main`, the test fails to compile since Flambda recognizes that `Compare_ints` doesn't work on null pointers.

Tagging @glittershark for the front-end review, @lthls for the middle-end.