### PR TITLE
Ensure root safety in caml_register_named_value.

### DIFF
--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -703,7 +703,7 @@ static int caml_set_signal_action(int signo, int action)
 CAMLprim value caml_install_signal_handler(value signal_number, value action)
 {
   CAMLparam2 (signal_number, action);
-  CAMLlocal2 (res, tmp_signal_handlers);
+  CAMLlocal1 (res);
   int sig, act, oldact;
 
   sig = caml_convert_signal_number(Int_val(signal_number));


### PR DESCRIPTION
Fix a bug identified by @stedolan in [this comment](https://github.com/ocaml-flambda/flambda-backend/pull/3603#issuecomment-2696730631) on #3603: the `caml_plat_lock_non_blocking` might conceal a GC and/or compaction which moves `vname` and/or `val`, and so invalidate `name`.