### PR TITLE
Keep track of relevant axes when descending in normalize

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/modalities.ml
@@ -65,6 +65,24 @@ type 'a t = { x : 'a @@ contended; }
 type 'a t = { x : 'a @@ portable; }
 |}]
 
+(* Types with modalities cross even if the inner type doesn't, at deep levels of nesting *)
+
+type 'a portable : value mod portable = { portable : 'a @@ portable }
+[%%expect{|
+type 'a portable = { portable : 'a @@ portable; }
+|}]
+
+let foo (x : (int -> int) ref portable @@ nonportable) = use_portable x
+(* CR aspsmith: This should be accepted! *)
+[%%expect{|
+Line 1, characters 70-71:
+1 | let foo (x : (int -> int) ref portable @@ nonportable) = use_portable x
+                                                                          ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+(* Product layouts *)
+
 let use_global : ('a : value & value). 'a @ global -> unit = fun _ -> ()
 let cross_global : ('a : value & value mod global). 'a -> unit = fun _ -> ()
 let use_portable : ('a : value & value). 'a @ portable -> unit = fun _ -> ()

--- a/testsuite/tests/typing-jkind-bounds/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/modalities.ml
@@ -73,12 +73,8 @@ type 'a portable = { portable : 'a @@ portable; }
 |}]
 
 let foo (x : (int -> int) ref portable @@ nonportable) = use_portable x
-(* CR aspsmith: This should be accepted! *)
 [%%expect{|
-Line 1, characters 70-71:
-1 | let foo (x : (int -> int) ref portable @@ nonportable) = use_portable x
-                                                                          ^
-Error: This value is "nonportable" but expected to be "portable".
+val foo : (int -> int) ref portable -> unit = <fun>
 |}]
 
 (* Product layouts *)


### PR DESCRIPTION
When we descend through types in normalize, we need to keep track of a successive intersection of which axes we actually care about (eg if some are skipped because of modalities). This adds a new `relevant_axes` argument to loop which tracks that, and only does the join along the intersection of those relevant axes and the relevant axes in the type_info.

This fixes a bug where we didn't actually mode cross when a type which doesn't normally mode cross along that axis was nested inside a modality which should have allowed crossing.