### PR TITLE
Fix untypeast/pprintast bug (backport upstream 13845)

### DIFF
--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -67,14 +67,14 @@ run {| fun x y z -> (function w -> x y z w) |};;
 run {| let foo : 'a. 'a -> 'a = fun x -> x in foo |}
 
 [%%expect{|
-- : string = "let (foo : ('a : value) . 'a -> 'a) = fun x -> x in foo"
+- : string = "let foo : ('a : value) . 'a -> 'a = fun x -> x in foo"
 |}];;
 
 run {| let foo : type a . a -> a = fun x -> x in foo |}
 
 [%%expect{|
 - : string =
-"let (foo : ('a : value) . 'a -> 'a) =\n  fun (type a) -> ( (fun x -> x : a -> a)) in\nfoo"
+"let foo : ('a : value) . 'a -> 'a = fun (type a) -> ( (fun x -> x : a -> a)) in\nfoo"
 |}];;
 
 (* CR: untypeast/pprintast are totally busted on programs with modes in value
@@ -89,5 +89,5 @@ Exception: Misc.Fatal_error.
 run {| let foo : 'a . 'a -> 'a @@ portable = fun x -> x in foo |}
 
 [%%expect{|
-- : string = "let (foo : ('a : value) . 'a -> 'a) = fun x -> x in foo"
+- : string = "let foo : ('a : value) . 'a -> 'a = fun x -> x in foo"
 |}];;

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -60,3 +60,34 @@ run {| fun x y z -> (function w -> x y z w) |};;
 [%%expect{|
 - : string = "fun x y z -> (function | w -> x y z w)"
 |}];;
+
+(***********************************)
+(* Untypeast/pprintast correctly handle value binding type annotations. *)
+
+run {| let foo : 'a. 'a -> 'a = fun x -> x in foo |}
+
+[%%expect{|
+- : string = "let (foo : ('a : value) . 'a -> 'a) = fun x -> x in foo"
+|}];;
+
+run {| let foo : type a . a -> a = fun x -> x in foo |}
+
+[%%expect{|
+- : string =
+"let (foo : ('a : value) . 'a -> 'a) =\n  fun (type a) -> ( (fun x -> x : a -> a)) in\nfoo"
+|}];;
+
+(* CR: untypeast/pprintast are totally busted on programs with modes in value
+   bindings. Fix this. *)
+run {| let foo : 'a -> 'a @@ portable = fun x -> x in foo |}
+
+[%%expect{|
+>> Fatal error: Unrecognized mode portable - should not parse
+Exception: Misc.Fatal_error.
+|}];;
+
+run {| let foo : 'a . 'a -> 'a @@ portable = fun x -> x in foo |}
+
+[%%expect{|
+- : string = "let (foo : ('a : value) . 'a -> 'a) = fun x -> x in foo"
+|}];;


### PR DESCRIPTION
This tiny PR backports ocaml/ocaml#13845 to fix a bug in untypeast/pprintast.

It has already been reviewed upstream so low scrutiny is appropriate. The only question on our end is whether we need to do anything special about modes, and I think the answer is no because both `let x @ local = ...` and `let (x @ local) = ...` are valid syntax.

Request review from @tdelvecchio-jsc 