### PR TITLE
Add `Modes.Aliased` wrapper for aliased values in a unique context

### DIFF
--- a/stdlib/modes.ml
+++ b/stdlib/modes.ml
@@ -12,6 +12,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Aliased = struct
+  type 'a t = { aliased : 'a @@ aliased } [@@unboxed]
+  (** Wraps values in the [aliased] mode, even in a [unique] context. *)
+end
+
 module Global = struct
   type 'a t = { global : 'a @@ global } [@@unboxed]
 end

--- a/stdlib/modes.mli
+++ b/stdlib/modes.mli
@@ -18,6 +18,11 @@
     This module provides types that wrap a value in a different mode from its context. In
     the standard OCaml compiler, these types are all no-op wrappers. *)
 
+module Aliased : sig
+  type 'a t = { aliased : 'a @@ aliased } [@@unboxed]
+  (** Wraps values in the [aliased] mode, even in a [unique] context. *)
+end
+
 module Global : sig
   type 'a t = { global : 'a @@ global } [@@unboxed]
   (** Wraps values in the [global] mode, even in a [local] context. *)


### PR DESCRIPTION
This adds a `Modes.Aliased.t` wrapper for aliased values in a unique context that has turned out to be useful.