### PR TITLE
datalog: Always set table in Cursor.bind_table

### DIFF
--- a/middle_end/flambda2/datalog/cursor.ml
+++ b/middle_end/flambda2/datalog/cursor.ml
@@ -292,11 +292,8 @@ let create ?(calls = []) ?output context =
 
 let bind_table (Bind_table (id, handler)) database =
   let table = Table.Map.get id database in
-  if Trie.is_empty (Table.Id.is_trie id) table
-  then false
-  else (
-    handler.contents <- Table.Map.get id database;
-    true)
+  handler := table;
+  not (Trie.is_empty (Table.Id.is_trie id) table)
 
 let bind_table_list binders database =
   List.iter (fun binder -> ignore @@ bind_table binder database) binders


### PR DESCRIPTION
The `bind_table` function is used to bind a reference used in a rule or query to the appropriate value from a database (by loading the table with a given ID from the database).

The `bind_table` function returns a boolean indicating if the table was empty, which is used by semi-naive evaluation to skip components where the `diff` is empty. As a misguided optimization for this specific use case, the `bind_table` function does not actually set the reference if the table is empty, which makes the semantics dubious in other settings.

In fact, it causes a bug where evaluating a rule in different databases would cause the table of the old database to leak into the evaluation of in the new database if the table is empty in the new database.

Fix the issue by always setting the reference in `bind_table`, which is the sane behavior.