### PR TITLE
Move unboxed product arrays to stable

### DIFF
--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -555,19 +555,15 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
           (gen_array_set_kind (get_first_arg_mode ()), Punboxed_int_index Unboxed_nativeint)),
         3)
     | "%makearray_dynamic" ->
-      Language_extension.assert_enabled ~loc Layouts Language_extension.Beta;
       Primitive (Pmakearray_dynamic (gen_array_kind, mode, With_initializer), 2)
     | "%makearray_dynamic_uninit" ->
-      Language_extension.assert_enabled ~loc Layouts Language_extension.Beta;
       Primitive (Pmakearray_dynamic (gen_array_kind, mode, Uninitialized), 1)
     | "%arrayblit" ->
-      Language_extension.assert_enabled ~loc Layouts Language_extension.Beta;
       Primitive (Parrayblit {
         src_mutability = Mutable;
         dst_array_set_kind = gen_array_set_kind (get_third_arg_mode ())
       }, 5);
     | "%arrayblit_src_immut" ->
-      Language_extension.assert_enabled ~loc Layouts Language_extension.Beta;
       Primitive (Parrayblit {
         src_mutability = Immutable;
         dst_array_set_kind = gen_array_set_kind (get_third_arg_mode ())

--- a/testsuite/tests/flambda/incompatible_arrays.ml
+++ b/testsuite/tests/flambda/incompatible_arrays.ml
@@ -1,7 +1,6 @@
 (* TEST
  flambda2;
  arch_amd64;
- flags = "-extension layouts_beta";
  native;
 *)
 

--- a/testsuite/tests/lib-obj/uniform_or_mixed.ml
+++ b/testsuite/tests/lib-obj/uniform_or_mixed.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension layouts_beta";
    {
      reference = "${test_source_directory}/uniform_or_mixed.native.reference";
      compiler_reference2 = "${test_source_directory}/uniform_or_mixed.compiler.reference";
@@ -50,4 +49,3 @@ let () = run "t_uniform3" ((fun x -> x) : t_uniform3)
 let () = run "t_mixed0" ({ x = #4L } : t_mixed0)
 let () = run "t_mixed1" ({ x = ""; y = #5L } : t_mixed1)
 let () = run "t_mixed2" ({ x = ""; y = ""; z = #5L }: t_mixed2)
-

--- a/testsuite/tests/mixed-blocks/constructor_args.ml
+++ b/testsuite/tests/mixed-blocks/constructor_args.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension layouts_beta";
    flambda2;
    arch_amd64;
    include stdlib_stable;

--- a/testsuite/tests/mixed-blocks/generate_mixed_blocks_code.ml
+++ b/testsuite/tests/mixed-blocks/generate_mixed_blocks_code.ml
@@ -624,7 +624,6 @@ let main n ~bytecode =
  include stdlib_stable;
  include stdlib_upstream_compatible;|};
   if bytecode then (
-    line {| flags = "-extension layouts_beta";|};
     (* CR layouts: this test only runs on AMD64 because ARM64
        does not support float32# (including in bytecode).
        Split off the non-float32# parts into a separate test
@@ -633,7 +632,7 @@ let main n ~bytecode =
     line {| bytecode;|};
   ) else (
     line {| modules = "stubs.c";|};
-    line {| flags = "-extension layouts_beta -extension simd_beta";|};
+    line {| flags = "-extension simd_beta";|};
     line {| flambda2;|};
     line {| arch_amd64;|};
     line {| native;|};

--- a/testsuite/tests/mixed-blocks/generated_byte_test.ml
+++ b/testsuite/tests/mixed-blocks/generated_byte_test.ml
@@ -1,7 +1,6 @@
 (* TEST
  include stdlib_stable;
  include stdlib_upstream_compatible;
- flags = "-extension layouts_beta";
  arch_amd64;
  bytecode;
 *)

--- a/testsuite/tests/mixed-blocks/generated_native_test.ml
+++ b/testsuite/tests/mixed-blocks/generated_native_test.ml
@@ -2,7 +2,7 @@
  include stdlib_stable;
  include stdlib_upstream_compatible;
  modules = "stubs.c";
- flags = "-extension layouts_beta -extension simd_beta";
+ flags = "-extension simd_beta";
  flambda2;
  arch_amd64;
  native;

--- a/testsuite/tests/mixed-blocks/hash.ml
+++ b/testsuite/tests/mixed-blocks/hash.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags = "-extension layouts_beta";
  flambda2;
  {
    native;

--- a/testsuite/tests/mixed-blocks/recursive_mixed_blocks.ml
+++ b/testsuite/tests/mixed-blocks/recursive_mixed_blocks.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags = "-extension layouts_beta";
  flambda2;
  {
    native;

--- a/testsuite/tests/mixed-blocks/reified_constants.ml
+++ b/testsuite/tests/mixed-blocks/reified_constants.ml
@@ -1,6 +1,5 @@
 (* TEST
    flambda2;
-   flags="-extension layouts_beta";
    native;
 *)
 

--- a/testsuite/tests/mixed-blocks/structural_constants.ml
+++ b/testsuite/tests/mixed-blocks/structural_constants.ml
@@ -1,6 +1,5 @@
 (* TEST
    flambda2;
-   flags="-extension layouts_beta";
    { bytecode; }
    { native; }
 *)

--- a/testsuite/tests/mixed-blocks/test_mixed_blocks.ml
+++ b/testsuite/tests/mixed-blocks/test_mixed_blocks.ml
@@ -2,10 +2,8 @@
  flambda2;
  include stdlib_upstream_compatible;
  {
-   flags = "-extension layouts_beta";
    native;
  }{
-   flags = "-extension layouts_beta";
    bytecode;
  }
 *)

--- a/testsuite/tests/mixed-blocks/test_printing.ml
+++ b/testsuite/tests/mixed-blocks/test_printing.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags = "-extension layouts_beta";
  expect;
 *)
 

--- a/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
+++ b/testsuite/tests/mixed-blocks/typing_recursive_mixed_blocks.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags = "-extension layouts_beta";
  expect;
 *)
 

--- a/testsuite/tests/mixed-blocks/variant_unboxing.ml
+++ b/testsuite/tests/mixed-blocks/variant_unboxing.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension layouts_beta";
    native;
 *)
 

--- a/testsuite/tests/shape-index/index_unboxed_labels.ml
+++ b/testsuite/tests/shape-index/index_unboxed_labels.ml
@@ -1,6 +1,6 @@
 (* TEST
 
-flags = "-extension layouts_beta -bin-annot -bin-annot-occurrences";
+flags = "-bin-annot -bin-annot-occurrences";
 compile_only = "true";
 readonly_files = "index_unboxed_labels.ml";
 setup-ocamlc.byte-build-env;

--- a/testsuite/tests/shapes/unboxed_records.ml
+++ b/testsuite/tests/shapes/unboxed_records.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-dshape -extension layouts_beta";
+ flags = "-dshape";
  expect;
 *)
 

--- a/testsuite/tests/typing-layouts-arrays/array_element_size_in_bytes.ml
+++ b/testsuite/tests/typing-layouts-arrays/array_element_size_in_bytes.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags = "-extension layouts_beta";
  flambda2;
  stack-allocation;
  arch_amd64;

--- a/testsuite/tests/typing-layouts-arrays/generate_makearray_dynamic_tests.ml
+++ b/testsuite/tests/typing-layouts-arrays/generate_makearray_dynamic_tests.ml
@@ -601,13 +601,12 @@ let main ~bytecode =
  include stdlib_stable;
  include stdlib_upstream_compatible;|};
   if bytecode then (
-    line {| flags = "-extension layouts_beta";|};
     (* CR layouts: enable for arm64 once float32 is available *)
     line {| arch_amd64;|};
     line {| bytecode;|};
   ) else (
     line {| modules = "stubs.c";|};
-    line {| flags = "-extension layouts_beta -extension simd_beta";|};
+    line {| flags = "-extension simd_beta";|};
     line {| flambda2;|};
     line {| stack-allocation;|};
     line {| arch_amd64;|};

--- a/testsuite/tests/typing-layouts-arrays/generated_test.ml
+++ b/testsuite/tests/typing-layouts-arrays/generated_test.ml
@@ -2,7 +2,7 @@
  include stdlib_stable;
  include stdlib_upstream_compatible;
  modules = "stubs.c";
- flags = "-extension layouts_beta -extension simd_beta";
+ flags = "-extension simd_beta";
  flambda2;
  stack-allocation;
  arch_amd64;

--- a/testsuite/tests/typing-layouts-arrays/test_float_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_float_u_array.ml
@@ -7,11 +7,9 @@
  flambda2;
  arch_amd64;
  {
-   flags = "-extension layouts_beta";
    bytecode;
  }
  {
-   flags = "-extension layouts_beta";
    native;
  }
 *)

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_1.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_1.ml
@@ -7,11 +7,9 @@
  flambda2;
  arch_amd64;
  {
-   flags = "-extension layouts_beta";
    bytecode;
  }
  {
-   flags = "-extension layouts_beta";
    native;
  }
 *)

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_2.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_2.ml
@@ -7,11 +7,9 @@
  flambda2;
  arch_amd64;
  {
-   flags = "-extension layouts_beta";
    bytecode;
  }
  {
-   flags = "-extension layouts_beta";
    native;
  }
 *)

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_1.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_1.ml
@@ -7,11 +7,9 @@
  flambda2;
  arch_amd64;
  {
-   flags = "-extension layouts_beta";
    bytecode;
  }
  {
-   flags = "-extension layouts_beta";
    native;
  }
 *)

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_2.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_2.ml
@@ -7,11 +7,9 @@
  flambda2;
  arch_amd64;
  {
-   flags = "-extension layouts_beta";
    bytecode;
  }
  {
-   flags = "-extension layouts_beta";
    native;
  }
 *)

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_1.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_1.ml
@@ -8,11 +8,9 @@
  stack-allocation;
  arch_amd64;
  {
-   flags = "-extension layouts_beta";
    bytecode;
  }
  {
-   flags = "-extension layouts_beta";
    native;
  }
 *)

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_2.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_2.ml
@@ -8,11 +8,9 @@
  stack-allocation;
  arch_amd64;
  {
-   flags = "-extension layouts_beta";
    bytecode;
  }
  {
-   flags = "-extension layouts_beta";
    native;
  }
 *)

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_3.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_3.ml
@@ -8,11 +8,9 @@
  stack-allocation;
  arch_amd64;
  {
-   flags = "-extension layouts_beta";
    bytecode;
  }
  {
-   flags = "-extension layouts_beta";
    native;
  }
 *)

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_4.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_4.ml
@@ -8,11 +8,9 @@
  stack-allocation;
  arch_amd64;
  {
-   flags = "-extension layouts_beta";
    bytecode;
  }
  {
-   flags = "-extension layouts_beta";
    native;
  }
 *)

--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -1,7 +1,6 @@
 (* TEST
  flambda2;
  include stdlib_upstream_compatible;
- flags = "-extension layouts_beta";
  {
    expect;
  }

--- a/testsuite/tests/typing-layouts-products/product_iarrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_iarrays.ml
@@ -1,7 +1,6 @@
 (* TEST
  flambda2;
  include stdlib_upstream_compatible;
- flags = "-extension layouts_beta";
  {
    expect;
  }

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -711,34 +711,37 @@ Error: "[@layout_poly]" on this external declaration has no
        variable for it to operate on.
 |}]
 
-(********************************************************)
-(* Newer prims are gated to appropriate maturity levels *)
+(*********************************************)
+(* Tuple array prims no longer gated to beta *)
 
 external[@layout_poly] makearray_dynamic : ('a : any_non_null). int -> 'a -> 'a array =
   "%makearray_dynamic"
 [%%expect{|
-Lines 1-2, characters 0-22:
-1 | external[@layout_poly] makearray_dynamic : ('a : any_non_null). int -> 'a -> 'a array =
-2 |   "%makearray_dynamic"
-Error: This construct requires the beta version of the extension "layouts", which is disabled and cannot be used
+external makearray_dynamic : ('a : any_non_null). int -> 'a -> 'a array
+  = "%makearray_dynamic" [@@layout_poly]
 |}]
 
 external[@layout_poly] arrayblit :
   ('a : any_non_null). 'a array -> int -> 'a array -> int -> int -> unit =
   "%arrayblit"
 [%%expect{|
-Lines 1-3, characters 0-14:
-1 | external[@layout_poly] arrayblit :
-2 |   ('a : any_non_null). 'a array -> int -> 'a array -> int -> int -> unit =
-3 |   "%arrayblit"
-Error: This construct requires the beta version of the extension "layouts", which is disabled and cannot be used
+external arrayblit :
+  ('a : any_non_null). 'a array -> int -> 'a array -> int -> int -> unit
+  = "%arrayblit" [@@layout_poly]
 |}]
 
-external[@layout_poly] makearray_dynamic : ('a : any_non_null). int -> 'a -> 'a array =
+external[@layout_poly] makearray_dynamic : ('a : any_non_null). int -> 'a array =
   "%makearray_dynamic_uninit"
 [%%expect{|
-Lines 1-2, characters 0-29:
-1 | external[@layout_poly] makearray_dynamic : ('a : any_non_null). int -> 'a -> 'a array =
-2 |   "%makearray_dynamic_uninit"
-Error: This construct requires the beta version of the extension "layouts", which is disabled and cannot be used
+external makearray_dynamic : ('a : any_non_null). int -> 'a array
+  = "%makearray_dynamic_uninit" [@@layout_poly]
+|}]
+
+external[@layout_poly] arrayblit_src_immut :
+  ('a : any_non_null). 'a iarray -> int -> 'a array -> int -> int -> unit =
+  "%arrayblit_src_immut"
+[%%expect{|
+external arrayblit_src_immut :
+  ('a : any_non_null). 'a iarray -> int -> 'a array -> int -> int -> unit
+  = "%arrayblit_src_immut" [@@layout_poly]
 |}]

--- a/testsuite/tests/typing-local/local-layouts.ml
+++ b/testsuite/tests/typing-local/local-layouts.ml
@@ -1,5 +1,4 @@
 (* TEST
- flags = "-extension layouts_beta";
  expect;
 *)
 

--- a/testsuite/tests/typing-modes/tuple_modes.ml
+++ b/testsuite/tests/typing-modes/tuple_modes.ml
@@ -1,5 +1,4 @@
 (* TEST
-    flags = "-extension layouts_beta";
     expect;
 *)
 

--- a/testsuite/tests/typing-unique/unique_analysis.ml
+++ b/testsuite/tests/typing-unique/unique_analysis.ml
@@ -1,11 +1,8 @@
 (* TEST
- flags += "-extension layouts_beta";
  expect;
 *)
 
 (* This file is to test uniqueness_analysis.ml *)
-(* CR layouts v7.1: When tuples are out of beta, this test no longer needs
-   -extension layouts_beta *)
 
 (* First some helper functions *)
 let unique_id : unique_ 'a -> unique_ 'a = fun x -> x

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -228,14 +228,10 @@ let array_kind_of_elt ~elt_sort env loc ty =
         (type_legacy_sort ~why:Array_element env loc ty)
   in
   let classify_product ty sorts =
-    if Language_extension.(is_at_least Layouts Beta) then
-      if is_always_gc_ignorable env ty then
-        Pgcignorableproductarray (ignorable_product_array_kind loc sorts)
-      else
-        Pgcscannableproductarray (scannable_product_array_kind loc sorts)
+    if is_always_gc_ignorable env ty then
+      Pgcignorableproductarray (ignorable_product_array_kind loc sorts)
     else
-      let sort = Jkind.Sort.of_const (Jkind.Sort.Const.Product sorts) in
-      raise (Error (loc, Sort_without_extension (sort, Alpha, Some ty)))
+      Pgcscannableproductarray (scannable_product_array_kind loc sorts)
   in
   match classify ~classify_product env loc ty elt_sort with
   | Any -> if Config.flat_float_array then Pgenarray else Paddrarray


### PR DESCRIPTION
Unboxed product arrays have been languishing in "beta" for a while.  This moves them to stable.

For additional confidence that we are ready for this, I've also copied the unboxed product array tests from here into our internal build environment and will write a message about that elsewhere.

This is a small change - changing a few extension universe checks and updating some test stanzas to no longer require `extension_universe beta`.  As a bit of drive by cleanup, I've removed that requirement from a bunch of layout tests where it's no longer needed and was easy to do.