### PR TITLE
Allow (most) kind checks to be turned off

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -583,6 +583,14 @@ let mk_flambda2_unicode f =
     \     Flambda 2 code"
 ;;
 
+let mk_flambda2_kind_checks f =
+  "-flambda2-kind-checks", Arg.Unit f, " Perform kind checks on Flambda 2\n\
+    \     code (may cause fatal errors with layout-poly GADT code)"
+
+let mk_no_flambda2_kind_checks f =
+  "-no-flambda2-kind-checks", Arg.Unit f, " Elide kind checks on Flambda 2\n\
+    \     code"
+
 let mk_drawfexpr f =
   "-drawfexpr", Arg.Unit f, " Like -drawflambda but outputs fexpr language\n\
     \     (Flambda 2 only)"
@@ -813,6 +821,8 @@ module type Flambda_backend_options = sig
 
   val flambda2_unicode : unit -> unit
 
+  val flambda2_kind_checks : unit -> unit
+
   val drawfexpr : unit -> unit
   val drawfexpr_to : string -> unit
   val dfexpr : unit -> unit
@@ -971,6 +981,8 @@ struct
     mk_flambda2_inlining_report_bin F.flambda2_inlining_report_bin;
 
     mk_flambda2_unicode F.flambda2_unicode;
+
+    mk_flambda2_kind_checks F.flambda2_kind_checks;
 
     mk_drawfexpr F.drawfexpr;
     mk_drawfexpr_to F.drawfexpr_to;
@@ -1225,6 +1237,8 @@ module Flambda_backend_options_impl = struct
   let flambda2_inlining_report_bin = set' Flambda2.Inlining.report_bin
 
   let flambda2_unicode = set Flambda2.unicode
+
+  let flambda2_kind_checks = set Flambda2.kind_checks
 
   let drawfexpr () = Flambda2.Dump.rawfexpr := Flambda2.Dump.Main_dump_stream
   let drawfexpr_to file = Flambda2.Dump.rawfexpr := Flambda2.Dump.File file

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -133,6 +133,8 @@ module type Flambda_backend_options = sig
 
   val flambda2_unicode : unit -> unit
 
+  val flambda2_kind_checks : unit -> unit
+
   val drawfexpr : unit -> unit
   val drawfexpr_to : string -> unit
   val dfexpr : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -131,6 +131,7 @@ module Flambda2 = struct
     let meet_algorithm = Basic
     let enable_reaper = false
     let unicode = true
+    let kind_checks = false
   end
 
   type flags = {
@@ -144,6 +145,7 @@ module Flambda2 = struct
     meet_algorithm : meet_algorithm;
     enable_reaper : bool;
     unicode : bool;
+    kind_checks : bool;
   }
 
   let default = {
@@ -157,6 +159,7 @@ module Flambda2 = struct
     meet_algorithm = Default.meet_algorithm;
     enable_reaper = Default.enable_reaper;
     unicode = Default.unicode;
+    kind_checks = Default.kind_checks;
   }
 
   let oclassic = {
@@ -187,6 +190,7 @@ module Flambda2 = struct
   let cse_depth = ref Default
   let join_depth = ref Default
   let unicode = ref Default
+  let kind_checks = ref Default
   let function_result_types = ref Default
   let meet_algorithm = ref Default
   let enable_reaper = ref Default

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -111,8 +111,8 @@ module Flambda2 : sig
     val function_result_types : function_result_types
     val meet_algorithm : meet_algorithm
     val enable_reaper : bool
-
     val unicode : bool
+    val kind_checks : bool
   end
 
   (* CR-someday lmaurer: We could eliminate most of the per-flag boilerplate using GADTs
@@ -128,8 +128,8 @@ module Flambda2 : sig
     function_result_types : function_result_types;
     meet_algorithm : meet_algorithm;
     enable_reaper : bool;
-
     unicode : bool;
+    kind_checks : bool;
   }
 
   val default_for_opt_level : opt_level or_default -> flags
@@ -144,8 +144,8 @@ module Flambda2 : sig
   val cse_depth : int or_default ref
   val join_depth : int or_default ref
   val enable_reaper : bool or_default ref
-
   val unicode : bool or_default ref
+  val kind_checks : bool or_default ref
 
   module Dump : sig
     type target = Nowhere | Main_dump_stream | File of Misc.filepath

--- a/middle_end/flambda2/bound_identifiers/bound_parameter.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_parameter.ml
@@ -56,8 +56,6 @@ let with_kind t kind = { t with kind }
 
 let rename t = { t with param = Variable.rename t.param }
 
-let equal_kinds t1 t2 = Flambda_kind.With_subkind.equal t1.kind t2.kind
-
 let free_names ({ param = _; kind = _ } as t) =
   Name_occurrences.singleton_variable (var t) Name_mode.normal
 

--- a/middle_end/flambda2/bound_identifiers/bound_parameter.mli
+++ b/middle_end/flambda2/bound_identifiers/bound_parameter.mli
@@ -34,10 +34,6 @@ val kind : t -> Flambda_kind.With_subkind.t
 (** Replace the kind of the given parameter. *)
 val with_kind : t -> Flambda_kind.With_subkind.t -> t
 
-(** Returns [true] iff the provided kinded parameters have the same kind and
-    subkind. *)
-val equal_kinds : t -> t -> bool
-
 val rename : t -> t
 
 include Container_types.S with type t := t

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1224,6 +1224,8 @@ let close_let acc env let_bound_ids_with_kinds user_visible defining_expr
             | Unit -> Flambda_kind.value
             | Singleton result_kind -> result_kind
           in
+          (* This kind check is always ok since it happens prior to any beta
+             reduction. *)
           if not (Flambda_kind.equal kind result_kind)
           then
             Misc.fatal_errorf

--- a/middle_end/flambda2/simplify/env/continuation_uses.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses.ml
@@ -39,6 +39,7 @@ let [@ocamlformat "disable"] print ppf { continuation; arity; uses; } =
 let add_use t kind ~env_at_use id ~arg_types =
   try
     let arity = T.arity_of_list arg_types in
+    (* Kinds will always match at join points *)
     if not (Flambda_arity.equal_ignoring_subkinds arity t.arity)
     then
       Misc.fatal_errorf
@@ -60,6 +61,7 @@ let add_use t kind ~env_at_use id ~arg_types =
 
 let union t1 t2 =
   assert (Continuation.equal t1.continuation t2.continuation);
+  (* Kinds will always match at join points *)
   assert (Flambda_arity.equal_ignoring_subkinds t1.arity t2.arity);
   { continuation = t1.continuation; arity = t1.arity; uses = t1.uses @ t2.uses }
 

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -1146,8 +1146,8 @@ let simplify_method_call dacc apply ~callee_ty ~kind:_ ~obj ~arg_types
   DE.check_simple_is_bound denv obj;
   let args_arity = Apply.args_arity apply in
   let args_arity_from_types = T.arity_of_list arg_types in
-  (* Nothing layout-poly can be done with method calls, so this kind check is
-     always ok. *)
+  (* Method calls are not currently refined by the front end, so we can have a
+     kind check in place here at all times. *)
   if not
        (Flambda_arity.equal_ignoring_subkinds args_arity_from_types
           (Flambda_arity.unarize_t args_arity))

--- a/middle_end/flambda2/simplify/simplify_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive.ml
@@ -79,17 +79,22 @@ let try_cse dacc dbg ~original_prim ~min_name_mode ~result_var : cse_result =
       in
       Not_applied dacc
 
-let check_arg_kinds prim arg_tys_with_expected_kinds =
+let arg_kind_mismatch prim arg_tys_with_expected_kinds =
+  let found_mismatch = ref false in
   List.iter
     (fun (arg_ty, expected_kind) ->
       let arg_kind = T.kind arg_ty in
       if not (K.equal arg_kind expected_kind)
       then
-        Misc.fatal_errorf
-          "Argument type %a has wrong kind (%a), expected kind %a for \
-           primitive: %a"
-          T.print arg_ty K.print arg_kind K.print expected_kind P.print prim)
-    arg_tys_with_expected_kinds
+        if Flambda_features.kind_checks ()
+        then
+          Misc.fatal_errorf
+            "Argument type %a has wrong kind (%a), expected kind %a for \
+             primitive: %a"
+            T.print arg_ty K.print arg_kind K.print expected_kind P.print prim
+        else found_mismatch := true)
+    arg_tys_with_expected_kinds;
+  !found_mismatch
 
 let simplify_primitive dacc (prim : P.t) dbg ~result_var =
   let min_name_mode = Bound_var.name_mode result_var in
@@ -99,100 +104,100 @@ let simplify_primitive dacc (prim : P.t) dbg ~result_var =
       ~result_var
   | Unary (unary_prim, orig_arg) -> (
     let arg_ty, arg = S.simplify_simple dacc orig_arg ~min_name_mode in
-    (if Flambda_features.check_invariants ()
-    then
-      let arg_kind = P.arg_kind_of_unary_primitive unary_prim in
-      check_arg_kinds prim [arg_ty, arg_kind]);
-    let original_prim : P.t =
-      if orig_arg == arg then prim else Unary (unary_prim, arg)
-    in
-    match try_cse dacc dbg ~original_prim ~min_name_mode ~result_var with
-    | Applied result -> result
-    | Not_applied dacc ->
-      Simplify_unary_primitive.simplify_unary_primitive dacc original_prim
-        unary_prim ~arg ~arg_ty dbg ~result_var)
+    let arg_kind = P.arg_kind_of_unary_primitive unary_prim in
+    if arg_kind_mismatch prim [arg_ty, arg_kind]
+    then SPR.create_invalid dacc
+    else
+      let original_prim : P.t =
+        if orig_arg == arg then prim else Unary (unary_prim, arg)
+      in
+      match try_cse dacc dbg ~original_prim ~min_name_mode ~result_var with
+      | Applied result -> result
+      | Not_applied dacc ->
+        Simplify_unary_primitive.simplify_unary_primitive dacc original_prim
+          unary_prim ~arg ~arg_ty dbg ~result_var)
   | Binary (binary_prim, orig_arg1, orig_arg2) -> (
     let arg1_ty, arg1 = S.simplify_simple dacc orig_arg1 ~min_name_mode in
     let arg2_ty, arg2 = S.simplify_simple dacc orig_arg2 ~min_name_mode in
-    (if Flambda_features.check_invariants ()
-    then
-      let arg1_kind, arg2_kind = P.args_kind_of_binary_primitive binary_prim in
-      check_arg_kinds prim [arg1_ty, arg1_kind; arg2_ty, arg2_kind]);
-    let original_prim : P.t =
-      if orig_arg1 == arg1 && orig_arg2 == arg2
-      then prim
-      else Binary (binary_prim, arg1, arg2)
-    in
-    match try_cse dacc dbg ~original_prim ~min_name_mode ~result_var with
-    | Applied result -> result
-    | Not_applied dacc ->
-      Simplify_binary_primitive.simplify_binary_primitive dacc original_prim
-        binary_prim ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var)
+    let arg1_kind, arg2_kind = P.args_kind_of_binary_primitive binary_prim in
+    if arg_kind_mismatch prim [arg1_ty, arg1_kind; arg2_ty, arg2_kind]
+    then SPR.create_invalid dacc
+    else
+      let original_prim : P.t =
+        if orig_arg1 == arg1 && orig_arg2 == arg2
+        then prim
+        else Binary (binary_prim, arg1, arg2)
+      in
+      match try_cse dacc dbg ~original_prim ~min_name_mode ~result_var with
+      | Applied result -> result
+      | Not_applied dacc ->
+        Simplify_binary_primitive.simplify_binary_primitive dacc original_prim
+          binary_prim ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var)
   | Ternary (ternary_prim, orig_arg1, orig_arg2, orig_arg3) -> (
     let arg1_ty, arg1 = S.simplify_simple dacc orig_arg1 ~min_name_mode in
     let arg2_ty, arg2 = S.simplify_simple dacc orig_arg2 ~min_name_mode in
     let arg3_ty, arg3 = S.simplify_simple dacc orig_arg3 ~min_name_mode in
-    (if Flambda_features.check_invariants ()
-    then
-      let arg1_kind, arg2_kind, arg3_kind =
-        P.args_kind_of_ternary_primitive ternary_prim
-      in
-      check_arg_kinds prim
-        [arg1_ty, arg1_kind; arg2_ty, arg2_kind; arg3_ty, arg3_kind]);
-    let original_prim : P.t =
-      if orig_arg1 == arg1 && orig_arg2 == arg2 && orig_arg3 == arg3
-      then prim
-      else Ternary (ternary_prim, arg1, arg2, arg3)
+    let arg1_kind, arg2_kind, arg3_kind =
+      P.args_kind_of_ternary_primitive ternary_prim
     in
-    match try_cse dacc dbg ~original_prim ~min_name_mode ~result_var with
-    | Applied result -> result
-    | Not_applied dacc ->
-      Simplify_ternary_primitive.simplify_ternary_primitive dacc original_prim
-        ternary_prim ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty dbg
-        ~result_var)
+    if arg_kind_mismatch prim
+         [arg1_ty, arg1_kind; arg2_ty, arg2_kind; arg3_ty, arg3_kind]
+    then SPR.create_invalid dacc
+    else
+      let original_prim : P.t =
+        if orig_arg1 == arg1 && orig_arg2 == arg2 && orig_arg3 == arg3
+        then prim
+        else Ternary (ternary_prim, arg1, arg2, arg3)
+      in
+      match try_cse dacc dbg ~original_prim ~min_name_mode ~result_var with
+      | Applied result -> result
+      | Not_applied dacc ->
+        Simplify_ternary_primitive.simplify_ternary_primitive dacc original_prim
+          ternary_prim ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty dbg
+          ~result_var)
   | Variadic (variadic_prim, orig_args) -> (
     let args_with_tys =
       ListLabels.fold_right orig_args ~init:[] ~f:(fun arg args_rev ->
           let arg_ty, arg = S.simplify_simple dacc arg ~min_name_mode in
           (arg, arg_ty) :: args_rev)
     in
-    (if Flambda_features.check_invariants ()
-    then
-      let arg_tys = List.map snd args_with_tys in
-      let arg_tys_and_expected_kinds =
-        match P.args_kind_of_variadic_primitive variadic_prim with
-        | Variadic_mixed arg_kinds ->
-          List.combine arg_tys
-            (Array.to_list (K.Mixed_block_shape.field_kinds arg_kinds))
-        | Variadic_all_of_kind kind ->
-          List.map (fun arg_ty -> arg_ty, kind) arg_tys
-        | Variadic_zero_or_one kind ->
-          (match arg_tys with
-          | [] | [_] -> ()
-          | _ :: _ :: _ ->
-            Misc.fatal_errorf "Too many arguments for primitive %a" P.print prim);
-          List.map (fun arg_ty -> arg_ty, kind) arg_tys
-        | Variadic_unboxed_product kinds ->
-          (* CR mshinwell: move to Misc, may be useful in e.g.
-             simplify_variadic_primitive.ml for Make_array *)
-          let num_arg_tys = List.length arg_tys in
-          let num_kinds = List.length kinds in
-          if num_arg_tys mod num_kinds <> 0
-          then
-            Misc.fatal_errorf
-              "Number of arguments %d is not a multiple of the number of kinds \
-               %d for:@ %a"
-              num_arg_tys num_kinds P.print prim;
-          let num_repeats = num_arg_tys / num_kinds in
-          let kinds = List.init num_repeats (fun _ -> kinds) |> List.concat in
-          List.combine arg_tys kinds
-      in
-      check_arg_kinds prim arg_tys_and_expected_kinds);
-    let original_prim : P.t =
-      Variadic (variadic_prim, List.map fst args_with_tys)
+    let arg_tys = List.map snd args_with_tys in
+    let arg_tys_and_expected_kinds =
+      match P.args_kind_of_variadic_primitive variadic_prim with
+      | Variadic_mixed arg_kinds ->
+        List.combine arg_tys
+          (Array.to_list (K.Mixed_block_shape.field_kinds arg_kinds))
+      | Variadic_all_of_kind kind ->
+        List.map (fun arg_ty -> arg_ty, kind) arg_tys
+      | Variadic_zero_or_one kind ->
+        (match arg_tys with
+        | [] | [_] -> ()
+        | _ :: _ :: _ ->
+          Misc.fatal_errorf "Too many arguments for primitive %a" P.print prim);
+        List.map (fun arg_ty -> arg_ty, kind) arg_tys
+      | Variadic_unboxed_product kinds ->
+        (* CR mshinwell: move to Misc, may be useful in e.g.
+           simplify_variadic_primitive.ml for Make_array *)
+        let num_arg_tys = List.length arg_tys in
+        let num_kinds = List.length kinds in
+        if num_arg_tys mod num_kinds <> 0
+        then
+          Misc.fatal_errorf
+            "Number of arguments %d is not a multiple of the number of kinds \
+             %d for:@ %a"
+            num_arg_tys num_kinds P.print prim;
+        let num_repeats = num_arg_tys / num_kinds in
+        let kinds = List.init num_repeats (fun _ -> kinds) |> List.concat in
+        List.combine arg_tys kinds
     in
-    match try_cse dacc dbg ~original_prim ~min_name_mode ~result_var with
-    | Applied result -> result
-    | Not_applied dacc ->
-      Simplify_variadic_primitive.simplify_variadic_primitive dacc original_prim
-        variadic_prim ~args_with_tys dbg ~result_var)
+    if arg_kind_mismatch prim arg_tys_and_expected_kinds
+    then SPR.create_invalid dacc
+    else
+      let original_prim : P.t =
+        Variadic (variadic_prim, List.map fst args_with_tys)
+      in
+      match try_cse dacc dbg ~original_prim ~min_name_mode ~result_var with
+      | Applied result -> result
+      | Not_applied dacc ->
+        Simplify_variadic_primitive.simplify_variadic_primitive dacc
+          original_prim variadic_prim ~args_with_tys dbg ~result_var)

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -26,8 +26,9 @@ let simplify_field_of_block dacc (field, expected_kind) =
   let field =
     Simple.With_debuginfo.create simple (Simple.With_debuginfo.dbg field)
   in
-  (* We should always be at toplevel here and therefore not under any GADT
-     refinement. As such this kind check should always be ok. *)
+  (* CR mshinwell: maybe we should produce a normal user error? *)
+  (* We would like to prevent kind mismatches at toplevel, since they will turn
+     into programs that potentially always fail with an invalid trap. *)
   if not (K.equal (T.kind ty) expected_kind)
   then
     Misc.fatal_errorf

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -26,6 +26,8 @@ let simplify_field_of_block dacc (field, expected_kind) =
   let field =
     Simple.With_debuginfo.create simple (Simple.With_debuginfo.dbg field)
   in
+  (* We should always be at toplevel here and therefore not under any GADT
+     refinement. As such this kind check should always be ok. *)
   if not (K.equal (T.kind ty) expected_kind)
   then
     Misc.fatal_errorf

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -172,6 +172,8 @@ let simplify_box_number (boxable_number_kind : K.Boxable_number.t) alloc_mode
     dacc ~original_term ~arg:_ ~arg_ty:naked_number_ty ~result_var =
   let ty =
     let alloc_mode = Alloc_mode.For_allocations.as_type alloc_mode in
+    (* The following functions already check kinds, but we will only get here if
+       the kinds are correct (see [Simplify_primitive]). *)
     match boxable_number_kind with
     | Naked_float32 -> T.box_float32 naked_number_ty alloc_mode
     | Naked_float -> T.box_float naked_number_ty alloc_mode
@@ -185,7 +187,11 @@ let simplify_box_number (boxable_number_kind : K.Boxable_number.t) alloc_mode
 
 let simplify_tag_immediate dacc ~original_term ~arg:_ ~arg_ty:naked_number_ty
     ~result_var =
-  let ty = T.tag_immediate naked_number_ty in
+  let ty =
+    (* The following function checks the kind, but we will only get here if the
+       kind is correct (see [Simplify_primitive]). *)
+    T.tag_immediate naked_number_ty
+  in
   let dacc = DA.add_variable dacc result_var ty in
   SPR.create original_term ~try_reify:true dacc
 

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -1462,8 +1462,6 @@ module Invalid = struct
         [`Unarized] Flambda_arity.t * Apply_expr.t
     | Application_result_kind_mismatch of
         [`Unarized] Flambda_arity.t * Apply_expr.t
-    | Extcall_argument_kind_mismatch of
-        [`Unarized] Flambda_arity.t * Apply_expr.t
     | Partial_application_mode_mismatch of Apply_expr.t
     | Partial_application_mode_mismatch_in_lambda of Debuginfo.t
     | Calling_local_returning_closure_with_normal_apply of Apply_expr.t
@@ -1501,11 +1499,6 @@ module Invalid = struct
         "@[<hov 1>(Application_result_kind_mismatch@ @[<hov 1>(result_arity@ \
          %a)@ (apply_expr@ %a)@])@]"
         Flambda_arity.print result_arity Apply_expr.print apply_expr
-    | Extcall_argument_kind_mismatch (args_arity, apply_expr) ->
-      Format.asprintf
-        "@[<hov 1>(Extcall_argument_kind_mismatch@ @[<hov 1>(args_arity@ %a)@ \
-         (apply_expr@ %a)@])@]"
-        Flambda_arity.print args_arity Apply_expr.print apply_expr
     | Partial_application_mode_mismatch apply_expr ->
       Format.asprintf
         "@[<hov 1>(Partial_application_mode_mismatch@ @[<hov 1>(apply_expr@ \

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -1456,6 +1456,9 @@ module Invalid = struct
     | Apply_cont_of_unreachable_continuation of Continuation.t
     | Defining_expr_of_let of Bound_pattern.t * Named.t
     | Closure_type_was_invalid of Apply_expr.t
+    | Application_argument_kind_mismatch of Apply_expr.t
+    | Application_result_kind_mismatch of Apply_expr.t
+    | Extcall_argument_kind_mismatch of Apply_expr.t
     | Partial_application_mode_mismatch of Apply_expr.t
     | Partial_application_mode_mismatch_in_lambda of Debuginfo.t
     | Calling_local_returning_closure_with_normal_apply of Apply_expr.t
@@ -1482,6 +1485,21 @@ module Invalid = struct
     | Closure_type_was_invalid apply_expr ->
       Format.asprintf
         "@[<hov 1>(Closure_type_was_invalid@ @[<hov 1>(apply_expr@ %a)@])@]"
+        Apply_expr.print apply_expr
+    | Application_argument_kind_mismatch apply_expr ->
+      Format.asprintf
+        "@[<hov 1>(Application_argument_kind_mismatch@ @[<hov 1>(apply_expr@ \
+         %a)@])@]"
+        Apply_expr.print apply_expr
+    | Application_result_kind_mismatch apply_expr ->
+      Format.asprintf
+        "@[<hov 1>(Application_result_kind_mismatch@ @[<hov 1>(apply_expr@ \
+         %a)@])@]"
+        Apply_expr.print apply_expr
+    | Extcall_argument_kind_mismatch apply_expr ->
+      Format.asprintf
+        "@[<hov 1>(Extcall_argument_kind_mismatch@ @[<hov 1>(apply_expr@ \
+         %a)@])@]"
         Apply_expr.print apply_expr
     | Partial_application_mode_mismatch apply_expr ->
       Format.asprintf

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -113,8 +113,6 @@ module Invalid : sig
         [`Unarized] Flambda_arity.t * Apply_expr.t
     | Application_result_kind_mismatch of
         [`Unarized] Flambda_arity.t * Apply_expr.t
-    | Extcall_argument_kind_mismatch of
-        [`Unarized] Flambda_arity.t * Apply_expr.t
     | Partial_application_mode_mismatch of Apply_expr.t
     | Partial_application_mode_mismatch_in_lambda of Debuginfo.t
     | Calling_local_returning_closure_with_normal_apply of Apply_expr.t

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -109,6 +109,9 @@ module Invalid : sig
     | Apply_cont_of_unreachable_continuation of Continuation.t
     | Defining_expr_of_let of Bound_pattern.t * named
     | Closure_type_was_invalid of Apply_expr.t
+    | Application_argument_kind_mismatch of Apply_expr.t
+    | Application_result_kind_mismatch of Apply_expr.t
+    | Extcall_argument_kind_mismatch of Apply_expr.t
     | Partial_application_mode_mismatch of Apply_expr.t
     | Partial_application_mode_mismatch_in_lambda of Debuginfo.t
     | Calling_local_returning_closure_with_normal_apply of Apply_expr.t

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -109,9 +109,12 @@ module Invalid : sig
     | Apply_cont_of_unreachable_continuation of Continuation.t
     | Defining_expr_of_let of Bound_pattern.t * named
     | Closure_type_was_invalid of Apply_expr.t
-    | Application_argument_kind_mismatch of Apply_expr.t
-    | Application_result_kind_mismatch of Apply_expr.t
-    | Extcall_argument_kind_mismatch of Apply_expr.t
+    | Application_argument_kind_mismatch of
+        [`Unarized] Flambda_arity.t * Apply_expr.t
+    | Application_result_kind_mismatch of
+        [`Unarized] Flambda_arity.t * Apply_expr.t
+    | Extcall_argument_kind_mismatch of
+        [`Unarized] Flambda_arity.t * Apply_expr.t
     | Partial_application_mode_mismatch of Apply_expr.t
     | Partial_application_mode_mismatch_in_lambda of Debuginfo.t
     | Calling_local_returning_closure_with_normal_apply of Apply_expr.t

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -294,20 +294,27 @@ val boxed_nativeint_alias_to :
 val boxed_vec128_alias_to :
   naked_vec128:Variable.t -> Alloc_mode.For_types.t -> t
 
+(** This function checks the kind of its argument. *)
 val box_float32 : t -> Alloc_mode.For_types.t -> t
 
+(** This function checks the kind of its argument. *)
 val box_float : t -> Alloc_mode.For_types.t -> t
 
+(** This function checks the kind of its argument. *)
 val box_int32 : t -> Alloc_mode.For_types.t -> t
 
+(** This function checks the kind of its argument. *)
 val box_int64 : t -> Alloc_mode.For_types.t -> t
 
+(** This function checks the kind of its argument. *)
 val box_nativeint : t -> Alloc_mode.For_types.t -> t
 
+(** This function checks the kind of its argument. *)
 val box_vec128 : t -> Alloc_mode.For_types.t -> t
 
 val tagged_immediate_alias_to : naked_immediate:Variable.t -> t
 
+(** This function checks the kind of its argument. *)
 val tag_immediate : t -> t
 
 val is_int_for_scrutinee : scrutinee:Simple.t -> t

--- a/middle_end/flambda2/types/meet_and_join_new.ml
+++ b/middle_end/flambda2/types/meet_and_join_new.ml
@@ -489,6 +489,8 @@ let join_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
     else Unknown
 
 let rec meet env (t1 : TG.t) (t2 : TG.t) : TG.t meet_result =
+  (* Kind mismatches should have been caught (either turned into Invalid or a
+     fatal error) before we get here. *)
   if not (K.equal (TG.kind t1) (TG.kind t2))
   then
     Misc.fatal_errorf "Kind mismatch upon meet:@ %a@ versus@ %a" TG.print t1
@@ -1533,6 +1535,8 @@ and meet_type env t1 t2 : _ Or_bottom.t =
     | Bottom _ -> Bottom
 
 and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
+  (* Kind mismatches should have been caught (either turned into Invalid or a
+     fatal error) before we get here. *)
   if not (K.equal (TG.kind t1) (TG.kind t2))
   then
     Misc.fatal_errorf "Kind mismatch upon join:@ %a@ versus@ %a" TG.print t1

--- a/middle_end/flambda2/types/meet_and_join_old.ml
+++ b/middle_end/flambda2/types/meet_and_join_old.ml
@@ -137,6 +137,8 @@ let rec meet env (t1 : TG.t) (t2 : TG.t) : (TG.t * TEE.t) Or_bottom.t =
     if TG.is_obviously_bottom t then Bottom else Ok (t, env_extension)
 
 and meet0 env (t1 : TG.t) (t2 : TG.t) : TG.t * TEE.t =
+  (* Kind mismatches should have been caught (either turned into Invalid or a
+     fatal error) before we get here. *)
   if not (K.equal (TG.kind t1) (TG.kind t2))
   then
     Misc.fatal_errorf "Kind mismatch upon meet:@ %a@ versus@ %a" TG.print t1
@@ -1165,6 +1167,8 @@ and meet_env_extension (env : Meet_env.t) t1 t2 : TEE.t Or_bottom.t =
   else try Ok (meet_env_extension0 env t1 t2 []) with Bottom_meet -> Bottom
 
 and join ?bound_name env (t1 : TG.t) (t2 : TG.t) : TG.t Or_unknown.t =
+  (* Kind mismatches should have been caught (either turned into Invalid or a
+     fatal error) before we get here. *)
   if not (K.equal (TG.kind t1) (TG.kind t2))
   then
     Misc.fatal_errorf "Kind mismatch upon join:@ %a@ versus@ %a" TG.print t1

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -31,8 +31,10 @@ let is_bottom = Expand_head.is_bottom
 let expand_head env ty =
   Expand_head.expand_head env ty |> Expand_head.Expanded_type.descr_oub
 
-let wrong_kind kind_string t =
-  Misc.fatal_errorf "Kind error: expected [%s]:@ %a" kind_string TG.print t
+let wrong_kind kind_string t default =
+  if Flambda_features.kind_checks ()
+  then Misc.fatal_errorf "Kind error: expected [%s]:@ %a" kind_string TG.print t
+  else default
 
 type 'a meet_shortcut =
   | Known_result of 'a
@@ -69,7 +71,7 @@ let gen_value_to_gen prove_gen env t : _ generic_proof =
   | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
   | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ | Rec_info _ | Region _
     ->
-    wrong_kind "Value" t
+    wrong_kind "Value" t (Invalid : _ generic_proof)
 
 let gen_value_to_proof prove_gen env t : _ proof_of_property =
   match expand_head env t with
@@ -82,7 +84,7 @@ let gen_value_to_proof prove_gen env t : _ proof_of_property =
   | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
   | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ | Rec_info _ | Region _
     ->
-    wrong_kind "Value" t
+    wrong_kind "Value" t (Unknown : _ proof_of_property)
 
 let gen_value_to_meet prove_gen env t : _ meet_shortcut =
   match expand_head env t with
@@ -93,12 +95,16 @@ let gen_value_to_meet prove_gen env t : _ meet_shortcut =
   | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
   | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ | Rec_info _ | Region _
     ->
-    wrong_kind "Value" t
+    wrong_kind "Value" t (Invalid : _ meet_shortcut)
 
 let prove_equals_to_simple_of_kind env t kind : Simple.t proof_of_property =
   let original_kind = TG.kind t in
   if not (K.equal original_kind kind)
-  then wrong_kind (Format.asprintf "%a" K.print kind) t
+  then
+    wrong_kind
+      (Format.asprintf "%a" K.print kind)
+      t
+      (Unknown : _ proof_of_property)
   else
     (* CR pchambart: add TE.get_alias_opt *)
     match TG.get_alias_exn t with
@@ -195,7 +201,7 @@ let prove_is_null_generic env t : _ generic_proof =
   | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
   | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _ | Rec_info _ | Region _
     ->
-    wrong_kind "Value" t
+    wrong_kind "Value" t (Invalid : _ generic_proof)
 
 let meet_is_null env t = as_meet_shortcut (prove_is_null_generic env t)
 
@@ -235,7 +241,7 @@ let prove_naked_immediates_generic env t : Targetint_31_63.Set.t generic_proof =
   | Naked_immediate Bottom -> Invalid
   | Value _ | Naked_float _ | Naked_float32 _ | Naked_int32 _ | Naked_int64 _
   | Naked_nativeint _ | Naked_vec128 _ | Rec_info _ | Region _ ->
-    wrong_kind "Naked_immediate" t
+    wrong_kind "Naked_immediate" t (Invalid : _ generic_proof)
 
 let meet_naked_immediates env t =
   as_meet_shortcut (prove_naked_immediates_generic env t)
@@ -321,7 +327,7 @@ let[@inline] meet_naked_number (type a) (kind : a meet_naked_number_kind) env t
       | Nativeint -> "Naked_nativeint"
       | Vec128 -> "Naked_vec128"
     in
-    wrong_kind kind_string t
+    wrong_kind kind_string t (Invalid : _ meet_shortcut)
   in
   match expand_head env t with
   | Value _ -> wrong_kind ()
@@ -789,7 +795,7 @@ let[@inline always] meet_boxed_number_containing_simple
   | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
   | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _
     ->
-    Misc.fatal_errorf "Kind error: expected [Value]:@ %a" TG.print t
+    wrong_kind "Value" t (Invalid : _ meet_shortcut)
 
 let meet_boxed_float32_containing_simple =
   meet_boxed_number_containing_simple
@@ -958,7 +964,7 @@ let meet_rec_info env t : Rec_info_expr.t meet_shortcut =
   | Value _ | Naked_immediate _ | Naked_float _ | Naked_float32 _
   | Naked_int32 _ | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _
   | Region _ ->
-    wrong_kind "Rec_info" t
+    wrong_kind "Rec_info" t (Invalid : _ meet_shortcut)
 
 let prove_alloc_mode_of_boxed_number_value _env
     (value_head : TG.head_of_kind_value_non_null) :
@@ -1047,12 +1053,12 @@ let prove_physical_equality env t1 t2 =
         | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _
         | Region _ ),
         _ ) ->
-      wrong_kind "Value" t1
+      wrong_kind "Value" t1 (Unknown : _ proof_of_property)
     | ( _,
         ( Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
         | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _
         | Region _ ) ) ->
-      wrong_kind "Value" t2
+      wrong_kind "Value" t2 (Unknown : _ proof_of_property)
     | Value (Unknown | Bottom), _ | _, Value (Unknown | Bottom) -> Unknown
     | Value (Ok head1), Value (Ok head2) -> (
       match head1, head2 with

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -99,6 +99,10 @@ let unicode () =
   !Flambda_backend_flags.Flambda2.unicode
   |> with_default ~f:(fun d -> d.unicode)
 
+let kind_checks () =
+  !Flambda_backend_flags.Flambda2.kind_checks
+  |> with_default ~f:(fun d -> d.kind_checks)
+
 let check_invariants () =
   match !Clflags.flambda_invariant_checks with
   | No_checks | Light_checks -> false

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -38,6 +38,8 @@ val join_depth : unit -> int
 
 val enable_reaper : unit -> bool
 
+val kind_checks : unit -> bool
+
 val flat_float_array : unit -> bool
 
 val function_result_types : is_a_functor:bool -> bool


### PR DESCRIPTION
We have inadvertently ended up in a situation where kind checks in Flambda 2 can prevent valid code from being compiled.  Before it was possible for GADT matches to refine to different layouts, kind errors in Flambda 2 were always compiler errors; however, that is no longer the case.  For example:
```
type _ t =
| A : (float# -> int) t
| B : (int -> int) t

let[@inline] f (type a) (x : a t) (g : a) =
  match x with
  | A -> g #3.14
  | B -> g 42

let n =
  f (Sys.opaque_identity B) (fun i -> succ i)
```
We are trying to find ways of reinstating the checks in situations where we know they will be safe, but for now this PR disables the majority of them, guarded by a flag (defaulting to the checks being absent, `-no-flambda2-kind-checks`).  Some of the kind checks are still in place as they are either pre-beta-reduction or at places where there still should never be any mismatch.

When the kind checks are disabled, code exhibiting kind mismatches (e.g. the `A` branch in the above example) is replaced by `Invalid`.