### PR TITLE
optimize cmm shifts and tags

### DIFF
--- a/backend/amd64/selection.ml
+++ b/backend/amd64/selection.ml
@@ -15,61 +15,58 @@
 
 (* Instruction selection for the AMD64 *)
 
-open! Int_replace_polymorphic_compare
-
 [@@@ocaml.warning "+a-4-9-40-41-42"]
+
+(* note: no `open! Int_replace_polymorphic_compare` as the module is about to be
+   deleted. *)
 
 open Arch
 open Selection_utils
 
-let specific x =
-  assert (not (Arch.operation_can_raise x));
-  Cfg_selectgen.Basic (Op (Specific x))
-
 let pseudoregs_for_operation op arg res =
-  match (op : Operation.t) with
+  match (op : Mach.operation) with
   (* Two-address binary operations: arg.(0) and res.(0) must be the same *)
-  | Intop (Iadd | Isub | Imul | Iand | Ior | Ixor)
-  | Floatop ((Float32 | Float64), (Iaddf | Isubf | Imulf | Idivf)) ->
+  | Iintop (Iadd | Isub | Imul | Iand | Ior | Ixor)
+  | Ifloatop ((Float32 | Float64), (Iaddf | Isubf | Imulf | Idivf)) ->
     [| res.(0); arg.(1) |], res
-  | Intop_atomic { op = Compare_set; size = _; addr = _ } ->
+  | Iintop_atomic { op = Compare_set; size = _; addr = _ } ->
     (* first arg must be rax *)
     let arg = Array.copy arg in
     arg.(0) <- rax;
     arg, res
-  | Intop_atomic { op = Compare_exchange; size = _; addr = _ } ->
+  | Iintop_atomic { op = Compare_exchange; size = _; addr = _ } ->
     (* first arg must be rax, res.(0) must be rax. *)
     let arg = Array.copy arg in
     arg.(0) <- rax;
     arg, [| rax |]
-  | Intop_atomic { op = Exchange | Fetch_and_add; size = _; addr = _ } ->
+  | Iintop_atomic { op = Exchange | Fetch_and_add; size = _; addr = _ } ->
     (* first arg must be the same as res.(0) *)
     let arg = Array.copy arg in
     arg.(0) <- res.(0);
     arg, res
   (* One-address unary operations: arg.(0) and res.(0) must be the same *)
-  | Intop_imm ((Iadd | Isub | Imul | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr), _)
-  | Floatop ((Float64 | Float32), (Iabsf | Inegf))
-  | Specific (Ibswap { bitwidth = Thirtytwo | Sixtyfour }) ->
+  | Iintop_imm ((Iadd | Isub | Imul | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr), _)
+  | Ifloatop ((Float64 | Float32), (Iabsf | Inegf))
+  | Ispecific (Ibswap { bitwidth = Thirtytwo | Sixtyfour }) ->
     res, res
   (* For xchg, args must be a register allowing access to high 8 bit register
      (rax, rbx, rcx or rdx). Keep it simple, just force the argument in rax. *)
-  | Specific (Ibswap { bitwidth = Sixteen }) -> [| rax |], [| rax |]
+  | Ispecific (Ibswap { bitwidth = Sixteen }) -> [| rax |], [| rax |]
   (* For imulh, first arg must be in rax, rax is clobbered, and result is in
      rdx. *)
-  | Intop (Imulh _) -> [| rax; arg.(1) |], [| rdx |]
-  | Specific (Ifloatarithmem (_, _, _)) ->
+  | Iintop (Imulh _) -> [| rax; arg.(1) |], [| rdx |]
+  | Ispecific (Ifloatarithmem (_, _, _)) ->
     let arg' = Array.copy arg in
     arg'.(0) <- res.(0);
     arg', res
   (* For shifts with variable shift count, second arg must be in rcx *)
-  | Intop (Ilsl | Ilsr | Iasr) -> [| res.(0); rcx |], res
+  | Iintop (Ilsl | Ilsr | Iasr) -> [| res.(0); rcx |], res
   (* For div and mod, first arg must be in rax, rdx is clobbered, and result is
      in rax or rdx respectively. Keep it simple, just force second argument in
      rcx. *)
-  | Intop Idiv -> [| rax; rcx |], [| rax |]
-  | Intop Imod -> [| rax; rcx |], [| rdx |]
-  | Floatop (Float64, Icompf cond) ->
+  | Iintop Idiv -> [| rax; rcx |], [| rax |]
+  | Iintop Imod -> [| rax; rcx |], [| rdx |]
+  | Ifloatop (Float64, Icompf cond) ->
     (* CR gyorsh: make this optimization as a separate PR. *)
     (* We need to temporarily store the result of the comparison in a float
        register, but we don't want to clobber any of the inputs if they would
@@ -81,53 +78,54 @@ let pseudoregs_for_operation op arg res =
     let _, is_swapped = float_cond_and_need_swap cond in
     ( (if is_swapped then [| arg.(0); treg |] else [| treg; arg.(1) |]),
       [| res.(0); treg |] )
-  | Floatop (Float32, Icompf cond) ->
+  | Ifloatop (Float32, Icompf cond) ->
     let treg = Reg.create Float32 in
     let _, is_swapped = float_cond_and_need_swap cond in
     ( (if is_swapped then [| arg.(0); treg |] else [| treg; arg.(1) |]),
       [| res.(0); treg |] )
-  | Specific Irdpmc ->
+  | Ispecific Irdpmc ->
     (* For rdpmc instruction, the argument must be in ecx and the result is in
        edx (high) and eax (low). Make it simple and force the argument in rcx,
        and rax and rdx clobbered *)
     [| rcx |], res
-  | Specific (Isimd op) ->
+  | Ispecific (Isimd op) ->
     Simd_selection.pseudoregs_for_operation
       (Simd_proc.register_behavior op)
       arg res
-  | Specific (Isimd_mem (op, _addr)) ->
+  | Ispecific (Isimd_mem (op, _addr)) ->
     Simd_selection.pseudoregs_for_operation
       (Simd_proc.Mem.register_behavior op)
       arg res
-  | Csel _ ->
+  | Icsel _ ->
     (* last arg must be the same as res.(0) *)
     let len = Array.length arg in
     let arg = Array.copy arg in
     arg.(len - 1) <- res.(0);
     arg, res
   (* Other instructions are regular *)
-  | Intop_atomic { op = Add | Sub | Land | Lor | Lxor; _ }
-  | Intop (Ipopcnt | Iclz _ | Ictz _ | Icomp _)
-  | Intop_imm ((Imulh _ | Idiv | Imod | Icomp _ | Ipopcnt | Iclz _ | Ictz _), _)
-  | Specific
+  | Iintop_atomic { op = Add | Sub | Land | Lor | Lxor; _ }
+  | Iintop (Ipopcnt | Iclz _ | Ictz _ | Icomp _)
+  | Iintop_imm ((Imulh _ | Idiv | Imod | Icomp _ | Ipopcnt | Iclz _ | Ictz _), _)
+  | Ispecific
       ( Isextend32 | Izextend32 | Ilea _
       | Istore_int (_, _, _)
       | Ipause | Ilfence | Isfence | Imfence
       | Ioffset_loc (_, _)
       | Irdtsc | Icldemote _ | Iprefetch _ )
-  | Move | Spill | Reload | Reinterpret_cast _ | Static_cast _ | Const_int _
-  | Const_float32 _ | Const_float _ | Const_vec128 _ | Const_symbol _
-  | Stackoffset _ | Load _
-  | Store (_, _, _)
-  | Alloc _ | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Begin_region
-  | End_region | Poll | Dls_get ->
+  | Imove | Ispill | Ireload | Ireinterpret_cast _ | Istatic_cast _
+  | Iconst_int _ | Iconst_float32 _ | Iconst_float _ | Iconst_vec128 _
+  | Iconst_symbol _ | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
+  | Iextcall _ | Istackoffset _ | Iload _
+  | Istore (_, _, _)
+  | Ialloc _ | Iname_for_debugger _ | Iprobe _ | Iprobe_is_enabled _ | Iopaque
+  | Ibeginregion | Iendregion | Ipoll _ | Idls_get ->
     raise Use_default
 
 (* The selector class *)
 
 class selector =
   object (self)
-    inherit Cfg_selectgen.selector_generic as super
+    inherit Selectgen.selector_generic as super
 
     method! is_immediate op n =
       match op with
@@ -170,9 +168,9 @@ class selector =
     method! select_store is_assign addr exp =
       match exp with
       | Cconst_int (n, _dbg) when is_immediate n ->
-        Specific (Istore_int (Nativeint.of_int n, addr, is_assign)), Ctuple []
+        Ispecific (Istore_int (Nativeint.of_int n, addr, is_assign)), Ctuple []
       | Cconst_natint (n, _dbg) when is_immediate_natint n ->
-        Specific (Istore_int (n, addr, is_assign)), Ctuple []
+        Ispecific (Istore_int (n, addr, is_assign)), Ctuple []
       | Cconst_int _ | Cconst_vec128 _
       | Cconst_natint (_, _)
       | Cconst_float32 (_, _)
@@ -180,7 +178,9 @@ class selector =
       | Cconst_symbol (_, _)
       | Cvar _
       | Clet (_, _, _)
+      | Clet_mut (_, _, _, _)
       | Cphantom_let (_, _, _)
+      | Cassign (_, _)
       | Ctuple _
       | Cop (_, _, _)
       | Csequence (_, _)
@@ -188,19 +188,18 @@ class selector =
       | Cswitch (_, _, _, _, _)
       | Ccatch (_, _, _, _)
       | Cexit (_, _, _)
-      | Ctrywith (_, _, _, _, _, _, _) ->
+      | Ctrywith (_, _, _, _, _, _) ->
         super#select_store is_assign addr exp
 
-    method! select_operation op args dbg ~label_after =
+    method! select_operation op args dbg =
       match op with
       (* Recognize the LEA instruction *)
       | Caddi | Caddv | Cadda | Csubi | Cor -> (
         match self#select_addressing Word_int (Cop (op, args, dbg)) with
-        | Iindexed _, _ | Iindexed2 0, _ ->
-          super#select_operation op args dbg ~label_after
+        | Iindexed _, _ | Iindexed2 0, _ -> super#select_operation op args dbg
         | ( ((Iindexed2 _ | Iscaled _ | Iindexed2scaled _ | Ibased _) as addr),
             arg ) ->
-          specific (Ilea addr), [arg])
+          Ispecific (Ilea addr), [arg])
       (* Recognize float arithmetic with memory. *)
       | Caddf width ->
         self#select_floatarith true width Simple_operation.Iaddf Arch.Ifloatadd
@@ -219,59 +218,60 @@ class selector =
            was a float stack slot, the resulting UNPCKLPS instruction would
            enforce the validity of loading it as a 128-bit memory location, even
            though it only loads 64 bits. *)
-        specific (Isimd (SSE Interleave_low_32_regs)), args
+        Ispecific (Isimd (SSE Interleave_low_32_regs)), args
       (* Special cases overriding C implementations (regardless of
          [@@builtin]). *)
       | Cextcall { func = "sqrt" as func; _ }
       (* x86 intrinsics ([@@builtin]) *)
       | Cextcall { func; builtin = true; _ } -> (
         match func with
-        | "caml_rdtsc_unboxed" -> specific Irdtsc, args
-        | "caml_rdpmc_unboxed" -> specific Irdpmc, args
-        | "caml_pause_hint" -> specific Ipause, args
-        | "caml_load_fence" -> specific Ilfence, args
-        | "caml_store_fence" -> specific Isfence, args
-        | "caml_memory_fence" -> specific Imfence, args
+        | "caml_rdtsc_unboxed" -> Ispecific Irdtsc, args
+        | "caml_rdpmc_unboxed" -> Ispecific Irdpmc, args
+        | "caml_pause_hint" -> Ispecific Ipause, args
+        | "caml_load_fence" -> Ispecific Ilfence, args
+        | "caml_store_fence" -> Ispecific Isfence, args
+        | "caml_memory_fence" -> Ispecific Imfence, args
         | "caml_cldemote" ->
           let addr, eloc =
             self#select_addressing Word_int (one_arg "cldemote" args)
           in
-          specific (Icldemote addr), [eloc]
+          Ispecific (Icldemote addr), [eloc]
         | _ -> (
-          match Simd_selection.select_operation_cfg func args with
-          | Some (op, args) -> Basic (Op op), args
-          | None -> super#select_operation op args dbg ~label_after))
+          match Simd_selection.select_operation func args with
+          | Some (op, args) -> op, args
+          | None -> super#select_operation op args dbg))
       (* Recognize store instructions *)
       | Cstore (((Word_int | Word_val) as chunk), _init) -> (
         match args with
         | [loc; Cop (Caddi, [Cop (Cload _, [loc'], _); Cconst_int (n, _dbg)], _)]
-          when Stdlib.( = ) loc loc' && is_immediate n ->
+          when loc = loc' && is_immediate n ->
           let addr, arg = self#select_addressing chunk loc in
-          specific (Ioffset_loc (n, addr)), [arg]
-        | _ -> super#select_operation op args dbg ~label_after)
+          Ispecific (Ioffset_loc (n, addr)), [arg]
+        | _ -> super#select_operation op args dbg)
       | Cbswap { bitwidth } ->
         let bitwidth = select_bitwidth bitwidth in
-        specific (Ibswap { bitwidth }), args
+        Ispecific (Ibswap { bitwidth }), args
+      (* Recognize sign extension *)
       | Casr -> (
-        (* Recognize sign extension *)
         match args with
         | [Cop (Clsl, [k; Cconst_int (32, _)], _); Cconst_int (32, _)] ->
-          specific Isextend32, [k]
-        | _ -> super#select_operation op args dbg ~label_after)
+          Ispecific Isextend32, [k]
+        | _ -> super#select_operation op args dbg)
       (* Recognize zero extension *)
       | Clsr -> (
         match args with
         | [Cop (Clsl, [k; Cconst_int (32, _)], _); Cconst_int (32, _)] ->
-          specific Izextend32, [k]
-        | _ -> super#select_operation op args dbg ~label_after)
+          Ispecific Izextend32, [k]
+        | _ -> super#select_operation op args dbg)
+      (* Recognize zero extension again *)
       | Cand -> (
         match args with
         | [arg; Cconst_int (0xffff_ffff, _)]
         | [arg; Cconst_natint (0xffff_ffffn, _)]
         | [Cconst_int (0xffff_ffff, _); arg]
         | [Cconst_natint (0xffff_ffffn, _); arg] ->
-          specific Izextend32, [arg]
-        | _ -> super#select_operation op args dbg ~label_after)
+          Ispecific Izextend32, [arg]
+        | _ -> super#select_operation op args dbg)
       | Ccsel _ -> (
         match args with
         | [cond; ifso; ifnot] -> (
@@ -281,9 +281,9 @@ class selector =
             (* CFeq cannot be represented as cmov without a jump. CFneq emits
                cmov for "unordered" and "not equal" cases. Use Cneq and swap the
                arguments. *)
-            Basic (Op (Csel (Ifloattest (w, CFneq)))), [earg; ifnot; ifso]
-          | _ -> Basic (Op (Csel cond)), [earg; ifso; ifnot])
-        | _ -> super#select_operation op args dbg ~label_after)
+            Icsel (Ifloattest (w, CFneq)), [earg; ifnot; ifso]
+          | _ -> Icsel cond, [earg; ifso; ifnot])
+        | _ -> super#select_operation op args dbg)
       | Cprefetch { is_write; locality } ->
         (* Emit prefetch for read hint when prefetchw is not supported. Matches
            the behavior of gcc's __builtin_prefetch *)
@@ -302,13 +302,12 @@ class selector =
         let addr, eloc =
           self#select_addressing Word_int (one_arg "prefetch" args)
         in
-        specific (Iprefetch { is_write; addr; locality }), [eloc]
-      | _ -> super#select_operation op args dbg ~label_after
+        Ispecific (Iprefetch { is_write; addr; locality }), [eloc]
+      | _ -> super#select_operation op args dbg
 
     (* Recognize float arithmetic with mem *)
 
-    method select_floatarith commutative width regular_op mem_op args
-        : Cfg_selectgen.basic_or_terminator * Cmm.expression list =
+    method select_floatarith commutative width regular_op mem_op args =
       let open Cmm in
       match width, args with
       | ( Float64,
@@ -320,7 +319,7 @@ class selector =
                 [loc2],
                 _ ) ] ) ->
         let addr, arg2 = self#select_addressing chunk loc2 in
-        specific (Ifloatarithmem (width, mem_op, addr)), [arg1; arg2]
+        Mach.Ispecific (Ifloatarithmem (width, mem_op, addr)), [arg1; arg2]
       | ( Float64,
           [Cop (Cload { memory_chunk = Double as chunk; _ }, [loc1], _); arg2] )
       | ( Float32,
@@ -331,9 +330,11 @@ class selector =
             arg2 ] )
         when commutative ->
         let addr, arg1 = self#select_addressing chunk loc1 in
-        specific (Ifloatarithmem (width, mem_op, addr)), [arg2; arg1]
-      | _, [arg1; arg2] -> Basic (Op (Floatop (width, regular_op))), [arg1; arg2]
+        Mach.Ispecific (Ifloatarithmem (width, mem_op, addr)), [arg2; arg1]
+      | _, [arg1; arg2] -> Mach.Ifloatop (width, regular_op), [arg1; arg2]
       | _ -> assert false
+
+    method! mark_c_tailcall = contains_calls := true
 
     (* Deal with register constraints *)
 
@@ -341,12 +342,11 @@ class selector =
       try
         let rsrc, rdst = pseudoregs_for_operation op rs rd in
         self#insert_moves env rs rsrc;
-        self#insert_debug env (Op op) dbg rsrc rdst;
+        self#insert_debug env (Iop op) dbg rsrc rdst;
         self#insert_moves env rdst rd;
         rd
       with Use_default -> super#insert_op_debug env op dbg rs rd
   end
 
 let fundecl ~future_funcnames f =
-  Cfg.reset_instr_id ();
   (new selector)#emit_fundecl ~future_funcnames f

--- a/backend/amd64/selection_utils.ml
+++ b/backend/amd64/selection_utils.ml
@@ -76,6 +76,13 @@ let rec select_addr exp =
     | ( ((Asymbol _ | Aadd (_, _) | Ascaledadd (_, _, _)), _),
         ((Asymbol _ | Alinear _ | Aadd (_, _) | Ascaledadd (_, _, _)), _) ) ->
       Aadd (arg1, arg2), 0)
+  | Cmm.Cop (Cor, [arg; Cconst_int (1, _)], _)
+  | Cmm.Cop (Cor, [Cconst_int (1, _); arg], _) -> (
+    (* optimize tagging integers *)
+    match select_addr arg with
+    | Ascale (e, scale), off when scale mod 2 = 0 ->
+      Ascale (e, scale), off lor 1
+    | _ -> default)
   | _ -> default
 
 (* Special constraints on operand and result registers *)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -681,10 +681,6 @@ let rec mul_int c1 c2 dbg =
 let tag_int i dbg =
   match i with
   | Cconst_int (n, _) -> int_const dbg n
-  | Cop (Casr, [c; Cconst_int (n, _)], _) when n > 0 && is_defined_shift n ->
-    or_const (asr_const c (n - 1) dbg) 1n dbg
-  | Cop (Clsr, [c; Cconst_int (n, _)], _) when n > 0 && is_defined_shift n ->
-    or_const (lsr_const c (n - 1) dbg) 1n dbg
   | c -> incr_int (lsl_const c 1 dbg) dbg
 
 let untag_int i dbg =

--- a/middle_end/flambda2/z3/sign_extension.py
+++ b/middle_end/flambda2/z3/sign_extension.py
@@ -29,10 +29,15 @@ class Op:
 
     def experimental_sign_extend(self, bits) -> BitVecRef:
         unused_bits = self.size() - bits
+
         return If(
-            self.shift_right > unused_bits,
-            self.as_ast(),
-            (self.inner << (unused_bits - self.shift_right)) >> unused_bits,
+            self.shift_right == unused_bits,
+            If(self.arith, self.as_ast(), self.inner >> unused_bits),
+            If(
+                self.shift_right > unused_bits,
+                self.as_ast(),
+                (self.inner << (unused_bits - self.shift_right)) >> unused_bits,
+            ),
         )
 
 


### PR DESCRIPTION
add some optimizations for shifts and tags in preparation for cmm-scalar-type, which needs these to keep decent performance