### PR TITLE
Linscan: use doubly-linked lists for intervals

### DIFF
--- a/backend/reg.mli
+++ b/backend/reg.mli
@@ -114,6 +114,7 @@ val set_has_collisions : Set.t -> bool
 
 val reset: unit -> unit
 val all_registers: unit -> t list
+val num_registers: unit -> int
 val reinit: unit -> unit
 
 val same_phys_reg : t -> t -> bool

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -140,18 +140,21 @@ let allocate_free_register : State.t -> Interval.t -> spilling_reg =
     | num_available_registers ->
       let available = Array.make num_available_registers true in
       let num_still_available = ref num_available_registers in
-      let set_not_available r =
+      let set_not_available (r : int) : unit =
         let idx = r - first_available in
         if available.(idx) then decr num_still_available;
         available.(idx) <- false;
         if !num_still_available = 0 then raise No_free_register
       in
-      List.iter intervals.active ~f:(fun (interval : Interval.t) ->
-          match interval.reg.loc with
-          | Reg r ->
-            if r - first_available < num_available_registers
-            then set_not_available r
-          | Stack _ | Unknown -> ());
+      let set_not_available_if_valid_phys_reg (interval : Interval.t) : unit =
+        match interval.reg.loc with
+        | Reg r ->
+          if r - first_available < num_available_registers
+          then set_not_available r
+        | Stack _ | Unknown -> ()
+      in
+      List.iter intervals.active_list ~f:set_not_available_if_valid_phys_reg;
+      DLL.iter intervals.active_dll ~f:set_not_available_if_valid_phys_reg;
       let remove_bound_overlapping (itv : Interval.t) : unit =
         match itv.reg.loc with
         | Reg r ->
@@ -161,8 +164,10 @@ let allocate_free_register : State.t -> Interval.t -> spilling_reg =
           then set_not_available r
         | Stack _ | Unknown -> ()
       in
-      List.iter intervals.inactive ~f:remove_bound_overlapping;
-      List.iter intervals.fixed ~f:remove_bound_overlapping;
+      List.iter intervals.inactive_list ~f:remove_bound_overlapping;
+      DLL.iter intervals.inactive_dll ~f:remove_bound_overlapping;
+      List.iter intervals.fixed_list ~f:remove_bound_overlapping;
+      DLL.iter intervals.fixed_dll ~f:remove_bound_overlapping;
       let rec assign idx =
         if idx >= num_available_registers
         then Misc.fatal_error "No_free_register should have been raised earlier"
@@ -170,8 +175,8 @@ let allocate_free_register : State.t -> Interval.t -> spilling_reg =
         then (
           reg.loc <- Reg (first_available + idx);
           reg.spill <- false;
-          intervals.active
-            <- Interval.List.insert_sorted intervals.active interval;
+          intervals.active_list
+            <- Interval.List.insert_sorted intervals.active_list interval;
           if debug
           then (
             indent ();
@@ -188,7 +193,7 @@ let allocate_blocked_register : State.t -> Interval.t -> spilling_reg =
   let reg = interval.reg in
   let reg_class = Proc.register_class reg in
   let intervals = State.active state ~reg_class in
-  match intervals.active with
+  match intervals.active_list with
   | hd :: tl ->
     let chk r =
       assert (same_reg_class r.Interval.reg hd.Interval.reg);
@@ -196,12 +201,17 @@ let allocate_blocked_register : State.t -> Interval.t -> spilling_reg =
     in
     if hd.end_ > interval.end_
        && not
-            (List.exists ~f:chk intervals.fixed
-            || List.exists ~f:chk intervals.inactive)
+            (List.exists ~f:chk intervals.fixed_list
+            || List.exists ~f:chk intervals.inactive_list)
     then (
       (match hd.reg.loc with Reg _ -> () | Stack _ | Unknown -> assert false);
       interval.reg.loc <- hd.reg.loc;
-      intervals.active <- Interval.List.insert_sorted tl interval;
+      intervals.active_list <- Interval.List.insert_sorted tl interval;
+      (match DLL.hd_cell intervals.active_dll with
+      | None -> assert false
+      | Some cell ->
+        DLL.delete_curr cell;
+        Interval.DLL.insert_sorted intervals.active_dll interval);
       allocate_stack_slot hd.reg)
     else allocate_stack_slot reg
   | [] -> allocate_stack_slot reg

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -177,6 +177,7 @@ let allocate_free_register : State.t -> Interval.t -> spilling_reg =
           reg.spill <- false;
           intervals.active_list
             <- Interval.List.insert_sorted intervals.active_list interval;
+          Interval.DLL.insert_sorted intervals.active_dll interval;
           if debug
           then (
             indent ();

--- a/backend/regalloc/regalloc_ls_state.ml
+++ b/backend/regalloc/regalloc_ls_state.ml
@@ -58,6 +58,8 @@ let dummy_interval =
   { Interval.reg = Reg.dummy;
     begin_ = -1;
     end_ = -1;
+    (* this list can be safely duplicated below, because the empty list is
+       stateless *)
     ranges = DLL.make_empty ()
   }
 

--- a/backend/regalloc/regalloc_ls_state.ml
+++ b/backend/regalloc/regalloc_ls_state.ml
@@ -3,54 +3,134 @@
 open! Int_replace_polymorphic_compare
 open! Regalloc_utils
 open! Regalloc_ls_utils
+module DLL = Flambda_backend_utils.Doubly_linked_list
 
 type t =
-  { mutable intervals : Interval.t list;
+  { mutable interval_list : Interval.t list;
+    interval_dll : Interval.t DLL.t;
     active : ClassIntervals.t array;
     stack_slots : Regalloc_stack_slots.t;
     instruction_id : InstructionId.sequence
   }
 
+let print_intervals ppf (t : t) : unit =
+  Format.fprintf ppf "interval_list(%d): %a\n"
+    (List.length t.interval_list)
+    Interval.List.print t.interval_list;
+  Format.fprintf ppf "interval_dll(%d): %a\n"
+    (DLL.length t.interval_dll)
+    Interval.DLL.print t.interval_dll
+
+let check_consistency t msg : unit =
+  Array.iteri t.active ~f:(fun i ci ->
+      ClassIntervals.check_consistency ci (Printf.sprintf "%s (idx=%d)" msg i));
+  let consistent =
+    equal_list_dll Interval.equal t.interval_list t.interval_dll
+  in
+  if not consistent
+  then (
+    print_intervals Format.err_formatter t;
+    Misc.fatal_errorf "Regalloc_ls_state.check_consistency")
+
 let for_fatal t =
-  ( List.map t.intervals ~f:Interval.copy,
+  ( List.map t.interval_list ~f:Interval.copy,
     Array.map t.active ~f:ClassIntervals.copy )
 
 let[@inline] make ~stack_slots ~last_used =
-  let intervals = [] in
+  let interval_list = [] in
+  let interval_dll = DLL.make_empty () in
   let active =
     Array.init Proc.num_register_classes ~f:(fun _ -> ClassIntervals.make ())
   in
   let instruction_id = InstructionId.make_sequence ~last_used () in
-  { intervals; active; stack_slots; instruction_id }
+  let res =
+    { interval_list; interval_dll; active; stack_slots; instruction_id }
+  in
+  check_consistency res "State.make/end";
+  res
+
+type class_interval_array =
+  { elements : Interval.t array;
+    mutable length : int
+  }
+
+let dummy_interval =
+  { Interval.reg = Reg.dummy;
+    begin_ = -1;
+    end_ = -1;
+    ranges = DLL.make_empty ()
+  }
+
+let make_class_interval_array () =
+  (* CR-soon xclerc for xclerc: this will essentially use twice the required
+     memory *)
+  { elements = Array.make (Reg.num_registers ()) dummy_interval; length = 0 }
+
+let add_class_interval_array ci x =
+  assert (ci.length < Array.length ci.elements);
+  ci.elements.(ci.length) <- x;
+  ci.length <- succ ci.length
+
+let extract_class_interval_array ci : Interval.t array =
+  Array.sub ci.elements ~pos:0 ~len:ci.length
+
+let compare_asc_begin (left : Interval.t) (right : Interval.t) =
+  match Int.compare left.begin_ right.begin_ with
+  | 0 ->
+    (* note: not necessary, used to enforce a unique order *)
+    Reg.compare left.reg right.reg
+  | c -> c
+
+let compare_desc_end (left : Interval.t) (right : Interval.t) =
+  match Int.compare right.end_ left.end_ with
+  | 0 ->
+    (* note: not necessary, used to enforce a unique order *)
+    Reg.compare right.reg left.reg
+  | c -> c
 
 let[@inline] update_intervals state map =
-  let active = state.active in
+  check_consistency state "State.update_intervals/begin";
+  let active : ClassIntervals.t array = state.active in
   Array.iter active ~f:ClassIntervals.clear;
-  state.intervals
+  let active' : class_interval_array array =
+    Array.init (Array.length active) ~f:(fun _ -> make_class_interval_array ())
+  in
+  let class_intervals = make_class_interval_array () in
+  state.interval_list
     <- Reg.Tbl.fold
          (fun reg interval acc ->
            match reg.loc with
            | Reg _ ->
              let reg_class = Proc.register_class reg in
-             active.(reg_class).fixed <- interval :: active.(reg_class).fixed;
+             active.(reg_class).fixed_list
+               <- interval :: active.(reg_class).fixed_list;
+             add_class_interval_array active'.(reg_class) interval;
              acc
-           | Stack _ | Unknown -> interval :: acc)
+           | Stack _ | Unknown ->
+             add_class_interval_array class_intervals interval;
+             interval :: acc)
          map []
-       |> List.sort ~cmp:(fun (left : Interval.t) (right : Interval.t) ->
-              Int.compare left.begin_ right.begin_);
-  if debug then log_intervals ~kind:"regular" state.intervals;
+       |> List.sort ~cmp:compare_asc_begin;
+  let class_intervals = extract_class_interval_array class_intervals in
+  Array.sort ~cmp:compare_asc_begin class_intervals;
+  DLL.clear state.interval_dll;
+  DLL.add_array state.interval_dll class_intervals;
+  if debug then log_interval_list ~kind:"regular" state.interval_list;
+  Array.iteri active' ~f:(fun i (intervals : class_interval_array) ->
+      let extracted = extract_class_interval_array intervals in
+      Array.sort extracted ~cmp:compare_desc_end;
+      DLL.clear active.(i).fixed_dll;
+      DLL.add_array active.(i).fixed_dll extracted);
   Array.iter active ~f:(fun (intervals : ClassIntervals.t) ->
-      intervals.fixed
-        <- List.sort
-             ~cmp:(fun (left : Interval.t) (right : Interval.t) ->
-               Int.compare right.end_ left.end_)
-             intervals.fixed;
-      if debug then log_intervals ~kind:"fixed" intervals.fixed)
+      intervals.fixed_list
+        <- List.sort ~cmp:compare_desc_end intervals.fixed_list;
+      if debug then log_interval_list ~kind:"fixed" intervals.fixed_list);
+  check_consistency state "State.update_intervals/end"
 
-let[@inline] iter_intervals state ~f = List.iter state.intervals ~f
+let[@inline] iter_intervals state ~f = List.iter state.interval_list ~f
 
 let[@inline] fold_intervals state ~f ~init =
-  List.fold_left state.intervals ~f ~init
+  List.fold_left state.interval_list ~f ~init
 
 let[@inline] release_expired_intervals state ~pos =
   Array.iter state.active ~f:(fun x ->
@@ -106,7 +186,9 @@ let rec is_in_a_range ls_order (cell : Range.t DLL.cell option) : bool =
 let[@inline] invariant_intervals state cfg_with_infos =
   if debug && Lazy.force invariants
   then (
-    (match state.intervals with [] -> () | hd :: tl -> check_intervals hd tl);
+    (match state.interval_list with
+    | [] -> ()
+    | hd :: tl -> check_intervals hd tl);
     let interval_map : Interval.t Reg.Map.t =
       fold_intervals state ~init:Reg.Map.empty ~f:(fun acc interval ->
           Reg.Map.update interval.reg
@@ -151,7 +233,7 @@ let[@inline] invariant_intervals state cfg_with_infos =
       (Cfg_with_infos.cfg_with_layout cfg_with_infos)
       ~instruction:check_instr ~terminator:check_instr)
 
-let invariant_active_field (reg_class : int) (field_name : string)
+let invariant_field_list (reg_class : int) (field_name : string)
     (l : Interval.t list) =
   let rec is prev l =
     match l with
@@ -160,19 +242,43 @@ let invariant_active_field (reg_class : int) (field_name : string)
       if hd.Interval.end_ > prev.Interval.end_
       then
         fatal
-          "Regalloc_ls_state.invariant_active_field: active.(%d).%s is not \
-           sorted"
+          "Regalloc_ls_state.invariant_field_list: active.(%d).%s is not sorted"
           reg_class field_name
       else is hd tl
   in
   match l with [] -> () | hd :: tl -> is hd tl
 
+let invariant_field_dll (reg_class : int) (field_name : string)
+    (l : Interval.t DLL.t) =
+  let rec is prev curr =
+    match curr with
+    | None -> ()
+    | Some cell ->
+      let value = DLL.value cell in
+      if value.Interval.end_ > prev.Interval.end_
+      then
+        fatal
+          "Regalloc_ls_state.invariant_field_dll: active.(%d).%s is not sorted"
+          reg_class field_name
+      else is value (DLL.next cell)
+  in
+  match DLL.hd_cell l with
+  | None -> ()
+  | Some cell -> is (DLL.value cell) (DLL.next cell)
+
 let[@inline] invariant_active state =
   if debug && Lazy.force invariants
   then
     Array.iteri state.active ~f:(fun reg_class intervals ->
-        invariant_active_field reg_class "fixed " intervals.ClassIntervals.fixed;
-        invariant_active_field reg_class "active "
-          intervals.ClassIntervals.active;
-        invariant_active_field reg_class "inactive "
-          intervals.ClassIntervals.inactive)
+        invariant_field_list reg_class "fixed "
+          intervals.ClassIntervals.fixed_list;
+        invariant_field_list reg_class "active "
+          intervals.ClassIntervals.active_list;
+        invariant_field_list reg_class "inactive "
+          intervals.ClassIntervals.inactive_list;
+        invariant_field_dll reg_class "fixed "
+          intervals.ClassIntervals.fixed_dll;
+        invariant_field_dll reg_class "active "
+          intervals.ClassIntervals.active_dll;
+        invariant_field_dll reg_class "inactive "
+          intervals.ClassIntervals.inactive_dll)

--- a/backend/regalloc/regalloc_ls_utils.mli
+++ b/backend/regalloc/regalloc_ls_utils.mli
@@ -5,6 +5,8 @@ module DLL = Flambda_backend_utils.Doubly_linked_list
 
 val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
 
+val equal_list_dll : ('a -> 'a -> bool) -> 'a list -> 'a DLL.t -> bool
+
 val indent : unit -> unit
 
 val dedent : unit -> unit
@@ -57,6 +59,8 @@ module Interval : sig
       ranges : Range.t DLL.t
     }
 
+  val equal : t -> t -> bool
+
   val copy : t -> t
 
   val print : Format.formatter -> t -> unit
@@ -68,18 +72,31 @@ module Interval : sig
   val remove_expired : t -> pos:int -> unit
 
   module List : sig
+    val print : Format.formatter -> t list -> unit
+
     val release_expired_fixed : t list -> pos:int -> t list
 
     val insert_sorted : t list -> t -> t list
   end
+
+  module DLL : sig
+    val print : Format.formatter -> t DLL.t -> unit
+
+    val release_expired_fixed : t DLL.t -> pos:int -> unit
+
+    val insert_sorted : t DLL.t -> t -> unit
+  end
 end
 
 module ClassIntervals : sig
-  (* Similar to [Linscan.class_intervals] (in "backend/linscan.mln"). *)
+  (* Similar to [Linscan.class_intervals] (in "backend/linscan.ml"). *)
   type t =
-    { mutable fixed : Interval.t list;
-      mutable active : Interval.t list;
-      mutable inactive : Interval.t list
+    { mutable fixed_list : Interval.t list;
+      mutable active_list : Interval.t list;
+      mutable inactive_list : Interval.t list;
+      fixed_dll : Interval.t DLL.t;
+      active_dll : Interval.t DLL.t;
+      inactive_dll : Interval.t DLL.t
     }
 
   val make : unit -> t
@@ -91,8 +108,12 @@ module ClassIntervals : sig
   val clear : t -> unit
 
   val release_expired_intervals : t -> pos:int -> unit
+
+  val check_consistency : t -> string -> unit
 end
 
 val log_interval : kind:string -> Interval.t -> unit
 
-val log_intervals : kind:string -> Interval.t list -> unit
+val log_interval_list : kind:string -> Interval.t list -> unit
+
+val log_interval_dll : kind:string -> Interval.t DLL.t -> unit

--- a/utils/.ocamlformat-enable
+++ b/utils/.ocamlformat-enable
@@ -1,5 +1,7 @@
 compilation_unit.ml
 compilation_unit.mli
+doubly_linked_list.ml
+doubly_linked_list.mli
 import_info.ml
 import_info.mli
 language_extension_kernel.ml

--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -431,11 +431,10 @@ let copy t = map t ~f:Fun.id
 let equal eq left right =
   let rec aux eq left right =
     match left, right with
-    | None, None -> true
-    | None, Some _ | Some _, None -> false
-    | Some left_cell, Some right_cell ->
-      let left_value = value left_cell in
-      let right_value = value right_cell in
-      eq left_value right_value && aux eq (next left_cell) (next right_cell)
+    | Empty, Empty -> true
+    | Empty, Node _ | Node _, Empty -> false
+    | ( Node { value = left_value; next = left_next; prev = _ },
+        Node { value = right_value; next = right_next; prev = _ } ) ->
+      eq left_value right_value && aux eq left_next right_next
   in
-  aux eq (hd_cell left) (hd_cell right)
+  aux eq left.first right.first

--- a/utils/doubly_linked_list.ml
+++ b/utils/doubly_linked_list.ml
@@ -9,8 +9,7 @@ type 'a node =
 let[@inline] unattached_node value = Node { value; prev = Empty; next = Empty }
 
 type 'a t =
-  { mutable length : int;
-    mutable first : 'a node;
+  { mutable first : 'a node;
     mutable last : 'a node
   }
 
@@ -33,7 +32,6 @@ let insert_and_return_before cell value =
       new_node.next <- cell.node;
       new_node.prev <- cell_node.prev;
       cell_node.prev <- value_node;
-      cell.t.length <- succ cell.t.length;
       (match new_node.prev with
       | Empty -> cell.t.first <- value_node
       | Node node -> node.next <- value_node);
@@ -55,7 +53,6 @@ let insert_and_return_after cell value =
       (new_node.next <- cell_node.next;
        new_node.prev <- cell.node;
        cell_node.next <- value_node;
-       cell.t.length <- succ cell.t.length;
        match new_node.next with
        | Empty -> cell.t.last <- value_node
        | Node node -> node.prev <- value_node);
@@ -97,14 +94,29 @@ let next cell =
     let next = cell_node.next in
     match next with Empty -> None | Node _ -> Some { node = next; t = cell.t })
 
-let make_empty () = { length = 0; first = Empty; last = Empty }
+let cut_from cell =
+  let t = cell.t in
+  match cell.node with
+  | Empty ->
+    (* internal invariant: cell's nodes are not empty *)
+    assert false
+  | Node curr -> (
+    match curr.prev with
+    | Empty ->
+      t.first <- Empty;
+      t.last <- Empty
+    | Node prev_node as last_node ->
+      t.last <- last_node;
+      prev_node.next <- Empty;
+      curr.prev <- Empty)
+
+let make_empty () = { first = Empty; last = Empty }
 
 let make_single value =
   let node = unattached_node value in
-  { length = 1; first = node; last = node }
+  { first = node; last = node }
 
 let clear t =
-  t.length <- 0;
   t.first <- Empty;
   t.last <- Empty
 
@@ -122,19 +134,15 @@ let add_begin t value =
     (* internal invariant: unattached node returns a non-empty node *)
     assert false
   | Node node as value_node -> (
-    let len = t.length in
     match t.first with
     | Empty ->
       assert (t.last = Empty);
-      assert (len = 0);
       t.first <- value_node;
-      t.last <- value_node;
-      t.length <- 1
+      t.last <- value_node
     | Node first_node ->
       node.next <- t.first;
       first_node.prev <- value_node;
-      t.first <- value_node;
-      t.length <- succ len)
+      t.first <- value_node)
 
 let add_end t value =
   match unattached_node value with
@@ -142,19 +150,15 @@ let add_end t value =
     (* internal invariant: unattached node returns a non-empty node *)
     assert false
   | Node node as value_node -> (
-    let len = t.length in
     match t.last with
     | Empty ->
       assert (t.first = Empty);
-      assert (len = 0);
       t.first <- value_node;
-      t.last <- value_node;
-      t.length <- 1
+      t.last <- value_node
     | Node last_node ->
       node.prev <- t.last;
       last_node.next <- value_node;
-      t.last <- value_node;
-      t.length <- succ len)
+      t.last <- value_node)
 
 let add_list t l = List.iter (fun x -> add_end t x) l
 
@@ -163,23 +167,38 @@ let of_list l =
   add_list res l;
   res
 
-let is_empty t = Int.equal t.length 0
+let add_array t arr =
+  for i = 0 to pred (Array.length arr) do
+    add_end t (Array.unsafe_get arr i)
+  done
 
-let length t = t.length
+let of_array arr =
+  let res = make_empty () in
+  add_array res arr;
+  res
+
+let is_empty (t : _ t) = match t.first with Empty -> true | Node _ -> false
+
+let length t =
+  let rec aux acc curr =
+    match curr with
+    | Empty -> acc
+    | Node { value = _; prev = _; next } -> aux (succ acc) next
+  in
+  aux 0 t.first
 
 let remove t curr =
   match curr with
   | Empty ->
     (* internal invariant: the node given to [remove] is never empty *)
     assert false
-  | Node curr ->
+  | Node curr -> (
     (match curr.prev with
     | Empty -> t.first <- curr.next
     | Node node -> node.next <- curr.next);
-    (match curr.next with
+    match curr.next with
     | Empty -> t.last <- curr.prev
-    | Node node -> node.prev <- curr.prev);
-    t.length <- pred t.length
+    | Node node -> node.prev <- curr.prev)
 
 let delete_curr cell = remove cell.t cell.node
 
@@ -358,29 +377,24 @@ let transfer ~to_ ~from () =
   | Empty, _ ->
     to_.first <- from.first;
     to_.last <- from.last;
-    to_.length <- from.length;
     from.first <- Empty;
-    from.last <- Empty;
-    from.length <- 0
+    from.last <- Empty
   | Node to_last, Node from_first ->
     to_last.next <- from.first;
     from_first.prev <- to_.last;
     to_.last <- from.last;
-    to_.length <- to_.length + from.length;
     from.first <- Empty;
-    from.last <- Empty;
-    from.length <- 0
+    from.last <- Empty
 
 let map t ~f =
   let res = make_empty () in
   iter t ~f:(fun x -> add_end res (f x));
   res
 
-
 module Cursor = struct
   type nonrec 'a t =
-    { t : 'a t
-    ; mutable node : 'a node
+    { t : 'a t;
+      mutable node : 'a node
     }
 
   let value (t : _ t) =
@@ -389,27 +403,39 @@ module Cursor = struct
       (* internal invariant: cell's nodes are not empty *)
       assert false
     | Node node -> node.value
-  ;;
 
   let next (t : _ t) =
     match t.node with
     | Empty ->
       (* internal invariant: cell's nodes are not empty *)
       assert false
-    | Node content ->
-      (match content.next with
-       | Empty -> Error `End_of_list
-       | Node _ ->
-         t.node <- content.next;
-         Ok ())
-  ;;
+    | Node content -> (
+      match content.next with
+      | Empty -> Error `End_of_list
+      | Node _ ->
+        t.node <- content.next;
+        Ok ())
 
   let delete_and_next (t : _ t) =
     remove t.t t.node;
     next t
 end
 
-let create_hd_cursor t : (_ Cursor.t, [`Empty]) result  =
+let create_hd_cursor t : (_ Cursor.t, [`Empty]) result =
   match t.first with
   | Empty -> Error `Empty
   | Node _ -> Ok { t; node = t.first }
+
+let copy t = map t ~f:Fun.id
+
+let equal eq left right =
+  let rec aux eq left right =
+    match left, right with
+    | None, None -> true
+    | None, Some _ | Some _, None -> false
+    | Some left_cell, Some right_cell ->
+      let left_value = value left_cell in
+      let right_value = value right_cell in
+      eq left_value right_value && aux eq (next left_cell) (next right_cell)
+  in
+  aux eq (hd_cell left) (hd_cell right)

--- a/utils/doubly_linked_list.mli
+++ b/utils/doubly_linked_list.mli
@@ -16,6 +16,7 @@ val prev : 'a cell -> 'a cell option
 
 val next : 'a cell -> 'a cell option
 
+(* Deletes the passed cell and all the cells after it. *)
 val cut_from : 'a cell -> unit
 
 type 'a t

--- a/utils/doubly_linked_list.mli
+++ b/utils/doubly_linked_list.mli
@@ -16,13 +16,21 @@ val prev : 'a cell -> 'a cell option
 
 val next : 'a cell -> 'a cell option
 
+val cut_from : 'a cell -> unit
+
 type 'a t
 
 val make_empty : unit -> _ t
 
 val make_single : 'a -> 'a t
 
+val add_list : 'a t -> 'a list -> unit
+
 val of_list : 'a list -> 'a t
+
+val add_array : 'a t -> 'a array -> unit
+
+val of_array : 'a array -> 'a t
 
 val clear : 'a t -> unit
 
@@ -37,8 +45,6 @@ val last_cell : 'a t -> 'a cell option
 val add_begin : 'a t -> 'a -> unit
 
 val add_end : 'a t -> 'a -> unit
-
-val add_list : 'a t -> 'a list -> unit
 
 val is_empty : 'a t -> bool
 
@@ -93,7 +99,12 @@ module Cursor : sig
   val value : 'a t -> 'a
 
   val next : 'a t -> (unit, [`End_of_list]) result
+
   val delete_and_next : 'a t -> (unit, [`End_of_list]) result
 end
 
 val create_hd_cursor : 'a t -> ('a Cursor.t, [`Empty]) result
+
+val copy : 'a t -> 'a t
+
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool


### PR DESCRIPTION
This pull request change the list implementation
used to stored intervals from `list` to
`Doubly_linked_list.t`.

The existing fields storing such interval list are
renamed from `xyz` to `xyz_list`, and additional
fields named `xyz_dll` are added. The `xyz_dll`
contain a copy of the list, simply using the new
representation. The functions updating the lists
are modified to check whether the contents of
`xyz_list` and `xyz_dll` are equal.

A follow-up pull request will delete the `xyz_list`
fields.