### PR TITLE
Arm64: runtime simd intrinsics

### DIFF
--- a/runtime/caml/simd.h
+++ b/runtime/caml/simd.h
@@ -31,6 +31,14 @@
 #ifdef ARCH_SSE2
 #include <emmintrin.h>
 
+typedef __m128 simd_poly128_t;
+typedef __m128 simd_float32x4_t;
+typedef __m128 simd_float32x2_t;
+typedef __m128d simd_float64x2_t;
+typedef __m128i simd_int128_t;
+typedef __m128i simd_int64x2_t;
+typedef __m128i simd_int32x4_t;
+
 #define Vec128_val(v)  _mm_loadu_ps((const float*)Bp_val(v))
 #define Vec128_vald(v) _mm_loadu_pd((const double*)Bp_val(v))
 #define Vec128_vali(v) _mm_loadu_si128((const __m128i*)Bp_val(v))
@@ -38,9 +46,32 @@
 #define Store_vec128_vald(v,x) _mm_storeu_pd((double*)Bp_val(v), x)
 #define Store_vec128_vali(v,x) _mm_storeu_si128((__m128i*)Bp_val(v), x)
 
-CAMLextern value caml_copy_vec128(__m128);
-CAMLextern value caml_copy_vec128i(__m128i);
-CAMLextern value caml_copy_vec128d(__m128d);
-#endif
+#else /* ARCH_SSE2 */
+
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+
+typedef poly128_t simd_poly128_t;
+typedef float32x4_t simd_float32x4_t;
+typedef float32x2_t simd_float32x2_t;
+typedef float64x2_t simd_float64x2_t;
+typedef poly128_t simd_int128_t;
+typedef int64x2_t simd_int64x2_t;
+
+#define Vec128_val(v)  vld1q_f32((const float*)Bp_val(v))
+#define Vec128_vald(v) vld1q_f64((const double*)Bp_val(v))
+#define Vec128_vali(v) vldrq_p128((const simd_int128_t*)Bp_val(v))
+#define Store_vec128_val(v,x)  vst1q_f32((float*)Bp_val(v), x)
+#define Store_vec128_vald(v,x) vst1q_f64((double*)Bp_val(v), x)
+#define Store_vec128_vali(v,x) vstrq_p128((simd_int128_t*)Bp_val(v), x)
+
+#else /* __ARM_NEON */
+#error "Target not supported"
+#endif /* __ARM_NEON */
+#endif /* ARCH_SSE2 */
+
+CAMLextern value caml_copy_vec128(simd_float32x4_t);
+CAMLextern value caml_copy_vec128i(simd_int128_t);
+CAMLextern value caml_copy_vec128d(simd_float64x2_t);
 
 #endif /* CAML_SIMD_H */

--- a/runtime/caml/simd.h
+++ b/runtime/caml/simd.h
@@ -33,11 +33,9 @@
 
 typedef __m128 simd_poly128_t;
 typedef __m128 simd_float32x4_t;
-typedef __m128 simd_float32x2_t;
 typedef __m128d simd_float64x2_t;
 typedef __m128i simd_int128_t;
 typedef __m128i simd_int64x2_t;
-typedef __m128i simd_int32x4_t;
 
 #define Vec128_val(v)  _mm_loadu_ps((const float*)Bp_val(v))
 #define Vec128_vald(v) _mm_loadu_pd((const double*)Bp_val(v))

--- a/runtime/simd.c
+++ b/runtime/simd.c
@@ -26,7 +26,7 @@
 // SIMD is only supported on 64-bit targets
 #define Max_unboxed_vec128_array_wosize    (Max_custom_array_wosize / 2)
 
-#ifdef ARCH_SSE2
+#if defined(ARCH_SSE2) || defined(__ARM_NEON)
 
 CAMLexport value caml_copy_vec128(simd_float32x4_t v) {
     value res = caml_alloc_small(2, Abstract_tag);
@@ -127,4 +127,4 @@ CAMLprim value caml_make_unboxed_vec128_vect_bytecode(value len) {
   caml_failwith("SIMD is not supported on this platform.");
 }
 
-#endif
+#endif // defined(ARCH_SSE2) || defined(__ARM_NEON)

--- a/runtime/simd.c
+++ b/runtime/simd.c
@@ -28,19 +28,19 @@
 
 #ifdef ARCH_SSE2
 
-CAMLexport value caml_copy_vec128(__m128 v) {
+CAMLexport value caml_copy_vec128(simd_float32x4_t v) {
     value res = caml_alloc_small(2, Abstract_tag);
     Store_vec128_val(res, v);
     return res;
 }
 
-CAMLexport value caml_copy_vec128i(__m128i v) {
+CAMLexport value caml_copy_vec128i(simd_int128_t v) {
     value res = caml_alloc_small(2, Abstract_tag);
     Store_vec128_vali(res, v);
     return res;
 }
 
-CAMLexport value caml_copy_vec128d(__m128d v) {
+CAMLexport value caml_copy_vec128d(simd_float64x2_t v) {
     value res = caml_alloc_small(2, Abstract_tag);
     Store_vec128_vald(res, v);
     return res;
@@ -69,9 +69,9 @@ CAMLprim value caml_unboxed_vec128_vect_blit(value a1, value ofs1, value a2,
     /* See memory model [MM] notes in memory.c */
     atomic_thread_fence(memory_order_acquire);
     // Need to skip the custom_operations field
-    memmove((__m128 *)((uintnat *)a2 + 1) + Long_val(ofs2),
-            (__m128 *)((uintnat *)a1 + 1) + Long_val(ofs1),
-            Long_val(n) * sizeof(__m128));
+    memmove((simd_poly128_t *)((uintnat *)a2 + 1) + Long_val(ofs2),
+            (simd_poly128_t *)((uintnat *)a1 + 1) + Long_val(ofs1),
+            Long_val(n) * sizeof(simd_poly128_t));
     return Val_unit;
 }
 

--- a/runtime4/caml/simd.h
+++ b/runtime4/caml/simd.h
@@ -33,11 +33,9 @@
 
 typedef __m128 simd_poly128_t;
 typedef __m128 simd_float32x4_t;
-typedef __m128 simd_float32x2_t;
 typedef __m128d simd_float64x2_t;
 typedef __m128i simd_int128_t;
 typedef __m128i simd_int64x2_t;
-typedef __m128i simd_int32x4_t;
 
 #define Vec128_val(v)  _mm_loadu_ps((const float*)Bp_val(v))
 #define Vec128_vald(v) _mm_loadu_pd((const double*)Bp_val(v))
@@ -53,7 +51,6 @@ typedef __m128i simd_int32x4_t;
 
 typedef poly128_t simd_poly128_t;
 typedef float32x4_t simd_float32x4_t;
-typedef float32x2_t simd_float32x2_t;
 typedef float64x2_t simd_float64x2_t;
 typedef poly128_t simd_int128_t;
 typedef int64x2_t simd_int64x2_t;

--- a/runtime4/caml/simd.h
+++ b/runtime4/caml/simd.h
@@ -31,6 +31,14 @@
 #ifdef ARCH_SSE2
 #include <emmintrin.h>
 
+typedef __m128 simd_poly128_t;
+typedef __m128 simd_float32x4_t;
+typedef __m128 simd_float32x2_t;
+typedef __m128d simd_float64x2_t;
+typedef __m128i simd_int128_t;
+typedef __m128i simd_int64x2_t;
+typedef __m128i simd_int32x4_t;
+
 #define Vec128_val(v)  _mm_loadu_ps((const float*)Bp_val(v))
 #define Vec128_vald(v) _mm_loadu_pd((const double*)Bp_val(v))
 #define Vec128_vali(v) _mm_loadu_si128((const __m128i*)Bp_val(v))
@@ -38,9 +46,32 @@
 #define Store_vec128_vald(v,x) _mm_storeu_pd((double*)Bp_val(v), x)
 #define Store_vec128_vali(v,x) _mm_storeu_si128((__m128i*)Bp_val(v), x)
 
-CAMLextern value caml_copy_vec128(__m128);
-CAMLextern value caml_copy_vec128i(__m128i);
-CAMLextern value caml_copy_vec128d(__m128d);
-#endif
+#else /* ARCH_SSE2 */
+
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+
+typedef poly128_t simd_poly128_t;
+typedef float32x4_t simd_float32x4_t;
+typedef float32x2_t simd_float32x2_t;
+typedef float64x2_t simd_float64x2_t;
+typedef poly128_t simd_int128_t;
+typedef int64x2_t simd_int64x2_t;
+
+#define Vec128_val(v)  vld1q_f32((const float*)Bp_val(v))
+#define Vec128_vald(v) vld1q_f64((const double*)Bp_val(v))
+#define Vec128_vali(v) vldrq_p128((const simd_int128_t*)Bp_val(v))
+#define Store_vec128_val(v,x)  vst1q_f32((float*)Bp_val(v), x)
+#define Store_vec128_vald(v,x) vst1q_f64((double*)Bp_val(v), x)
+#define Store_vec128_vali(v,x) vstrq_p128((simd_int128_t*)Bp_val(v), x)
+
+#else /* __ARM_NEON */
+#error "Target not supported"
+#endif /* __ARM_NEON */
+#endif /* ARCH_SSE2 */
+
+CAMLextern value caml_copy_vec128(simd_float32x4_t);
+CAMLextern value caml_copy_vec128i(simd_int128_t);
+CAMLextern value caml_copy_vec128d(simd_float64x2_t);
 
 #endif /* CAML_SIMD_H */

--- a/runtime4/simd.c
+++ b/runtime4/simd.c
@@ -26,7 +26,7 @@
 // SIMD is only supported on 64-bit targets
 #define Max_unboxed_vec128_array_wosize    (Max_custom_array_wosize / 2)
 
-#ifdef ARCH_SSE2
+#if defined(ARCH_SSE2) || defined(__ARM_NEON)
 
 CAMLexport value caml_copy_vec128(simd_float32x4_t v) {
     value res = caml_alloc_small(2, Abstract_tag);
@@ -125,4 +125,4 @@ CAMLprim value caml_make_unboxed_vec128_vect_bytecode(value len) {
   caml_failwith("SIMD is not supported on this platform.");
 }
 
-#endif
+#endif // defined(ARCH_SSE2) || defined(__ARM_NEON)

--- a/runtime4/simd.c
+++ b/runtime4/simd.c
@@ -28,19 +28,19 @@
 
 #ifdef ARCH_SSE2
 
-CAMLexport value caml_copy_vec128(__m128 v) {
+CAMLexport value caml_copy_vec128(simd_float32x4_t v) {
     value res = caml_alloc_small(2, Abstract_tag);
     Store_vec128_val(res, v);
     return res;
 }
 
-CAMLexport value caml_copy_vec128i(__m128i v) {
+CAMLexport value caml_copy_vec128i(simd_int128_t v) {
     value res = caml_alloc_small(2, Abstract_tag);
     Store_vec128_vali(res, v);
     return res;
 }
 
-CAMLexport value caml_copy_vec128d(__m128d v) {
+CAMLexport value caml_copy_vec128d(simd_float64x2_t v) {
     value res = caml_alloc_small(2, Abstract_tag);
     Store_vec128_vald(res, v);
     return res;
@@ -67,9 +67,9 @@ CAMLexport struct custom_operations caml_unboxed_vec128_array_ops = {
 CAMLprim value caml_unboxed_vec128_vect_blit(value a1, value ofs1, value a2,
                                              value ofs2, value n) {
     // Need to skip the custom_operations field
-    memmove((__m128 *)((uintnat *)a2 + 1) + Long_val(ofs2),
-            (__m128 *)((uintnat *)a1 + 1) + Long_val(ofs1),
-            Long_val(n) * sizeof(__m128));
+    memmove((simd_poly128_t *)((uintnat *)a2 + 1) + Long_val(ofs2),
+            (simd_poly128_t *)((uintnat *)a1 + 1) + Long_val(ofs1),
+            Long_val(n) * sizeof(simd_poly128_t));
     return Val_unit;
 }
 


### PR DESCRIPTION
This small patch just adds NEON version of the simd intrinsics to the runtime. The `typedef`s for target specific types are used in the runtime stubs and also in tests with C stubs that include `simd.h` from the runtime (in an upcoming PR).