### PR TITLE
Remove `-infer-with-bounds` flag, defaulting to `true`

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -759,10 +759,6 @@ in
   \    allows a set of extensions, and every successive universe includes \n\
   \    the previous one."
 
-let mk_infer_with_bounds f =
-  "-infer-with-bounds", Arg.Unit f,
-  "Infer with-bounds on kinds for type declarations. May impact performance."
-
 let mk_dump_dir f =
   "-dump-dir", Arg.String f,
   "redirects any file(s) that would be outputted as a result of other flags\n\
@@ -957,7 +953,6 @@ module type Common_options = sig
   val _extension : string -> unit
   val _no_extension : string -> unit
   val _extension_universe : string -> unit
-  val _infer_with_bounds : unit -> unit
   val _noassert : unit -> unit
   val _nolabels : unit -> unit
   val _nostdlib : unit -> unit
@@ -1245,7 +1240,6 @@ struct
     mk_extension F._extension;
     mk_no_extension F._no_extension;
     mk_extension_universe F._extension_universe;
-    mk_infer_with_bounds F._infer_with_bounds;
     mk_for_pack_byt F._for_pack;
     mk_g_byt F._g;
     mk_no_g F._no_g;
@@ -1377,7 +1371,6 @@ struct
     mk_extension F._extension;
     mk_no_extension F._no_extension;
     mk_extension_universe F._extension_universe;
-    mk_infer_with_bounds F._infer_with_bounds;
     mk_noassert F._noassert;
     mk_noinit F._noinit;
     mk_nolabels F._nolabels;
@@ -1472,7 +1465,6 @@ struct
     mk_extension F._extension;
     mk_no_extension F._no_extension;
     mk_extension_universe F._extension_universe;
-    mk_infer_with_bounds F._infer_with_bounds;
     mk_for_pack_opt F._for_pack;
     mk_g_opt F._g;
     mk_no_g F._no_g;
@@ -1664,7 +1656,6 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_extension F._extension;
     mk_no_extension F._no_extension;
     mk_extension_universe F._extension_universe;
-    mk_infer_with_bounds F._infer_with_bounds;
     mk_no_float_const_prop F._no_float_const_prop;
     mk_noassert F._noassert;
     mk_noinit F._noinit;
@@ -1772,7 +1763,6 @@ struct
     mk_extension F._extension;
     mk_no_extension F._no_extension;
     mk_extension_universe F._extension_universe;
-    mk_infer_with_bounds F._infer_with_bounds;
     mk_noassert F._noassert;
     mk_nolabels F._nolabels;
     mk_nostdlib F._nostdlib;
@@ -1884,7 +1874,6 @@ module Default = struct
     let _no_extension s = Language_extension.(disable_of_string_exn s)
     let _extension_universe s =
       Language_extension.(set_universe_and_enable_all_of_string_exn s)
-    let _infer_with_bounds = set Clflags.infer_with_bounds
     let _noassert = set noassert
     let _nolabels = set classic
     let _nostdlib = set no_std_include

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -34,7 +34,6 @@ module type Common_options = sig
   val _extension : string -> unit
   val _no_extension : string -> unit
   val _extension_universe : string -> unit
-  val _infer_with_bounds : unit -> unit
   val _noassert : unit -> unit
   val _nolabels : unit -> unit
   val _nostdlib : unit -> unit

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2213,7 +2213,6 @@ let rec estimate_type_jkind ~expand_component env ty =
      in
      let layouts = List.map Jkind.extract_layout jkinds in
      Jkind.Builtin.product
-       ~jkind_of_type:(estimate_type_jkind ~expand_component env)
        ~jkind_of_first_type:(fun () ->
        match jkinds with
          | first_jkind :: _ -> first_jkind

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -348,7 +348,6 @@ module Builtin : sig
       are represented in the with-bounds. *)
   val product :
     jkind_of_first_type:(unit -> Types.jkind_l) ->
-    jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
     why:History.product_creation_reason ->
     (Types.type_expr * Mode.Modality.Value.Const.t) list ->
     Sort.t Layout.t list ->
@@ -473,7 +472,6 @@ val for_boxed_record : Types.label_declaration list -> Types.jkind_l
     unboxed record must match that of the single field. *)
 val for_unboxed_record :
   jkind_of_first_type:(unit -> Types.jkind_l) ->
-  jkind_of_type:(Types.type_expr -> Types.jkind_l) ->
   Types.label_declaration list ->
   Types.jkind_l
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1861,7 +1861,6 @@ let update_decl_jkind env id decl =
           in
           let type_jkind =
             Jkind.for_unboxed_record
-              ~jkind_of_type:(Ctype.type_jkind env)
               ~jkind_of_first_type:(fun () ->
                 match lbls with
                 | [lbl] -> Ctype.type_jkind env lbl.ld_type

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -222,7 +222,6 @@ let afl_inst_ratio = ref 100           (* -afl-inst-ratio *)
 
 let function_sections = ref false      (* -function-sections *)
 let probes = ref Config.probes         (* -probes *)
-let infer_with_bounds = ref false       (* -infer-with-bounds *)
 let simplify_rounds = ref None        (* -rounds *)
 let default_simplify_rounds = ref 1        (* -rounds *)
 let rounds () =

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -226,7 +226,6 @@ val afl_instrument : bool ref
 val afl_inst_ratio : int ref
 val function_sections : bool ref
 val probes : bool ref
-val infer_with_bounds : bool ref
 
 val all_passes : string list ref
 val dumped_pass : string -> bool


### PR DESCRIPTION
It now looks like performance of with-bounds is satisfactory to release enabled
by default, so let's just remove this flag entirely to clean things up.