### PR TITLE
Avoid checking pending actions in Condition.wait

### DIFF
--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -168,7 +168,10 @@ CAMLprim value caml_ml_condition_wait(value wcond, value wmut)
   sync_retcode retcode;
 
   CAML_EV_BEGIN(EV_DOMAIN_CONDITION_WAIT);
-  caml_enter_blocking_section();
+  /* no_pending here: we don't want to delay releasing the mutex.
+     (We're waiting for another thread to wake us up anyway: they
+     can handle any pending actions)) */
+  caml_enter_blocking_section_no_pending();
   retcode = sync_condvar_wait(cond, mut);
   caml_leave_blocking_section();
   sync_check_error(retcode, "Condition.wait");


### PR DESCRIPTION
`Condition.wait` is a bad time to process pending actions, as other threads may be blocking for the mutex we're about to release. (Since we're only woken up by another thread choosing to signal us, there must eventually be someone else to process any such pending actions)