### PR TITLE
Support kind annotations on existential type variables in pattern matches

### DIFF
--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -122,7 +122,7 @@ module Pat:
                        -> (string option * pattern) list -> closed_flag
                        -> pattern
     val construct: ?loc:loc -> ?attrs:attrs ->
-      lid -> (str list * pattern) option -> pattern
+      lid -> ((str * jkind_annotation option) list * pattern) option -> pattern
     val variant: ?loc:loc -> ?attrs:attrs -> label -> pattern option -> pattern
     val record: ?loc:loc -> ?attrs:attrs -> (lid * pattern) list -> closed_flag
                 -> pattern

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -569,8 +569,12 @@ module P = struct
         iter_loc sub l;
         iter_opt
           (fun (vl,p) ->
-            List.iter (iter_loc sub) vl;
-            sub.pat sub p)
+             List.iter
+               (fun (v,j) ->
+                  iter_loc sub v;
+                  iter_opt (sub.jkind_annotation sub) j)
+               vl;
+             sub.pat sub p)
           p
     | Ppat_variant (_l, p) -> iter_opt (sub.pat sub) p
     | Ppat_record (lpl, _cf)

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -649,7 +649,12 @@ module P = struct
     | Ppat_construct (l, p) ->
         construct ~loc ~attrs (map_loc sub l)
           (map_opt
-             (fun (vl, p) -> List.map (map_loc sub) vl, sub.pat sub p)
+             (fun (vl, p) ->
+                List.map
+                  (fun (v, jk) ->
+                     map_loc sub v, Option.map (sub.jkind_annotation sub) jk)
+                  vl,
+                sub.pat sub p)
              p)
     | Ppat_variant (l, p) -> variant ~loc ~attrs l (map_opt (sub.pat sub) p)
     | Ppat_record (lpl, cf) ->

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -3154,10 +3154,6 @@ labeled_simple_expr:
   | OPTLABEL simple_expr %prec below_HASH
       { (Optional $1, $2) }
 ;
-%inline lident_list:
-  xs = mkrhs(LIDENT)+
-    { xs }
-;
 %inline let_ident:
     val_ident { mkpatvar ~loc:$sloc $1 }
 ;
@@ -3653,7 +3649,7 @@ pattern_gen:
   | mkpat(
       mkrhs(constr_longident) pattern %prec prec_constr_appl
         { Ppat_construct($1, Some ([], $2)) }
-    | constr=mkrhs(constr_longident) LPAREN TYPE newtypes=lident_list RPAREN
+    | constr=mkrhs(constr_longident) LPAREN TYPE newtypes=newtypes RPAREN
         pat=simple_pattern
         { Ppat_construct(constr, Some (newtypes, pat)) }
     | name_tag pattern %prec prec_constr_appl

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -3652,6 +3652,10 @@ pattern_gen:
     | constr=mkrhs(constr_longident) LPAREN TYPE newtypes=newtypes RPAREN
         pat=simple_pattern
         { Ppat_construct(constr, Some (newtypes, pat)) }
+    | constr=mkrhs(constr_longident)
+        LPAREN TYPE ty=mkrhs(LIDENT) COLON jkind=jkind_annotation RPAREN
+        pat=simple_pattern
+        { Ppat_construct(constr, Some ([(ty,Some jkind)], pat)) }
     | name_tag pattern %prec prec_constr_appl
         { Ppat_variant($1, Some $2) }
     ) { $1 }

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -290,13 +290,17 @@ and pattern_desc =
           - If Closed, [n >= 2]
           - If Open, [n >= 1]
         *)
-  | Ppat_construct of Longident.t loc * (string loc list * pattern) option
+  | Ppat_construct of
+      Longident.t loc
+      * ((string loc * jkind_annotation option) list * pattern) option
       (** [Ppat_construct(C, args)] represents:
             - [C]               when [args] is [None],
             - [C P]             when [args] is [Some ([], P)]
             - [C (P1, ..., Pn)] when [args] is
                                            [Some ([], Ppat_tuple [P1; ...; Pn])]
-            - [C (type a b) P]  when [args] is [Some ([a; b], P)]
+            - [C (type a b) P]  when [args] is [Some ([a, None; b, None], P)]
+            - [C (type (a : k) b) P]
+                                when [args] is [Some ([a, Some k; b, None], P)]
          *)
   | Ppat_variant of label * pattern option
       (** [Ppat_variant(`A, pat)] represents:

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -105,8 +105,6 @@ let ident_of_name ppf txt =
     else "(%s)"
   in fprintf ppf format txt
 
-let ident_of_name_loc ppf s = ident_of_name ppf s.txt
-
 let protect_longident ppf print_longident longprefix txt =
     if not (needs_parens txt) then
       fprintf ppf "%a.%a" print_longident longprefix ident_of_name txt
@@ -499,6 +497,8 @@ and name_jkind f (name, jkind) =
         ident_of_name name
         (jkind_annotation reset_ctxt) jkind
 
+and name_loc_jkind f (str, jkind) = name_jkind f (str.txt,jkind)
+
 and core_type ctxt f x =
   let filtered_attrs = filter_curry_attrs x.ptyp_attributes in
   if filtered_attrs <> [] then begin
@@ -686,7 +686,7 @@ and pattern1 ctxt (f:Format.formatter) (x:pattern) : unit =
                pp f "%a@;%a"  longident_loc li (simple_pattern ctxt) x
            | Some (vl, x) ->
                pp f "%a@ (type %a)@;%a" longident_loc li
-                 (list ~sep:"@ " ident_of_name_loc) vl
+                 (list ~sep:"@ " name_loc_jkind) vl
                  (simple_pattern ctxt) x
            | None -> pp f "%a" longident_loc li)
     | _ -> simple_pattern ctxt f x

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -255,7 +255,11 @@ and pattern i ppf x =
       line i ppf "Ppat_construct %a\n" fmt_longident_loc li;
       option i
         (fun i ppf (vl, p) ->
-          list i string_loc ppf vl;
+          list i
+            (fun i ppf (v, jk) ->
+               string_loc i ppf v;
+               jkind_annotation_opt i ppf jk)
+            ppf vl;
           pattern i ppf p)
         ppf po
   | Ppat_variant (l, po) ->

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -277,7 +277,11 @@ and pattern i ppf x =
       line i ppf "Ppat_construct %a\n" fmt_longident_loc li;
       option i
         (fun i ppf (vl, p) ->
-          list i string_loc ppf vl;
+          list i
+            (fun i ppf (v, jk) ->
+               string_loc i ppf v;
+               jkind_annotation_opt i ppf jk)
+            ppf vl;
           pattern i ppf p)
         ppf po
   | Ppat_variant (l, po) ->

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -177,6 +177,34 @@ external id : ('a : any). 'a -> 'a = "%identity" [@@layout_poly]
 external id : ('a : any). 'a -> 'a = "%identity" [@@layout_poly]
 |}]
 
+type packed1 = T1 : ('a : float64). 'a -> packed1
+
+let f1 p =
+  match p with
+  | T1 (type (a : float64)) (_ : a) -> ()
+
+type packed2 = T2 : 'a 'b. 'a * 'b -> packed2
+
+let f2 p =
+  match p with
+  | T2 (type (a : value) b) (_ : a * b) -> ()
+
+let f3 p =
+  match p with
+  | T2 (type a (b : value)) (_ : a * b) -> ()
+
+let f4 p =
+  match p with
+  | T2 (type (a : value) (b : value)) (_ : a * b) -> ()
+[%%expect{|
+type packed1 = T1 : ('a : float64). 'a -> packed1
+val f1 : packed1 -> unit = <fun>
+type packed2 = T2 : 'a * 'b -> packed2
+val f2 : packed2 -> unit = <fun>
+val f3 : packed2 -> unit = <fun>
+val f4 : packed2 -> unit = <fun>
+|}]
+
 (******************)
 (* Comprehensions *)
 

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -183,6 +183,10 @@ let f1 p =
   match p with
   | T1 (type (a : float64)) (_ : a) -> ()
 
+let f1_no_parens p =
+  match p with
+  | T1 (type a : float64) (_ : a) -> ()
+
 type packed2 = T2 : 'a 'b. 'a * 'b -> packed2
 
 let f2 p =
@@ -199,6 +203,7 @@ let f4 p =
 [%%expect{|
 type packed1 = T1 : ('a : float64). 'a -> packed1
 val f1 : packed1 -> unit = <fun>
+val f1_no_parens : packed1 -> unit = <fun>
 type packed2 = T2 : 'a * 'b -> packed2
 val f2 : packed2 -> unit = <fun>
 val f3 : packed2 -> unit = <fun>

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -1714,17 +1714,9 @@ type packed = T : ('a : float64) . 'a -> packed
 
 let f p =
   match p with
-  | T (type a) (_ : a) -> ()
+  | T (type (a : float64)) (_ : a) -> ()
 
 [%%expect{|
 type packed = T : ('a : float64). 'a -> packed
-Line 5, characters 20-21:
-5 |   | T (type a) (_ : a) -> ()
-                        ^
-Error: This pattern matches values of type "a"
-       but a pattern was expected which matches values of type "('a : float64)"
-       The layout of a is value
-         because it's an unannotated existential type variable.
-       But the layout of a must be a sublayout of float64
-         because of the definition of packed at line 1, characters 0-47.
+val f : packed -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -1720,3 +1720,18 @@ let f p =
 type packed = T : ('a : float64). 'a -> packed
 val f : packed -> unit = <fun>
 |}]
+
+let bad p =
+  match p with
+  | T (type (a : float64)) (x : a) -> Some x
+[%%expect{|
+Line 3, characters 43-44:
+3 |   | T (type (a : float64)) (x : a) -> Some x
+                                               ^
+Error: This expression has type "a" but an expression was expected of type
+         "('a : value_or_null)"
+       The layout of a is float64
+         because of the annotation on the existential variable a.
+       But the layout of a must be a sublayout of value
+         because the type argument of option has layout value_or_null.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -1707,3 +1707,24 @@ type t = int
 type t = int
 type t = nativeint#
 |}]
+
+(*********************************************************)
+(* Test 14: annotation on existential variable in unpack *)
+type packed = T : ('a : float64) . 'a -> packed
+
+let f p =
+  match p with
+  | T (type a) (_ : a) -> ()
+
+[%%expect{|
+type packed = T : ('a : float64). 'a -> packed
+Line 5, characters 20-21:
+5 |   | T (type a) (_ : a) -> ()
+                        ^
+Error: This pattern matches values of type "a"
+       but a pattern was expected which matches values of type "('a : float64)"
+       The layout of a is value
+         because it's an unannotated existential type variable.
+       But the layout of a must be a sublayout of float64
+         because of the definition of packed at line 1, characters 0-47.
+|}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2423,6 +2423,7 @@ module Format_history = struct
     | Constructor_type_parameter (cstr, name) ->
       fprintf ppf "@[%s@ in the declaration of constructor@ %a@]" name
         !printtyp_path cstr
+    | Existential_unpack name -> fprintf ppf "the existential variable %s" name
     | Univar name -> fprintf ppf "the universal variable %s" name
     | Type_variable name -> fprintf ppf "the type variable %s" name
     | Type_wildcard loc ->
@@ -3173,6 +3174,7 @@ module Debug_printers = struct
     | Newtype_declaration name -> fprintf ppf "Newtype_declaration %s" name
     | Constructor_type_parameter (cstr, name) ->
       fprintf ppf "Constructor_type_parameter (%a, %S)" Path.print cstr name
+    | Existential_unpack name -> fprintf ppf "Existential_unpack %s" name
     | Univar name -> fprintf ppf "Univar %S" name
     | Type_variable name -> fprintf ppf "Type_variable %S" name
     | Type_wildcard loc ->

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -231,6 +231,7 @@ module History = struct
     | Constructor_type_parameter :
         Path.t * string
         -> (allowed * allowed) annotation_context
+    | Existential_unpack : string -> (allowed * allowed) annotation_context
     | Univar : string -> (allowed * allowed) annotation_context
     | Type_variable : string -> (allowed * allowed) annotation_context
     | Type_wildcard : Location.t -> (allowed * allowed) annotation_context

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -99,7 +99,7 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
       | (_, _, Some ([], _t)) ->
           fprintf ppf "@[<2>%s@ @[(%a : _)@]@]" name (pretty_vals ",") vs
       | (_, _, Some (vl, _t)) ->
-          let vars = List.map (fun x -> Ident.name x.txt) vl in
+          let vars = List.map (fun (x, _) -> Ident.name x.txt) vl in
           fprintf ppf "@[<2>%s@ (type %s)@ @[(%a : _)@]@]"
             name (String.concat " " vars) (pretty_vals ",") vs
       end

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -349,7 +349,13 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
       list i pattern ppf po;
       option i
         (fun i ppf (vl,ct) ->
-          let names = List.map (fun {txt} -> "\""^Ident.name txt^"\"") vl in
+          let names =
+            List.map
+              (fun ({txt}, jk) ->
+                 asprintf "\"%s\", %a"
+                   (Ident.name txt) (option i jkind_annotation) jk)
+              vl
+          in
           line i ppf "[%s]\n" (String.concat "; " names);
           core_type i ppf ct)
         ppf vto

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -349,14 +349,11 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
       list i pattern ppf po;
       option i
         (fun i ppf (vl,ct) ->
-          let names =
-            List.map
-              (fun ({txt}, jk) ->
-                 asprintf "\"%s\", %a"
-                   (Ident.name txt) (option i jkind_annotation) jk)
-              vl
-          in
-          line i ppf "[%s]\n" (String.concat "; " names);
+          line i ppf "vars%a\n"
+            (fun ppf ->
+              List.iter (fun ({txt}, jk) ->
+                typevar_jkind ~print_quote:false ppf (Ident.name txt, jk)))
+            vl;
           core_type i ppf ct)
         ppf vto
   | Tpat_variant (l, po, _) ->

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -262,8 +262,13 @@ let pat
   | Tpat_construct (lid, _, l, vto) ->
       iter_loc sub lid;
       List.iter (sub.pat sub) l;
-      Option.iter (fun (ids, ct) ->
-        List.iter (iter_loc sub) ids; sub.typ sub ct) vto
+      Option.iter (fun (vs, ct) ->
+        List.iter
+          (fun (v, jk) ->
+             iter_loc sub v;
+             Option.iter (sub.jkind_annotation sub) jk)
+          vs;
+        sub.typ sub ct) vto
   | Tpat_variant (_, po, _) -> Option.iter (sub.pat sub) po
   | Tpat_record (l, _) ->
       List.iter (fun (lid, _, i) -> iter_loc sub lid; sub.pat sub i) l

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -309,7 +309,11 @@ let pat
         (List.map (fun (label, p, sort) -> label, sub.pat sub p, sort) l)
     | Tpat_construct (loc, cd, l, vto) ->
         let vto = Option.map (fun (vl,cty) ->
-          List.map (map_loc sub) vl, sub.typ sub cty) vto in
+          List.map
+            (fun (v, jk) ->
+               (map_loc sub v,
+                Option.map (sub.jkind_annotation sub) jk))
+            vl, sub.typ sub cty) vto in
         Tpat_construct (map_loc sub loc, cd, List.map (sub.pat sub) l, vto)
     | Tpat_variant (l, po, rd) ->
         Tpat_variant (l, Option.map (sub.pat sub) po, rd)

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -157,8 +157,10 @@ and 'k pattern_desc =
       (string option * value general_pattern * Jkind.sort) list ->
       value pattern_desc
   | Tpat_construct :
-      Longident.t loc * constructor_description * value general_pattern list
-      * (Ident.t loc list * core_type) option ->
+      Longident.t loc * Types.constructor_description *
+        value general_pattern list *
+        ((Ident.t loc * Parsetree.jkind_annotation option) list * core_type)
+          option ->
       value pattern_desc
   | Tpat_variant :
       label * value general_pattern option * row_desc ref ->

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -184,7 +184,9 @@ and 'k pattern_desc =
          *)
   | Tpat_construct :
       Longident.t loc * Types.constructor_description *
-        value general_pattern list * (Ident.t loc list * core_type) option ->
+        value general_pattern list *
+        ((Ident.t loc * Parsetree.jkind_annotation option) list * core_type)
+          option ->
       value pattern_desc
         (** C                             ([], None)
             C P                           ([P], None)
@@ -192,7 +194,9 @@ and 'k pattern_desc =
             C (P : t)                     ([P], Some ([], t))
             C (P1, ..., Pn : t)           ([P1; ...; Pn], Some ([], t))
             C (type a) (P : t)            ([P], Some ([a], t))
-            C (type a) (P1, ..., Pn : t)  ([P1; ...; Pn], Some ([a], t))
+            C (type a) (P1, ..., Pn : t)  ([P1; ...; Pn], Some ([a, None], t))
+            C (type (a : k)) (P1, ..., Pn : t)
+                                   ([P1; ...; Pn], Some ([a, Some k], t))
           *)
   | Tpat_variant :
       label * value general_pattern option * Types.row_desc ref ->

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -372,7 +372,7 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
             None -> None
           | Some (vl, ty) ->
               let vl =
-                List.map (fun x -> {x with txt = Ident.name x.txt}) vl
+                List.map (fun (x, jk) -> {x with txt = Ident.name x.txt}, jk) vl
               in
               Some (vl, sub.typ sub ty)
         in


### PR DESCRIPTION
If you have a type like this
```ocaml
type packed = T : ('a : float64) . 'a -> packed
```
there is currently no way to match on the constructor and give a name to the existential variable, because there's no way to write a kind annotation on the variable and without that annotation it is defaulted to value
```ocaml
let f p =
  match p with
  | T (type a) (_ : a) -> ()
```

```
Line 5, characters 20-21:
5 |   | T (type a) (_ : a) -> ()
                        ^
Error: This pattern matches values of type "a"
       but a pattern was expected which matches values of type "('a : float64)"
       The layout of a is value
         because it's an unannotated existential type variable.
       But the layout of a must be a sublayout of float64
         because of the definition of packed at line 1, characters 0-47.
```

This PR adds support for the syntax:
```ocaml
let f p =
  match p with
  | T (type (a : float64)) (_ : a) -> ()
```

Two commits - the first adds this test case with the error, the second adds support for the annotation and fixes the test. It's 95% boilerplate.

Review: @rtjoa