### PR TITLE
Avoid needless dependency on parameter .cmi by introducing `Parameter_name.t`

### DIFF
--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -108,10 +108,7 @@ let implementation_aux ~start_from ~source_file ~output_prefix
     let backend info typed =
       let as_arg_for =
         !Clflags.as_argument_for
-        |> Option.map (fun param ->
-          (* Currently, parameters don't have parameters, so we assume the argument
-             list is empty *)
-          Global_module.Name.create_no_args param)
+        |> Option.map Global_module.Parameter_name.of_string
       in
       let bytecode = to_bytecode info typed ~as_arg_for in
       emit_bytecode info bytecode

--- a/driver/compile.mli
+++ b/driver/compile.mli
@@ -33,7 +33,7 @@ val instance:
 val to_bytecode :
   Compile_common.info ->
   Typedtree.implementation ->
-  as_arg_for:Global_module.Name.t option ->
+  as_arg_for:Global_module.Parameter_name.t option ->
   Instruct.instruction list * Compilation_unit.Set.t *
     Lambda.main_module_block_format *
     Lambda.arg_descr option

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -99,9 +99,8 @@ let emit_signature info alerts tsg =
         Parameter
       else begin
         let cmi_arg_for =
-          match !Clflags.as_argument_for with
-          | Some arg_type -> Some (Global_module.Name.create_no_args arg_type)
-          | None -> None
+          !Clflags.as_argument_for
+          |> Option.map Global_module.Parameter_name.of_string
         in
         Normal { cmi_impl = info.module_name; cmi_arg_for }
       end

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -61,8 +61,7 @@ let init_parameters () =
   let param_names = !Clflags.parameters in
   List.iter
     (fun param_name ->
-        (* We don't (yet!) support parameterised parameters *)
-        let param = Global_module.Name.create_no_args param_name in
+        let param = Global_module.Parameter_name.of_string param_name in
         Env.register_parameter param
     )
     param_names

--- a/driver/instantiator.ml
+++ b/driver/instantiator.ml
@@ -42,15 +42,15 @@ type error =
       compilation_unit : CU.t;
       filename : Misc.filepath;
     }
-  | Missing_argument of { param : Global_module.Name.t }
+  | Missing_argument of { param : Global_module.Parameter_name.t }
   | No_such_parameter of {
       base_unit : CU.t;
-      available_params : Global_module.Name.t list;
-      param : Global_module.Name.t;
+      available_params : Global_module.Parameter_name.t list;
+      param : Global_module.Parameter_name.t;
       arg : Global_module.Name.t;
     }
   | Repeated_parameter of {
-      param : Global_module.Name.t;
+      param : Global_module.Parameter_name.t;
       arg1 : CU.t;
       arg2 : CU.t;
     }
@@ -85,11 +85,11 @@ let instantiate
   let arg_pairs : CU.argument list =
     List.map
       (fun (param, (value, _)) : CU.argument ->
-         { param = CU.of_global_name param; value })
+         { param = CU.Name.of_parameter_name param; value })
       arg_infos
   in
-  let arg_map : (CU.t * int) Global_module.Name.Map.t =
-    match Global_module.Name.Map.of_list_checked arg_infos with
+  let arg_map : (CU.t * int) Global_module.Parameter_name.Map.t =
+    match Global_module.Parameter_name.Map.of_list_checked arg_infos with
     | Ok map -> map
     | Error (Duplicate { key; value1 = (arg1, _); value2 = (arg2, _) }) ->
       error (Repeated_parameter { param = key; arg1; arg2 })
@@ -138,7 +138,7 @@ let instantiate
   let arg_subst : Global_module.subst =
     global.visible_args
     |> List.map (fun ({ param; value } : Global_module.argument) -> param, value)
-    |> Global_module.Name.Map.of_list
+    |> Global_module.Parameter_name.Map.of_list
   in
   let runtime_params, main_module_block_size =
     match base_unit_info.ui_format with
@@ -154,10 +154,9 @@ let instantiate
     |> List.map (fun runtime_param : Translmod.runtime_arg ->
          match (runtime_param : Lambda.runtime_param) with
            | Rp_argument_block global ->
-             let global_name = Global_module.to_name global in
              begin
                match
-                 Global_module.Name.Map.find_opt global_name arg_map
+                 Global_module.find_in_parameter_map global arg_map
                with
                | Some (ra_unit, ra_field_idx) ->
                  Argument_block { ra_unit; ra_field_idx }
@@ -165,7 +164,7 @@ let instantiate
                  (* This should have been caught by
                     [Env.global_of_instance_compilation_unit] earlier *)
                  Misc.fatal_errorf "Can't find value for %a"
-                   Global_module.Name.print global_name
+                   Global_module.print global
              end
            | Rp_main_module_block global ->
              (* Substitute away any references to parameters in [global] *)
@@ -192,7 +191,7 @@ module Style = Misc.Style
 let pp_parameters ppf params =
   fprintf ppf "@[<hov>%a@]"
     (pp_print_list ~pp_sep:pp_print_space
-       (Style.as_inline_code Global_module.Name.print))
+       (Style.as_inline_code Global_module.Parameter_name.print))
     params
 
 let report_error ppf = function
@@ -231,7 +230,7 @@ let report_error ppf = function
       (Style.as_inline_code Location.print_filename) filename
   | Missing_argument { param } ->
     fprintf ppf "No argument given for parameter %a"
-      (Style.as_inline_code Global_module.Name.print) param
+      (Style.as_inline_code Global_module.Parameter_name.print) param
   | No_such_parameter { base_unit; available_params; param; arg } ->
     fprintf ppf
       "@[<hov>Module %a@ is an argument for parameter %a,@ \
@@ -239,10 +238,11 @@ let report_error ppf = function
        @[<hov>@{<hint>Hint@}: @[<hov>%a@ was compiled with %a.@]@]@.\
        @[<hov>@{<hint>Hint@}: @[<hov>Parameters of %a:@ %a@]@]"
       (Style.as_inline_code Global_module.Name.print) arg
-      (Style.as_inline_code Global_module.Name.print) param
+      (Style.as_inline_code Global_module.Parameter_name.print) param
       (Style.as_inline_code CU.print) base_unit
       (Style.as_inline_code Global_module.Name.print) arg
-      (Style.as_clflag "-as-argument-for" Global_module.Name.print) param
+      (Style.as_clflag "-as-argument-for" Global_module.Parameter_name.print)
+        param
       (Style.as_inline_code CU.print) base_unit
       pp_parameters available_params
   | Repeated_parameter { param; arg1; arg2 } ->
@@ -254,10 +254,11 @@ let report_error ppf = function
          with %a.@]@]"
       (Style.as_inline_code CU.print) arg1
       (Style.as_inline_code CU.print) arg2
-      (Style.as_inline_code Global_module.Name.print) param
+      (Style.as_inline_code Global_module.Parameter_name.print) param
       (Style.as_inline_code CU.print) arg1
       (Style.as_inline_code CU.print) arg2
-      (Style.as_clflag "-as-argument-for" Global_module.Name.print) param
+      (Style.as_clflag "-as-argument-for" Global_module.Parameter_name.print)
+        param
 let () =
   Location.register_error_of_exn
     (function

--- a/driver/instantiator.mli
+++ b/driver/instantiator.mli
@@ -63,15 +63,15 @@ type error =
       compilation_unit : CU.t;
       filename : Misc.filepath;
     }
-  | Missing_argument of { param : Global_module.Name.t }
+  | Missing_argument of { param : Global_module.Parameter_name.t }
   | No_such_parameter of {
       base_unit : CU.t;
-      available_params : Global_module.Name.t list;
-      param : Global_module.Name.t;
+      available_params : Global_module.Parameter_name.t list;
+      param : Global_module.Parameter_name.t;
       arg : Global_module.Name.t
     }
   | Repeated_parameter of {
-      param : Global_module.Name.t;
+      param : Global_module.Parameter_name.t;
       arg1 : CU.t;
       arg2 : CU.t;
     }

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -133,10 +133,7 @@ let implementation_aux unix ~(flambda2 : flambda2) ~start_from
       let typed = structure, coercion, argument_coercion in
       let as_arg_for =
         !Clflags.as_argument_for
-        |> Option.map (fun param ->
-          (* Currently, parameters don't have parameters, so we assume the argument
-             list is empty *)
-          Global_module.Name.create_no_args param)
+        |> Option.map Global_module.Parameter_name.of_string
       in
       if not (Config.flambda || Config.flambda2) then Clflags.set_oclassic ();
       compile_from_typed info typed ~unix ~transl_style ~pipeline ~as_arg_for

--- a/file_formats/cmi_format.ml
+++ b/file_formats/cmi_format.ml
@@ -23,7 +23,7 @@ type pers_flags =
 type kind =
   | Normal of {
       cmi_impl : Compilation_unit.t;
-      cmi_arg_for : Global_module.Name.t option;
+      cmi_arg_for : Global_module.Parameter_name.t option;
     }
   | Parameter
 
@@ -65,7 +65,7 @@ type header = {
     header_kind : kind;
     header_globals : Global_module.With_precision.t array;
     header_sign : Serialized.signature;
-    header_params : Global_module.t list;
+    header_params : Global_module.Parameter_name.t list;
 }
 
 type 'sg cmi_infos_generic = {
@@ -73,7 +73,7 @@ type 'sg cmi_infos_generic = {
     cmi_kind : kind;
     cmi_globals : Global_module.With_precision.t array;
     cmi_sign : 'sg;
-    cmi_params : Global_module.t list;
+    cmi_params : Global_module.Parameter_name.t list;
     cmi_crcs : crcs;
     cmi_flags : flags;
 }

--- a/file_formats/cmi_format.mli
+++ b/file_formats/cmi_format.mli
@@ -25,7 +25,7 @@ type kind =
       cmi_impl : Compilation_unit.t;
         (* If this module takes parameters, [cmi_impl] will be the functor that
            generates instances *)
-      cmi_arg_for : Global_module.Name.t option;
+      cmi_arg_for : Global_module.Parameter_name.t option;
     }
   | Parameter
 
@@ -34,7 +34,7 @@ type 'sg cmi_infos_generic = {
     cmi_kind : kind;
     cmi_globals : Global_module.With_precision.t array;
     cmi_sign : 'sg;
-    cmi_params : Global_module.t list; (* CR lmaurer: Should be [Parameter_name.t list] *)
+    cmi_params : Global_module.Parameter_name.t list;
     cmi_crcs : Import_info.t array;
     cmi_flags : pers_flags list;
 }

--- a/flambda-backend/tests/typing/global_module_test.expected
+++ b/flambda-backend/tests/typing/global_module_test.expected
@@ -13,6 +13,7 @@ Print{Conv}{I}
   { (Conv Opaque{I}) (I Option{I}) }
   =
   Print[Conv:Opaque{I}][I:Option{I}]
+Print[Conv:Opaque{I}]{I} { (I Unit) } = Print[Conv:Opaque[I:Unit]][I:Unit]
 
 Tests of check:
 

--- a/flambda-backend/tests/typing/global_module_test.expected
+++ b/flambda-backend/tests/typing/global_module_test.expected
@@ -2,17 +2,17 @@
 Tests of subst:
 
 X { (X Unit) } = Unit
-Y{X} { (X Unit) } = Y[X:Unit]
-Y[X:Unit] { (X String) } = Y[X:Unit]
-Y[X:Unit] { (Y[X:Unit] String) } = String
-M{X}{Y:Y{X}} { (X A) } = M[X:A]{Y:Y[X:A]}
-M{X}{Y:Y{X}} { (X A) (Y B) } = M[X:A][Y:B]
+Y { (X Unit) } = Y
+Y { (X String) } = Y
+M{X}{Y} { (X A) } = M[X:A]{Y}
+M{X}{Y} { (X A) (Y B) } = M[X:A][Y:B]
 X { (I Unit) } = X
-Y{X} { (I Unit) } = Y{X}
-Print{Conv[O:String]:Conv[O:String]{I}}{I}
-  { (I Unit) }
+Y { (I Unit) } = Y
+Print{Conv}{I} { (I Unit) } = Print[I:Unit]{Conv}
+Print{Conv}{I}
+  { (Conv Opaque{I}) (I Option{I}) }
   =
-  Print[I:Unit]{Conv[O:String]:Conv[I:Unit][O:String]}
+  Print[Conv:Opaque{I}][I:Option{I}]
 
 Tests of check:
 
@@ -22,7 +22,6 @@ check { (X String) } [] = false
 check { (X String) } [ X ] = true
 check { (I Unit) } [ I ] = true
 check { (I Unit) } [ O ] = false
-check { (I Unit) } [ Conv{I}{O}; I ] = true
-check { (Conv Opaque{I}) (O String) } [ Conv{I}{O}; I; O ] = true
-check { (Conv[O:String] Opaque{I}) } [ Conv{I}{O}; I; O ] = false
-check { (Conv[O:String] Opaque{I}) } [ Conv[O:String]{I}; I ] = true
+check { (I Unit) } [ Conv; I ] = true
+check { (I Option{I}) } [ Conv; I ] = true
+check { (I Option[I:Unit]) } [ Conv; I ] = true

--- a/flambda-backend/tests/typing/global_module_test.ml
+++ b/flambda-backend/tests/typing/global_module_test.ml
@@ -70,6 +70,8 @@ module Test_data = struct
   let opaque_g = g "Opaque" ~hid:[i]
 
   let print_g = g "Print" ~hid:[i; conv]
+
+  let print_g_opaque = g "Print" ~hid:[i] ~vis:[conv, opaque_g]
 end
 
 module Subst_tests = struct
@@ -99,6 +101,7 @@ module Subst_tests = struct
     case y_g [i, unit_g];
     case print_g [i, unit_g];
     case print_g [i, option_g; conv, opaque_g];
+    case print_g_opaque [i, unit_g];
     ()
 end
 

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -931,7 +931,7 @@ type program =
     code : lambda }
 
 type arg_descr =
-  { arg_param: Global_module.Name.t;
+  { arg_param: Global_module.Parameter_name.t;
     arg_block_idx: int; }
 
 let const_int n = Const_base (Const_int n)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -937,7 +937,8 @@ type program =
    parameterised, this information (in particular [arg_block_idx]) describes
    instances rather than the base CU gs. *)
 type arg_descr =
-  { arg_param: Global_module.Name.t;    (* The parameter implemented (the [P] in
+  { arg_param: Global_module.Parameter_name.t;
+                                        (* The parameter implemented (the [P] in
                                            [-as-argument-for P]) *)
     arg_block_idx: int; }               (* The index within the main module
                                            block of the _argument block_. If

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -144,7 +144,7 @@ let read_library_info filename =
 let equal_args arg1 arg2 =
   let ({ param = name1; value = value1 } : CU.argument) = arg1 in
   let ({ param = name2; value = value2 } : CU.argument) = arg2 in
-  CU.equal name1 name2 && CU.equal value1 value2
+  CU.Name.equal name1 name2 && CU.equal value1 value2
 
 let equal_up_to_pack_prefix cu1 cu2 =
   CU.Name.equal (CU.name cu1) (CU.name cu2)

--- a/testsuite/tests/templates/basic/main-ocamlobjinfo.reference
+++ b/testsuite/tests/templates/basic/main-ocamlobjinfo.reference
@@ -21,18 +21,18 @@ Interfaces imported:
 	00000000000000000000000000000000	Category
 	00000000000000000000000000000000	CamlinternalFormatBasics
 Runtime parameters:
+	Category_utils[Category:Category_of_monoid[Monoid:List_monoid]]
+	Chain[Category:Category_of_monoid[Monoid:List_monoid]]
 	Chain[Category:Category_of_monoid[Monoid:Monoid_of_semigroup]]
 	Category_utils[Category:Category_of_monoid[Monoid:Monoid_of_semigroup]]
 	Monoid_utils[Monoid:Monoid_of_semigroup]
 	Monoid_of_semigroup
-	Chain[Category:Category_of_monoid[Monoid:List_monoid]]
-	Category_of_monoid[Monoid:List_monoid]
+	Category_of_monoid[Monoid:Monoid_of_semigroup]
 	Import
 	List_element
 	List_monoid
-	Category_utils[Category:Category_of_monoid[Monoid:List_monoid]]
 	Semigroup
-	Category_of_monoid[Monoid:Monoid_of_semigroup]
+	Category_of_monoid[Monoid:List_monoid]
 Required globals:
 	Monoid_utils[Monoid:Monoid_of_semigroup[Semigroup:String_semigroup]]
 	Stdlib__List
@@ -59,10 +59,10 @@ Interfaces imported:
 	00000000000000000000000000000000	Category
 	00000000000000000000000000000000	CamlinternalFormatBasics
 Globals in scope:
+	Chain[Category:Category_of_monoid[Monoid:List_monoid{List_element}]]
 	Chain[Category:Category_of_monoid[Monoid:Monoid_of_semigroup{Semigroup}]]
 	Monoid_of_semigroup{Semigroup}
-	Chain[Category:Category_of_monoid[Monoid:List_monoid{List_element}]]
-	Import{List_element}{Semigroup}
-	Category_of_monoid[Monoid:List_monoid{List_element}]
-	List_monoid{List_element}
 	Category_of_monoid[Monoid:Monoid_of_semigroup{Semigroup}]
+	Import{List_element}{Semigroup}
+	List_monoid{List_element}
+	Category_of_monoid[Monoid:List_monoid{List_element}]

--- a/testsuite/tests/templates/dunelike/test_byte.ml
+++ b/testsuite/tests/templates/dunelike/test_byte.ml
@@ -211,7 +211,7 @@
    ocamlc.byte;
 
    set flg_main_basic = "\
-     $flg -I p -I p_int -I p_string -I basic -I main_basic -I instances \
+     $flg -I p_int -I p_string -I basic -I main_basic -I instances \
      -open Main_basic__ -open No_direct_access_to_main_basic \
    ";
 
@@ -311,7 +311,7 @@
    ocamlc.byte;
 
    set flg_util = "\
-     $flg -parameter P -I p -I q -I q_impl -I basic -I fancy -I util \
+     $flg -parameter P -I p -I q_impl -I basic -I fancy -I util \
      -open Util__ -open No_direct_access_to_util \
    ";
 
@@ -324,7 +324,7 @@
    ocamlc.byte;
 
    {
-     flags = "$flg -I p -I p_int -I util";
+     flags = "$flg -I p_int -I util";
      module = "bad_use_util_wrongly.ml";
      ocamlc_byte_exit_status = "2";
      compiler_output = "bad_use_util_wrongly.output";
@@ -350,7 +350,7 @@
    ocamlc.byte;
 
    set flg_export_fancy_q_impl = "\
-     $flg -parameter P -I p -I q -I q_impl -I basic -I fancy \
+     $flg -parameter P -I p -I q_impl -I basic -I fancy \
      -I export_fancy_q_impl -I util \
      -open Export_fancy_q_impl__ -open No_direct_access_to_export_fancy_q_impl \
    ";
@@ -367,7 +367,7 @@
    ocamlc.byte;
 
    set flg_export_fancy_q_impl_p_int =
-     "$flg_instance -I export_fancy_q_impl -I p -I p_int";
+     "$flg_instance -I export_fancy_q_impl -I p_int";
 
    flags = "$flg_export_fancy_q_impl_p_int -instantiate";
    module = "";
@@ -382,7 +382,7 @@
    ocamlc.byte;
 
    set flg_use_fancy_q_impl = "\
-     $flg -parameter P -I p -I q -I q_impl -I basic -I fancy \
+     $flg -parameter P -I p -I q_impl -I basic -I fancy \
      -I export_fancy_q_impl -I use_fancy_q_impl -I util \
      -open Use_fancy_q_impl__ -open No_direct_access_to_use_fancy_q_impl \
    ";
@@ -396,7 +396,7 @@
    ocamlc.byte;
 
    set flg_use_fancy_q_impl_p_int =
-     "$flg_instance -I use_fancy_q_impl -I p -I p_int";
+     "$flg_instance -I use_fancy_q_impl -I p_int";
 
    flags = "$flg_use_fancy_q_impl_p_int -instantiate";
    module = "";
@@ -411,7 +411,7 @@
    ocamlc.byte;
 
    set flg_main = "\
-     $flg -I p -I p_int -I p_string -I q -I q_impl -I fancy -I basic -I main \
+     $flg -I p_int -I p_string -I q_impl -I fancy -I basic -I main \
      -H export_fancy_q_impl -I use_fancy_q_impl -I util -I instances \
      -open Main__ -open No_direct_access_to_main \
    ";

--- a/testsuite/tests/templates/dunelike/test_native.ml
+++ b/testsuite/tests/templates/dunelike/test_native.ml
@@ -211,7 +211,7 @@
    ocamlopt.byte;
 
    set flg_main_basic = "\
-     $flg -I p -I p_int -I p_string -I basic -I main_basic -I instances \
+     $flg -I p_int -I p_string -I basic -I main_basic -I instances \
      -open Main_basic__ -open No_direct_access_to_main_basic \
    ";
 
@@ -311,7 +311,7 @@
    ocamlopt.byte;
 
    set flg_util = "\
-     $flg -parameter P -I p -I q -I q_impl -I basic -I fancy -I util \
+     $flg -parameter P -I p -I q_impl -I basic -I fancy -I util \
      -open Util__ -open No_direct_access_to_util \
    ";
 
@@ -324,7 +324,7 @@
    ocamlopt.byte;
 
    {
-     flags = "$flg -I p -I p_int -I util";
+     flags = "$flg -I p_int -I util";
      module = "bad_use_util_wrongly.ml";
      ocamlopt_byte_exit_status = "2";
      compiler_output = "bad_use_util_wrongly.output";
@@ -350,7 +350,7 @@
    ocamlopt.byte;
 
    set flg_export_fancy_q_impl = "\
-     $flg -parameter P -I p -I q -I q_impl -I basic -I fancy \
+     $flg -parameter P -I p -I q_impl -I basic -I fancy \
      -I export_fancy_q_impl -I util \
      -open Export_fancy_q_impl__ -open No_direct_access_to_export_fancy_q_impl \
    ";
@@ -367,7 +367,7 @@
    ocamlopt.byte;
 
    set flg_export_fancy_q_impl_p_int =
-     "$flg_instance -I export_fancy_q_impl -I p -I p_int";
+     "$flg_instance -I export_fancy_q_impl -I p_int";
 
    flags = "$flg_export_fancy_q_impl_p_int -instantiate";
    module = "";
@@ -382,7 +382,7 @@
    ocamlopt.byte;
 
    set flg_use_fancy_q_impl = "\
-     $flg -parameter P -I p -I q -I q_impl -I basic -I fancy \
+     $flg -parameter P -I p -I q_impl -I basic -I fancy \
      -I export_fancy_q_impl -I use_fancy_q_impl -I util \
      -open Use_fancy_q_impl__ -open No_direct_access_to_use_fancy_q_impl \
    ";
@@ -396,7 +396,7 @@
    ocamlopt.byte;
 
    set flg_use_fancy_q_impl_p_int =
-     "$flg_instance -I use_fancy_q_impl -I p -I p_int";
+     "$flg_instance -I use_fancy_q_impl -I p_int";
 
    flags = "$flg_use_fancy_q_impl_p_int -instantiate";
    module = "";
@@ -411,7 +411,7 @@
    ocamlopt.byte;
 
    set flg_main = "\
-     $flg -I p -I p_int -I p_string -I q -I q_impl -I fancy -I basic -I main \
+     $flg -I p_int -I p_string -I q_impl -I fancy -I basic -I main \
      -H export_fancy_q_impl -I use_fancy_q_impl -I util -I instances \
      -open Main__ -open No_direct_access_to_main \
    ";

--- a/tools/objinfo.ml
+++ b/tools/objinfo.ml
@@ -87,11 +87,11 @@ let print_global_name_binding global =
 let print_line name =
   printf "\t%s\n" name
 
-let print_global_line glob =
-  printf "\t%a\n" Global_module.Name.output glob
-
 let print_global_as_name_line glob =
   printf "\t%a\n" Global_module.Name.output (Global_module.to_name glob)
+
+let print_parameter_name_line name =
+  printf "\t%a\n" Global_module.Parameter_name.output name
 
 let print_name_line cu =
   printf "\t%a\n" print_cu_without_prefix cu
@@ -114,7 +114,8 @@ let print_required_global id =
 
 let print_arg_descr arg_descr =
   let ({ arg_param; arg_block_idx = _ } : Lambda.arg_descr) = arg_descr in
-  printf "Parameter implemented: %a\n" Global_module.Name.output arg_param
+  printf "Parameter implemented: %a\n"
+    Global_module.Parameter_name.output arg_param
 
 let print_cmo_infos cu =
   printf "Unit name: %a\n" Compilation_unit.output cu.cu_name;
@@ -160,12 +161,12 @@ let print_cmi_infos name crcs kind params global_name_bindings =
     in
     printf "Is parameter: %s\n" (if is_param then "YES" else "no");
     print_string "Parameters:\n";
-    List.iter print_global_as_name_line params;
+    List.iter print_parameter_name_line params;
     begin
       match kind with
       | Normal { cmi_arg_for = Some arg_for; _ } ->
         printf "Argument for parameter:\n";
-        print_global_line arg_for
+        print_parameter_name_line arg_for
       | Normal _ | Parameter ->
         ()
     end;

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -812,7 +812,7 @@ type error =
   | Missing_module of Location.t * Path.t * Path.t
   | Illegal_value_name of Location.t * string
   | Lookup_error of Location.t * t * lookup_error
-  | Incomplete_instantiation of { unset_param : Global_module.Name.t }
+  | Incomplete_instantiation of { unset_param : Global_module.Parameter_name.t }
 
 exception Error of error
 
@@ -4624,7 +4624,7 @@ let report_error ppf = function
   | Incomplete_instantiation { unset_param } ->
       fprintf ppf "@[<hov>Not enough instance arguments: the parameter@ %a@ is \
                    required.@]"
-        Global_module.Name.print unset_param
+        Global_module.Parameter_name.print unset_param
 
 let () =
   Location.register_error_of_exn

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -539,7 +539,7 @@ val save_signature_with_imports:
            file name, imported units with their CRCs. *)
 
 (* Register a module as a parameter to this unit. *)
-val register_parameter: Global_module.Name.t -> unit
+val register_parameter: Global_module.Parameter_name.t -> unit
 
 (* Return the CRC of the interface of the given compilation unit *)
 val crc_of_unit: Compilation_unit.Name.t -> Digest.t
@@ -556,7 +556,7 @@ val runtime_parameter_bindings: unit -> (Global_module.t * Ident.t) list
 
 (* Return the list of parameters specified for the current unit, in
    alphabetical order *)
-val parameters: unit -> Global_module.Name.t list
+val parameters: unit -> Global_module.Parameter_name.t list
 
 (* [is_imported_opaque md] returns true if [md] is an opaque imported module *)
 val is_imported_opaque: Compilation_unit.Name.t -> bool
@@ -570,7 +570,8 @@ val is_parameter_unit: Global_module.Name.t -> bool
 
 (* [implemented_parameter md] is the argument given to -as-argument-for when
    [md] was compiled *)
-val implemented_parameter: Global_module.Name.t -> Global_module.Name.t option
+val implemented_parameter:
+  Global_module.Name.t -> Global_module.Parameter_name.t option
 
 (* [is_imported_parameter md] is true if [md] has been imported and is a
    parameter to this module *)
@@ -594,7 +595,7 @@ type error =
   | Missing_module of Location.t * Path.t * Path.t
   | Illegal_value_name of Location.t * string
   | Lookup_error of Location.t * t * lookup_error
-  | Incomplete_instantiation of { unset_param : Global_module.Name.t; }
+  | Incomplete_instantiation of { unset_param : Global_module.Parameter_name.t; }
 
 exception Error of error
 

--- a/typing/global_module.ml
+++ b/typing/global_module.ml
@@ -1,52 +1,72 @@
-[@@@ocaml.warning "+a-40-41-42"]
+module Parameter_name = struct
+  type t = string
+
+  let of_string t = t
+
+  let to_string t = t
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+
+    let compare = String.compare
+
+    let equal a b = compare a b = 0
+
+    let print = Format.pp_print_string
+
+    let output = print |> Misc.output_of_print
+
+    let hash = Hashtbl.hash
+  end)
+end
 
 let pp_concat pp ppf list =
   Format.pp_print_list ~pp_sep:Format.pp_print_cut pp ppf list
 
-type ('name, 'value) duplicate =
-  | Duplicate of { name : 'name; value1 : 'value; value2 : 'value }
+type 'value duplicate =
+  | Duplicate of { name : Parameter_name.t; value1 : 'value; value2 : 'value }
 
 module Argument = struct
-  type ('param, 'value) t = {
-    param : 'param;
+  type 'value t = {
+    param : Parameter_name.t;
     value : 'value;
   }
 
-  let compare cmp_param cmp_value
+  let compare cmp_value
         ({ param = param1; value = value1 } as t1)
         ({ param = param2; value = value2 } as t2) =
     if t1 == t2 then 0 else
-      match cmp_param param1 param2 with
+      match Parameter_name.compare param1 param2 with
       | 0 -> cmp_value value1 value2
       | c -> c
+
+  let compare_by_param t1 t2 = Parameter_name.compare t1.param t2.param
 end
 
-let check_uniqueness_of_sorted l ~cmp =
+let check_uniqueness_of_sorted l =
   let rec loop n1 v1 l =
-    match (l : (_, _) Argument.t list) with
+    match (l : _ Argument.t list) with
     | [] -> Ok ()
     | { param = n2; value = v2 } :: l ->
-      if cmp n1 n2 = 0 then
+      if Parameter_name.compare n1 n2 = 0 then
         Error (Duplicate { name = n1; value1 = v1; value2 = v2 })
       else
         loop n2 v2 l
   in
-  match (l : (_, _) Argument.t list) with
+  match (l : _ Argument.t list) with
   | [] -> Ok ()
   | { param = n1; value = v1 } :: l -> loop n1 v1 l
 
-let sort_and_check_uniqueness l ~cmp =
-  let open Argument in
-  let l = List.stable_sort (fun arg1 arg2 -> cmp arg1.param arg2.param) l in
-  check_uniqueness_of_sorted l ~cmp |> Result.map (fun () -> l)
+let sort_and_check_uniqueness l =
+  let l = List.stable_sort Argument.compare_by_param l in
+  check_uniqueness_of_sorted l |> Result.map (fun () -> l)
 
-let check_uniqueness_of_merged (type n v)
-      (l1 : (n, v) Argument.t list) l2 ~(cmp : n -> n -> int) =
+let check_uniqueness_of_merged (type v) l1 l2 =
   let open Argument in
-  let exception Found_duplicate of (n, v) duplicate in
+  let exception Found_duplicate of v duplicate in
   match
     Misc.Stdlib.List.merge_iter l1 l2
-      ~cmp:(fun arg1 arg2 -> cmp arg1.param arg2.param)
+      ~cmp:Argument.compare_by_param
       ~left_only:ignore
       ~right_only:ignore
       ~both:(fun { param = name; value = value1 } { value = value2; _ } ->
@@ -60,15 +80,21 @@ module Name : sig
     head : string;
     args : argument list;
   }
-  and argument = (t, t) Argument.t
+  and argument = t Argument.t
 
-  val create : string -> argument list -> (t, (t, t) duplicate) Result.t
+  val create : string -> argument list -> (t, t duplicate) Result.t
 
   val create_exn : string -> argument list -> t
 
   val create_no_args : string -> t
 
+  val of_parameter_name : Parameter_name.t -> t
+
   val unsafe_create_unchecked : string -> argument list -> t
+
+  val find_in_parameter_map : t -> 'a Parameter_name.Map.t -> 'a option
+
+  val mem_parameter_set : t -> Parameter_name.Set.t -> bool
 
   val to_string : t -> string
 
@@ -78,7 +104,7 @@ end = struct
     head : string;
     args : argument list;
   }
-  and argument = (t, t) Argument.t
+  and argument = t Argument.t
 
   include Identifiable.Make (struct
     type nonrec t = t
@@ -91,7 +117,8 @@ end = struct
         match String.compare head1 head2 with
         | 0 -> List.compare compare_arg args1 args2
         | c -> c
-    and compare_arg arg1 arg2 = Argument.compare compare compare arg1 arg2
+
+    and compare_arg arg1 arg2 = Argument.compare compare arg1 arg2
 
     let equal t1 t2 = compare t1 t2 = 0
 
@@ -105,7 +132,7 @@ end = struct
             head
             (pp_concat print_arg_pair) args
     and print_arg_pair ppf ({ param = name; value = arg } : argument) =
-      Format.fprintf ppf "[%a:%a]" print name print arg
+      Format.fprintf ppf "[%a:%a]" Parameter_name.print name print arg
 
     let output = print |> Misc.output_of_print
 
@@ -113,7 +140,7 @@ end = struct
   end)
 
   let create head args =
-    sort_and_check_uniqueness args ~cmp:compare
+    sort_and_check_uniqueness args
     |> Result.map (fun args -> { head; args })
 
   let create_exn head args =
@@ -125,51 +152,85 @@ end = struct
 
   let create_no_args head = create_exn head []
 
+  let of_parameter_name param =
+    create_no_args (param |> Parameter_name.to_string)
+
   let unsafe_create_unchecked head args = { head; args }
+
+  let unsafe_to_parameter_name_opt t =
+    (* Only safe for use as a lookup key, since it might actually not be a
+       parameter name *)
+    match t with
+    | { head; args = [] } -> Some (head |> Parameter_name.of_string)
+    | _ -> None
+
+  let find_in_parameter_map t map =
+    match unsafe_to_parameter_name_opt t with
+    | Some param -> Parameter_name.Map.find_opt param map
+    | None -> None
+
+  let mem_parameter_set t set =
+    match unsafe_to_parameter_name_opt t with
+    | Some param -> Parameter_name.Set.mem param set
+    | None -> false
 
   let to_string = print |> Misc.to_string_of_print
 end
-
-let compare_arg_name arg1 arg2 =
-   let open Argument in
-   Name.compare arg1.param arg2.param
-
-let rec list_similar f list1 list2 =
-  match list1, list2 with
-  | [], [] -> true
-  | a :: list1, b :: list2 -> f a b && list_similar f list1 list2
-  | (_ :: _), [] | [], (_ :: _) -> false
 
 module T0 : sig
   type t = private {
     head : string;
     visible_args : argument list;
+    (* CR-someday lmaurer: Could just be the parameter names *)
     hidden_args : argument list;
   }
-  and argument = (Name.t, t) Argument.t
+
+  and argument = t Argument.t
 
   include Identifiable.S with type t := t
 
   val create
      : string
     -> argument list
-    -> hidden_args:argument list
-    -> (t, (Name.t, t) duplicate) Result.t
+    -> hidden_args:Parameter_name.t list
+    -> (t, t duplicate) Result.t
 
   val create_exn
      : string
     -> argument list
-    -> hidden_args:argument list
+    -> hidden_args:Parameter_name.t list
     -> t
 
   val to_name : t -> Name.t
+
+  val unsafe_create_unchecked
+     : string
+    -> argument list
+    -> hidden_args:argument list
+    -> t
 end = struct
   type t = {
     head : string;
     visible_args : argument list;
     hidden_args : argument list;
   }
-  and argument = (Name.t, t) Argument.t
+  and argument = t Argument.t
+
+  let rec print ppf { head; visible_args; hidden_args } =
+    let hidden_args =
+      (* Assume the value is just the name (because it is) *)
+      List.map (fun ({ param; value = _ } : argument) -> param) hidden_args
+    in
+    print_syntax ppf ~head ~visible_args ~hidden_args
+  and print_syntax ppf ~head ~visible_args ~hidden_args =
+    Format.fprintf ppf "@[<hov 1>%s%a%a@]"
+      head
+      (pp_concat print_visible_pair) visible_args
+      (pp_concat print_hidden_pair) hidden_args
+  and print_visible_pair ppf ({ param = name; value } : argument) =
+    Format.fprintf ppf "[%a:%a]" Parameter_name.print name print value
+  and print_hidden_pair ppf name =
+    Format.fprintf ppf "{%a}" Parameter_name.print name
 
   include Identifiable.Make (struct
     type nonrec t = t
@@ -186,44 +247,31 @@ end = struct
             | c -> c
           end
         | c -> c
-    and compare_pairs arg1 arg2 = Argument.compare Name.compare compare arg1 arg2
+
+    and compare_pairs arg1 arg2 = Argument.compare compare arg1 arg2
 
     let equal t1 t2 = compare t1 t2 = 0
 
-    let rec equal_looking t name =
-      let { head; visible_args; hidden_args } = t in
-      let { Name.head = name_head; args = name_args } = name in
-      hidden_args = []
-      && String.equal head name_head
-      && list_similar equal_looking_args visible_args name_args
-    and equal_looking_args
-          ({ param = name1; value = value1 } : argument)
-          ({ param = name2; value = value2 } : Name.argument) =
-      Name.equal name1 name2 && equal_looking value1 value2
-
-    let rec print ppf { head; visible_args; hidden_args } =
-      Format.fprintf ppf "@[<hov 1>%s%a%a@]"
-        head
-        (pp_concat print_visible_pair) visible_args
-        (pp_concat print_hidden_pair) hidden_args
-    and print_visible_pair ppf ({ param = name; value } : argument) =
-      Format.fprintf ppf "[%a:%a]" Name.print name print value
-    and print_hidden_pair ppf ({ param = name; value } : argument) =
-      if equal_looking value name then
-        Format.fprintf ppf "{%a}" Name.print name
-      else
-        Format.fprintf ppf "{%a:%a}" Name.print name print value
+    let print = print
 
     let output = print |> Misc.output_of_print
 
     let hash = Hashtbl.hash
   end)
 
+  let of_parameter_name param =
+    { head = Parameter_name.to_string param; hidden_args = []; visible_args = [] }
+
   let create head visible_args ~hidden_args =
+    let hidden_args =
+      List.map
+        (fun param -> Argument.{ param; value = of_parameter_name param })
+        hidden_args
+    in
     let (let*) = Result.bind in
-    let* visible_args = sort_and_check_uniqueness visible_args ~cmp:Name.compare in
-    let* hidden_args = sort_and_check_uniqueness hidden_args ~cmp:Name.compare in
-    let* () = check_uniqueness_of_merged visible_args hidden_args ~cmp:Name.compare in
+    let* visible_args = sort_and_check_uniqueness visible_args in
+    let* hidden_args = sort_and_check_uniqueness hidden_args in
+    let* () = check_uniqueness_of_merged visible_args hidden_args in
     Ok { head; visible_args; hidden_args }
 
   let create_exn head visible_args ~hidden_args =
@@ -231,7 +279,10 @@ end = struct
     | Ok t -> t
     | Error (Duplicate _) ->
       Misc.fatal_errorf "Names of arguments and parameters must be unique:@ %a"
-        print { head; visible_args; hidden_args }
+        (fun ppf () -> print_syntax ppf ~head ~visible_args ~hidden_args) ()
+
+  let unsafe_create_unchecked head visible_args ~hidden_args =
+    { head; visible_args; hidden_args }
 
   (* CR-someday lmaurer: Should try and make this unnecessary or at least cheap.
      Could do it by making [Name.t] an unboxed existential so that converting from
@@ -247,20 +298,24 @@ include T0
 
 let to_string = print |> Misc.to_string_of_print
 
-let all_args t = t.visible_args @ t.hidden_args
-
-module Subst = Name.Map
+module Subst = Parameter_name.Map
 type subst = t Subst.t
 
+let find_in_parameter_map t map =
+  match t with
+  | { head; visible_args = []; hidden_args = []; } ->
+    Parameter_name.Map.find_opt (head |> Parameter_name.of_string) map
+  | _ -> None
+
 let rec subst0 (t : t) (s : subst) ~changed =
-  match Subst.find_opt (to_name t) s with
+  match find_in_parameter_map t s with
   | Some rhs -> changed := true; rhs
   | None -> subst0_inside t s ~changed
 and subst0_inside { head; visible_args; hidden_args } s ~changed =
   let matching_hidden_args, non_matching_hidden_args =
     List.partition_map
       (fun (({ param = name; value } : argument) as pair) ->
-          match Subst.find_opt (to_name value) s with
+          match find_in_parameter_map value s with
           | Some rhs ->
             changed := true;
             Left ({ param = name; value = rhs } : argument)
@@ -268,11 +323,15 @@ and subst0_inside { head; visible_args; hidden_args } s ~changed =
       hidden_args
   in
   let visible_args = subst0_alist visible_args s ~changed in
-  let hidden_args = subst0_alist non_matching_hidden_args s ~changed in
   let visible_args =
-    List.merge compare_arg_name visible_args matching_hidden_args
+    List.merge Argument.compare_by_param visible_args matching_hidden_args
   in
-  create_exn head visible_args ~hidden_args
+  let hidden_args =
+    (* Don't bother substituting: these never have deeper structure *)
+    non_matching_hidden_args
+  in
+  (* The [List.merge] preserved sorting so everything must still be valid *)
+  unsafe_create_unchecked head visible_args ~hidden_args
 and subst0_alist l s ~changed =
   List.map
     (fun (arg : argument) -> { arg with value = subst0 arg.value s ~changed })
@@ -288,15 +347,15 @@ let subst_inside t s =
   let new_t = subst0_inside t s ~changed in
   if !changed then new_t else t
 
-let check s args =
+let check s params =
   (* This could do more - say, check that the replacement (the argument) has
       all the parameters of the original (the parameter). (The subset rule
       requires this, since an argument has to refer to the parameter it
       implements, and thus the parameter's parameters must include the
       argument's parameters.) It would be redundant with the checks
       implemented elsewhere but could still be helpful. *)
-  let param_set = List.map to_name args |> Name.Set.of_list in
-  Name.Set.subset (Name.Map.keys s) param_set
+  let param_set = Parameter_name.Set.of_list params in
+  Parameter_name.Set.subset (Parameter_name.Map.keys s) param_set
 
 let rec is_complete t =
   let open Argument in
@@ -345,7 +404,7 @@ module With_precision = struct
     let rec meet glob1 glob2 =
       let visible_args_rev =
         Misc.Stdlib.List.merge_fold glob1.visible_args glob2.visible_args
-          ~cmp:compare_arg_name
+          ~cmp:Argument.compare_by_param
           ~init:[]
           ~left_only:(fun _ _ -> raise Inconsistent)
           ~right_only:(fun _ _ -> raise Inconsistent)
@@ -354,7 +413,7 @@ module With_precision = struct
       let hidden_args_rev =
         (* Keep only the hidden arguments that appear in both lists *)
         Misc.Stdlib.List.merge_fold glob1.hidden_args glob2.hidden_args
-          ~cmp:compare_arg_name
+          ~cmp:Argument.compare_by_param
           ~init:[]
           ~left_only:(fun acc_rev _ -> acc_rev)
           ~right_only:(fun acc_rev _ -> acc_rev)
@@ -363,9 +422,9 @@ module With_precision = struct
       meet_atom String.equal glob1.head glob2.head;
       let visible_args = List.rev visible_args_rev in
       let hidden_args = List.rev hidden_args_rev in
-      create_exn glob1.head visible_args ~hidden_args
+      unsafe_create_unchecked glob1.head visible_args ~hidden_args
     and meet_args (arg1 : _ Argument.t) (arg2 : _ Argument.t) =
-      meet_atom Name.equal arg1.param arg2.param;
+      meet_atom Parameter_name.equal arg1.param arg2.param;
       let value = meet arg1.value arg2.value in
       ({ param = arg1.param; value } : _ Argument.t)
     in

--- a/typing/global_module.ml
+++ b/typing/global_module.ml
@@ -152,8 +152,7 @@ end = struct
 
   let create_no_args head = create_exn head []
 
-  let of_parameter_name param =
-    create_no_args (param |> Parameter_name.to_string)
+  let of_parameter_name param = create_no_args param
 
   let unsafe_create_unchecked head args = { head; args }
 
@@ -161,7 +160,7 @@ end = struct
     (* Only safe for use as a lookup key, since it might actually not be a
        parameter name *)
     match t with
-    | { head; args = [] } -> Some (head |> Parameter_name.of_string)
+    | { head; args = [] } -> Some head
     | _ -> None
 
   let find_in_parameter_map t map =
@@ -259,8 +258,7 @@ end = struct
     let hash = Hashtbl.hash
   end)
 
-  let of_parameter_name param =
-    { head = Parameter_name.to_string param; hidden_args = []; visible_args = [] }
+  let of_parameter_name param = { head = param; hidden_args = []; visible_args = [] }
 
   let create head visible_args ~hidden_args =
     let hidden_args =
@@ -304,7 +302,7 @@ type subst = t Subst.t
 let find_in_parameter_map t map =
   match t with
   | { head; visible_args = []; hidden_args = []; } ->
-    Parameter_name.Map.find_opt (head |> Parameter_name.of_string) map
+    Parameter_name.Map.find_opt head map
   | _ -> None
 
 let rec subst0 (t : t) (s : subst) ~changed =

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -593,15 +593,6 @@ and compute_global penv modname ~params ~check ~allow_excess_args =
                              filename = pn.pn_import.imp_filename })
               | Some ty -> ty
             in
-            let _ : Global_module.t =
-              (* CR-soon lmaurer: It's wholly unnecessary to do this, since the only
-                 point is to learn what parameters [actual_type] has, but it can't have
-                 parameters because a parameter can't have parameters. It does have the
-                 side effect of loading the .cmi, though, so I'm keeping it for now so
-                 that introducing [Parameter_name.t] is a pure refactor. *)
-              global_of_global_name ~allow_excess_args penv ~check
-                (actual_type |> Global_module.Name.of_parameter_name)
-            in
             if not (Global_module.Parameter_name.equal expected_type actual_type)
             then begin
               raise (Error (Argument_type_mismatch {

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -37,24 +37,24 @@ type error =
   | Not_compiled_as_parameter of Global_module.Name.t
   | Imported_module_has_unset_parameter of
       { imported : Global_module.Name.t;
-        parameter : Global_module.Name.t;
+        parameter : Global_module.Parameter_name.t;
       }
   | Imported_module_has_no_such_parameter of
       { imported : CU.Name.t;
-        valid_parameters : Global_module.Name.t list;
-        parameter : Global_module.Name.t;
+        valid_parameters : Global_module.Parameter_name.t list;
+        parameter : Global_module.Parameter_name.t;
         value : Global_module.Name.t;
       }
   | Not_compiled_as_argument of
-      { param : Global_module.Name.t;
+      { param : Global_module.Parameter_name.t;
         value : Global_module.Name.t;
         filename : filepath;
       }
   | Argument_type_mismatch of
       { value : Global_module.Name.t;
         filename : filepath;
-        expected : Global_module.Name.t;
-        actual : Global_module.Name.t;
+        expected : Global_module.Parameter_name.t;
+        actual : Global_module.Parameter_name.t;
       }
   | Unbound_module_as_argument_value of
       { instance: Global_module.Name.t;
@@ -99,8 +99,8 @@ type global_name_info = {
 (* Data relating directly to a .cmi - does not depend on arguments *)
 type import = {
   imp_is_param : bool;
-  imp_params : Global_module.t list; (* CR lmaurer: Should be [Parameter_name.t list] *)
-  imp_arg_for : Global_module.Name.t option;
+  imp_params : Global_module.Parameter_name.t list;
+  imp_arg_for : Global_module.Parameter_name.t option;
   imp_impl : CU.t option; (* None iff import is a parameter *)
   imp_raw_sign : Signature_with_global_bindings.t;
   imp_filename : string;
@@ -124,9 +124,6 @@ type import_info =
 type pers_name = {
   pn_import : import;
   pn_global : Global_module.t;
-  pn_arg_for : Global_module.Name.t option;
-    (* Currently always the same as [pn_import.imp_arg_for], since parameters
-       don't have parameters *)
   pn_sign : Subst.Lazy.signature;
 }
 
@@ -144,7 +141,7 @@ type 'a pers_struct_info = {
   ps_val : 'a;
 }
 
-module Param_set = Global_module.Name.Set
+module Param_set = Global_module.Parameter_name.Set
 
 (* If you add something here, _do not forget_ to add it to [clear]! *)
 type 'a t = {
@@ -209,7 +206,7 @@ let add_import {imported_units; _} s =
 let rec add_imports_in_name penv (g : Global_module.Name.t) =
   add_import penv (g |> CU.Name.of_head_of_global_name);
   let add_in_arg ({ param; value } : Global_module.Name.argument) =
-    add_imports_in_name penv param;
+    add_import penv (param |> CU.Name.of_parameter_name);
     add_imports_in_name penv value
   in
   List.iter add_in_arg g.args
@@ -237,18 +234,15 @@ let find_in_cache penv name =
   find_info_in_cache penv name |> Option.map (fun ps -> ps.ps_val)
 
 let register_parameter ({param_imports; _} as penv) modname =
-  let import =
-    (* Note that parameters cannot themselves be parameterised. (This may be lifted in the
-       future, but dependent types are hard.) *)
-    CU.Name.of_global_name_no_args_exn modname
-  in
+  let import = CU.Name.of_parameter_name modname in
   begin match find_import_info_in_cache penv import with
   | None ->
       (* Not loaded yet; if it's wrong, we'll get an error at load time *)
       ()
   | Some imp ->
       if not imp.imp_is_param then
-        raise (Error (Not_compiled_as_parameter modname))
+        raise (Error (Not_compiled_as_parameter
+                        (Global_module.Name.of_parameter_name modname)))
   end;
   param_imports := Param_set.add modname !param_imports
 
@@ -281,8 +275,8 @@ let check_consistency penv imp =
     | (Normal _ | Parameter), _ ->
       error (Inconsistent_import(name, auth, source))
 
-let is_registered_parameter_import {param_imports; _} import =
-  Param_set.mem import !param_imports
+let is_registered_parameter_import {param_imports; _} name =
+  Global_module.Name.mem_parameter_set name !param_imports
 
 let is_parameter_import t modname =
   let import = CU.Name.of_head_of_global_name modname in
@@ -478,16 +472,8 @@ let rec approximate_global_by_name penv global_name =
       !param_imports
       visible_args
   in
-  let arg_of_param (param : Global_module.Name.t) : Global_module.t =
-    (* CR-someday Really should just have a separate Parameter_name.t type *)
-    (* Assume the parameter has no arguments because it can't have any *)
-    Global_module.create_exn param.head [] ~hidden_args:[]
-  in
   let hidden_args =
     Param_set.elements params_not_being_passed
-    |> List.map
-      (fun param ->
-         ({ param; value = arg_of_param param } : _ Global_module.Argument.t))
   in
   let global = Global_module.create_exn head visible_args ~hidden_args in
   remember_global penv global ~precision:Approximate ~mentioned_by:Current;
@@ -533,12 +519,12 @@ let current_unit_is_instance_of name =
    parameter.) *)
 let check_for_unset_parameters penv global =
   List.iter
-    (fun ({ param = _; value = arg_value } : Global_module.argument) ->
+    (fun ({ param = parameter; value = arg_value } : Global_module.argument) ->
        let value_name = Global_module.to_name arg_value in
        if not (is_registered_parameter_import penv value_name) then
          error (Imported_module_has_unset_parameter {
              imported = Global_module.to_name global;
-             parameter = value_name;
+             parameter;
            }))
     global.Global_module.hidden_args
 
@@ -565,31 +551,16 @@ and compute_global penv modname ~params ~check ~allow_excess_args =
                (Unbound_module_as_argument_value { instance = modname; value }))
       modname.Global_module.Name.args
   in
-  let subst : Global_module.subst = Global_module.Name.Map.of_list arg_global_by_param_name in
+  let subst : Global_module.subst =
+    Global_module.Parameter_name.Map.of_list arg_global_by_param_name
+  in
   if check && modname.Global_module.Name.args <> [] then begin
-    (* A paragraph for the future that I don't want to lose track of:
-
-       Produce the expected type of each argument. This takes into account
-       substitutions among the parameter types: if the parameters are T and
-       To_string[T] and the arguments are [Int] and [Int_to_string], we want to
-       check that [Int] has type [T] and that [Int_to_string] has type
-       [To_string[T\Int]].
-
-       For now, our parameters don't take parameters, so we can just assert that
-       the parameter name has no arguments and keep it as the expected type. *)
-    let expected_type_by_param_name =
-      List.map
-        (fun param ->
-           assert (not (Global_module.has_arguments param));
-           Global_module.to_name param, param)
-        params
-    in
-    let compare_by_param (param1, _) (param2, _) =
-      Global_module.Name.compare param1 param2
+    let compare_by_param param1 (param2, _) =
+      Global_module.Parameter_name.compare param1 param2
     in
     Misc.Stdlib.List.merge_iter
       ~cmp:compare_by_param
-      expected_type_by_param_name
+      params
       arg_global_by_param_name
       ~left_only:
         (fun _ ->
@@ -603,61 +574,50 @@ and compute_global penv modname ~params ~check ~allow_excess_args =
               raise
                 (Error (Imported_module_has_no_such_parameter {
                           imported = CU.Name.of_head_of_global_name modname;
-                          valid_parameters =
-                            params |> List.map Global_module.to_name;
+                          valid_parameters = params;
                           parameter = param;
                           value = value |> Global_module.to_name;
                         })))
       ~both:
-        (fun (param_name, expected_type_global) (_arg_name, arg_value_global) ->
+        (fun expected_type (_arg_name, arg_value_global) ->
             let arg_value = arg_value_global |> Global_module.to_name in
             let pn =
               find_pers_name ~allow_hidden:true penv ~check arg_value
                 ~allow_excess_args
             in
             let actual_type =
-              match pn.pn_arg_for with
+              match pn.pn_import.imp_arg_for with
               | None ->
                   error (Not_compiled_as_argument
-                           { param = param_name; value = arg_value;
+                           { param = expected_type; value = arg_value;
                              filename = pn.pn_import.imp_filename })
               | Some ty -> ty
             in
-            let actual_type_global =
-              global_of_global_name ~allow_excess_args penv ~check actual_type
+            let _ : Global_module.t =
+              (* CR-soon lmaurer: It's wholly unnecessary to do this, since the only
+                 point is to learn what parameters [actual_type] has, but it can't have
+                 parameters because a parameter can't have parameters. It does have the
+                 side effect of loading the .cmi, though, so I'm keeping it for now so
+                 that introducing [Parameter_name.t] is a pure refactor. *)
+              global_of_global_name ~allow_excess_args penv ~check
+                (actual_type |> Global_module.Name.of_parameter_name)
             in
-            if not (Global_module.equal expected_type_global actual_type_global)
+            if not (Global_module.Parameter_name.equal expected_type actual_type)
             then begin
-              let expected_type = Global_module.to_name expected_type_global in
-              if Global_module.Name.equal expected_type actual_type then
-                (* This shouldn't happen, I don't think, but if it does, I'd rather
-                  not output an "X != X" sort of error message *)
-                Misc.fatal_errorf
-                  "Mismatched argument type (despite same name):@ \
-                  expected %a,@ got %a"
-                  Global_module.print expected_type_global
-                  Global_module.print actual_type_global
-              else
-                raise (Error (Argument_type_mismatch {
-                    value = arg_value;
-                    filename = pn.pn_import.imp_filename;
-                    expected = expected_type;
-                    actual = actual_type;
-                  }))
+              raise (Error (Argument_type_mismatch {
+                  value = arg_value;
+                  filename = pn.pn_import.imp_filename;
+                  expected = expected_type;
+                  actual = actual_type;
+                }))
             end)
   end;
   (* Form the name without any arguments at all, then substitute in all the
      arguments. A bit roundabout but should be sound *)
-  let hidden_args =
-    List.map
-      (fun param : Global_module.argument ->
-         { param = Global_module.to_name param; value = param })
-      params
-  in
   let global_without_args =
     (* Won't raise an exception, since the hidden args are all different
        (since the params are different, or else we have bigger problems) *)
-    Global_module.create_exn modname.Global_module.Name.head [] ~hidden_args
+    Global_module.create_exn modname.Global_module.Name.head [] ~hidden_args:params
   in
   let global, _changed = Global_module.subst global_without_args subst in
   global
@@ -701,7 +661,6 @@ and acknowledge_new_pers_name penv check global_name global import =
      through here already. *)
   check_for_unset_parameters penv global;
   let {persistent_names; _} = penv in
-  let arg_for = import.imp_arg_for in
   let sign = import.imp_raw_sign in
   let sign =
     let bindings =
@@ -720,7 +679,6 @@ and acknowledge_new_pers_name penv check global_name global import =
     sign.bound_globals;
   let pn = { pn_import = import;
              pn_global = global;
-             pn_arg_for = arg_for;
              pn_sign = sign.sign;
            } in
   if check then check_consistency penv import;
@@ -812,7 +770,7 @@ let make_binding penv (global : Global_module.t) (impl : CU.t option) : binding 
       | _ ->
           (* Make sure the unit isn't supposed to be packed *)
           assert (not (CU.is_packed unit_from_cmi));
-          CU.of_global_name name
+          CU.of_complete_global_exn global
     in
     Constant unit
 
@@ -1051,7 +1009,7 @@ let is_imported_opaque {imported_opaque_units; _} s =
 
 let implemented_parameter penv modname =
   match find_name_info_in_cache penv modname with
-  | Some { pn_arg_for; _ } -> pn_arg_for
+  | Some { pn_import = { imp_arg_for; _ }; _ } -> imp_arg_for
   | None -> None
 
 let make_cmi penv modname kind sign alerts =
@@ -1065,7 +1023,6 @@ let make_cmi penv modname kind sign alerts =
   let params =
     (* Needs to be consistent with [Translmod] *)
     parameters penv
-    |> List.map (global_of_global_name penv ~check:true ~allow_excess_args:false)
   in
   (* Need to calculate [params] before these since [global_of_global_name] has
      side effects *)
@@ -1178,9 +1135,9 @@ let report_error ppf =
            @[<hov>Pass @{<inline_code>-parameter %a@}@ to add %a@ as a parameter@ \
            of the current unit.@]@]"
         (Style.as_inline_code Global_module.Name.print) modname
-        (Style.as_inline_code Global_module.Name.print) param
-        Global_module.Name.print param
-        (Style.as_inline_code Global_module.Name.print) param
+        (Style.as_inline_code Global_module.Parameter_name.print) param
+        Global_module.Parameter_name.print param
+        (Style.as_inline_code Global_module.Parameter_name.print) param
   | Imported_module_has_no_such_parameter
         { valid_parameters; imported = modname; parameter = param; value = _; } ->
       let pp_hint ppf () =
@@ -1190,11 +1147,11 @@ let report_error ppf =
               "Compile %a@ with @{<inline_code>-parameter %a@}@ to make it a \
                parameter."
               (Style.as_inline_code CU.Name.print) modname
-              Global_module.Name.print param
+              Global_module.Parameter_name.print param
         | _ ->
           let print_params =
             Format.pp_print_list ~pp_sep:Format.pp_print_space
-              (Style.as_inline_code Global_module.Name.print)
+              (Style.as_inline_code Global_module.Parameter_name.print)
           in
           fprintf ppf "Parameters for %a:@ @[<hov>%a@]"
             (Style.as_inline_code CU.Name.print) modname
@@ -1204,7 +1161,7 @@ let report_error ppf =
         "@[<hov>The module %a@ has no parameter %a.@]@.\
          @[<hov>@{<hint>Hint@}: @[<hov>%a@]@]"
         (Style.as_inline_code CU.Name.print) modname
-        (Style.as_inline_code Global_module.Name.print) param
+        (Style.as_inline_code Global_module.Parameter_name.print) param
         pp_hint ()
   | Not_compiled_as_argument { param; value; filename } ->
       fprintf ppf
@@ -1213,9 +1170,9 @@ let report_error ppf =
          @[<hov>@{<hint>Hint@}: \
            @[<hov>Compile %a@ with @{<inline_code>-as-argument-for %a@}.@]@]"
         (Style.as_inline_code Global_module.Name.print) value
-        (Style.as_inline_code Global_module.Name.print) param
+        (Style.as_inline_code Global_module.Parameter_name.print) param
         (Style.as_inline_code Location.print_filename) filename
-        Global_module.Name.print param
+        Global_module.Parameter_name.print param
   | Argument_type_mismatch { value; filename; expected; actual; } ->
       fprintf ppf
         "@[<hov>The module %a@ is used as an argument for the parameter %a@ \
@@ -1224,11 +1181,11 @@ let report_error ppf =
            @[<hov>%a@ was compiled with \
              @{<inline_code>-as-argument-for %a@}.@]@]"
         (Style.as_inline_code Global_module.Name.print) value
-        (Style.as_inline_code Global_module.Name.print) expected
+        (Style.as_inline_code Global_module.Parameter_name.print) expected
         (Style.as_inline_code Global_module.Name.print) value
-        (Style.as_inline_code Global_module.Name.print) actual
+        (Style.as_inline_code Global_module.Parameter_name.print) actual
         (Style.as_inline_code Location.print_filename) filename
-        Global_module.Name.print expected
+        Global_module.Parameter_name.print expected
   | Unbound_module_as_argument_value { instance; value } ->
       fprintf ppf
         "@[<hov>Unbound module %a@ in instance %a@]"

--- a/typing/persistent_env.mli
+++ b/typing/persistent_env.mli
@@ -34,24 +34,24 @@ type error =
   | Not_compiled_as_parameter of Global_module.Name.t
   | Imported_module_has_unset_parameter of
       { imported : Global_module.Name.t;
-        parameter : Global_module.Name.t;
+        parameter : Global_module.Parameter_name.t;
       }
   | Imported_module_has_no_such_parameter of
       { imported : Compilation_unit.Name.t;
-        valid_parameters : Global_module.Name.t list;
-        parameter : Global_module.Name.t;
+        valid_parameters : Global_module.Parameter_name.t list;
+        parameter : Global_module.Parameter_name.t;
         value : Global_module.Name.t;
       }
   | Not_compiled_as_argument of
-      { param : Global_module.Name.t;
+      { param : Global_module.Parameter_name.t;
         value : Global_module.Name.t;
         filename : filepath;
       }
   | Argument_type_mismatch of
       { value : Global_module.Name.t;
         filename : filepath;
-        expected : Global_module.Name.t;
-        actual : Global_module.Name.t;
+        expected : Global_module.Parameter_name.t;
+        actual : Global_module.Parameter_name.t;
       }
   | Unbound_module_as_argument_value of
       { instance : Global_module.Name.t; value : Global_module.Name.t; }
@@ -116,7 +116,7 @@ val check : allow_hidden:bool -> 'a t -> 'a sig_reader
 (* Lets it be known that the given module is a parameter to this module and thus is
    expected to have been compiled as such. Raises an exception if the module has already
    been imported as a non-parameter. *)
-val register_parameter : 'a t -> Global_module.Name.t -> unit
+val register_parameter : 'a t -> Global_module.Parameter_name.t -> unit
 
 (* [is_parameter_import penv md] checks if [md] is a parameter. Raises a fatal
    error if the module has not been imported. *)
@@ -138,7 +138,7 @@ val register_import_as_opaque : 'a t -> Compilation_unit.Name.t -> unit
 (* [implemented_parameter penv md] returns the argument to [-as-argument-for]
    that [md] was compiled with. *)
 val implemented_parameter : 'a t
-  -> Global_module.Name.t -> Global_module.Name.t option
+  -> Global_module.Name.t -> Global_module.Parameter_name.t option
 
 val global_of_global_name : 'a t
   -> check:bool
@@ -192,7 +192,7 @@ val is_imported_parameter : 'a t -> Global_module.Name.t -> bool
    All of these will have been specified by [-parameter] but not all of them are
    necessarily imported - any that don't appear in the source are still considered
    parameters of the module but will not appear in [imports]. *)
-val parameters : 'a t -> Global_module.Name.t list
+val parameters : 'a t -> Global_module.Parameter_name.t list
 
 (* Return the CRC of the interface of the given compilation unit *)
 val crc_of_unit: 'a t -> Compilation_unit.Name.t -> Digest.t

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -451,7 +451,8 @@ let instance_name global =
     String.concat "" (head :: List.map string_of_arg args)
   and string_of_arg arg =
     let ({ param; value } : Global_module.Name.argument) = arg in
-    sprintf "(%s)(%s)" (string_of_global param) (string_of_global value)
+    sprintf "(%s)(%s)"
+      (Global_module.Parameter_name.to_string param) (string_of_global value)
   in
   let printed_name =
     string_of_global global ^ " [@jane.non_erasable.instances]"

--- a/typing/signature_with_global_bindings.mli
+++ b/typing/signature_with_global_bindings.mli
@@ -51,4 +51,4 @@ val read_from_cmi : Cmi_format.cmi_infos_lazy -> t
     Note that the argument values themselves won't be returned in the new list
     of bound globals, since it's assumed that they are already accounted for in
     the environment. *)
-val subst : t -> (Global_module.Name.t * Global_module.t) list -> t
+val subst : t -> (Global_module.Parameter_name.t * Global_module.t) list -> t

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -156,13 +156,13 @@ type error =
   | Cannot_compile_implementation_as_parameter
   | Cannot_implement_parameter of Compilation_unit.Name.t * Misc.filepath
   | Argument_for_non_parameter of Global_module.Name.t * Misc.filepath
-  | Cannot_find_argument_type of Global_module.Name.t
+  | Cannot_find_argument_type of Global_module.Parameter_name.t
   | Inconsistent_argument_types of {
-      new_arg_type: Global_module.Name.t option;
-      old_arg_type: Global_module.Name.t option;
+      new_arg_type: Global_module.Parameter_name.t option;
+      old_arg_type: Global_module.Parameter_name.t option;
       old_source_file: Misc.filepath;
     }
-  | Duplicate_parameter_name of Global_module.Name.t
+  | Duplicate_parameter_name of Global_module.Parameter_name.t
   | Submode_failed of Mode.Value.error
   | Modal_module_not_supported
 

--- a/utils/compilation_unit.mli
+++ b/utils/compilation_unit.mli
@@ -47,7 +47,7 @@ module Name : sig
 
   val of_head_of_global_name : Global_module.Name.t -> t
 
-  val of_global_name_no_args_exn : Global_module.Name.t -> t
+  val of_parameter_name : Global_module.Parameter_name.t -> t
 
   val to_global_name : t -> Global_module.Name.t
 
@@ -105,7 +105,7 @@ val create : Prefix.t -> Name.t -> t
 val create_child : t -> Name.t -> t
 
 type argument =
-  { param : t;
+  { param : Name.t;
     value : t
   }
 
@@ -113,26 +113,6 @@ type argument =
     given arguments. The arguments will be sorted alphabetically by
     parameter name. *)
 val create_instance : t -> argument list -> t
-
-(* CR lmaurer: [of_global_name] would be better if (a) it insisted on taking a
-   complete instantiation (the exceptional cases mentioned are handled by other
-   functions) and (b) it took a [Global_module.t], which would allow it to
-   verify that it's complete. (For (b), we'll also want an [of_parameter]
-   function taking [Parameter.t] once that exists.) *)
-
-(** Create the compilation unit named by the given [Global_module.Name.t].
-    Usually only meaningful if the global name is a _complete instantiation_,
-    which is to say either (a) the named module has no parameters, or (b) there
-    is an argument for each parameter and each argument is itself a complete
-    instantiation. This ensures the name determines a compile-time constant, and
-    then the [t] returned here is the module corresponding to that constant.
-
-    The exception to the above is that a global name with _no_ arguments makes
-    sense even if the named module takes parameters, only in this case the [t]
-    refers to the module with the instantiating functor. This is only relevant
-    in two cases: when we're compiling the parameterised module itself, and
-    when we're instantiating it. *)
-val of_global_name : Global_module.Name.t -> t
 
 (** Convert the compilation unit to a [Global_module.Name.t], if possible (which
     is to say, if its prefix is empty). *)


### PR DESCRIPTION
Based on #3172, though a bit more narrow to focus on just putting the new type in all the places.

The new type `Global_module.Parameter_name.t` takes the place of any `Global_module.t` or `Global_module.Name.t` that is known to be the name of a parameter. Can't have parameters. (Notably, even the current half-worked-out plans for parameterized parameters would actually keep this type in many places, so this isn't as much in the way as one might think.)

Concretely, the immediate benefit is that we no longer load the .cmi file of a parameter just because it's used in the name of an instance. (All that we actually need to check in `Foo[Bar:Baz]` is (a) that `Foo` expects a `Bar`, (b) that `Baz` implements `Bar`, and (c) that `Foo` and `Baz` agree on what `Bar` says, none of which requires loading `bar.cmi`.) This is tested in the Dune-like tests by removing `-I` flags that shouldn't be necessary.