### PR TITLE
Only set the young limit if we are actually (un)suspending.

### DIFF
--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -2200,8 +2200,12 @@ CAMLexport void caml_memprof_delete_thread(memprof_thread_t thread)
 CAMLexport void caml_memprof_enter_thread(memprof_thread_t thread)
 {
   CAMLassert(thread);
-  thread->domain->current = thread;
-  update_suspended(thread->domain, thread->suspended);
+  memprof_domain_t domain = thread->domain;
+  bool old_suspended = domain->current && domain->current->suspended;
+  domain->current = thread;
+  if (old_suspended != thread->suspended) {
+    update_suspended(thread->domain, thread->suspended);
+  }
 }
 
 /**** Interface to OCaml ****/


### PR DESCRIPTION
Statmemprof suspends sampling when running its own callbacks. So when switching threads, statmemprof may switch from "suspended" to "unsuspended" or vice versa. If the suspended status changes, the runtime has to change various things (e.g. setting the young limit) which can have expensive side-effects. But we can avoid this if the suspended status doesn't change.