### PR TITLE
Shape UIDs for parameter modules

### DIFF
--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -78,6 +78,9 @@ module Uid = struct
   let of_compilation_unit_id id =
     Compilation_unit (id |> Compilation_unit.full_path_as_string)
 
+  let of_compilation_unit_name name =
+    Compilation_unit (name |> Compilation_unit.Name.to_string)
+
   let of_predef_id id =
     if not (Ident.is_predef id) then
       Misc.fatal_errorf "Types.Uid.of_predef_id %S" (Ident.name id);

--- a/typing/shape.mli
+++ b/typing/shape.mli
@@ -66,6 +66,7 @@ module Uid : sig
 
   val mk : current_unit:Compilation_unit.t option -> t
   val of_compilation_unit_id : Compilation_unit.t -> t
+  val of_compilation_unit_name : Compilation_unit.Name.t -> t
   val of_predef_id : Ident.t -> t
   val internal_not_actually_unique : t
   val unboxed_version : t -> t


### PR DESCRIPTION
This will fix a Merlin bug where it's not possible to jump to interface when the
cursor is on a parameter module.