### PR TITLE
Eliminate some memory allocations in the register allocator

### DIFF
--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -391,6 +391,19 @@ module Cursor = struct
     | Node node -> node.value
   ;;
 
+  let next (t : _ t) =
+    match t.node with
+    | Empty ->
+      (* internal invariant: cell's nodes are not empty *)
+      assert false
+    | Node content ->
+      (match content.next with
+       | Empty -> Error `End_of_list
+       | Node _ ->
+         t.node <- content.next;
+         Ok ())
+  ;;
+
   let delete_and_next (t : _ t) =
     remove t.t t.node;
     match t.node with

--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -406,17 +406,7 @@ module Cursor = struct
 
   let delete_and_next (t : _ t) =
     remove t.t t.node;
-    match t.node with
-    | Empty ->
-      (* internal invariant: cell's nodes are not empty *)
-      assert false
-    | Node content ->
-      (match content.next with
-      | Empty -> Error `End_of_list
-      | Node _ ->
-        t.node <- content.next;
-        Ok ())
-  ;;
+    next t
 end
 
 let create_hd_cursor t : (_ Cursor.t, [`Empty]) result  =

--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -375,3 +375,38 @@ let map t ~f =
   let res = make_empty () in
   iter t ~f:(fun x -> add_end res (f x));
   res
+
+
+module Cursor = struct
+  type nonrec 'a t =
+    { t : 'a t
+    ; mutable node : 'a node
+    }
+
+  let value (t : _ t) =
+    match t.node with
+    | Empty ->
+      (* internal invariant: cell's nodes are not empty *)
+      assert false
+    | Node node -> node.value
+  ;;
+
+  let delete_and_next (t : _ t) =
+    remove t.t t.node;
+    match t.node with
+    | Empty ->
+      (* internal invariant: cell's nodes are not empty *)
+      assert false
+    | Node content ->
+      (match content.next with
+      | Empty -> Error `End_of_list
+      | Node _ ->
+        t.node <- content.next;
+        Ok ())
+  ;;
+end
+
+let create_hd_cursor t : (_ Cursor.t, [`Empty]) result  =
+  match t.first with
+  | Empty -> Error `Empty
+  | Node _ -> Ok { t; node = t.first }

--- a/utils/doubly_linked_list.mli
+++ b/utils/doubly_linked_list.mli
@@ -91,6 +91,8 @@ module Cursor : sig
   type 'a t
 
   val value : 'a t -> 'a
+
+  val next : 'a t -> (unit, [`End_of_list]) result
   val delete_and_next : 'a t -> (unit, [`End_of_list]) result
 end
 

--- a/utils/doubly_linked_list.mli
+++ b/utils/doubly_linked_list.mli
@@ -86,3 +86,12 @@ val to_list : 'a t -> 'a list
 val transfer : to_:'a t -> from:'a t -> unit -> unit
 
 val map : 'a t -> f:('a -> 'b) -> 'b t
+
+module Cursor : sig
+  type 'a t
+
+  val value : 'a t -> 'a
+  val delete_and_next : 'a t -> (unit, [`End_of_list]) result
+end
+
+val create_hd_cursor : 'a t -> ('a Cursor.t, [`Empty]) result


### PR DESCRIPTION
This pull request eliminates some memory allocations in the register allocator by introducing a `Cursor.t` type to the doubly-linked list implementation.

Previously, some util functions used the doubly-linked list's `cell` API to iterate. This API allocates when the intiial cell is created, regardless of whether the list is empty, and then further allocates each time a pointer in the list is traversed.

The cursor API on the other hand:
* Does not allocate if the list is empty
* Allocates exactly once upon creation from a non-empty list
* Does not allocate when advancing the cursor.