### PR TITLE
datalog: Clear binders after rule evaluation

### DIFF
--- a/middle_end/flambda2/datalog/cursor.ml
+++ b/middle_end/flambda2/datalog/cursor.ml
@@ -301,6 +301,25 @@ let bind_table (Bind_table (id, handler)) database =
 let bind_table_list binders database =
   List.iter (fun binder -> ignore @@ bind_table binder database) binders
 
+let bind_cursor cursor ?(callback = ignore) db =
+  bind_table_list cursor.cursor_binders db;
+  bind_table_list cursor.cursor_naive_binders db;
+  cursor.callback := callback
+
+let unbind_table (Bind_table (id, handler)) =
+  handler := Trie.empty (Table.Id.is_trie id)
+
+let unbind_table_list binders = List.iter unbind_table binders
+
+let unbind_cursor cursor =
+  cursor.callback := ignore;
+  unbind_table_list cursor.cursor_naive_binders;
+  unbind_table_list cursor.cursor_binders
+
+let with_bound_cursor ?callback cursor db f =
+  bind_cursor ?callback cursor db;
+  Fun.protect ~finally:(fun () -> unbind_cursor cursor) f
+
 let evaluate = function
   | Unless (is_trie, cell, args, _cell_name, _args_names) ->
     if Option.is_some
@@ -309,11 +328,8 @@ let evaluate = function
     else Virtual_machine.Accept
 
 let naive_iter cursor db f =
-  bind_table_list cursor.cursor_binders db;
-  bind_table_list cursor.cursor_naive_binders db;
-  cursor.callback := f;
-  VM.run (VM.create ~evaluate cursor.instruction);
-  cursor.callback := ignore
+  with_bound_cursor ~callback:f cursor db @@ fun () ->
+  VM.run (VM.create ~evaluate cursor.instruction)
 
 let naive_fold cursor db f acc =
   let acc = ref acc in
@@ -325,8 +341,7 @@ let naive_fold cursor db f acc =
 
    [current] must be equal to [concat ~earlier:previous ~later:diff]. *)
 let[@inline] seminaive_run cursor ~previous ~diff ~current =
-  bind_table_list cursor.cursor_binders current;
-  bind_table_list cursor.cursor_naive_binders current;
+  with_bound_cursor cursor current @@ fun () ->
   let rec loop binders =
     match binders with
     | [] -> ()


### PR DESCRIPTION
Clear out references after evaluating a Datalog rule or query to avoid keeping tables alive longer than needed.