### PR TITLE
Cfg: Treat noalloc extcalls as not raising

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -406,8 +406,9 @@ let print_instruction ppf i = print_instruction' ppf i
 let can_raise_terminator (i : terminator) =
   match i with
   | Raise _ | Tailcall_func _ | Call_no_return _ | Call _
-  | Prim { op = External _ | Probe _; label_after = _ } ->
+  | Prim { op = Probe _; label_after = _ } ->
     true
+  | Prim { op = External { alloc; _ }; label_after = _ } -> alloc
   | Specific_can_raise { op; _ } ->
     assert (Arch.operation_can_raise op);
     true


### PR DESCRIPTION
This is just an optimisation for now, but #3688 adds exception handlers with non-standard calling conventions (with extra arguments), and it is important that we do not add edges in Cfg to these handlers from places that are not aware of this convention (typically, function or external calls).
The C calls that were already present in Flambda2 are going to be wrapped properly (whether they are marked as `[@noalloc]` or not), but the calls inserted during translation to Cmm, typically to `caml_modify`, are not wrapped.