### PR TITLE
Allow adding with_bounds via `[@@unsafe_allow_any_mode_crossing]`

### DIFF
--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -407,3 +407,133 @@ Error: This variant or record definition does not match that of type
          the original has: mod many portable contended with 'b
          but this has: mod many portable contended with 'a
 |}]
+
+(* mcomp *)
+
+type (_, _) eq = Refl : ('a, 'a) eq
+
+module M1 = struct
+  type 'a t : value mod contended = { x : 'a }
+  [@@unsafe_allow_any_mode_crossing]
+end
+
+module M2 = struct
+  type 'a t : value mod contended = { x : 'a }
+  [@@unsafe_allow_any_mode_crossing]
+end
+
+module M3 = struct
+  type 'a t : value mod portable = { x : 'a }
+  [@@unsafe_allow_any_mode_crossing]
+end
+
+module M4 = struct
+  type 'a t : value mod contended with 'a = { mutable x : 'a }
+  [@@unsafe_allow_any_mode_crossing]
+end
+
+module M5 = struct
+  type 'a t : value mod contended with 'a = { mutable x : 'a }
+  [@@unsafe_allow_any_mode_crossing]
+end
+
+module M6 = struct
+  type 'a t : immutable_data with 'a = { mutable x : 'a }
+  [@@unsafe_allow_any_mode_crossing]
+end
+
+module M7 = struct
+  type ('a, 'b) t : value mod contended with 'a = { mutable x : 'b }
+  [@@unsafe_allow_any_mode_crossing]
+end
+
+module M8 = struct
+  type ('a, 'b) t : value mod contended with 'a = { mutable x : 'b }
+  [@@unsafe_allow_any_mode_crossing]
+end
+
+module M9 = struct
+  type ('a, 'b) t : value mod contended with 'b = { mutable x : 'b }
+  [@@unsafe_allow_any_mode_crossing]
+end
+
+[%%expect{|
+type (_, _) eq = Refl : ('a, 'a) eq
+module M1 :
+  sig
+    type 'a t : value mod contended = { x : 'a; }
+    [@@unsafe_allow_any_mode_crossing]
+  end
+module M2 :
+  sig
+    type 'a t : value mod contended = { x : 'a; }
+    [@@unsafe_allow_any_mode_crossing]
+  end
+module M3 :
+  sig
+    type 'a t : value mod portable = { x : 'a; }
+    [@@unsafe_allow_any_mode_crossing]
+  end
+module M4 :
+  sig
+    type 'a t : value mod contended with 'a = { mutable x : 'a; }
+    [@@unsafe_allow_any_mode_crossing]
+  end
+module M5 :
+  sig
+    type 'a t : value mod contended with 'a = { mutable x : 'a; }
+    [@@unsafe_allow_any_mode_crossing]
+  end
+module M6 :
+  sig
+    type 'a t : immutable_data with 'a = { mutable x : 'a; }
+    [@@unsafe_allow_any_mode_crossing]
+  end
+module M7 :
+  sig
+    type ('a, 'b) t : value mod contended with 'a = { mutable x : 'b; }
+    [@@unsafe_allow_any_mode_crossing]
+  end
+module M8 :
+  sig
+    type ('a, 'b) t : value mod contended with 'a = { mutable x : 'b; }
+    [@@unsafe_allow_any_mode_crossing]
+  end
+module M9 :
+  sig
+    type ('a, 'b) t : value mod contended with 'b = { mutable x : 'b; }
+    [@@unsafe_allow_any_mode_crossing]
+  end
+|}]
+
+
+let f (type a) (eq : (a M1.t, a M2.t) eq) = match eq with Refl -> ()
+[%%expect{|
+val f : ('a M1.t, 'a M2.t) eq -> unit = <fun>
+|}]
+
+let f (eq : ('a M1.t, 'a M3.t) eq) = match eq with _ -> .
+[%%expect{|
+val f : ('a M1.t, 'a M3.t) eq -> 'b = <fun>
+|}]
+
+let f (type a) (eq : (a M4.t, a M5.t) eq) = match eq with Refl -> ()
+[%%expect{|
+val f : ('a M4.t, 'a M5.t) eq -> unit = <fun>
+|}]
+
+let f (type a) (eq : (a M4.t, a M6.t) eq) = match eq with _ -> .
+[%%expect{|
+val f : ('a M4.t, 'a M6.t) eq -> 'b = <fun>
+|}]
+
+let f (type a b) (eq : ((a, b) M7.t, (a, b) M8.t) eq) = match eq with Refl -> ()
+[%%expect{|
+val f : (('a, 'b) M7.t, ('a, 'b) M8.t) eq -> unit = <fun>
+|}]
+
+let f (type a b) (eq : ((a, b) M7.t, (a, b) M9.t) eq) = match eq with Refl -> ()
+(* CR layouts v2.8: Plausibly this should be refutable, but maybe that's impossible? *)
+[%%expect{|
+val f : (('a, 'b) M7.t, ('a, 'b) M9.t) eq -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -55,10 +55,10 @@ Error: The layout of type "t" is value
 |}]
 
 (* Annotations with with-bounds are allowed *)
-type 'a t : value mod uncontended with 'a = { mutable contents : 'a }
+type 'a t : value mod contended with 'a = { mutable contents : 'a }
 [@@unsafe_allow_any_mode_crossing]
 [%%expect{|
-type 'a t : value with 'a = { mutable contents : 'a; }
+type 'a t : value mod contended with 'a = { mutable contents : 'a; }
 [@@unsafe_allow_any_mode_crossing]
 |}]
 
@@ -296,8 +296,8 @@ Error: Signature mismatch:
        [@@unsafe_allow_any_mode_crossing]
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their bounds are not equal
-         the first has: portable contended with   but the second has:
-         contended with
+         the first has: mod portable contended
+         but the second has: mod contended
 |}]
 
 module A : sig
@@ -385,8 +385,8 @@ Lines 1-2, characters 0-34:
 Error: This variant or record definition does not match that of type "'a t"
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their bounds are not equal
-         the original has: many portable contended with with 'a
-         but this has: many portable contended with
+         the original has: mod many portable contended with 'a
+         but this has: mod many portable contended
 |}]
 
 type ('a, 'b) arity_2 : immutable_data with 'b = { x : 'a }
@@ -404,6 +404,6 @@ Error: This variant or record definition does not match that of type
          "('a, 'b) arity_2"
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their bounds are not equal
-         the original has: many portable contended with with 'b
-         but this has: many portable contended with with 'a
+         the original has: mod many portable contended with 'b
+         but this has: mod many portable contended with 'a
 |}]

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -385,8 +385,8 @@ Lines 1-2, characters 0-34:
 Error: This variant or record definition does not match that of type "'a t"
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their bounds are not equal
-         the original has: mod many portable contended with 'a
-         but this has: mod many portable contended
+         the original has: mod many portable unyielding contended with 'a
+         but this has: mod many portable unyielding contended
 |}]
 
 type ('a, 'b) arity_2 : immutable_data with 'b = { x : 'a }
@@ -404,8 +404,8 @@ Error: This variant or record definition does not match that of type
          "('a, 'b) arity_2"
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their bounds are not equal
-         the original has: mod many portable contended with 'b
-         but this has: mod many portable contended with 'a
+         the original has: mod many portable unyielding contended with 'b
+         but this has: mod many portable unyielding contended with 'a
 |}]
 
 (* mcomp *)

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -533,7 +533,6 @@ val f : (('a, 'b) M7.t, ('a, 'b) M8.t) eq -> unit = <fun>
 |}]
 
 let f (type a b) (eq : ((a, b) M7.t, (a, b) M9.t) eq) = match eq with Refl -> ()
-(* CR layouts v2.8: Plausibly this should be refutable, but maybe that's impossible? *)
 [%%expect{|
 val f : (('a, 'b) M7.t, ('a, 'b) M9.t) eq -> unit = <fun>
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1473,6 +1473,9 @@ let instance_parameterized_kind args jkind =
     (ty_args, jkind)
   )
 
+let map_unsafe_mode_crossing f umc =
+  { umc with unsafe_with_bounds = Jkind.With_bounds.map_type_expr f umc.unsafe_with_bounds }
+
 (* [map_kind f kind] maps [f] over all the types in [kind]. [f] must preserve jkinds *)
 let map_kind f = function
   | (Type_abstract _ | Type_open) as k -> k
@@ -1484,19 +1487,19 @@ let map_kind f = function
               cd_args = map_type_expr_cstr_args f c.cd_args;
               cd_res = Option.map f c.cd_res
              })
-          cl, rep, mc)
+          cl, rep, Option.map (map_unsafe_mode_crossing f) mc)
   | Type_record (fl, rr, mc) ->
       Type_record (
         List.map
           (fun l ->
              {l with ld_type = f l.ld_type}
-          ) fl, rr, mc)
+          ) fl, rr, Option.map (map_unsafe_mode_crossing f) mc)
   | Type_record_unboxed_product (fl, rr, mc) ->
       Type_record_unboxed_product (
         List.map
           (fun l ->
              {l with ld_type = f l.ld_type}
-          ) fl, rr, mc)
+          ) fl, rr, Option.map (map_unsafe_mode_crossing f) mc)
 
 
 let instance_declaration decl =
@@ -3389,16 +3392,6 @@ and mcomp_row type_pairs env row1 row2 =
       | _ -> ())
     pairs
 
-and mcomp_unsafe_mode_crossing umc1 umc2 =
-  match umc1, umc2 with
-  | None, None -> ()
-  | Some _, None -> raise Incompatible
-  | None, Some _ -> raise Incompatible
-  | Some umc1, Some umc2 ->
-      if equal_unsafe_mode_crossing umc1 umc2
-      then ()
-      else raise Incompatible
-
 and mcomp_type_decl type_pairs env p1 p2 tl1 tl2 =
   try
     let decl = Env.find_type p1 env in
@@ -3419,22 +3412,19 @@ and mcomp_type_decl type_pairs env p1 p2 tl1 tl2 =
       raise Incompatible
     else
       match decl.type_kind, decl'.type_kind with
-      | Type_record (lst,r,umc), Type_record (lst',r',umc')
+      | Type_record (lst,r,_), Type_record (lst',r',_)
         when equal_record_representation r r' ->
           mcomp_list type_pairs env tl1 tl2;
-          mcomp_record_description type_pairs env lst lst';
-          mcomp_unsafe_mode_crossing umc umc'
-      | Type_record_unboxed_product (lst,r,umc),
-        Type_record_unboxed_product (lst',r',umc')
+          mcomp_record_description type_pairs env lst lst'
+      | Type_record_unboxed_product (lst,r,_),
+        Type_record_unboxed_product (lst',r',_)
         when equal_record_unboxed_product_representation r r' ->
           mcomp_list type_pairs env tl1 tl2;
-          mcomp_record_description type_pairs env lst lst';
-          mcomp_unsafe_mode_crossing umc umc'
-      | Type_variant (v1,r,umc), Type_variant (v2,r',umc')
+          mcomp_record_description type_pairs env lst lst'
+      | Type_variant (v1,r,_), Type_variant (v2,r',_)
         when equal_variant_representation r r' ->
           mcomp_list type_pairs env tl1 tl2;
           mcomp_variant_description type_pairs env v1 v2;
-          mcomp_unsafe_mode_crossing umc umc'
       | Type_open, Type_open ->
           mcomp_list type_pairs env tl1 tl2
       | Type_abstract _, Type_abstract _ -> check_jkinds ()

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -314,8 +314,7 @@ type variant_change =
 
 type unsafe_mode_crossing_mismatch =
   | Mode_crossing_only_on of position
-  | Mode_crossing_not_equal of unsafe_mode_crossing * unsafe_mode_crossing
-
+  | Bounds_not_equal of unsafe_mode_crossing * unsafe_mode_crossing
 
 type type_mismatch =
   | Arity
@@ -618,6 +617,11 @@ let report_kind_mismatch first second ppf (kind1, kind2) =
     second
     (kind_to_string kind2)
 
+let print_unsafe_mode_crossing ppf umc =
+  Format.fprintf ppf "%a with %a"
+    Mode.Crossing.print umc.unsafe_mod_bounds
+    Jkind.With_bounds.format umc.unsafe_with_bounds
+
 let report_unsafe_mode_crossing_mismatch first second ppf e =
   let pr fmt = Format.fprintf ppf fmt in
   match e with
@@ -625,15 +629,15 @@ let report_unsafe_mode_crossing_mismatch first second ppf e =
     pr "%s has [%@%@unsafe_allow_any_mode_crossing], but %s does not"
       (choose ord first second)
       (choose_other ord first second)
-  | Mode_crossing_not_equal (first_mb, second_mb) ->
+  | Bounds_not_equal (first_umc, second_umc) ->
     (* CR layouts v2.8: It'd be nice to specifically highlight the offending axis,
        rather than printing all axes here. *)
     pr "Both specify [%@%@unsafe_allow_any_mode_crossing], but their \
-        mod-bounds are not equal:@ \
-        %s has mod-bounds:@ @[<h 4>%a@]@ \
-        but %s has mod-bounds:@ @[<h 4>%a@]"
-      first Mode.Crossing.print first_mb
-      second Mode.Crossing.print second_mb
+        bounds are not equal@,\
+        @[%s has:@]@ @[<h 4>%a@]@ @;\
+        @[but %s has:@]@ @[<h 4>%a@]"
+      first print_unsafe_mode_crossing first_umc
+      second print_unsafe_mode_crossing second_umc
 
 let report_type_mismatch first second decl env ppf err =
   let pr fmt = Format.fprintf ppf fmt in
@@ -690,18 +694,20 @@ let report_type_mismatch first second decl env ppf err =
          report_unsafe_mode_crossing_mismatch first second ppf mismatch)
       (first, second, mismatch)
 
-let compare_unsafe_mode_crossing umc1 umc2 =
+let compare_unsafe_mode_crossing ~env umc1 umc2 =
   match umc1, umc2 with
   | None, None -> None
   | Some _, None -> Some (Unsafe_mode_crossing (Mode_crossing_only_on First))
   | None, Some _ -> Some (Unsafe_mode_crossing (Mode_crossing_only_on Second))
   | Some umc1, Some umc2 ->
-    if equal_unsafe_mode_crossing umc1 umc2
+    if equal_unsafe_mode_crossing
+         ~type_equal:(Ctype.type_equal env)
+         umc1 umc2
     then None
     else
       Some (
         Unsafe_mode_crossing (
-          Mode_crossing_not_equal (umc1, umc2)))
+          Bounds_not_equal (umc1, umc2)))
 
 module Record_diffing = struct
 
@@ -1444,18 +1450,18 @@ let type_declarations ?(equality = false) ~loc env ~mark name
               cstrs2
               rep1
               rep2)
-          (fun () -> compare_unsafe_mode_crossing umc1 umc2)
+          (fun () -> compare_unsafe_mode_crossing ~env umc1 umc2)
       end
     | (Type_record(labels1,rep1,umc1), Type_record(labels2,rep2,umc2)) -> begin
         Misc.Stdlib.Option.first_some
           (mark_and_compare_records Legacy labels1 rep1 labels2 rep2)
-          (fun () -> compare_unsafe_mode_crossing umc1 umc2)
+          (fun () -> compare_unsafe_mode_crossing ~env umc1 umc2)
       end
     | (Type_record_unboxed_product(labels1,rep1,umc1),
        Type_record_unboxed_product(labels2,rep2,umc2)) -> begin
         Misc.Stdlib.Option.first_some
           (mark_and_compare_records Unboxed_product labels1 rep1 labels2 rep2)
-          (fun () -> compare_unsafe_mode_crossing umc1 umc2)
+          (fun () -> compare_unsafe_mode_crossing ~env umc1 umc2)
       end
     | (Type_open, Type_open) -> None
     | (_, _) -> Some (Kind (of_kind decl1.type_kind, of_kind decl2.type_kind))

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -618,7 +618,7 @@ let report_kind_mismatch first second ppf (kind1, kind2) =
     (kind_to_string kind2)
 
 let print_unsafe_mode_crossing ppf umc =
-  Format.fprintf ppf "%a with %a"
+  Format.fprintf ppf "mod %a@ %a"
     Mode.Crossing.print umc.unsafe_mod_bounds
     Jkind.With_bounds.format umc.unsafe_with_bounds
 
@@ -634,8 +634,8 @@ let report_unsafe_mode_crossing_mismatch first second ppf e =
        rather than printing all axes here. *)
     pr "Both specify [%@%@unsafe_allow_any_mode_crossing], but their \
         bounds are not equal@,\
-        @[%s has:@]@ @[<h 4>%a@]@ @;\
-        @[but %s has:@]@ @[<h 4>%a@]"
+        @[%s has:@ %a@]@ \
+        @[but %s has:@ %a@]"
       first print_unsafe_mode_crossing first_umc
       second print_unsafe_mode_crossing second_umc
 
@@ -689,7 +689,7 @@ let report_type_mismatch first second decl env ppf err =
   | Jkind v ->
       Jkind.Violation.report_with_name ~name:first ppf v
   | Unsafe_mode_crossing mismatch ->
-    pr "They have different unsafe mode crossing behavior:@,@[<hov 2>%a@]"
+    pr "They have different unsafe mode crossing behavior:@,@[<v 2>%a@]"
       (fun ppf (first, second, mismatch) ->
          report_unsafe_mode_crossing_mismatch first second ppf mismatch)
       (first, second, mismatch)

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -107,7 +107,7 @@ type private_object_mismatch =
 
 type unsafe_mode_crossing_mismatch =
   | Mode_crossing_only_on of position
-  | Mode_crossing_not_equal of unsafe_mode_crossing * unsafe_mode_crossing
+  | Bounds_not_equal of unsafe_mode_crossing * unsafe_mode_crossing
 
 type type_mismatch =
   | Arity

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -547,6 +547,18 @@ module Mod_bounds = struct
       ~uniqueness:Uniqueness.min ~portability:Portability.max
       ~contention:Contention.min ~yielding:Yielding.max
       ~externality:Externality.max ~nullability:Nullability.Non_null
+
+  let to_mode_crossing t =
+    Mode.Crossing.of_bounds
+      Types.Jkind_mod_bounds.
+        { comonadic =
+            { areality = locality t;
+              linearity = linearity t;
+              portability = portability t;
+              yielding = yielding t
+            };
+          monadic = { uniqueness = uniqueness t; contention = contention t }
+        }
 end
 
 module With_bounds = struct
@@ -696,6 +708,28 @@ module With_bounds = struct
         (With_bounds_types.singleton type_expr
            ({ relevant_axes } : With_bounds_type_info.t))
     | With_bounds tys -> With_bounds (add_bound type_expr { relevant_axes } tys)
+
+  let format (type l r) ppf (t : (l * r) t) =
+    match t with
+    | No_with_bounds -> ()
+    | With_bounds wbs ->
+      let type_exprs =
+        wbs |> With_bounds_types.to_seq
+        |> Seq.map (fun (ty, _) -> Format.asprintf "%a" !print_type_expr ty)
+        |> List.of_seq
+        (* HACK: we pre-format the types as strings so we so we can sort them
+           lexicographically, because otherwise the order of printed [with]s is
+           nondeterministic. This is sad, but we'd need deterministic sorting of types to
+           work around it.
+
+           CR aspsmith: remove this (and the same HACK in Oprint) if we ever add
+           deterministic, semantic type comparison *)
+        |> List.sort String.compare
+      in
+      Format.(
+        fprintf ppf "%a"
+          (pp_print_list (fun ppf -> fprintf ppf "with@ %s"))
+          type_exprs)
 end
 
 module Layout_and_axes = struct
@@ -1703,8 +1737,8 @@ module Jkind_desc = struct
       mod_bounds = Mod_bounds.set_nullability Nullability.min t.mod_bounds
     }
 
-  let unsafely_set_mod_bounds t ~from =
-    { t with mod_bounds = from.mod_bounds; with_bounds = No_with_bounds }
+  let unsafely_set_bounds t ~from =
+    { t with mod_bounds = from.mod_bounds; with_bounds = from.with_bounds }
 
   let add_with_bounds ~relevant_for_nullability ~type_expr ~modality t =
     match Types.get_desc type_expr with
@@ -1916,14 +1950,8 @@ end
 let add_nullability_crossing t =
   { t with jkind = Jkind_desc.add_nullability_crossing t.jkind }
 
-let unsafely_set_mod_bounds (type l r) ~(from : (l * r) jkind) t =
-  match from.jkind.with_bounds with
-  | With_bounds _ -> Error ()
-  | No_with_bounds ->
-    Ok
-      { t with
-        jkind = Jkind_desc.unsafely_set_mod_bounds t.jkind ~from:from.jkind
-      }
+let unsafely_set_bounds (type l r) ~(from : (l * r) jkind) t =
+  { t with jkind = Jkind_desc.unsafely_set_bounds t.jkind ~from:from.jkind }
 
 let add_with_bounds ~modality ~type_expr t =
   { t with

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2245,6 +2245,11 @@ let get_mode_crossing (type l r) ~jkind_of_type (jk : (l * r) jkind) =
   let bounds = get_modal_bounds ~jkind_of_type jk in
   Mode.Crossing.of_bounds bounds
 
+let to_unsafe_mode_crossing jkind =
+  { unsafe_mod_bounds = Mod_bounds.to_mode_crossing jkind.jkind.mod_bounds;
+    unsafe_with_bounds = jkind.jkind.with_bounds
+  }
+
 let all_except_externality =
   Axis_set.singleton (Nonmodal Externality) |> Axis_set.complement
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -111,10 +111,23 @@ module Layout : sig
   end
 end
 
+module Mod_bounds : sig
+  type t = Types.Jkind_mod_bounds.t
+
+  val to_mode_crossing : t -> Mode.Crossing.t
+end
+
 module With_bounds : sig
   val debug_print_types : Format.formatter -> Types.with_bounds_types -> unit
 
   val debug_print : Format.formatter -> ('l * 'r) Types.with_bounds -> unit
+
+  val map_type_expr :
+    (Types.type_expr -> Types.type_expr) ->
+    ('l * 'r) Types.with_bounds ->
+    ('l * 'r) Types.with_bounds
+
+  val format : Format.formatter -> ('l * 'r) Types.with_bounds -> unit
 end
 
 (** A [jkind] is a full description of the runtime representation of values
@@ -360,12 +373,9 @@ end
 (** Take an existing [t] and add an ability to cross across the nullability axis. *)
 val add_nullability_crossing : 'd Types.jkind -> 'd Types.jkind
 
-(** Forcibly change the mod-bounds of a [t] based on the mod-bounds of
-    [from].
-
-    Returns [Error ()] if [from] contains with-bounds. *)
-val unsafely_set_mod_bounds :
-  from:'d Types.jkind -> 'd Types.jkind -> ('d Types.jkind, unit) Result.t
+(** Forcibly change the mod- and with-bounds of a [t] based on the mod- and with-bounds of [from]. *)
+val unsafely_set_bounds :
+  from:'d Types.jkind -> 'd Types.jkind -> 'd Types.jkind
 
 (** Take an existing [jkind_l] and add some with-bounds. *)
 val add_with_bounds :

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -543,6 +543,8 @@ val get_mode_crossing :
   'd Types.jkind ->
   Mode.Crossing.t
 
+val to_unsafe_mode_crossing : Types.jkind_l -> Types.unsafe_mode_crossing
+
 val get_externality_upper_bound :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
   'd Types.jkind ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2584,10 +2584,7 @@ let normalize_decl_jkinds env shapes decls =
           let type_jkind =
             Jkind.unsafely_set_bounds ~from:original_decl.type_jkind decl.type_jkind
           in
-          let umc = Some {
-            unsafe_mod_bounds = Jkind.Mod_bounds.to_mode_crossing type_jkind.jkind.mod_bounds;
-            unsafe_with_bounds = type_jkind.jkind.with_bounds
-          } in
+          let umc = Some (Jkind.to_unsafe_mode_crossing type_jkind) in
           let type_kind =
             match decl.type_kind with
             | Type_abstract _ | Type_open -> assert false (* Checked above *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -139,7 +139,6 @@ type error =
       }
   | Non_abstract_reexport of Path.t
   | Unsafe_mode_crossing_on_invalid_type_kind
-  | Unsafe_mode_crossing_with_with_bounds
   | Illegal_baggage of jkind_l
   | No_unboxed_version of Path.t
 
@@ -2558,16 +2557,16 @@ let normalize_decl_jkinds env shapes decls =
       (* If the jkind has changed, check that it is a subjkind of the original jkind
         that we computed, either from a user-written annotation or as a dummy jkind.
 
-        (see Note [Default jkinds in transl_declaration]) *)
+         (see Note [Default jkinds in transl_declaration]) *)
       (* CR layouts v2.8: it almost definitely has changed, but also we probably trust
-        the new jkind (we really only want this check here to check against the
-        user-written annotation). We might be able to do a better job here and save
-        some work. *)
+         the new jkind (we really only want this check here to check against the
+         user-written annotation). We might be able to do a better job here and save
+         some work. *)
       let jkind_of_type ty = Some (Ctype.type_jkind_purely env ty) in
       let type_equal = Ctype.type_equal env in
       match
         (* CR layouts v2.8: Consider making a function that doesn't compute
-          histories for this use-case, which doesn't need it. *)
+           histories for this use-case, which doesn't need it. *)
         Jkind.sub_jkind_l
           ~type_equal
           ~jkind_of_type
@@ -2577,22 +2576,18 @@ let normalize_decl_jkinds env shapes decls =
       with
       | Ok _ ->
         if allow_any_crossing then
-          (* If the user is asking us to allow any crossing, we use the modal bounds from
-              the annotation rather than the modal bounds inferred from the type_kind.
-              However, we /only/ take the modal bounds, not the layout - because we still
-              want to be able to eg locally use a type declared as layout [any] as [value]
-              if that's its actual layout! *)
+          (* If the user is asking us to allow any crossing, we use the mod- and
+             with-bounds from the annotation rather than the modal bounds inferred from
+             the type_kind. However, we /only/ take the bounds, not the layout - because
+             we still want to be able to eg locally use a type declared as layout [any] as
+             [value] if that's its actual layout! *)
           let type_jkind =
-            match
-              Jkind.unsafely_set_mod_bounds
-                ~from:original_decl.type_jkind
-                decl.type_jkind
-            with
-            | Ok jkind -> jkind
-            | Error () ->
-              raise(Error(decl.type_loc, Unsafe_mode_crossing_with_with_bounds))
+            Jkind.unsafely_set_bounds ~from:original_decl.type_jkind decl.type_jkind
           in
-          let umc = Some (Jkind.get_mode_crossing ~jkind_of_type type_jkind) in
+          let umc = Some {
+            unsafe_mod_bounds = Jkind.Mod_bounds.to_mode_crossing type_jkind.jkind.mod_bounds;
+            unsafe_with_bounds = type_jkind.jkind.with_bounds
+          } in
           let type_kind =
             match decl.type_kind with
             | Type_abstract _ | Type_open -> assert false (* Checked above *)
@@ -2621,15 +2616,15 @@ let normalize_decl_jkinds env shapes decls =
   in
   Misc.Stdlib.List.fold_left_map2
     (fun env (id, original_decl, allow_any_crossing, decl) shape ->
-      let decl =
-        normalize_decl_jkind env original_decl allow_any_crossing decl
-          (Pident id)
-      in
-      (* Add the decl with the normalized kind back to the environment, so that later
-        kinds don't have to normalize this kind if they mention this type in their
-        with-bounds *)
-      let env = add_type ~check:false ~shape:shape id decl env in
-      env, (id, decl)
+       let decl =
+         normalize_decl_jkind env original_decl allow_any_crossing decl
+           (Pident id)
+       in
+       (* Add the decl with the normalized kind back to the environment, so that later
+          kinds don't have to normalize this kind if they mention this type in their
+          with-bounds *)
+       let env = add_type ~check:false ~shape:shape id decl env in
+       env, (id, decl)
     )
     env
     decls
@@ -4582,10 +4577,6 @@ let report_error ppf = function
       "@[[%@%@unsafe_allow_any_mode_crossing] is not allowed on this kind of \
        type declaration.@ Only records, unboxed products, and variants are \
        supported.@]"
-  | Unsafe_mode_crossing_with_with_bounds ->
-    fprintf ppf
-      "@[[%@%@unsafe_allow_any_mode_crossing] is not allowed with a kind \
-       annotation containing with-bounds.@]"
   | Illegal_baggage jkind ->
     fprintf ppf
       "@[Illegal %a in kind annotation of an abbreviation:@ %a@]"

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -175,7 +175,6 @@ type error =
       }
   | Non_abstract_reexport of Path.t
   | Unsafe_mode_crossing_on_invalid_type_kind
-  | Unsafe_mode_crossing_with_with_bounds
   | Illegal_baggage of jkind_l
   | No_unboxed_version of Path.t
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -706,7 +706,10 @@ type type_declaration =
 
 and type_decl_kind = (label_declaration, label_declaration, constructor_declaration) type_kind
 
-and unsafe_mode_crossing = Mode.Crossing.t
+and unsafe_mode_crossing =
+  { unsafe_mod_bounds : Mode.Crossing.t
+  ; unsafe_with_bounds : (allowed * disallowed) with_bounds
+  }
 
 and ('lbl, 'lbl_flat, 'cstr) type_kind =
     Type_abstract of type_origin
@@ -1117,6 +1120,7 @@ val mixed_block_element_to_string : mixed_block_element -> string
 val mixed_block_element_to_lowercase_string : mixed_block_element -> string
 
 val equal_unsafe_mode_crossing :
+  type_equal:(type_expr -> type_expr -> bool) ->
   unsafe_mode_crossing -> unsafe_mode_crossing -> bool
 
 (**** Utilities for backtracking ****)


### PR DESCRIPTION
Allow the `[@@unsafe_allow_any_mode_crossing]` attribute on a type declaration
to (unsafely) add with bounds as specified in the jkind annotation, but being
careful to still prevent reexports of types from *changing* these with-bounds.