### PR TITLE
Annotate Unix.file_descr as immediate

### DIFF
--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -322,7 +322,7 @@ val nice : int -> int
 (** {1 Basic file input/output} *)
 
 
-type file_descr
+type file_descr : immediate
 (** The abstract type of file descriptors. *)
 
 val stdin : file_descr


### PR DESCRIPTION
It's an int under the hood, so annotating it as immediate lets it mode cross
appropriately.