### PR TITLE
Specialise Atomic_compare_and_set and Atomic_compare_exchange

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2410,12 +2410,13 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
           atomic,
           new_value ) ]
   | ( Patomic_compare_exchange { immediate_or_pointer },
-      [[atomic]; [old_value]; [new_value]] ) ->
+      [[atomic]; [comparison_value]; [new_value]] ) ->
+    let access_kind = convert_block_access_field_kind immediate_or_pointer in
     [ Ternary
         ( Atomic_compare_exchange
-            (convert_block_access_field_kind immediate_or_pointer),
+            { atomic_kind = access_kind; args_kind = access_kind },
           atomic,
-          old_value,
+          comparison_value,
           new_value ) ]
   | ( Patomic_compare_set { immediate_or_pointer },
       [[atomic]; [old_value]; [new_value]] ) ->

--- a/middle_end/flambda2/simplify/simplify_primitive_result.mli
+++ b/middle_end/flambda2/simplify/simplify_primitive_result.mli
@@ -41,6 +41,9 @@ val create_unit :
   original_term:Flambda.Named.t ->
   t
 
+(** [original_term] is in the majority of cases the pre-simplification term
+    corresponding to the primitive, but it is fine for it to be a new term,
+    whose type is unknown. *)
 val create_unknown :
   Downwards_acc.t ->
   result_var:Bound_var.t ->

--- a/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
@@ -67,17 +67,83 @@ let simplify_bigarray_set ~num_dimensions:_ _bigarray_kind _bigarray_layout dacc
     ~result_var =
   SPR.create_unit dacc ~result_var ~original_term
 
-let simplify_atomic_compare_and_set ~original_prim dacc ~original_term _dbg
-    ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_ ~arg3_ty:_ ~result_var =
-  SPR.create_unknown dacc ~result_var
-    (P.result_kind' original_prim)
-    ~original_term
+let simplify_atomic_compare_and_set_or_exchange_args
+    (args_kind : P.Block_access_field_kind.t) dacc ~comparison_value_ty
+    ~new_value_ty : P.Block_access_field_kind.t =
+  match args_kind with
+  | Immediate ->
+    (* No further specialization can be done *)
+    Immediate
+  | Any_value ->
+    (* Unlike (for example) a normal write to a block, these primitives can be
+       specialized based on the observed types of the arguments. (In the case of
+       compare-exchange information can also be propagated based on the result
+       type; see below.)
 
-let simplify_atomic_compare_exchange ~original_prim dacc ~original_term _dbg
-    ~arg1:_ ~arg1_ty:_ ~arg2:_ ~arg2_ty:_ ~arg3:_ ~arg3_ty:_ ~result_var =
-  SPR.create_unknown dacc ~result_var
-    (P.result_kind' original_prim)
-    ~original_term
+       For example for [Atomic_compare_and_set], observe that if both the second
+       and third arguments (value with which to compare, and new value,
+       respectively) are immediate, then there is no need to generate a GC
+       barrier -- not only because the new value is immediate, but crucially
+       also because the old value cannot be a pointer if the operation is to
+       perform a write. *)
+    let is_immediate ty =
+      match T.prove_is_a_tagged_immediate (DA.typing_env dacc) ty with
+      | Proved () -> true
+      | Unknown -> false
+    in
+    if is_immediate comparison_value_ty && is_immediate new_value_ty
+    then Immediate
+    else Any_value
+
+let simplify_atomic_compare_and_set (args_kind : P.Block_access_field_kind.t)
+    ~original_prim:_ dacc ~original_term:_ dbg ~arg1:atomic ~arg1_ty:_
+    ~arg2:comparison_value ~arg2_ty:comparison_value_ty ~arg3:new_value
+    ~arg3_ty:new_value_ty ~result_var =
+  let args_kind =
+    simplify_atomic_compare_and_set_or_exchange_args args_kind dacc
+      ~comparison_value_ty ~new_value_ty
+  in
+  let new_term =
+    Named.create_prim
+      (Ternary
+         (Atomic_compare_and_set args_kind, atomic, comparison_value, new_value))
+      dbg
+  in
+  let dacc = DA.add_variable dacc result_var T.any_tagged_bool in
+  SPR.create new_term ~try_reify:false dacc
+
+let simplify_atomic_compare_exchange
+    ~(atomic_kind : P.Block_access_field_kind.t)
+    ~(args_kind : P.Block_access_field_kind.t) ~original_prim:_ dacc
+    ~original_term:_ dbg ~arg1:atomic ~arg1_ty:_ ~arg2:comparison_value
+    ~arg2_ty:comparison_value_ty ~arg3:new_value ~arg3_ty:new_value_ty
+    ~result_var =
+  (* This primitive can have its arguments specialised as for compare-and-set
+     (see above). However we can also propagate information about its result
+     type. Since this relates to all possible values that the atomic can hold,
+     we have to use the information provided by the frontend.
+
+     Recall that the compare-exchange returns the old value. *)
+  let args_kind =
+    simplify_atomic_compare_and_set_or_exchange_args args_kind dacc
+      ~comparison_value_ty ~new_value_ty
+  in
+  let new_term =
+    Named.create_prim
+      (Ternary
+         ( Atomic_compare_exchange { atomic_kind; args_kind },
+           atomic,
+           comparison_value,
+           new_value ))
+      dbg
+  in
+  let result_var_ty =
+    match atomic_kind (* N.B. not [args_kind] *) with
+    | Immediate -> T.any_tagged_immediate
+    | Any_value -> T.any_value
+  in
+  let dacc = DA.add_variable dacc result_var result_var_ty in
+  SPR.create new_term ~try_reify:false dacc
 
 let simplify_ternary_primitive dacc original_prim (prim : P.ternary_primitive)
     ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3 ~arg3_ty dbg ~result_var =
@@ -89,9 +155,10 @@ let simplify_ternary_primitive dacc original_prim (prim : P.ternary_primitive)
       simplify_bytes_or_bigstring_set bytes_like_value string_accessor_width
     | Bigarray_set (num_dimensions, bigarray_kind, bigarray_layout) ->
       simplify_bigarray_set ~num_dimensions bigarray_kind bigarray_layout
-    | Atomic_compare_and_set _ -> simplify_atomic_compare_and_set ~original_prim
-    | Atomic_compare_exchange _ ->
-      simplify_atomic_compare_exchange ~original_prim
+    | Atomic_compare_and_set access_kind ->
+      simplify_atomic_compare_and_set access_kind ~original_prim
+    | Atomic_compare_exchange { atomic_kind; args_kind } ->
+      simplify_atomic_compare_exchange ~atomic_kind ~args_kind ~original_prim
   in
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~arg3
     ~arg3_ty ~result_var

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -763,12 +763,16 @@ let simplify_get_header ~original_prim dacc ~original_term ~arg:_ ~arg_ty:_
     (P.result_kind' original_prim)
     ~original_term
 
-let simplify_atomic_load
-    (_block_access_field_kind : P.Block_access_field_kind.t) ~original_prim dacc
-    ~original_term ~arg:_ ~arg_ty:_ ~result_var =
-  SPR.create_unknown dacc ~result_var
-    (P.result_kind' original_prim)
-    ~original_term
+let simplify_atomic_load (block_access_field_kind : P.Block_access_field_kind.t)
+    ~original_prim dacc ~original_term ~arg:_ ~arg_ty:_ ~result_var =
+  match block_access_field_kind with
+  | Immediate ->
+    let dacc = DA.add_variable dacc result_var T.any_tagged_immediate in
+    SPR.create original_term ~try_reify:false dacc
+  | Any_value ->
+    SPR.create_unknown dacc ~result_var
+      (P.result_kind' original_prim)
+      ~original_term
 
 let[@inline always] simplify_immutable_block_load0
     (access_kind : P.Block_access_kind.t) ~field ~min_name_mode dacc

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -418,8 +418,9 @@ let ternary_prim_size prim =
   | Bigarray_set (_dims, _kind, _layout) -> 2
   (* ~ 1 block_load + 1 block_set *)
   | Atomic_compare_and_set Immediate -> 3
-  | Atomic_compare_exchange Immediate -> 1
-  | Atomic_compare_and_set Any_value | Atomic_compare_exchange Any_value ->
+  | Atomic_compare_exchange { atomic_kind = _; args_kind = Immediate } -> 1
+  | Atomic_compare_and_set Any_value
+  | Atomic_compare_exchange { atomic_kind = _; args_kind = Any_value } ->
     does_not_need_caml_c_call_extcall_size
 
 let variadic_prim_size prim args =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -530,7 +530,15 @@ type ternary_primitive =
   | Bytes_or_bigstring_set of bytes_like_value * string_accessor_width
   | Bigarray_set of num_dimensions * Bigarray_kind.t * Bigarray_layout.t
   | Atomic_compare_and_set of Block_access_field_kind.t
-  | Atomic_compare_exchange of Block_access_field_kind.t
+  | Atomic_compare_exchange of
+      { atomic_kind : Block_access_field_kind.t;
+            (** The kind of values which the atomic can hold. *)
+        args_kind : Block_access_field_kind.t
+            (** The kind of values which the compare-exchange operation is to
+                be used with on this particular occasion.  Note that this might
+                be [Immediate] even though the atomic is marked as [Any_value],
+                for example. *)
+      }
 
 (** Primitives taking zero or more arguments. *)
 type variadic_primitive =

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -1047,10 +1047,9 @@ let ternary_primitive _env dbg f x y z =
     C.atomic_compare_and_set ~dbg
       (imm_or_ptr block_access_kind)
       x ~old_value:y ~new_value:z
-  | Atomic_compare_exchange block_access_kind ->
-    C.atomic_compare_exchange ~dbg
-      (imm_or_ptr block_access_kind)
-      x ~old_value:y ~new_value:z
+  | Atomic_compare_exchange { atomic_kind = _; args_kind } ->
+    C.atomic_compare_exchange ~dbg (imm_or_ptr args_kind) x ~old_value:y
+      ~new_value:z
 
 let variadic_primitive _env dbg f args =
   match (f : P.variadic_primitive) with


### PR DESCRIPTION
This adds rules to specialise atomic compare-and-set operations in Flambda 2.  In addition, the optimizer now knows that an atomic load of block access kind `Immediate` always yields a tagged immediate.