### PR TITLE
Dynamic adjustment of space_overhead

### DIFF
--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -95,6 +95,9 @@ DOMAIN_STATE(uintnat, allocated_dependent_bytes)
 /* Number of external bytes whose pointers were promoted or allocated in
    the major heap since latest slice. */
 
+DOMAIN_STATE(uintnat, minor_words_at_last_slice)
+/* Number of minor heap words allocated before the latest slice */
+
 DOMAIN_STATE(uintnat, swept_words)
 
 DOMAIN_STATE(uintnat, major_slice_epoch)

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -151,6 +151,13 @@ Caml_inline void add_to_dependent_table (struct caml_dependent_table *tbl,
   elt->mem = mem;
 }
 
+Caml_inline uintnat caml_minor_words_allocated(void)
+{
+  return (Caml_state->stat_minor_words
+          + (Wsize_bsize((uintnat)Caml_state->young_end -
+                         (uintnat)Caml_state->young_ptr)));
+}
+
 #endif /* CAML_INTERNALS */
 
 #endif /* CAML_MINOR_GC_H */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -733,6 +733,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   domain_state->allocated_words = 0;
   domain_state->allocated_words_direct = 0;
+  domain_state->minor_words_at_last_slice = 0;
   domain_state->swept_words = 0;
 
   domain_state->local_roots = NULL;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -57,6 +57,7 @@ extern uintnat caml_compact_unmap;        /* see shared_heap.c */
 extern uintnat caml_pool_min_chunk_bsz;  /* see shared_heap.c */
 extern uintnat caml_percent_sweep_per_mark; /* see major_gc.c */
 extern uintnat caml_gc_pacing_policy;       /* see major_gc.c */
+extern uintnat caml_gc_overhead_adjustment; /* see major_gc.c */
 
 CAMLprim value caml_gc_quick_stat(value v)
 {
@@ -100,9 +101,7 @@ CAMLprim value caml_gc_quick_stat(value v)
 
 double caml_gc_minor_words_unboxed (void)
 {
-  return (Caml_state->stat_minor_words
-          + ((double) Wsize_bsize((uintnat)Caml_state->young_end -
-                                  (uintnat)Caml_state->young_ptr)));
+  return (double)caml_minor_words_allocated();
 }
 
 CAMLprim value caml_gc_minor_words(value v)
@@ -448,6 +447,7 @@ static struct gc_tweak gc_tweaks[] = {
   { "thread_stack_size", &caml_init_thread_stack_wsz, 0 },
   { "percent_sweep_per_mark", &caml_percent_sweep_per_mark, 0 },
   { "gc_pacing_policy", &caml_gc_pacing_policy, 0 },
+  { "gc_overhead_adjustment", &caml_gc_overhead_adjustment, 0 },
 };
 
 enum {N_GC_TWEAKS = sizeof(gc_tweaks)/sizeof(gc_tweaks[0])};


### PR DESCRIPTION
This patch adds a new GC tweak, `Xgc_overhead_adjustment`, which dynamically adjusts the current space_overhead according to the promotion rate.

With this patch, when the new GC policy is enabled, the space_overhead specified by the user is in fact the space_overhead setting at a nominal promotion rate of 10%. The actual space_overhead used by the GC will be larger or smaller than this one, when the promotion rate is respectively above or below 10%.

Roughly, the idea is that when large numbers of allocations into the major heap are being done, extra GC work to deal with those allocations is unusually expensive. So at such times, we should be willing to use more space to save time, which corresponds to a larger space_overhead.

The actual space_overhead calculation is to scale it by the promotion rate (normalised so that 10% = 1), raised to the power of `gc_overhead_adjustment` (in percent). This means that `Xgc_overhead_adjustment=0` is the current behaviour, and `Xgc_overhead_adjustment=50` adjusts overhead by the square root of promotion rate (which some theory suggests is optimal, but let's see).

I tried this mechanism out on a simple benchmark with a heavy-allocation and a light-allocation phase:
```ocaml
let () =
  (* Phase I: build a big data structure (high promotion rate) *)
  let thing = List.init 1_000 (fun _ -> List.init 50_000 ref) in
  (* Phase II: allocate mostly garbage (low promotion rate) *)
  for _i = 1 to 50_000 do ignore (List.init 20_000 ref) |> Sys.opaque_identity done;
  ignore (Sys.opaque_identity thing);
```

On this benchmark, the patch improves the space-time tradeoff at all values of space_overhead. The highlighted point is the default `o=80`:
![download](https://github.com/user-attachments/assets/74c18218-3560-4942-896c-017a707f8ffc)
