### PR TITLE
Remove unused fields from `Reg.t`

### DIFF
--- a/backend/reg.ml
+++ b/backend/reg.ml
@@ -94,8 +94,7 @@ type t =
     mutable interf: t list;
     mutable prefer: (t * int) list;
     mutable degree: int;
-    mutable spill_cost: int;
-    mutable visited: int }
+    mutable spill_cost: int; }
 
 and location =
     Unknown
@@ -114,34 +113,19 @@ let dummy =
   { raw_name = Raw_name.Anon; stamp = 0; typ = Int; loc = Unknown;
     irc_work_list = Unknown_list; irc_color = None; irc_alias = None;
     spill = false; interf = []; prefer = []; degree = 0; spill_cost = 0;
-    visited = 0; part = None;
+    part = None;
   }
 
 let currstamp = ref 0
 let reg_list = ref([] : t list)
 let hw_reg_list = ref ([] : t list)
 
-let visit_generation = ref 1
-
-(* Any visited value not equal to !visit_generation counts as "unvisited" *)
-let unvisited = 0
-
-let mark_visited r =
-  r.visited <- !visit_generation
-
-let is_visited r =
-  r.visited = !visit_generation
-
-let clear_visited_marks () =
-  incr visit_generation
-
-
 let create ty =
   let r = { raw_name = Raw_name.Anon; stamp = !currstamp; typ = ty;
             loc = Unknown;
             irc_work_list = Unknown_list; irc_color = None; irc_alias = None;
             spill = false; interf = []; prefer = []; degree = 0;
-            spill_cost = 0; visited = unvisited; part = None; } in
+            spill_cost = 0; part = None; } in
   reg_list := r :: !reg_list;
   incr currstamp;
   r
@@ -167,7 +151,7 @@ let at_location ty loc =
   let r = { raw_name = Raw_name.R; stamp = !currstamp; typ = ty; loc;
             irc_work_list = Unknown_list; irc_color = None; irc_alias = None;
             spill = false; interf = []; prefer = []; degree = 0;
-            spill_cost = 0; visited = unvisited; part = None; } in
+            spill_cost = 0; part = None; } in
   hw_reg_list := r :: !hw_reg_list;
   incr currstamp;
   r
@@ -226,10 +210,7 @@ let reset() =
     assert (!reg_list = []) (* Only hard regs created before now *)
   end;
   currstamp := !first_virtual_reg_stamp;
-  reg_list := [];
-  visit_generation := 1;
-  !hw_reg_list |> List.iter (fun r ->
-    r.visited <- unvisited)
+  reg_list := []
 
 let all_registers() = !reg_list
 let num_registers() = !currstamp

--- a/backend/reg.ml
+++ b/backend/reg.ml
@@ -92,7 +92,6 @@ type t =
     mutable spill: bool;
     mutable part: int option;
     mutable interf: t list;
-    mutable prefer: (t * int) list;
     mutable degree: int;
     mutable spill_cost: int; }
 
@@ -112,7 +111,7 @@ type reg = t
 let dummy =
   { raw_name = Raw_name.Anon; stamp = 0; typ = Int; loc = Unknown;
     irc_work_list = Unknown_list; irc_color = None; irc_alias = None;
-    spill = false; interf = []; prefer = []; degree = 0; spill_cost = 0;
+    spill = false; interf = []; degree = 0; spill_cost = 0;
     part = None;
   }
 
@@ -124,7 +123,7 @@ let create ty =
   let r = { raw_name = Raw_name.Anon; stamp = !currstamp; typ = ty;
             loc = Unknown;
             irc_work_list = Unknown_list; irc_color = None; irc_alias = None;
-            spill = false; interf = []; prefer = []; degree = 0;
+            spill = false; interf = []; degree = 0;
             spill_cost = 0; part = None; } in
   reg_list := r :: !reg_list;
   incr currstamp;
@@ -150,7 +149,7 @@ let clone r =
 let at_location ty loc =
   let r = { raw_name = Raw_name.R; stamp = !currstamp; typ = ty; loc;
             irc_work_list = Unknown_list; irc_color = None; irc_alias = None;
-            spill = false; interf = []; prefer = []; degree = 0;
+            spill = false; interf = []; degree = 0;
             spill_cost = 0; part = None; } in
   hw_reg_list := r :: !hw_reg_list;
   incr currstamp;
@@ -221,7 +220,6 @@ let reinit_reg r =
   r.irc_color <- None;
   r.irc_alias <- None;
   r.interf <- [];
-  r.prefer <- [];
   r.degree <- 0;
   (* Preserve the very high spill costs introduced by the reloading pass *)
   if r.spill_cost >= 100000

--- a/backend/reg.mli
+++ b/backend/reg.mli
@@ -49,8 +49,7 @@ type t =
     mutable interf: t list;               (* Other regs live simultaneously *)
     mutable prefer: (t * int) list;       (* Preferences for other regs *)
     mutable degree: int;                  (* Number of other regs live sim. *)
-    mutable spill_cost: int;              (* Estimate of spilling cost *)
-    mutable visited: int }                (* For graph walks *)
+    mutable spill_cost: int; }            (* Estimate of spilling cost *)
 
 and location =
     Unknown
@@ -120,10 +119,6 @@ val reset: unit -> unit
 val all_registers: unit -> t list
 val num_registers: unit -> int
 val reinit: unit -> unit
-
-val mark_visited : t -> unit
-val is_visited : t -> bool
-val clear_visited_marks : unit -> unit
 
 val same_phys_reg : t -> t -> bool
 val same_loc : t -> t -> bool

--- a/backend/reg.mli
+++ b/backend/reg.mli
@@ -47,7 +47,6 @@ type t =
     mutable spill: bool;                  (* "true" to force stack allocation  *)
     mutable part: int option;             (* Zero-based index of part of value *)
     mutable interf: t list;               (* Other regs live simultaneously *)
-    mutable prefer: (t * int) list;       (* Preferences for other regs *)
     mutable degree: int;                  (* Number of other regs live sim. *)
     mutable spill_cost: int; }            (* Estimate of spilling cost *)
 


### PR DESCRIPTION
After the deletion of the Mach pipeline,
and its register allocators, the `visit` and
`prefer` fields of `Reg.t` are no longer
used.