### PR TITLE
arm64: popcnt/ctz without CSSC

### DIFF
--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -25,6 +25,9 @@ let macosx = String.equal Config.system "macosx"
 
 let is_asan_enabled = ref false
 
+(* CR gyorsh: refactor to use [Arch.Extension] like amd64 *)
+let feat_cssc = ref false
+
 (* Machine-specific command-line options *)
 
 let command_line_options = [
@@ -32,6 +35,11 @@ let command_line_options = [
     Arg.Clear is_asan_enabled,
     " Disable AddressSanitizer. This is only meaningful if the compiler was \
      built with AddressSanitizer support enabled."
+  ;
+
+  "-fcssc",
+    Arg.Set feat_cssc,
+    " Enable the Common Short Sequence Compression (CSSC) instructions."
 ]
 
 (* Addressing modes *)

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -19,7 +19,7 @@
 
 val macosx : bool
 val is_asan_enabled : bool ref
-
+val feat_cssc : bool ref
 (* Machine-specific command-line options *)
 
 val command_line_options : (string * Arg.spec * string) list

--- a/backend/arm64_ast.ml
+++ b/backend/arm64_ast.ml
@@ -128,6 +128,9 @@ module Reg = struct
   let reg_w_array =
     reg_array ~last:GP_reg_name.last_numbered (Reg_name.GP GP_reg_name.W)
 
+  let reg_b_array =
+    reg_array ~last:Neon_reg_name.last (Reg_name.Neon (Neon_reg_name.Scalar B))
+
   let reg_s_array =
     reg_array ~last:Neon_reg_name.last (Reg_name.Neon (Neon_reg_name.Scalar S))
 
@@ -140,6 +143,10 @@ module Reg = struct
   let reg_v2d_array =
     reg_array ~last:Neon_reg_name.last
       (Reg_name.Neon (Neon_reg_name.Vector V2D))
+
+  let reg_v8b_array =
+    reg_array ~last:Neon_reg_name.last
+      (Reg_name.Neon (Neon_reg_name.Vector V8B))
 
   (* for special GP registers we use the last index *)
   let sp = create (GP SP) GP_reg_name.last
@@ -287,6 +294,7 @@ module Instruction_name = struct
     | LSR
     | ASR
     | CLZ
+    | CTZ
     | RBIT
     | CNT
     | SMULH
@@ -392,6 +400,7 @@ module Instruction_name = struct
     | LSR -> "lsr"
     | ASR -> "asr"
     | CLZ -> "clz"
+    | CTZ -> "ctz"
     | RBIT -> "rbit"
     | CNT -> "cnt"
     | SMULH -> "smulh"
@@ -651,6 +660,8 @@ module Operand = struct
 
   let reg_w = Array.map (fun x -> Reg x) Reg.reg_w_array
 
+  let reg_b = Array.map (fun x -> Reg x) Reg.reg_b_array
+
   let reg_s = Array.map (fun x -> Reg x) Reg.reg_s_array
 
   let reg_d = Array.map (fun x -> Reg x) Reg.reg_d_array
@@ -658,6 +669,8 @@ module Operand = struct
   let reg_q = Array.map (fun x -> Reg x) Reg.reg_q_array
 
   let reg_v2d = Array.map (fun x -> Reg x) Reg.reg_v2d_array
+
+  let reg_v8b = Array.map (fun x -> Reg x) Reg.reg_v8b_array
 end
 
 module Instruction = struct
@@ -789,6 +802,10 @@ module DSL = struct
     Operand.Reg (Reg.create (Reg_name.Neon (Vector V4S)) index)
 
   let reg_v2d index = Operand.reg_v2d.(index)
+
+  let reg_v8b index = Operand.reg_v8b.(index)
+
+  let reg_b index = Operand.reg_b.(index)
 
   let reg_s index = Operand.reg_s.(index)
 

--- a/backend/arm64_ast.mli
+++ b/backend/arm64_ast.mli
@@ -189,6 +189,7 @@ module Instruction_name : sig
     | LSR
     | ASR
     | CLZ
+    | CTZ
     | RBIT
     | CNT
     | SMULH
@@ -320,6 +321,10 @@ module DSL : sig
   val reg_v2s : int -> Operand.t
 
   val reg_v4s : int -> Operand.t
+
+  val reg_v8b : int -> Operand.t
+
+  val reg_b : int -> Operand.t
 
   val reg_s : int -> Operand.t
 


### PR DESCRIPTION
Emit a sequence for `Ipopcnt` and  `Ictz` on older version of `armv8` that don't support CSSC. Add a flag to enable the short sequence (off by default). Tests coming up in a separate PR.

(needs #3747) 