### PR TITLE
Drop `jkind_of_first_type`

### DIFF
--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1228,6 +1228,8 @@ let foo y =
   gbl
 [%%expect{|
 val foo : 'a -> 'a = <fun>
+|}, Principal{|
+val foo : '_weak1 -> '_weak1 = <fun>
 |}]
 let foo (local_ gbl) =
   let _ = #{ gbl } in

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1226,6 +1226,7 @@ val foo : local_ 'a gbl -> 'a = <fun>
 let foo y =
   let #{ gbl } = local_ #{ gbl = y } in
   gbl
+(* CR layouts v2.8: Fix principal case, or convince ourselves that it's expected *)
 [%%expect{|
 val foo : 'a -> 'a = <fun>
 |}, Principal{|

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2241,12 +2241,6 @@ let rec estimate_type_jkind ~(expand_component : type_expr -> open_type_expr) en
      in
      let layouts = List.map Jkind.extract_layout jkinds in
      Jkind.Builtin.product
-       ~jkind_of_first_type:(fun () ->
-       match jkinds with
-         | first_jkind :: _ -> first_jkind
-         | _ -> Misc.fatal_error
-                  "Ctype.estimate_type_jkind: use of jkind_of_first_type \
-                   with more than 1 type")
        ~why:Unboxed_tuple tys_modalities layouts |>
      close_open_jkind ~expand_component ~is_open env
   | Tconstr (p, args, _) -> begin try

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1769,24 +1769,17 @@ module Jkind_desc = struct
     let immediate_or_null = of_const Const.Builtin.immediate_or_null.jkind
   end
 
-  let product ~jkind_of_first_type tys_modalities layouts =
-    (* CR layouts v2.8: We can probably drop this special case once we
-       have proper subsumption. The general algorithm gets the right
-       jkind, but the subsumption check fails because it can't recognize
-       that the one it comes up with is right. *)
-    match layouts with
-    | [_] -> (jkind_of_first_type ()).jkind
-    | _ ->
-      let layout = Layout.product layouts in
-      let mod_bounds = Mod_bounds.min in
-      let with_bounds =
-        List.fold_right
-          (fun (type_expr, modality) bounds ->
-            With_bounds.add_modality ~relevant_for_nullability:`Relevant
-              ~type_expr ~modality bounds)
-          tys_modalities No_with_bounds
-      in
-      { layout; mod_bounds; with_bounds }
+  let product tys_modalities layouts =
+    let layout = Layout.product layouts in
+    let mod_bounds = Mod_bounds.min in
+    let with_bounds =
+      List.fold_right
+        (fun (type_expr, modality) bounds ->
+          With_bounds.add_modality ~relevant_for_nullability:`Relevant
+            ~type_expr ~modality bounds)
+        tys_modalities No_with_bounds
+    in
+    { layout; mod_bounds; with_bounds }
 
   let get t = Layout_and_axes.map Layout.get t
 
@@ -1875,8 +1868,8 @@ module Builtin = struct
       ~annotation:(mk_annot "immediate_or_null")
       ~why:(Immediate_or_null_creation why)
 
-  let product ~jkind_of_first_type ~why tys_modalities layouts =
-    let desc = Jkind_desc.product ~jkind_of_first_type tys_modalities layouts in
+  let product ~why tys_modalities layouts =
+    let desc = Jkind_desc.product tys_modalities layouts in
     fresh_jkind_poly desc ~annotation:None ~why:(Product_creation why)
     (* [mark_best] is correct here because the with-bounds of a product jkind
        include all the components of the product. Accordingly, looking through
@@ -2036,7 +2029,7 @@ let for_boxed_record lbls =
     in
     add_labels_as_with_bounds lbls base
 
-let for_unboxed_record ~jkind_of_first_type lbls =
+let for_unboxed_record lbls =
   let open Types in
   let tys_modalities =
     List.map (fun lbl -> lbl.ld_type, lbl.ld_modalities) lbls
@@ -2046,8 +2039,7 @@ let for_unboxed_record ~jkind_of_first_type lbls =
       (fun lbl -> lbl.ld_sort |> Layout.Const.of_sort_const |> Layout.of_const)
       lbls
   in
-  Builtin.product ~jkind_of_first_type ~why:Unboxed_record tys_modalities
-    layouts
+  Builtin.product ~why:Unboxed_record tys_modalities layouts
 
 (* CR layouts v2.8: This should take modalities into account. *)
 let for_boxed_variant cstrs =

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -335,8 +335,7 @@ module Builtin : sig
     why:History.immediate_or_null_creation_reason -> 'd Types.jkind
 
   (** Build a jkind of unboxed products, from a list of types with
-      their layouts. Errors if zero inputs are given. If only one input
-      is given, returns the result of calling [jkind_of_first_type].
+      their layouts. Errors if zero inputs are given.
 
       Precondition: both input lists are the same length.
 
@@ -346,7 +345,6 @@ module Builtin : sig
       The resulting jkind has quality [Best], because all the components of the product
       are represented in the with-bounds. *)
   val product :
-    jkind_of_first_type:(unit -> Types.jkind_l) ->
     why:History.product_creation_reason ->
     (Types.type_expr * Mode.Modality.Value.Const.t) list ->
     Sort.t Layout.t list ->
@@ -466,13 +464,8 @@ val of_type_decl_default :
 (** Choose an appropriate jkind for a boxed record type *)
 val for_boxed_record : Types.label_declaration list -> Types.jkind_l
 
-(** Choose an appropriate jkind for an unboxed record type. Uses
-    [jkind_of_first_type] only in the singleton case, where the jkind of the
-    unboxed record must match that of the single field. *)
-val for_unboxed_record :
-  jkind_of_first_type:(unit -> Types.jkind_l) ->
-  Types.label_declaration list ->
-  Types.jkind_l
+(** Choose an appropriate jkind for an unboxed record type. *)
+val for_unboxed_record : Types.label_declaration list -> Types.jkind_l
 
 (** Choose an appropriate jkind for a boxed variant type. *)
 val for_boxed_variant : Types.constructor_declaration list -> Types.jkind_l

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1900,10 +1900,7 @@ let rec update_decl_jkind env dpath decl =
               {lbl with ld_sort}
             ) lbls
           in
-          let type_jkind =
-            Jkind.for_unboxed_record
-              lbls
-          in
+          let type_jkind = Jkind.for_unboxed_record lbls in
           (* See Note [Quality of jkinds during inference] for more information about when we
              mark jkinds as best *)
           let type_jkind = Jkind.mark_best type_jkind in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1902,12 +1902,6 @@ let rec update_decl_jkind env dpath decl =
           in
           let type_jkind =
             Jkind.for_unboxed_record
-              ~jkind_of_first_type:(fun () ->
-                match lbls with
-                | [lbl] -> Ctype.type_jkind env lbl.ld_type
-                | [] | _ :: _ :: _ -> Misc.fatal_error
-                         "[for_unboxed_record] called [jkind_of_first_type] \
-                         for non-singleton record.")
               lbls
           in
           (* See Note [Quality of jkinds during inference] for more information about when we


### PR DESCRIPTION
Per the CR in `product`, this can go away entirely now that we have proper
subsumption, and simplify things a bit.