### PR TITLE
Remove as many magics and unsafe crossings as possible

### DIFF
--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -227,7 +227,6 @@ module Runtime_5 = struct
 
     let init () = create_dls ()
 
-    (* CR with-kinds: Remove [Key] wrapper. *)
     type 'a key = int * (Access.t -> 'a) Modes.Portable.t
 
     let key_counter = Atomic.Safe.make 0

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -395,9 +395,7 @@ module Runtime_5 = struct
 
   let spawn' f =
     do_before_first_spawn ();
-    let pk = DLS.access (fun access -> DLS.get_initial_keys access
-      |> Obj.magic_portable (* CR with-kinds: Unnecessary magic. *))
-    in
+    let pk = DLS.access (fun access -> DLS.get_initial_keys access) in
 
     (* [term_sync] is used to synchronize with the joining domains *)
     let term_sync =
@@ -407,7 +405,6 @@ module Runtime_5 = struct
     in
 
     let body () =
-      let pk = Obj.magic_uncontended pk (* CR with-kinds: Unneccessary magic. *) in
       match
         DLS.create_dls ();
         let access = DLS.Access.Access in

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -821,8 +821,7 @@ let pp_set_margin state n =
 
 
 (** Geometry functions and types *)
-type geometry : value mod portable contended = { max_indent:int; margin: int}
-[@@unsafe_allow_any_mode_crossing "CR with-kinds"]
+type geometry = { max_indent:int; margin: int}
 
 let validate_geometry {margin; max_indent} =
   if max_indent < 2 then

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -508,8 +508,7 @@ coupled variables, margin and maximum indentation limit.
 
 *)
 
-type geometry : value mod portable contended = { max_indent:int; margin: int}
-[@@unsafe_allow_any_mode_crossing "CR with-kinds"]
+type geometry = { max_indent:int; margin: int}
 (** @since 4.08 *)
 
 val check_geometry: geometry -> bool

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -114,8 +114,7 @@ external finalise_release : unit -> unit @@ portable = "caml_final_release"
 
 
 type alarm = bool Atomic.t
-type alarm_rec : value mod contended = {active : alarm; f : unit -> unit}
-[@@unsafe_allow_any_mode_crossing "CR with-kinds"]
+type alarm_rec = {active : alarm; f : unit -> unit}
 
 let rec call_alarm arec =
   if Atomic.Safe.get arec.active then begin

--- a/stdlib/modes.ml
+++ b/stdlib/modes.ml
@@ -17,17 +17,13 @@ module Global = struct
 end
 
 module Portable = struct
-  type 'a t : value mod portable = { portable : 'a @@ portable } [@@unboxed]
-  [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
+  type 'a t = { portable : 'a @@ portable } [@@unboxed]
 end
 
 module Contended = struct
-  type 'a t : value mod contended = { contended : 'a @@ contended } [@@unboxed]
-  [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
+  type 'a t = { contended : 'a @@ contended } [@@unboxed]
 end
 
 module Portended = struct
-  type 'a t : value mod portable contended = { portended : 'a @@ portable contended }
-  [@@unboxed]
-  [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
+  type 'a t = { portended : 'a @@ portable contended } [@@unboxed]
 end

--- a/stdlib/modes.mli
+++ b/stdlib/modes.mli
@@ -24,24 +24,16 @@ module Global : sig
 end
 
 module Portable : sig
-  type 'a t : value mod portable = { portable : 'a @@ portable } [@@unboxed]
-  [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
-  (** Wraps values in the [portable] mode, even in a [nonportable] context.
-      This additionally allows users to restrict a type that does not normally cross
-      portability to only portable values so that the resulting type does cross
-      portability. *)
+  type 'a t = { portable : 'a @@ portable } [@@unboxed]
 end
 
 module Contended : sig
-  type 'a t : value mod contended = { contended : 'a @@ contended } [@@unboxed]
-  [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
+  type 'a t = { contended : 'a @@ contended } [@@unboxed]
   (** Wraps values in the [contended] mode, even in an [uncontended] context. *)
 end
 
 module Portended : sig
-  type 'a t : value mod portable contended = { portended : 'a @@ portable contended }
-  [@@unboxed]
-  [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
+  type 'a t = { portended : 'a @@ portable contended } [@@unboxed]
   (** Wraps values in the [portable contended] mode, even in a [nonportable uncontended]
       context. A ['a Portended.t] is equivalent to a ['a Portable.t Contended.t] and a
       ['a Contended.t Portable.t], but much more ergonomic to work with. *)

--- a/stdlib/printexc.ml
+++ b/stdlib/printexc.ml
@@ -325,7 +325,6 @@ let errors = [| "";
       bytecode executable program file cannot be opened;\n \
       -- too many open files. Try running with OCAMLRUNPARAM=b=2)"
 |]
-|> Obj.magic_portable (* CR with-kinds: Unnecessary magic. *)
 
 let default_uncaught_exception_handler exn raw_backtrace =
   eprintf "Fatal error: exception %s\n" (to_string exn);

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -375,7 +375,7 @@ let bits32 = apply0 State.bits32
 let bits64 = apply0 State.bits64
 let nativebits = apply0 State.nativebits
 
-let full_init (seed : int array @@ contended) =
+let full_init (seed : int array @@ uncontended) =
   DLS.access (fun access ->
     State.reinit
       (DLS.get access random_key)

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -375,9 +375,7 @@ let bits32 = apply0 State.bits32
 let bits64 = apply0 State.bits64
 let nativebits = apply0 State.nativebits
 
-let full_init seed =
-  (* CR with-kinds: Unnecessary magic. *)
-  let seed = Obj.magic_portable seed in
+let full_init (seed : int array @@ contended) =
   DLS.access (fun access ->
     State.reinit
       (DLS.get access random_key)

--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -17,11 +17,10 @@
 
 open! Stdlib
 
-type backend_type : value mod portable contended =
+type backend_type =
   | Native
   | Bytecode
   | Other of string
-[@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 (* System interface *)
 
 external get_config: unit -> string * int * bool @@ portable = "caml_sys_get_config"
@@ -109,11 +108,10 @@ external readdir : string -> string array @@ portable = "caml_sys_read_directory
 
 let interactive = ref false
 
-type signal_behavior : value mod contended =
+type signal_behavior =
     Signal_default
   | Signal_ignore
   | Signal_handle of (int -> unit)
-[@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 
 module Safe = struct
   external signal
@@ -185,13 +183,12 @@ type extra_prefix = Plus | Tilde
 
 type extra_info = extra_prefix * string
 
-type ocaml_release_info : value mod portable contended = {
+type ocaml_release_info = {
   major : int;
   minor : int;
   patchlevel : int;
   extra : extra_info option
 }
-[@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 
 let ocaml_release = {
   major = @OCAML_VERSION_MAJOR@;

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -145,11 +145,10 @@ val os_type : string
 -  ["Win32"] (for MS-Windows, OCaml compiled with MSVC++ or MinGW-w64),
 -  ["Cygwin"] (for MS-Windows, OCaml compiled with Cygwin). *)
 
-type backend_type : value mod portable contended =
+type backend_type =
   | Native
   | Bytecode
   | Other of string (**)
-[@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 (** Currently, the official distribution only supports [Native] and
     [Bytecode], but it can be other backends with alternative
     compilers, for example, javascript.
@@ -245,11 +244,10 @@ external poll_actions : unit -> unit = "%poll"
 (** {1 Signal handling} *)
 
 
-type signal_behavior : value mod contended =
+type signal_behavior =
     Signal_default
   | Signal_ignore
   | Signal_handle of (int -> unit)   (** *)
-[@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 (** What to do when receiving a signal:
    - [Signal_default]: take the default behavior
      (usually: abort the program)
@@ -419,13 +417,12 @@ type extra_prefix = Plus | Tilde
 type extra_info = extra_prefix * string
 (** @since 4.14 *)
 
-type ocaml_release_info : value mod portable contended = {
+type ocaml_release_info = {
   major : int;
   minor : int;
   patchlevel : int;
   extra : extra_info option
 }
-[@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 (** @since 4.14 *)
 
 val ocaml_release : ocaml_release_info


### PR DESCRIPTION
Now that with-kinds has landed and inference is enabled by default, remove as many `[@@unsafe_allow_any_mode_crossing]` annotations and `Obj.magic`s which were annotated with "CR with-kinds" as possible

The correct mode crossing of the types in `Modes` is tested (extensively) in https://github.com/ocaml-flambda/flambda-backend/blob/aspsmith/fix-with-kinds-for-unboxed-records/testsuite/tests/typing-modal-kinds/unboxed.ml