### PR TITLE
Fix modality over zapping

### DIFF
--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -659,8 +659,9 @@ module type S = sig
             abitrary zappings of some [m], even after further mutations to [m].
             Essentially that means [c0 = c1].
 
-         NB: zapping an inferred modality will zap both [md_mode] and [mode] that
-         it contains. The caller is reponsible for correct zapping order.
+         NB: zapping an inferred modality will mutate both [md_mode] and [mode]
+         to the degree sufficient to fix the modality, but the modes could
+         remain unfixed.
       *)
 
       (** Zap an inferred modality towards identity modality. *)


### PR DESCRIPTION
Consider the example:
```
module M = struct let x = ref "hello" end
module type S = module type of M
```

`module type of` tries to zap the inferred modalities to identity, by zapping `M` to ceil (e.g. `contended`) and `M.x` to floor (e.g. `uncontended`). This is too much: neither modes needs to be zapped to a fixed point - they only need to be mutated to the degree that's sufficient to fix the modality.

Testing: this PR only causes observable changes after we introduce modal modules.