### PR TITLE
Merge Cmm Ctrywith with Ccatch

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -289,8 +289,7 @@ let select_store ~is_assign addr (exp : Cmm.expression) :
   | Cifthenelse (_, _, _, _, _, _)
   | Cswitch (_, _, _, _)
   | Ccatch (_, _, _)
-  | Cexit (_, _, _)
-  | Ctrywith (_, _, _, _, _, _) ->
+  | Cexit (_, _, _) ->
     Use_default
 
 let is_store_out_of_range _chunk ~byte_offset:_ :

--- a/backend/cfg/sub_cfg.ml
+++ b/backend/cfg/sub_cfg.ml
@@ -115,9 +115,7 @@ let update_exit_terminator ?arg sub_cfg desc =
          arg = Option.value arg ~default:sub_cfg.exit.terminator.arg
        }
 
-let mark_as_trap_handler sub_cfg ~exn_label =
-  sub_cfg.entry.start <- exn_label;
-  sub_cfg.entry.is_trap_handler <- true
+let mark_as_trap_handler sub_cfg = sub_cfg.entry.is_trap_handler <- true
 
 let dump sub_cfg =
   let liveness = InstructionId.Tbl.create 32 in

--- a/backend/cfg/sub_cfg.mli
+++ b/backend/cfg/sub_cfg.mli
@@ -72,6 +72,6 @@ val update_exit_terminator : ?arg:Reg.t array -> t -> Cfg.terminator -> unit
 
 val start_label : t -> Label.t
 
-val mark_as_trap_handler : t -> exn_label:Label.t -> unit
+val mark_as_trap_handler : t -> unit
 
 val dump : t -> unit

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -154,8 +154,6 @@ type exit_label =
   | Return_lbl
   | Lbl of static_label
 
-type rec_flag = Nonrecursive | Recursive
-
 type prefetch_temporal_locality_hint = Nonlocal | Low | Moderate | High
 
 type atomic_op =
@@ -345,6 +343,8 @@ type vec128_bits = { low : int64; high: int64 }
 
 let global_symbol sym_name = { sym_name; sym_global = Global }
 
+type ccatch_flag = Normal | Recursive | Exn_handler
+
 type expression =
     Cconst_int of int * Debuginfo.t
   | Cconst_natint of nativeint * Debuginfo.t
@@ -364,15 +364,11 @@ type expression =
   | Cswitch of expression * int array * (expression * Debuginfo.t) array
       * Debuginfo.t
   | Ccatch of
-      rec_flag
+      ccatch_flag
         * (static_label * (Backend_var.With_provenance.t * machtype) list
           * expression * Debuginfo.t * bool (* is_cold *)) list
         * expression
   | Cexit of exit_label * expression list * trap_action list
-  | Ctrywith of expression * trywith_shared_label
-      * Backend_var.With_provenance.t
-      * (Backend_var.With_provenance.t * machtype) list
-      * expression * Debuginfo.t
 
 type codegen_option =
   | Reduce_code_size
@@ -414,7 +410,12 @@ type phrase =
   | Cdata of data_item list
 
 let ccatch (i, ids, e1, e2, dbg, is_cold) =
-  Ccatch(Nonrecursive, [i, ids, e2, dbg, is_cold], e1)
+  Ccatch(Normal, [i, ids, e2, dbg, is_cold], e1)
+
+let ctrywith (body, lbl, id, extra_args, handler, dbg) =
+  Ccatch (Exn_handler,
+          [lbl, (id, typ_val) :: extra_args, handler, dbg, false],
+          body)
 
 let reset () =
   Label.reset ()
@@ -433,13 +434,9 @@ let iter_shallow_tail f = function
   | Cswitch(_e, _tbl, el, _dbg') ->
       Array.iter (fun (e, _dbg) -> f e) el;
       true
-  | Ccatch(_rec_flag, handlers, body) ->
+  | Ccatch(_flag, handlers, body) ->
       List.iter (fun (_, _, h, _dbg, _) -> f h) handlers;
       f body;
-      true
-  | Ctrywith(e1, _kind, _id, _extra_args, e2, _dbg) ->
-      f e1;
-      f e2;
       true
   | Cexit _ | Cop (Craise _, _, _) ->
       true
@@ -471,13 +468,11 @@ let map_shallow_tail f = function
       Csequence(e1, f e2)
   | Cswitch(e, tbl, el, dbg') ->
       Cswitch(e, tbl, Array.map (fun (e, dbg) -> f e, dbg) el, dbg')
-  | Ccatch(rec_flag, handlers, body) ->
+  | Ccatch(flag, handlers, body) ->
       let map_h (n, ids, handler, dbg, is_cold) =
         (n, ids, f handler, dbg, is_cold)
       in
-      Ccatch(rec_flag, List.map map_h handlers, f body)
-  | Ctrywith(e1, kind', id,extra_args, e2, dbg) ->
-      Ctrywith(f e1, kind', id,extra_args, f e2, dbg)
+      Ccatch(flag, List.map map_h handlers, f body)
   | Cexit _ | Cop (Craise _, _, _) as cmm ->
       cmm
   | Cconst_int _
@@ -520,13 +515,11 @@ let iter_shallow f = function
       f cond; f ifso; f ifnot
   | Cswitch (_e, _ia, ea, _dbg) ->
       Array.iter (fun (e, _) -> f e) ea
-  | Ccatch (_rf, hl, body) ->
+  | Ccatch (_f, hl, body) ->
       let iter_h (_n, _ids, handler, _dbg, _is_cold) = f handler in
       List.iter iter_h hl; f body
   | Cexit (_n, el, _traps) ->
       List.iter f el
-  | Ctrywith (e1, _kind, _id,_extra_args, e2, _dbg) ->
-      f e1; f e2
   | Cconst_int _
   | Cconst_natint _
   | Cconst_float32 _
@@ -551,15 +544,13 @@ let map_shallow f = function
       Cifthenelse(f cond, ifso_dbg, f ifso, ifnot_dbg, f ifnot, dbg)
   | Cswitch (e, ia, ea, dbg) ->
       Cswitch (e, ia, Array.map (fun (e, dbg) -> f e, dbg) ea, dbg)
-  | Ccatch (rf, hl, body) ->
+  | Ccatch (flag, hl, body) ->
       let map_h (n, ids, handler, dbg, is_cold) =
         (n, ids, f handler, dbg, is_cold)
       in
-      Ccatch (rf, List.map map_h hl, f body)
+      Ccatch (flag, List.map map_h hl, f body)
   | Cexit (n, el, traps) ->
       Cexit (n, List.map f el, traps)
-  | Ctrywith (e1, kind, id, extra_args, e2, dbg) ->
-      Ctrywith (f e1, kind, id, extra_args,f e2, dbg)
   | Cconst_int _
   | Cconst_natint _
   | Cconst_float32 _

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -746,3 +746,8 @@ let is_val (m: machtype_component) =
   match m with
   | Val -> true
   | Addr | Int | Float | Vec128 | Float32 | Valx2 -> false
+
+let is_exn_handler (flag : ccatch_flag) =
+  match flag with
+  | Exn_handler -> true
+  | Normal | Recursive -> false

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -456,3 +456,4 @@ val equal_integer_comparison : integer_comparison -> integer_comparison -> bool
 
 val caml_flambda2_invalid : string
 val is_val : machtype_component -> bool
+val is_exn_handler : ccatch_flag -> bool

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -349,7 +349,7 @@ let rec map_tail1 e ~f =
   | Csequence (e1, e2) -> Csequence (e1, map_tail1 e2 ~f)
   | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
   | Cconst_vec128 _ | Cconst_symbol _ | Cvar _ | Ctuple _ | Cop _
-  | Cifthenelse _ | Cexit _ | Ccatch _ | Ctrywith _ | Cswitch _ ->
+  | Cifthenelse _ | Cexit _ | Ccatch _ | Cswitch _ ->
     f e
 
 let map_tail2 x y ~f = map_tail1 y ~f:(fun y -> map_tail1 x ~f:(fun x -> f x y))
@@ -4023,8 +4023,7 @@ let letin v ~defining_expr ~body =
     defining_expr
   | Cvar _ | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
   | Cconst_symbol _ | Cconst_vec128 _ | Clet _ | Cphantom_let _ | Ctuple _
-  | Cop _ | Csequence _ | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _
-  | Ctrywith _ ->
+  | Cop _ | Csequence _ | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ ->
     Clet (v, defining_expr, body)
 
 let sequence x y =
@@ -4037,7 +4036,14 @@ let ite ~dbg ~then_dbg ~then_ ~else_dbg ~else_ cond =
   Cifthenelse (cond, then_dbg, then_, else_dbg, else_, dbg)
 
 let trywith ~dbg ~body ~exn_var ~extra_args ~handler_cont ~handler () =
-  Ctrywith (body, handler_cont, exn_var, extra_args, handler, dbg)
+  Ccatch
+    ( Exn_handler,
+      [ ( handler_cont,
+          (exn_var, typ_val) :: extra_args,
+          handler,
+          dbg,
+          false (* is_cold *) ) ],
+      body)
 
 type static_handler =
   int
@@ -4054,7 +4060,7 @@ let trap_return arg trap_actions =
   Cmm.Cexit (Cmm.Return_lbl, [arg], trap_actions)
 
 let create_ccatch ~rec_flag ~handlers ~body =
-  let rec_flag = if rec_flag then Cmm.Recursive else Cmm.Nonrecursive in
+  let rec_flag = if rec_flag then Cmm.Recursive else Cmm.Normal in
   Cmm.Ccatch (rec_flag, handlers, body)
 
 let unary op ~dbg x = Cop (op, [x], dbg)
@@ -4355,7 +4361,7 @@ let cmm_arith_size (e : Cmm.expression) =
     Some 0
   | Cop _ -> Some (cmm_arith_size0 e)
   | Clet _ | Cphantom_let _ | Ctuple _ | Csequence _ | Cifthenelse _ | Cswitch _
-  | Ccatch _ | Cexit _ | Ctrywith _ ->
+  | Ccatch _ | Cexit _ ->
     None
 
 (* Atomics *)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4043,7 +4043,7 @@ let trywith ~dbg ~body ~exn_var ~extra_args ~handler_cont ~handler () =
           handler,
           dbg,
           false (* is_cold *) ) ],
-      body)
+      body )
 
 type static_handler =
   int

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -152,7 +152,7 @@ let rec check env (expr : Cmm.expression) =
   | Cswitch (body, _, branches, _) ->
     check env body;
     Array.iter (fun (expr, _) -> check env expr) branches
-  | Ccatch (rec_flag, handlers, body) ->
+  | Ccatch (flag, handlers, body) ->
     let env_extended =
       List.fold_left
         (fun env (cont, args, _, _, _) ->
@@ -162,20 +162,13 @@ let rec check env (expr : Cmm.expression) =
     in
     check env_extended body;
     let env_handler =
-      match rec_flag with
+      match flag with
       | Recursive -> env_extended
-      | Nonrecursive -> env
+      | Normal | Exn_handler -> env
     in
     List.iter (fun (_, _, handler, _, _) -> check env_handler handler) handlers
   | Cexit (exit_label, args, _trap_actions) ->
     Env.jump env ~exit_label ~arg_num:(List.length args)
-  | Ctrywith (body, _trywith_kind, _, _, handler, _) ->
-    (* Jumping from inside a trywith body to outside isn't very nice,
-       but it's handled correctly by Linearize, as it happens
-       when compiling match ... with exception ..., for instance, so it is
-       not reported as an error. *)
-    check env body;
-    check env handler
 
 let run ppf (fundecl : Cmm.fundecl) =
   let env = Env.init () in

--- a/backend/printcmm.mli
+++ b/backend/printcmm.mli
@@ -18,7 +18,7 @@
 open Format
 
 val symbol : formatter -> Cmm.symbol -> unit
-val rec_flag : formatter -> Cmm.rec_flag -> unit
+val ccatch_flag : formatter -> Cmm.ccatch_flag -> unit
 val machtype_component : formatter -> Cmm.machtype_component -> unit
 val machtype : formatter -> Cmm.machtype -> unit
 val exttype : formatter -> Cmm.exttype -> unit

--- a/backend/select_utils.mli
+++ b/backend/select_utils.mli
@@ -77,7 +77,6 @@ val env_set_trap_stack : environment -> Operation.trap_stack -> environment
 val print_traps : Format.formatter -> Operation.trap_stack -> unit
 
 val set_traps :
-  environment ->
   Lambda.static_label ->
   trap_stack_info ref ->
   Operation.trap_stack ->

--- a/backend/select_utils.mli
+++ b/backend/select_utils.mli
@@ -43,7 +43,6 @@ type environment =
       (Reg.t array * V.Provenance.t option * Asttypes.mutable_flag) V.Map.t;
     static_exceptions : static_handler Int.Map.t;
     trap_stack : Operation.trap_stack;
-    regs_for_exception_extra_args : Reg.t array Int.Map.t;
     tailrec_label : Label.t
   }
 
@@ -68,25 +67,18 @@ val env_find : V.Map.key -> environment -> Reg.t array
 val env_find_mut :
   V.Map.key -> environment -> Reg.t array * Backend_var.Provenance.t option
 
-val env_add_regs_for_exception_extra_args :
-  Int.Map.key -> Reg.t array -> environment -> environment
-
 val env_find_regs_for_exception_extra_args :
-  Int.Map.key -> environment -> Reg.t array
+  Cmm.trywith_shared_label -> environment -> Reg.t array list
 
 val env_find_static_exception : Int.Map.key -> environment -> static_handler
 
-val env_enter_trywith : environment -> Int.Map.key -> Label.t -> environment
-
 val env_set_trap_stack : environment -> Operation.trap_stack -> environment
-
-val combine_traps :
-  Operation.trap_stack -> Cmm.trap_action list -> Operation.trap_stack
 
 val print_traps : Format.formatter -> Operation.trap_stack -> unit
 
 val set_traps :
-  int ->
+  environment ->
+  Lambda.static_label ->
   trap_stack_info ref ->
   Operation.trap_stack ->
   Cmm.trap_action list ->

--- a/flambda-backend/testsuite/tools/dune
+++ b/flambda-backend/testsuite/tools/dune
@@ -13,7 +13,7 @@
 
 (executable
  (name codegen_main)
- (modes byte)
+ (modes native)
  (libraries ocamlcommon ocamloptcomp unix)
  (modules codegen_main lexcmm parsecmm parsecmmaux))
 

--- a/flambda-backend/testsuite/tools/parsecmm.mly
+++ b/flambda-backend/testsuite/tools/parsecmm.mly
@@ -245,7 +245,7 @@ expr:
           | _ -> Cifthenelse($3, debuginfo (), $4, debuginfo (),
                              (Cexit(Cmm.Lbl lbl0,[],[])),
                              debuginfo ()) in
-        Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo (), false],
+        Ccatch(Normal, [lbl0, [], Ctuple [], debuginfo (), false],
           Ccatch(Recursive,
             [lbl1, [], Csequence(body, Cexit(Cmm.Lbl lbl1, [], [])), debuginfo (), false],
             Cexit(Cmm.Lbl lbl1, [], []))) }
@@ -264,10 +264,10 @@ expr:
         let result = Backend_var.create_local "result" in
         let result' = Backend_var.With_provenance.create result in
         unbind_ident $6;
-        Ctrywith (
-          Ccatch (Nonrecursive,
+        ctrywith (
+          Ccatch (Normal,
             [after_push_k, [],
-             Ccatch (Nonrecursive,
+             Ccatch (Normal,
                [after_pop_k, [result', $3],
                 Cvar result, debuginfo (), false],
                Cexit (Cmm.Lbl after_pop_k,

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -409,7 +409,7 @@ let is_cmm_simple cmm =
   | Cconst_vec128 _ | Cconst_symbol _ | Cvar _ ->
     true
   | Clet _ | Cphantom_let _ | Ctuple _ | Cop _ | Csequence _ | Cifthenelse _
-  | Cswitch _ | Ccatch _ | Cexit _ | Ctrywith _ ->
+  | Cswitch _ | Ccatch _ | Cexit _ ->
     false
 
 (* Helper function to create bindings *)

--- a/testsuite/tools/parsecmm.mly
+++ b/testsuite/tools/parsecmm.mly
@@ -233,7 +233,7 @@ expr:
           | _ -> Cifthenelse($3, debuginfo (), $4, debuginfo (),
                              (Cexit(lbl0,[])),
                              debuginfo (), Any) in
-        Ccatch(Nonrecursive, [lbl0, [], Ctuple [], debuginfo ()],
+        Ccatch(Normal, [lbl0, [], Ctuple [], debuginfo ()],
           Ccatch(Recursive,
             [lbl1, [], Csequence(body, Cexit(lbl1, [])), debuginfo ()],
             Cexit(lbl1, []), Any), Any) }
@@ -246,7 +246,8 @@ expr:
       Ccatch(Recursive, handlers, $3, Any) }
   | EXIT        { Cexit(0,[]) }
   | LPAREN TRY sequence WITH bind_ident sequence RPAREN
-                { unbind_ident $5; Ctrywith($3, $5, [], $6, debuginfo (), Any) }
+                { unbind_ident $5;
+                  ctrywith ($3, $5, [], $6, debuginfo (), Any) }
   | LPAREN VAL expr expr RPAREN
       { let open Asttypes in
         Cop(Cload {memory_chunk=Word_val;


### PR DESCRIPTION
The `Ctrywith` constructor in `Cmm` used to encode both declaring an exception handler and wrapping the body with the proper pushtrap/poptrap instructions.
Flambda2 needed a way to dissociate these two concepts, with the introduction of the handler being similar to `Ccatch` but the trap instructions being encoded elsewhere. For what I remember as upstreaming reasons, we chose to encode these handlers as special "delayed" cases of `Ctrywith` rather than `Ccatch`.
Since then, we have removed the support for non-Flambda2 middle-ends, so all the `Ctrywith` we generate are delayed. It seems now might be a good moment to finally merge these delayed exception handlers back into the `Ccatch` case where they fit better.

I need to add some comments here and there for some tricky parts of the patch, I will try to do this either tomorrow or on Friday.