### PR TITLE
Ensure that caml_check_pending_signals does not report blocked signals

### DIFF
--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -72,6 +72,8 @@ value caml_thread_sigmask(value cmd, value sigs)
   retcode = pthread_sigmask(how, &set, &oldset);
   caml_leave_blocking_section();
   sync_check_error(retcode, "Thread.sigmask");
+  /* A signal that was previously being blocked may now be pending */
+  caml_set_action_pending(Caml_state);
   /* Run any handlers for just-unmasked pending signals */
   caml_process_pending_actions();
   return st_encode_sigset(&oldset);


### PR DESCRIPTION
Since #3740, we're seeing frequent deadlocks in a test that tests `Thread.sigmask`. The issue is that it loops until all pending signals are handled, which never happens if there are signals that are both pending and blocked.

The fix is to make `caml_check_pending_signals` return false when all pending signals are blocked: this function reports whether there are signal handlers to run, and in this case there are not. That way, `caml_process_pending_signals_exn` will result in caml_check_pending_signals becoming false. Before this patch it does not if there are signals that are pending yet blocked.