### PR TITLE
Improved pending actions handling in caml_enter_blocking_section (r5 only)

### DIFF
--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -170,8 +170,10 @@ CAMLexport void caml_enter_blocking_section(void)
   if (Caml_state->in_minor_collection)
     caml_fatal_error("caml_enter_blocking_section from inside minor GC");
 
-  /* Execute pending actions until there are no more remaining */
-  while (check_pending_actions(domain)) {
+  /* Execute pending signal handlers until there are no more remaining.
+     We check [action_pending] as it's faster than the signals check. */
+  while (Caml_check_gc_interrupt(Caml_state)
+    || (Caml_state->action_pending && caml_check_pending_signals())) {
     /* First reset young_limit, and set action_pending in case there
        are further async callbacks pending beyond OCaml signal
        handlers. */

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -163,10 +163,13 @@ CAMLexport void (*caml_leave_blocking_section_hook)(void) =
 
 static int check_pending_actions(caml_domain_state * dom_st);
 
+CAMLexport void caml_enter_blocking_section_no_pending(void)
+{
+  caml_enter_blocking_section_hook ();
+}
+
 CAMLexport void caml_enter_blocking_section(void)
 {
-  caml_domain_state * domain = Caml_state;
-
   if (Caml_state->in_minor_collection)
     caml_fatal_error("caml_enter_blocking_section from inside minor GC");
 
@@ -182,14 +185,9 @@ CAMLexport void caml_enter_blocking_section(void)
   }
 
   /* Drop the systhreads lock */
-  caml_enter_blocking_section_hook ();
+  caml_enter_blocking_section_no_pending ();
   /* Any pending actions that happen at this point onwards can be handled by
      another thread, or by this thread upon leaving the blocking section. */
-}
-
-CAMLexport void caml_enter_blocking_section_no_pending(void)
-{
-  caml_enter_blocking_section_hook ();
 }
 
 CAMLexport void caml_leave_blocking_section(void)

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -166,25 +166,23 @@ static int check_pending_actions(caml_domain_state * dom_st);
 CAMLexport void caml_enter_blocking_section(void)
 {
   caml_domain_state * domain = Caml_state;
-  while (1){
-    if (Caml_state->in_minor_collection)
-      caml_fatal_error("caml_enter_blocking_section from inside minor GC");
-    /* Process all pending signals now */
-    if (check_pending_actions(domain)) {
-      /* First reset young_limit, and set action_pending in case there
-         are further async callbacks pending beyond OCaml signal
-         handlers. */
-      caml_handle_gc_interrupt();
-      caml_raise_async_if_exception(caml_process_pending_signals_exn(), "");
-    }
-    caml_enter_blocking_section_hook ();
-    /* Check again if a signal arrived in the meanwhile. If none,
-       done; otherwise, try again. Since we do not hold the domain
-       lock, we cannot read [young_ptr] and we cannot call
-       [Caml_check_gc_interrupt]. */
-    if (atomic_load_relaxed(&domain->young_limit) != UINTNAT_MAX) break;
-    caml_leave_blocking_section_hook ();
+
+  if (Caml_state->in_minor_collection)
+    caml_fatal_error("caml_enter_blocking_section from inside minor GC");
+
+  /* Execute pending actions until there are no more remaining */
+  while (check_pending_actions(domain)) {
+    /* First reset young_limit, and set action_pending in case there
+       are further async callbacks pending beyond OCaml signal
+       handlers. */
+    caml_handle_gc_interrupt();
+    caml_raise_async_if_exception(caml_process_pending_signals_exn(), "");
   }
+
+  /* Drop the systhreads lock */
+  caml_enter_blocking_section_hook ();
+  /* Any pending actions that happen at this point onwards can be handled by
+     another thread, or by this thread upon leaving the blocking section. */
 }
 
 CAMLexport void caml_enter_blocking_section_no_pending(void)


### PR DESCRIPTION
Currently, `caml_enter_blocking_section` checks the young limit (rather than any other pending action flag because the domain lock is not held) after dropping the systhreads lock.  If it is seen that an action is pending, hence, the lock is taken again and the whole process repeated.  This is racy with respect to another thread that could be handling pending actions, and more importantly, is unnecessary: any actions after the lock being dropped can just be picked up by another thread -- thus avoiding the current thread having to re-take the lock.  The existing semantics in particular causes unnecessary performance degradation in `Condition` (see #3741 ).  This PR changes the loop structure correspondingly.

In addition the condition is refined so it matches which actions are run directly from `caml_enter_blocking_section`: in particular, only signal handlers and GC interrupt-related actions (e.g. minor collection) are run, rather than e.g. memprof callbacks.

Finally `caml_enter_blocking_section_no_pending` is used to make it clear what does not happen if you use this (`no_pending`) function.