### PR TITLE
Remove allocation near unsafe effect primitive

### DIFF
--- a/otherlibs/stdlib_alpha/effect.ml
+++ b/otherlibs/stdlib_alpha/effect.ml
@@ -472,7 +472,7 @@ let run_stack
     | _ -> reperform perf k last_fiber
   in
   let s = alloc_stack valuec exnc {effc} in
-  runstack s (fun h -> f h) h
+  runstack s f h
 
 type (-'a, +'b, 'e, 'es) continuation =
   Cont :


### PR DESCRIPTION
The `alloc_stack` primitive used in effects is completely unsafe, and the runtime may crash if its result is held live across an allocation. That happens in one place, causing the `evenodd.ml` test to fail in bytecode on my machine (depending on, among other things, the length of the path to the test directory).

The right fix is to change this primitive to be less unsafe (e.g. by returning a continuation, not a `stack`). That's left for another PR, this one just removes the allocation.