### PR TITLE
Fix bug with Invalid and exception extra args etc.

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -405,8 +405,10 @@ let print_instruction ppf i = print_instruction' ppf i
 
 let can_raise_terminator (i : terminator) =
   match i with
-  | Raise _ | Tailcall_func _ | Call_no_return _ | Call _
-  | Prim { op = Probe _; label_after = _ } ->
+  | Call_no_return { func_symbol; _ } ->
+    not (String.equal func_symbol Cmm.caml_flambda2_invalid)
+  | Raise _ | Tailcall_func _ | Call _ | Prim { op = Probe _; label_after = _ }
+    ->
     true
   | Prim { op = External { alloc; _ }; label_after = _ } -> alloc
   | Specific_can_raise { op; _ } ->

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -146,7 +146,9 @@ module S = struct
     | Tailcall_self of { destination : Label.t }
     | Tailcall_func of func_call_operation
     | Call_no_return of external_call_operation
-      (* CR mshinwell: [Call_no_return] should have "external" in the name *)
+    (* CR mshinwell: [Call_no_return] should have "external" in the name *)
+    (* CR mshinwell: [Invalid] from flambda2 should have its own terminator, to
+       avoid the hack in [can_raise_terminator] *)
     | Call of func_call_operation with_label_after
     | Prim of prim_call_operation with_label_after
     | Specific_can_raise of Arch.specific_operation with_label_after

--- a/testsuite/tests/exception-extra-args/pr3688_bug.ml
+++ b/testsuite/tests/exception-extra-args/pr3688_bug.ml
@@ -1,0 +1,23 @@
+(* TEST *)
+
+[@@@ocaml.flambda_o3]
+
+let[@inline never] bar _ _ = ()
+
+let[@inline never] baz () = ()
+
+let[@inline] set arr x =
+  Array.set arr 0 x
+
+let foo size (x : int) arr =
+  let extra_arg_array = ref arr in
+  let extra_arg_int = ref 0 in
+  (try
+    for i = 0 to size - 1 do
+      if i > 20 then (
+        set !extra_arg_array x;
+        baz ()
+      )
+    done
+  with _exn -> ());
+  bar !extra_arg_array !extra_arg_int


### PR DESCRIPTION
This fixes a bug in #3688 where a `caml_flambda2_invalid` call would be seen as raising by Cfg, despite not having been wrapped by `To_cmm` for exception extra args, because it never raises.

In addition @lthls 's suggestion to remove redundant moves, which was in #3688, had not been applied to the tail case.  This fixes that and moves one line of code to make the non-tail and tail cases match up nicely.