### PR TITLE
Support modules of non-legacy modes

### DIFF
--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -86,7 +86,7 @@ let typecheck_intf info ast =
           (Printtyp.printed_signature (Unit_info.source_file info.target))
           sg);
   ignore (Includemod.signatures info.env ~mark:Mark_both
-    ~modes:(Legacy None) sg sg);
+    ~modes:Includemod.modes_unit sg sg);
   Typecore.force_delayed_checks ();
   Builtin_attributes.warn_unused ();
   Warnings.check_fatal ();

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -115,7 +115,6 @@ let builtin_attrs =
   ; "layout_poly"
   ; "no_mutable_implied_modalities"
   ; "or_null_reexport"
-  ; "no_recursive_modalities"
   ; "jane.non_erasable.instances"
   ]
 

--- a/stdlib/ephemeron.mli
+++ b/stdlib/ephemeron.mli
@@ -150,7 +150,7 @@ end
 (** The output signature of the functors {!K1.MakeSeeded} and {!K2.MakeSeeded}.
 *)
 
-module K1 : sig
+module K1 : sig @@ portable
   type ('k,'d) t (** an ephemeron with one key *)
 
   val make : 'k -> 'd -> ('k,'d) t
@@ -161,7 +161,7 @@ module K1 : sig
       ephemeron's data) if [key] is physically equal to [eph]'s key, and
       [None] if [eph] is empty or [key] is not equal to [eph]'s key. *)
 
-  module Make (H:Hashtbl.HashedType) : S with type key = H.t
+  module (Make @ nonportable) (H:Hashtbl.HashedType) : S with type key = H.t
   (** Functor building an implementation of a weak hash table *)
 
   module MakePortable (H:sig @@ portable include Hashtbl.HashedType end)
@@ -169,11 +169,11 @@ module K1 : sig
   (** Like {!Make}, but takes a portable [hash] function to
       portable [Ephemeron] operations. *)
 
-  module MakeSeeded (H:Hashtbl.SeededHashedType) : SeededS with type key = H.t
+  module (MakeSeeded @ nonportable) (H:Hashtbl.SeededHashedType) : SeededS with type key = H.t
   (** Functor building an implementation of a weak hash table.
       The seed is similar to the one of {!Hashtbl.MakeSeeded}. *)
 
-  module MakeSeededPortable (H:sig @@ portable include Hashtbl.SeededHashedType end)
+  module (MakeSeededPortable @ nonportable) (H:sig @@ portable include Hashtbl.SeededHashedType end)
     : sig @@ portable include SeededS with type key = H.t end
   (** Like {!MakeSeeded}, but takes a portable [seeded_hash] function to
       portable [Ephemeron] operations. *)
@@ -206,10 +206,10 @@ module K1 : sig
 
   end
 
-end
+end @@ nonportable
 (** Ephemerons with one key. *)
 
-module K2 : sig
+module K2 : sig @@ portable
   type ('k1,'k2,'d) t (** an ephemeron with two keys *)
 
   val make : 'k1 -> 'k2 -> 'd -> ('k1,'k2,'d) t
@@ -218,7 +218,7 @@ module K2 : sig
   val query : ('k1,'k2,'d) t -> 'k1 -> 'k2 -> 'd option
   (** Same as {!Ephemeron.K1.query} *)
 
-  module Make
+  module (Make @ nonportable)
       (H1:Hashtbl.HashedType)
       (H2:Hashtbl.HashedType) :
     S with type key = H1.t * H2.t
@@ -231,14 +231,14 @@ module K2 : sig
   (** Like {!Make}, but takes portable [hash] functions to
       portable [Ephemeron] operations. *)
 
-  module MakeSeeded
+  module (MakeSeeded @ nonportable)
       (H1:Hashtbl.SeededHashedType)
       (H2:Hashtbl.SeededHashedType) :
     SeededS with type key = H1.t * H2.t
   (** Functor building an implementation of a weak hash table.
       The seed is similar to the one of {!Hashtbl.MakeSeeded}. *)
 
-  module MakeSeededPortable
+  module (MakeSeededPortable @ nonportable)
       (H1:sig @@ portable include Hashtbl.SeededHashedType end)
       (H2:sig @@ portable include Hashtbl.SeededHashedType end) :
     sig @@ portable include SeededS with type key = H1.t * H2.t end
@@ -273,10 +273,10 @@ module K2 : sig
 
   end
 
-end
+end @@ nonportable
 (** Ephemerons with two keys. *)
 
-module Kn : sig
+module Kn : sig @@ portable
   type ('k,'d) t (** an ephemeron with an arbitrary number of keys
                       of the same type *)
 
@@ -286,7 +286,7 @@ module Kn : sig
   val query : ('k,'d) t -> 'k array -> 'd option
   (** Same as {!Ephemeron.K1.query} *)
 
-  module Make
+  module (Make @ nonportable)
       (H:Hashtbl.HashedType) :
     S with type key = H.t array
   (** Functor building an implementation of a weak hash table *)
@@ -297,13 +297,13 @@ module Kn : sig
   (** Like {!Make}, but takes a portable [hash] function to
       portable [Ephemeron] operations. *)
 
-  module MakeSeeded
+  module (MakeSeeded @ nonportable)
       (H:Hashtbl.SeededHashedType) :
     SeededS with type key = H.t array
   (** Functor building an implementation of a weak hash table.
       The seed is similar to the one of {!Hashtbl.MakeSeeded}. *)
 
-  module MakeSeededPortable
+  module (MakeSeededPortable @ nonportable)
       (H:sig @@ portable include Hashtbl.SeededHashedType end) :
     sig @@ portable include SeededS with type key = H.t array end
   (** Like {!MakeSeeded}, but takes a portable [seeded_hash] function to
@@ -337,5 +337,5 @@ module Kn : sig
 
   end
 
-end
+end @@ nonportable
 (** Ephemerons with arbitrary number of keys of the same type. *)

--- a/stdlib/hashtbl.mli
+++ b/stdlib/hashtbl.mli
@@ -421,7 +421,7 @@ module type S =
   end
 (** The output signature of the functor {!Make}. *)
 
-module Make (H : HashedType) : S with type key = H.t
+module (Make @ nonportable) (H : HashedType) : S with type key = H.t
 (** Functor building an implementation of the hashtable structure.
     The functor [Hashtbl.Make] returns a structure containing
     a type [key] of keys and a type ['a t] of hash tables
@@ -504,7 +504,7 @@ module type SeededS =
 (** The output signature of the functor {!MakeSeeded}.
     @since 4.00 *)
 
-module MakeSeeded (H : SeededHashedType) : SeededS with type key = H.t
+module (MakeSeeded @ nonportable) (H : SeededHashedType) : SeededS with type key = H.t
 (** Functor building an implementation of the hashtable structure.
     The functor [Hashtbl.MakeSeeded] returns a structure containing
     a type [key] of keys and a type ['a t] of hash tables

--- a/stdlib/moreLabels.mli
+++ b/stdlib/moreLabels.mli
@@ -39,7 +39,7 @@ open! Stdlib
 
 [@@@ocaml.nolabels]
 
-module Hashtbl : sig
+module Hashtbl : sig @@ portable
   (** Hash tables and hash functions.
 
      Hash tables are hashed association tables, with in-place modification.
@@ -440,7 +440,7 @@ module Hashtbl : sig
     end
   (** The output signature of the functor {!Make}. *)
 
-    module Make : functor (H : HashedType) -> S
+    module (Make @ nonportable) : functor (H : HashedType) -> S
     with type key = H.t
      and type 'a t = 'a Hashtbl.Make(H).t
   (** Functor building an implementation of the hashtable structure.
@@ -528,7 +528,7 @@ module Hashtbl : sig
   (** The output signature of the functor {!MakeSeeded}.
       @since 4.00 *)
 
-    module MakeSeeded (H : SeededHashedType) : SeededS
+    module (MakeSeeded @ nonportable) (H : SeededHashedType) : SeededS
     with type key = H.t
      and type 'a t = 'a Hashtbl.MakeSeeded(H).t
   (** Functor building an implementation of the hashtable structure.
@@ -685,7 +685,7 @@ module Hashtbl : sig
 
   *)
 
-end
+end @@ nonportable
 
 module Map : sig
   (** Association tables over ordered types.
@@ -1049,7 +1049,7 @@ module Map : sig
   (** Like {!Make}, but takes a portable [compare] function to
       portable [Map] operations. *)
 
-end
+end @@ nonportable
 
 module Set : sig
   (** Sets over ordered types.
@@ -1368,4 +1368,4 @@ module Set : sig
   (** Like {!Make}, but takes a portable [compare] function to
       portable [Set] operations. *)
 
-end
+end @@ nonportable

--- a/stdlib/stdLabels.mli
+++ b/stdlib/stdLabels.mli
@@ -37,7 +37,9 @@ open! Stdlib
 
 [@@@ocaml.nolabels]
 
+include sig
 module Array = ArrayLabels
 module Bytes = BytesLabels
 module List = ListLabels
 module String = StringLabels
+end @@ nonportable

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1412,6 +1412,7 @@ val do_domain_local_at_exit : (unit -> unit) ref @@ nonportable
 (** {1:modules Standard library modules } *)
 
 (*MODULE_ALIASES*)
+include sig
 module Arg            = Arg
 module Array          = Array
 module ArrayLabels    = ArrayLabels
@@ -1482,3 +1483,4 @@ module Type           = Type
 module Uchar          = Uchar
 module Unit           = Unit
 module Weak           = Weak
+end @@ nonportable

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -491,7 +491,7 @@ module Immediate64 : sig
       | Non_immediate : Non_immediate.t repr
     val repr : t repr
   end
-end
+end @@ nonportable
 
 (** Submodule containing non-backwards-compatible functions which enforce thread safety
     via modes. *)

--- a/stdlib/weak.mli
+++ b/stdlib/weak.mli
@@ -198,7 +198,7 @@ module type S = sig
 end
 (** The output signature of the functor {!Weak.Make}. *)
 
-module Make (H : Hashtbl.HashedType) : S with type data = H.t
+module (Make @ nonportable) (H : Hashtbl.HashedType) : S with type data = H.t
 (** Functor building an implementation of the weak hash set structure.
     [H.equal] can't be the physical equality, since only shallow
     copies of the elements in the set are given to it.

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -89,10 +89,10 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
-          value_mode global,many,portable,unyielding;imply(unique,uncontended)(modevar#1[aliased,contended .. unique,uncontended])
+          value_mode global,many,portable,unyielding;imply(unique,uncontended)(modevar#3[aliased,contended .. unique,uncontended])
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
-          alloc_mode global,many,portable,unyielding;id(modevar#7[aliased,contended .. unique,uncontended])
+          alloc_mode global,many,portable,unyielding;id(modevar#9[aliased,contended .. unique,uncontended])
           []
           Tfunction_cases (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           alloc_mode global,many,nonportable,unyielding;aliased,uncontended

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -89,10 +89,10 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern 
           Tpat_var "fib"
-          value_mode global,many,portable,unyielding;imply(unique,uncontended)(modevar#1[aliased,contended .. unique,uncontended])
+          value_mode global,many,portable,unyielding;imply(unique,uncontended)(modevar#3[aliased,contended .. unique,uncontended])
         expression 
           Texp_function
-          alloc_mode global,many,portable,unyielding;id(modevar#7[aliased,contended .. unique,uncontended])
+          alloc_mode global,many,portable,unyielding;id(modevar#9[aliased,contended .. unique,uncontended])
           []
           Tfunction_cases 
           alloc_mode global,many,nonportable,unyielding;aliased,uncontended

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -597,7 +597,7 @@ module type S = sig
 end
 
 module type S' = sig
-  include [@no_recursive_modalities] S @@ portable
+  include S @@ portable
 end
 
 [%%expect{|
@@ -606,7 +606,7 @@ module type S =
 module type S' =
   sig
     val bar : 'a -> 'a @@ portable
-    module M : sig val foo : 'a -> 'a end
+    module M : sig val foo : 'a -> 'a end @@ portable
   end
 |}]
 
@@ -625,7 +625,7 @@ end
 Line 1, characters 19-27:
 1 | module F (X : S @@ portable) = struct
                        ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
 module F (_ : S @@ portable) = struct
@@ -634,15 +634,12 @@ end
 Line 1, characters 19-27:
 1 | module F (_ : S @@ portable) = struct
                        ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
 module M' = (M : S @@ portable)
 [%%expect{|
-Line 1, characters 22-30:
-1 | module M' = (M : S @@ portable)
-                          ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+module M' : S
 |}]
 
 module F (M : S @@ portable) : S @@ portable = struct
@@ -651,7 +648,7 @@ end
 Line 1, characters 19-27:
 1 | module F (M : S @@ portable) : S @@ portable = struct
                        ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
 module F (M : S @@ portable) @ portable = struct
@@ -660,43 +657,31 @@ end
 Line 1, characters 19-27:
 1 | module F (M : S @@ portable) @ portable = struct
                        ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
 
 
-(* CR zqian: the similar syntax for expressions are not allowed because @ might
+(* the similar syntax for expressions are not allowed because @ might
   be an binary operator *)
 module M' = (M @ portable)
 [%%expect{|
-Line 1, characters 17-25:
-1 | module M' = (M @ portable)
-                     ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+module M' = M
 |}]
 
 module M' = (M : S @@ portable)
 [%%expect{|
-Line 1, characters 22-30:
-1 | module M' = (M : S @@ portable)
-                          ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+module M' : S
 |}]
 
 module M @ portable = struct end
 [%%expect{|
-Line 1, characters 11-19:
-1 | module M @ portable = struct end
-               ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+module M : sig end
 |}]
 
 module M : S @@ portable = struct end
 [%%expect{|
-Line 1, characters 16-24:
-1 | module M : S @@ portable = struct end
-                    ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+module M : S
 |}]
 
 module type S' = functor () (M : S @@ portable) (_ : S @@ portable) -> S @ portable
@@ -704,7 +689,7 @@ module type S' = functor () (M : S @@ portable) (_ : S @@ portable) -> S @ porta
 Line 1, characters 38-46:
 1 | module type S' = functor () (M : S @@ portable) (_ : S @@ portable) -> S @ portable
                                           ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
 
@@ -713,24 +698,19 @@ module type S' = () -> S @ portable -> S @ portable -> S @ portable
 Line 1, characters 27-35:
 1 | module type S' = () -> S @ portable -> S @ portable -> S @ portable
                                ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
 module (F @ portable) () = struct end
 [%%expect{|
-Line 1, characters 12-20:
-1 | module (F @ portable) () = struct end
-                ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+module F : functor () -> sig end
 |}]
 
 module rec (F @ portable) () = struct end
 and (G @ portable) () = struct end
 [%%expect{|
-Line 1, characters 16-24:
-1 | module rec (F @ portable) () = struct end
-                    ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+File "_none_", line 1:
+Error: Recursive modules require an explicit module type.
 |}]
 
 module type T = sig
@@ -759,10 +739,7 @@ let foo () =
   let module (F @ portable) () = struct end in
   ()
 [%%expect{|
-Line 2, characters 18-26:
-2 |   let module (F @ portable) () = struct end in
-                      ^^^^^^^^
-Error: Mode annotations on modules are not supported yet.
+val foo : unit -> unit = <fun>
 |}]
 
 (**********)

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -617,7 +617,8 @@ val no_leak_id : unit = ()
 
 module type S = sig val s : string end
 
-(* Don't escape through being unpacked as a module *)
+(* Currently we can't stack-allocate modules, but it's fine to take modules as
+  local parameters. *)
 
 let bar (local_ (m : (module S))) =
   let (module _) = m in
@@ -627,24 +628,27 @@ module type S = sig val s : string end
 val bar : local_ (module S) -> unit = <fun>
 |}]
 
+(* Currently first class modules don't cross modes *)
 let bar (local_ (m : (module S))) =
   let (module M) = m in
   M.s
 [%%expect{|
-Line 2, characters 19-20:
-2 |   let (module M) = m in
-                       ^
-Error: This value escapes its region.
+val bar : local_ (module S) -> local_ string = <fun>
 |}]
 
 let bar (local_ m) =
   let module M = (val m : S) in
   M.s
 [%%expect{|
-Line 2, characters 22-23:
-2 |   let module M = (val m : S) in
-                          ^
-Error: This value escapes its region.
+val bar : local_ (module S) -> local_ string = <fun>
+|}]
+
+(* packing crosses modes *)
+let bar (local_ m) =
+  let module M = (val m : S) in
+  (module M : S)
+[%%expect{|
+val bar : local_ (module S) -> (module S) = <fun>
 |}]
 
 (* Don't escape through a lazy value *)
@@ -671,7 +675,7 @@ let foo (local_ x) =
 Line 3, characters 27-28:
 3 |     let () = print_string !x
                                ^
-Error: The value "x" is local, so cannot be used inside a module.
+Error: The value "x" is local, so cannot be used inside a functor.
 |}]
 
 (* Don't escape through a class method *)

--- a/testsuite/tests/typing-modes/incl_modalities.ml
+++ b/testsuite/tests/typing-modes/incl_modalities.ml
@@ -107,18 +107,7 @@ end
 module type S' =
   sig
     val bar : 'a -> 'a @@ portable
-    module M : sig val foo : 'a -> 'a @@ portable end
-  end
-|}]
-
-module type S' = sig
-  include [@no_recursive_modalities] S @@ portable
-end
-[%%expect{|
-module type S' =
-  sig
-    val bar : 'a -> 'a @@ portable
-    module M : sig val foo : 'a -> 'a end
+    module M : sig val foo : 'a -> 'a end @@ portable
   end
 |}]
 
@@ -135,21 +124,7 @@ module type T' = sig
 end
 [%%expect{|
 module type T' =
-  sig
-    val baz : 'a -> 'a @@ portable
-    module M :
-      sig
-        val bar : 'a -> 'a @@ portable
-        module M : sig val foo : 'a -> 'a @@ portable end
-      end
-  end
-|}]
-
-module type T' = sig
-  include [@no_recursive_modalities] T @@ portable
-end
-[%%expect{|
-module type T' = sig val baz : 'a -> 'a @@ portable module M : S end
+  sig val baz : 'a -> 'a @@ portable module M : S @@ portable end
 |}]
 
 (* submodule whose type is in the signature *)
@@ -169,7 +144,7 @@ module type S =
 module type S' =
   sig
     module type MT = sig val foo : 'a -> 'a end
-    module M : sig val foo : 'a -> 'a @@ portable end
+    module M : MT @@ portable
   end
 |}]
 
@@ -194,7 +169,7 @@ module type S =
 module type S' =
   sig
     module type MT = sig val foo : 'a -> 'a end
-    module M : sig module N : sig val foo : 'a -> 'a @@ portable end end
+    module M : sig module N : MT end @@ portable
   end
 |}]
 
@@ -218,7 +193,7 @@ module M :
     module type Foo' = Foo
     module type S = sig module N : Foo' end
   end
-module type S' = sig module N : sig val foo : 'a -> 'a @@ portable end end
+module type S' = sig module N : M.Foo' @@ portable end
 |}]
 
 (* include abstract module type is still not allowed *)
@@ -244,7 +219,7 @@ end
 [%%expect{|
 module type MT
 module type S = sig module M : MT end
-module type S' = sig module M : MT end
+module type S' = sig module M : MT @@ portable end
 |}]
 
 (* strenghtened module type *)
@@ -270,14 +245,8 @@ module type S =
 module type S' =
   sig
     module type T = sig type a val baz : a val foo : a -> a end
-    module MT :
-      sig type a val baz : a @@ portable val foo : a -> a @@ portable end
-    module M :
-      sig
-        type a = MT.a
-        val baz : a @@ portable
-        val foo : a -> a @@ portable
-      end
+    module MT : T @@ portable
+    module M : sig type a = MT.a val baz : a val foo : a -> a end @@ portable
   end
 |}]
 
@@ -295,5 +264,5 @@ module type T = sig @@ portable
   include T
 end
 [%%expect{|
-module type T = sig module M : sig val foo : 'a -> 'a @@ portable end end
+module type T = sig module M : sig val foo : 'a -> 'a end @@ portable end
 |}]

--- a/testsuite/tests/typing-modes/md_modalities.ml
+++ b/testsuite/tests/typing-modes/md_modalities.ml
@@ -16,10 +16,8 @@ end
 module type S =
   sig
     module M :
-      sig
-        val foo : 'a -> 'a @@ portable
-        module N : sig val bar : 'a -> 'a @@ portable end
-      end
+      sig val foo : 'a -> 'a module N : sig val bar : 'a -> 'a end end @@
+      portable
   end
 |}]
 
@@ -35,10 +33,8 @@ end
 module type S =
   sig
     module M :
-      sig
-        val foo : 'a -> 'a @@ portable
-        module N : sig val bar : 'a -> 'a @@ portable end
-      end
+      sig val foo : 'a -> 'a module N : sig val bar : 'a -> 'a end end @@
+      portable
   end
 |}]
 
@@ -74,7 +70,7 @@ end
 module type S =
   sig
     module rec M : sig val foo : 'a -> 'a end
-    and N : sig val bar : 'a -> 'a @@ portable end
+    and N : sig val bar : 'a -> 'a end @@ portable
   end
 |}]
 
@@ -88,7 +84,7 @@ module type S = sig @@ portable
 end
 [%%expect{|
 module type T = sig val foo : 'a -> 'a end
-module type S = sig module M : sig val foo : 'a -> 'a @@ portable end end
+module type S = sig module M : T @@ portable end
 |}]
 
 (* doesn't work for Mty_functor *)
@@ -97,7 +93,10 @@ module type S = sig @@ portable
 end
 [%%expect{|
 module type S =
-  sig module M : sig val foo : 'a -> 'a end -> sig val bar : 'a -> 'a end end
+  sig
+    module M : sig val foo : 'a -> 'a end -> sig val bar : 'a -> 'a end @@
+      portable
+  end
 |}]
 
 module M : T = struct
@@ -111,7 +110,7 @@ module type S = sig @@ portable
 end
 [%%expect{|
 module M : T
-module type S = sig module M' = M end
+module type S = sig module M' = M @@ portable end
 |}]
 
 (* works for Mty_strenthen, and type check keeps working *)
@@ -119,28 +118,12 @@ module type S = sig @@ portable
   module M' : T with M
 end
 [%%expect{|
-module type S = sig module M' : sig val foo : 'a -> 'a @@ portable end end
+module type S = sig module M' : sig val foo : 'a -> 'a end @@ portable end
 |}]
 
 module M : S = struct
   module M' = M
 end
 [%%expect{|
-Lines 1-3, characters 15-3:
-1 | ...............struct
-2 |   module M' = M
-3 | end
-Error: Signature mismatch:
-       Modules do not match: sig module M' = M end is not included in S
-       In module "M'":
-       Modules do not match:
-         sig val foo : 'a -> 'a end
-       is not included in
-         sig val foo : 'a -> 'a @@ portable end
-       In module "M'":
-       Values do not match:
-         val foo : 'a -> 'a
-       is not included in
-         val foo : 'a -> 'a @@ portable
-       The second is portable and the first is nonportable.
+module M : S
 |}]

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -57,25 +57,17 @@ let u =
 val u : unit = ()
 |}]
 
-(* first class modules are produced at legacy *)
-let x = ((module M : SL) : _ @@ portable)
+(* Packing produces first class modules at the same mode as the module *)
+let () = portable_use (module M : S)
 [%%expect{|
-Line 1, characters 9-24:
-1 | let x = ((module M : SL) : _ @@ portable)
-             ^^^^^^^^^^^^^^^
-Error: This value is "nonportable" but expected to be "portable".
 |}]
 
-(* first class modules are consumed at legacy *)
-let foo () =
-    let m @ local = (module M : SL) in
+(* Unpacking produces module at the same mode as the first class module *)
+let foo (m : (module S)) =
     let module M = (val m) in
-    ()
+    portable_use M.x
 [%%expect{|
-Line 3, characters 24-25:
-3 |     let module M = (val m) in
-                            ^
-Error: This value escapes its region.
+val foo : (module S) @ portable -> unit = <fun>
 |}]
 
 let foo () =
@@ -160,7 +152,7 @@ module type S = sig
 end
 
 module M : S = struct
-    let foo = fun x -> x
+    let foo @ nonportable = fun x -> x
     let baz = fun x -> x
 end
 [%%expect{|
@@ -229,5 +221,5 @@ let (bar @ portable) () =
 Line 3, characters 19-20:
 3 |         module L = M
                        ^
-Error: "M" is a module, and modules are always nonportable, so cannot be used inside a function that is portable.
+Error: The module "M" is nonportable, so cannot be used inside a function that is portable.
 |}]

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -73,46 +73,46 @@ module Module_type_of_comonadic = struct
     module M = struct
         let x @ portable = fun x -> x
     end
-    (* for comonadic axes, we default to id = meet_with_max, which is the
-    weakest. *)
+    (* [module type of] zaps the modailty on [x] to identity, which constrains
+    submoding [M <= M.x] for comonadic axes *)
     module M' : module type of M = struct
         let x @ portable = fun x -> x
     end
+    (* This requires [M.x] to be [portable], and by extension [M] to be
+    [portable]. *)
     let _ = portable_use M.x (* The original inferred modality is zapped *)
+
+    module (_ @ portable) = M
 end
+module _ = (Module_type_of_comonadic @ portable)
 [%%expect{|
-Line 10, characters 25-28:
-10 |     let _ = portable_use M.x (* The original inferred modality is zapped *)
-                              ^^^
-Error: This value is "nonportable" but expected to be "portable".
+module Module_type_of_comonadic :
+  sig
+    module M : sig val x : 'a -> 'a end
+    module M' : sig val x : 'a -> 'a end
+  end
 |}]
 
 module Module_type_of_monadic = struct
     module M = struct
         let x @ uncontended = ref "hello"
     end
+    (* [module type of] zap the modality on [x] to be identity, which constrains
+    submoding [M.x <= M] for monadic axes *)
     module M' : module type of M = M
-    (* for monadic axes, we try to push to the id = join_with_min. The original
-    modality is pushed to floor. *)
-    module M' : module type of M = struct
+    (* For this to type check, [M''] has to be at [contended] to so that [M''.x]
+    is expected at [contended]. *)
+    module M'' : module type of M = struct
         let x @ contended = ref "hello"
     end
 end
 [%%expect{|
-Lines 8-10, characters 35-7:
- 8 | ...................................struct
- 9 |         let x @ contended = ref "hello"
-10 |     end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val x : string ref @@ contended end
-       is not included in
-         sig val x : string ref end
-       Values do not match:
-         val x : string ref @@ contended
-       is not included in
-         val x : string ref
-       The second is uncontended and the first is contended.
+module Module_type_of_monadic :
+  sig
+    module M : sig val x : string ref end
+    module M' : sig val x : string ref end
+    module M'' : sig val x : string ref end @@ contended
+  end
 |}]
 
 module Module_type_nested = struct
@@ -122,6 +122,10 @@ module Module_type_nested = struct
             let y @ uncontended = ref "hello"
         end
     end
+    (* [module type of] zaps all modalities to id. For this to type check,
+    [M'] needs to be at [nonportable] so that [M'.x] is expected at [nonportable].
+    [M'] needs to be at [contended] so that [M'.N.y] is expected at [contended].
+    *)
     module M' : module type of M = struct
         let x @ nonportable = fun t -> t
         module N = struct
@@ -130,32 +134,13 @@ module Module_type_nested = struct
     end
 end
 [%%expect{|
-Lines 8-13, characters 35-7:
- 8 | ...................................struct
- 9 |         let x @ nonportable = fun t -> t
-10 |         module N = struct
-11 |             let y @ contended = ref "hello"
-12 |         end
-13 |     end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           val x : 'a -> 'a
-           module N : sig val y : string ref @@ contended end
-         end
-       is not included in
-         sig val x : 'a -> 'a module N : sig val y : string ref end end
-       In module "N":
-       Modules do not match:
-         sig val y : string ref @@ contended end
-       is not included in
-         sig val y : string ref end
-       In module "N":
-       Values do not match:
-         val y : string ref @@ contended
-       is not included in
-         val y : string ref
-       The second is uncontended and the first is contended.
+module Module_type_nested :
+  sig
+    module M : sig val x : 'a -> 'a module N : sig val y : string ref end end
+    module M' :
+      sig val x : 'a -> 'a module N : sig val y : string ref end end @@
+      contended
+  end
 |}]
 
 (* When defaulting, prioritize modes in arrow types over modalities. *)
@@ -169,9 +154,10 @@ module Without_inclusion = struct
     end
     let () = portable_use M.x
 end
+module Without_inclusion' = (Without_inclusion @ contended)
 [%%expect{|
-module Without_inclusion :
-  sig module M : sig val x : 'a -> 'a @@ portable end end
+module Without_inclusion : sig module M : sig val x : 'a -> 'a end end
+module Without_inclusion' = Without_inclusion @@ contended
 |}]
 
 module Without_inclusion = struct
@@ -189,26 +175,15 @@ Error: This value is "nonportable" but expected to be "portable".
 
 module Inclusion_fail = struct
     module M : sig
-        val x : string ref @@ uncontended
+        val x : string ref
     end = struct
         let x @ contended = ref "hello"
     end
 end
+(* For this to type check, M has to be at [contended] *)
 [%%expect{|
-Lines 4-6, characters 10-7:
-4 | ..........struct
-5 |         let x @ contended = ref "hello"
-6 |     end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val x : string ref @@ contended end
-       is not included in
-         sig val x : string ref end
-       Values do not match:
-         val x : string ref @@ contended
-       is not included in
-         val x : string ref
-       The second is uncontended and the first is contended.
+module Inclusion_fail :
+  sig module M : sig val x : string ref end @@ contended end
 |}]
 
 module Inclusion_weakens_monadic = struct
@@ -228,17 +203,16 @@ Error: This value is "contended" but expected to be "uncontended".
 
 module Inclusion_weakens_comonadic = struct
   module M : sig
-      val x : 'a -> 'a @@ nonportable
+      val x : 'a -> 'a
   end = struct
       let x @ portable = fun x -> x
   end
   let _ = portable_use M.x
 end
+(* This is fine, because [M] is infered to be [portable] in order to type check *)
 [%%expect{|
-Line 7, characters 23-26:
-7 |   let _ = portable_use M.x
-                           ^^^
-Error: This value is "nonportable" but expected to be "portable".
+module Inclusion_weakens_comonadic :
+  sig module M : sig val x : 'a -> 'a end end
 |}]
 
 module Inclusion_match = struct
@@ -264,10 +238,7 @@ module Close_over_value = struct
 end
 [%%expect{|
 module Close_over_value :
-  sig
-    module M : sig val x : 'a -> 'a @@ portable end
-    val foo : unit -> unit
-  end
+  sig module M : sig val x : 'a -> 'a end val foo : unit -> unit end
 |}]
 
 (* CR mode-crossing: This is used for the below test in place of a mutable record. *)
@@ -319,16 +290,21 @@ Error: The value "M.x" is nonportable, so cannot be used inside a function that 
 module M : sig
   external length : string -> int @@ portable = "%string_length"
 end = struct
+  let (x @ nonportable) = fun x -> x (* to avoid the whole module portable *)
   external length : string -> int = "%string_length"
 end
 [%%expect{|
-Lines 3-5, characters 6-3:
+Lines 3-6, characters 6-3:
 3 | ......struct
-4 |   external length : string -> int = "%string_length"
-5 | end
+4 |   let (x @ nonportable) = fun x -> x (* to avoid the whole module portable *)
+5 |   external length : string -> int = "%string_length"
+6 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig external length : string -> int = "%string_length" end
+         sig
+           val x : 'a -> 'a
+           external length : string -> int = "%string_length"
+         end
        is not included in
          sig
            external length : string -> int @@ portable = "%string_length"
@@ -360,13 +336,11 @@ end = struct
   external length : string -> int @@ portable = "%string_length"
 end
 
+(* the whole module is portable *)
 let _ = portable_use M.length
 [%%expect{|
 module M : sig external length : string -> int = "%string_length" end
-Line 7, characters 21-29:
-7 | let _ = portable_use M.length
-                         ^^^^^^^^
-Error: This value is "nonportable" but expected to be "portable".
+- : unit = ()
 |}]
 
 (* The example below demonstrates the need to zap modalities from [with module]
@@ -539,14 +513,14 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val t : [> `Foo ] @@ contended end
+         sig val t : [> `Foo ] end
        is not included in
          sig
            val t : [ `Bar of 'a -> 'a | `Baz of string ref | `Foo ] @@
              portable
          end
        Values do not match:
-         val t : [> `Foo ] @@ contended
+         val t : [> `Foo ]
        is not included in
          val t : [ `Bar of 'a -> 'a | `Baz of string ref | `Foo ] @@ portable
        The second is portable and the first is nonportable.
@@ -651,22 +625,20 @@ end
 
 [%%expect{|
 module type S = sig module M : sig val foo : 'a -> 'a @@ global many end end
-module type F =
-  functor (M' : sig val foo : 'a -> 'a end) ->
-    sig
-      module Subst :
-        sig
-          module type S' = sig end
-          module M'' : sig val foo : 'a -> 'a end
-          module type S'' = sig end
-        end
-      module Eq :
-        sig
-          module type S' = sig module M : sig val foo : 'a -> 'a end end
-          module M'' : sig val foo : 'a -> 'a end
-          module type S'' = sig end
-        end
-    end
+Line 9, characters 21-42:
+9 |     module type S' = S with module M := M'
+                         ^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "M"
+       does not match its original definition in the constrained signature:
+       Modules do not match:
+         sig val foo : 'a -> 'a end
+       is not included in
+         sig val foo : 'a -> 'a @@ global many end
+       Values do not match:
+         val foo : 'a -> 'a
+       is not included in
+         val foo : 'a -> 'a @@ global many
+       The second is global_ and the first is not.
 |}]
 
 (* strenghtening inclusion check looks at module modes, even inside a module
@@ -675,9 +647,20 @@ module type F = functor (M : sig val foo : 'a -> 'a end) -> sig
   module type S = sig val foo : 'a -> 'a @@ global many end with M
 end
 [%%expect{|
-module type F =
-  functor (M : sig val foo : 'a -> 'a end) ->
-    sig module type S = sig val foo : 'a -> 'a @@ global many end end
+Line 2, characters 18-66:
+2 |   module type S = sig val foo : 'a -> 'a @@ global many end with M
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this strengthened module type, the type of "M"
+       does not match the underlying type
+       Modules do not match:
+         sig val foo : 'a -> 'a end
+       is not included in
+         sig val foo : 'a -> 'a @@ global many end
+       Values do not match:
+         val foo : 'a -> 'a
+       is not included in
+         val foo : 'a -> 'a @@ global many
+       The second is global_ and the first is not.
 |}]
 
 
@@ -1038,15 +1021,13 @@ val bar : unit -> unit = <fun>
   inside would be better *)
 module M_Func_portable : Func_portable = M
 
+(* closing over a portable module *)
 let (bar @ portable) () =
   let k = (module M_Func_portable : Func_portable) in
   k
 [%%expect{|
 module M_Func_portable : Func_portable
-Line 4, characters 18-33:
-4 |   let k = (module M_Func_portable : Func_portable) in
-                      ^^^^^^^^^^^^^^^
-Error: "M_Func_portable" is a module, and modules are always nonportable, so cannot be used inside a function that is portable.
+val bar : unit -> (module Func_portable) @ contended = <fun>
 |}]
 
 (* Closing over a module in a module. *)
@@ -1072,7 +1053,7 @@ val bar : unit -> (module S'_Func_portable) = <fun>
 
 (* closing over a functor is still closing over the functor *)
 module type F = sig end -> sig end
-module F (X : sig end) = struct end
+module (F @ nonportable) (X : sig end) = struct end
 let (bar @ portable) () =
   let k = (module F : F) in
   k
@@ -1082,7 +1063,7 @@ module F : functor (X : sig end) -> sig end
 Line 4, characters 18-19:
 4 |   let k = (module F : F) in
                       ^
-Error: "F" is a module, and modules are always nonportable, so cannot be used inside a function that is portable.
+Error: The module "F" is nonportable, so cannot be used inside a function that is portable.
 |}]
 
 (* closing over class in structure is still prevented *)

--- a/testsuite/tests/typing-zero-alloc/cmi_test.ml
+++ b/testsuite/tests/typing-zero-alloc/cmi_test.ml
@@ -22,8 +22,8 @@ Error: Signature mismatch:
          sig
            val f_unconstrained_variable : int -> int @@ portable
            module M_constrained_variable =
-             Cmi_test_lib.M_constrained_variable
-           module M_no_variable = Cmi_test_lib.M_no_variable
+             Cmi_test_lib.M_constrained_variable @@ portable
+           module M_no_variable = Cmi_test_lib.M_no_variable @@ portable
          end
        is not included in
          sig val f_unconstrained_variable : int -> int [@@zero_alloc] end
@@ -45,11 +45,11 @@ Line 3, characters 6-41:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : int -> int @@ portable [@@zero_alloc] end
+         sig val f : int -> int [@@zero_alloc] end
        is not included in
          sig val f : int -> int [@@zero_alloc strict] end
        Values do not match:
-         val f : int -> int @@ portable [@@zero_alloc]
+         val f : int -> int [@@zero_alloc]
        is not included in
          val f : int -> int [@@zero_alloc strict]
        The former provides a weaker "zero_alloc" guarantee than the latter.

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -125,8 +125,8 @@ let execute_phrase print_outcome ppf phr =
       in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv sn sg in
-      ignore (Includemod.signatures ~mark:Mark_positive oldenv
-        ~modes:(Legacy None) sg sg');
+      let modes = Includemod.modes_toplevel in
+      ignore (Includemod.signatures ~mark:Mark_positive oldenv ~modes sg sg');
       Typecore.force_delayed_checks ();
       let shape = Shape_reduce.local_reduce Env.empty shape in
       if !Clflags.dump_shape then Shape.print ppf shape;

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -400,9 +400,9 @@ let execute_phrase print_outcome ppf phr =
       in
       if !Clflags.dump_typedtree then Printtyped.implementation ppf str;
       let sg' = Typemod.Signature_names.simplify newenv names sg in
+      let modes = Includemod.modes_toplevel in
       let coercion =
-        Includemod.signatures oldenv ~mark:Mark_positive
-          ~modes:(Legacy None) sg sg'
+        Includemod.signatures oldenv ~mark:Mark_positive ~modes sg sg'
       in
       Typecore.force_delayed_checks ();
       let str, sg', rewritten =

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -430,7 +430,7 @@ let reg_show_prim name to_sig doc =
 let () =
   reg_show_prim "show_val"
     (fun env loc id lid ->
-       let _path, desc, _, _= Env.lookup_value ~loc lid env in
+       let _path, desc, _ = Env.lookup_value ~loc lid env in
        [ Sig_value (id, desc, Exported) ]
     )
     "Print the signature of the corresponding value."

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -720,3 +720,45 @@ val is_principal : type_expr -> bool
 type global_state
 val global_state : global_state
 val print_global_state : Format.formatter -> global_state -> unit
+
+(** Get the crossing of a jkind  *)
+val crossing_of_jkind : Env.t -> 'd Types.jkind -> Mode.Crossing.t
+
+(** Get the crossing of a type wrapped in modalities *)
+val crossing_of_ty :
+  Env.t ->
+  ?modalities:Mode.Modality.Value.Const.t ->
+  Types.type_expr ->
+  Mode.Crossing.t
+
+(** Cross a right mode according to a type wrapped in modalities. *)
+val cross_right :
+  Env.t ->
+  ?modalities:Mode.Modality.Value.Const.t ->
+  Types.type_expr ->
+  Mode.Value.r ->
+  Mode.Value.r
+
+(** Cross a left mode according to a type wrapped in modalities. *)
+val cross_left :
+  Env.t ->
+  ?modalities:Mode.Modality.Value.Const.t ->
+  Types.type_expr ->
+  Mode.Value.l ->
+  Mode.Value.l
+
+(** Similar to [cross_right] but for [Mode.Alloc]  *)
+val cross_right_alloc :
+  Env.t ->
+  ?modalities:Mode.Modality.Value.Const.t ->
+  Types.type_expr ->
+  Mode.Alloc.r ->
+  Mode.Alloc.r
+
+(** Similar to [cross_left] but for [Mode.Alloc]  *)
+val cross_left_alloc :
+  Env.t ->
+  ?modalities:Mode.Modality.Value.Const.t ->
+  Types.type_expr ->
+  Mode.Alloc.l ->
+  Mode.Alloc.l

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -142,12 +142,49 @@ type value_unbound_reason =
 type module_unbound_reason =
   | Mod_unbound_illegal_recursion
 
+type locality_context =
+  | Tailcall_function
+  | Tailcall_argument
+  | Partial_application
+  | Return
+  | Lazy
+
+type closure_context =
+  | Function of locality_context option
+  | Functor
+  | Lazy
+
+type escaping_context =
+  | Letop
+  | Probe
+  | Class
+
+type shared_context =
+  | For_loop
+  | While_loop
+  | Letop
+  | Closure
+  | Comprehension
+  | Class
+  | Probe
+
+type lock =
+  | Escape_lock of escaping_context
+  | Share_lock of shared_context
+  | Closure_lock of closure_context * Mode.Value.Comonadic.r
+  | Region_lock
+  | Exclave_lock
+  | Unboxed_lock (* to prevent capture of terms with non-value types *)
+
+type locks = lock list
+
 type summary =
     Env_empty
   | Env_value of summary * Ident.t * value_description * Mode.Value.l
   | Env_type of summary * Ident.t * type_declaration
   | Env_extension of summary * Ident.t * extension_constructor
-  | Env_module of summary * Ident.t * module_presence * module_declaration
+  | Env_module of summary * Ident.t * module_presence * module_declaration *
+      Mode.Value.l * locks
   | Env_modtype of summary * Ident.t * modtype_declaration
   | Env_class of summary * Ident.t * class_declaration
   | Env_cltype of summary * Ident.t * class_type_declaration
@@ -164,7 +201,7 @@ let map_summary f = function
   | Env_value (s, id, d, m) -> Env_value (f s, id, d, m)
   | Env_type (s, id, d) -> Env_type (f s, id, d)
   | Env_extension (s, id, d) -> Env_extension (f s, id, d)
-  | Env_module (s, id, p, d) -> Env_module (f s, id, p, d)
+  | Env_module (s, id, p, d, m, l) -> Env_module (f s, id, p, d, m, l)
   | Env_modtype (s, id, d) -> Env_modtype (f s, id, d)
   | Env_class (s, id, d) -> Env_class (f s, id, d)
   | Env_cltype (s, id, d) -> Env_cltype (f s, id, d)
@@ -304,44 +341,7 @@ module TycompTbl =
 
 type empty = |
 
-type locality_context =
-  | Tailcall_function
-  | Tailcall_argument
-  | Partial_application
-  | Return
-  | Lazy
-
-type closure_context =
-  | Function of locality_context option
-  | Lazy
-
-type escaping_context =
-  | Letop
-  | Probe
-  | Class
-  | Module
-
-type shared_context =
-  | For_loop
-  | While_loop
-  | Letop
-  | Closure
-  | Comprehension
-  | Class
-  | Module
-  | Probe
-
-type lock =
-  | Escape_lock of escaping_context
-  | Share_lock of shared_context
-  | Closure_lock of closure_context * Mode.Value.Comonadic.r
-  | Region_lock
-  | Exclave_lock
-  | Unboxed_lock (* to prevent capture of terms with non-value types *)
-
-type locks = lock list
-
-type held_locks = locks * Longident.t * Location.t
+type mode_with_locks = Mode.Value.l * locks
 
 let locks_empty = []
 
@@ -661,6 +661,7 @@ and components_maker = {
   cm_path: Path.t;
   cm_addr: address_lazy;
   cm_mty: Subst.Lazy.module_type;
+  cm_mode : Mode.Value.l;
   cm_shape: Shape.t;
 }
 
@@ -725,6 +726,7 @@ and module_data =
   { mda_declaration : Subst.Lazy.module_declaration;
     mda_components : module_components;
     mda_address : address_lazy;
+    mda_mode : Mode.Value.l;
     mda_shape: Shape.t; }
 
 and module_alias_locks = locks
@@ -753,7 +755,7 @@ and cltype_data =
 
 let clda_mode = Mode.Value.legacy |> Mode.Value.disallow_right
 
-let cm_mode = Mode.Value.legacy |> Mode.Value.disallow_right
+let fcomp_res_mode = Types.functor_res_mode |> Mode.Alloc.disallow_right
 
 let empty_structure =
   Structure_comps {
@@ -981,8 +983,8 @@ let scrape_alias =
         t -> Subst.Lazy.module_type -> Subst.Lazy.module_type)
 
 let md md_type =
-  {md_type; md_attributes=[]; md_loc=Location.none
-  ;md_uid = Uid.internal_not_actually_unique}
+  {md_type; md_modalities = Mode.Modality.Value.id; md_attributes=[];
+   md_loc=Location.none; md_uid = Uid.internal_not_actually_unique}
 
 (** The caller is not interested in modes, and thus [val_modalities] is
 invalidated. *)
@@ -990,14 +992,25 @@ let vda_description vda =
   let vda_description = vda.vda_description in
   {vda_description with val_modalities = Mode.Modality.Value.undefined}
 
+let normalize_mode modality mode =
+  let vda_mode = Mode.Modality.Value.apply modality mode in
+  Mode.Modality.Value.id, vda_mode
+
 let normalize_vda_mode vda =
   let vda_description = vda.vda_description in
-  let modalities = vda_description.val_modalities in
-  let vda_description =
-    {vda_description with val_modalities = Mode.Modality.Value.id}
+  let val_modalities, vda_mode =
+    normalize_mode vda_description.val_modalities vda.vda_mode
   in
-  let vda_mode = Mode.Modality.Value.apply modalities vda.vda_mode in
+  let vda_description = {vda_description with val_modalities} in
   vda_description, vda_mode
+
+let normalize_md_mode (md : Subst.Lazy.module_declaration) mode =
+  let md_modalities, mode = normalize_mode md.md_modalities mode in
+  let md = {md with md_modalities} in
+  md, mode
+
+let normalize_mda_mode mda =
+  normalize_md_mode mda.mda_declaration mda.mda_mode
 
 (* Print addresses *)
 
@@ -1091,7 +1104,7 @@ let add_persistent_structure id env =
     { env with modules; summary }
   end
 
-let components_of_module ~alerts ~uid env ps path addr mty shape =
+let components_of_module ~alerts ~uid env ps path addr mty mode shape =
   {
     alerts;
     uid;
@@ -1101,9 +1114,12 @@ let components_of_module ~alerts ~uid env ps path addr mty shape =
       cm_path = path;
       cm_addr = addr;
       cm_mty = mty;
+      cm_mode = mode;
       cm_shape = shape;
     }
   }
+
+let mode_unit = Mode.Value.legacy
 
 let read_sign_of_cmi sign name uid ~shape ~address:addr ~flags =
   let id = Ident.create_global name in
@@ -1115,6 +1131,7 @@ let read_sign_of_cmi sign name uid ~shape ~address:addr ~flags =
   in
   let md =
     { Subst.Lazy.md_type = Mty_signature sign;
+      md_modalities = Mode.Modality.Value.id;
       md_loc = Location.none;
       md_attributes = [];
       md_uid = uid;
@@ -1122,17 +1139,19 @@ let read_sign_of_cmi sign name uid ~shape ~address:addr ~flags =
   in
   let mda_address = Lazy_backtrack.create_forced addr in
   let mda_declaration = md in
+  let mda_mode = Mode.Value.disallow_right mode_unit in
   let mda_shape = shape in
   let mda_components =
     let mty = md.md_type in
     components_of_module ~alerts ~uid:md.md_uid
       empty Subst.identity
-      path mda_address mty mda_shape
+      path mda_address mty mda_mode mda_shape
   in
   {
     mda_declaration;
     mda_components;
     mda_address;
+    mda_mode;
     mda_shape;
   }
 
@@ -2077,7 +2096,7 @@ let is_identchar c =
 
 let rec components_of_module_maker
           {cm_env; cm_prefixing_subst;
-           cm_path; cm_addr; cm_mty; cm_shape} : _ result =
+           cm_path; cm_addr; cm_mty; cm_mode; cm_shape} : _ result =
   match !scrape_alias cm_env cm_mty with
     Mty_signature sg ->
       let c =
@@ -2188,6 +2207,7 @@ let rec components_of_module_maker
             in
             c.comp_constrs <- add_to_tbl (Ident.name id) cda c.comp_constrs
         | Sig_module(id, pres, md, _, _) ->
+            let md, mode = normalize_md_mode md cm_mode in
             let md' =
               (* The prefixed items get the same scope as [cm_path], which is
                  the prefix. *)
@@ -2210,10 +2230,11 @@ let rec components_of_module_maker
             let shape = Shape.proj cm_shape (Shape.Item.module_ id) in
             let comps =
               components_of_module ~alerts ~uid:md.md_uid !env
-                sub path addr md.md_type shape
+                sub path addr md.md_type mode shape
             in
             let mda =
               { mda_declaration = md';
+                mda_mode = mode;
                 mda_components = comps;
                 mda_address = addr;
                 mda_shape = shape; }
@@ -2222,7 +2243,7 @@ let rec components_of_module_maker
               NameMap.add (Ident.name id) mda c.comp_modules;
             env :=
               store_module ~update_summary:false ~check:None
-                id addr pres md shape locks_empty !env
+                id addr pres md mode shape locks_empty !env
         | Sig_modtype(id, decl, _) ->
             let final_decl =
               (* The prefixed items get the same scope as [cm_path], which is
@@ -2497,26 +2518,30 @@ and store_extension ~check ~rebind id addr ext shape env =
     summary = Env_extension(env.summary, id, ext) }
 
 and store_module ?(update_summary=true) ~check
-                 id addr presence md shape alias_locks env =
+                 id addr presence md mode shape alias_locks env =
   let open Subst.Lazy in
   let loc = md.md_loc in
   Option.iter
     (fun f -> check_usage loc id md.md_uid f !module_declarations) check;
   Builtin_attributes.mark_alerts_used md.md_attributes;
   let alerts = Builtin_attributes.alerts_of_attrs md.md_attributes in
+  let md, mode = normalize_md_mode md mode in
   let comps =
     components_of_module ~alerts ~uid:md.md_uid
-      env Subst.identity (Pident id) addr md.md_type shape
+      env Subst.identity (Pident id) addr md.md_type mode shape
   in
   let mda =
     { mda_declaration = md;
+      mda_mode = mode;
       mda_components = comps;
       mda_address = addr;
       mda_shape = shape }
   in
   let summary =
     if not update_summary then env.summary
-    else Env_module (env.summary, id, presence, force_module_decl md) in
+    else Env_module (env.summary, id, presence, force_module_decl md, mode,
+      alias_locks)
+  in
   { env with
     modules = IdTbl.add id (Mod_local (mda, alias_locks)) env.modules;
     summary }
@@ -2577,7 +2602,8 @@ let components_of_functor_appl ~loc ~f_path ~f_comp ~arg env =
       components_of_module ~alerts:Misc.Stdlib.String.Map.empty
         ~uid:Uid.internal_not_actually_unique
         (*???*)
-        env Subst.identity p addr (Subst.Lazy.of_modtype mty) shape
+        env Subst.identity p addr (Subst.Lazy.of_modtype mty)
+        (Mode.alloc_as_value fcomp_res_mode) shape
     in
     Hashtbl.add f_comp.fcomp_cache arg comps;
     comps
@@ -2611,7 +2637,7 @@ and add_extension ~check ?shape ~rebind id ext env =
   store_extension ~check ~rebind id addr ext shape env
 
 and add_module_declaration_lazy
-      ~update_summary ?(arg=false) ?shape ~check id presence md ?(locks = []) env =
+      ~update_summary ?(arg=false) ?shape ~check id presence md ?(mode = Mode.Value.(allow_right max)) ?(locks = []) env =
   let check =
     if not check then
       None
@@ -2622,14 +2648,15 @@ and add_module_declaration_lazy
   in
   let addr = module_declaration_address env id presence md in
   let shape = shape_or_leaf md.Subst.Lazy.md_uid shape in
+  let mode = Mode.Value.disallow_right mode in
   let env =
-    store_module ~update_summary ~check id addr presence md shape locks env
+    store_module ~update_summary ~check id addr presence md mode shape locks env
   in
   if arg then add_functor_arg id env else env
 
-let add_module_declaration ?(arg=false) ?shape ~check id presence md ?locks env =
+let add_module_declaration ?(arg=false) ?shape ~check id presence md ?mode ?locks env =
   add_module_declaration_lazy ~update_summary:true ~arg ?shape ~check id
-    presence (Subst.Lazy.of_module_decl md) ?locks env
+    presence (Subst.Lazy.of_module_decl md) ?mode ?locks env
 
 and add_modtype_lazy ~update_summary ?shape id info env =
   let shape = shape_or_leaf info.Subst.Lazy.mtd_uid shape in
@@ -2648,16 +2675,17 @@ and add_cltype ?shape id ty env =
   let shape = shape_or_leaf ty.clty_uid shape in
   store_cltype id ty shape env
 
-let add_module_lazy ~update_summary id presence mty env =
+let add_module_lazy ~update_summary id presence mty ?mode env =
   let md = Subst.Lazy.{md_type = mty;
+                       md_modalities = Mode.Modality.Value.id;
                        md_attributes = [];
                        md_loc = Location.none;
                        md_uid = Uid.internal_not_actually_unique}
   in
-  add_module_declaration_lazy ~update_summary ~check:false id presence md env
+  add_module_declaration_lazy ~update_summary ~check:false id presence md ?mode env
 
-let add_module ?arg ?shape id presence mty env =
-  add_module_declaration ~check:false ?arg ?shape id presence (md mty) env
+let add_module ?arg ?shape id presence mty ?mode env =
+  add_module_declaration ~check:false ?arg ?shape id presence (md mty) ?mode env
 
 let add_local_constraint path info env =
   { env with
@@ -2688,9 +2716,9 @@ let enter_extension ~scope ~rebind name ext env =
   let env = store_extension ~check:true ~rebind id addr ext shape env in
   (id, env)
 
-let enter_module_declaration ~scope ?arg ?shape s presence md ?locks env =
+let enter_module_declaration ~scope ?arg ?shape s presence md ?mode ?locks env =
   let id = Ident.create_scoped ~scope s in
-  (id, add_module_declaration ?arg ?shape ~check:true id presence md ?locks env)
+  (id, add_module_declaration ?arg ?shape ~check:true id presence md ?mode ?locks env)
 
 let enter_modtype ~scope name mtd env =
   let id = Ident.create_scoped ~scope name in
@@ -2709,8 +2737,8 @@ let enter_cltype ~scope name desc env =
   let env = store_cltype id desc (Shape.leaf desc.clty_uid) env in
   (id, env)
 
-let enter_module ~scope ?arg s presence mty env =
-  enter_module_declaration ~scope ?arg s presence (md mty) env
+let enter_module ~scope ?arg s presence mty ?mode env =
+  enter_module_declaration ~scope ?arg s presence (md mty) ?mode env
 
 let add_lock lock env =
   { env with
@@ -2753,17 +2781,17 @@ module Add_signature(T : Types.Wrapped)(M : sig
   val add_value: ?shape:Shape.t -> mode:(Mode.allowed * 'r0) Mode.Value.t -> Ident.t ->
     T.value_description  -> t -> t
   val add_module_declaration: ?arg:bool -> ?shape:Shape.t -> check:bool
-    -> Ident.t -> module_presence -> T.module_declaration -> ?locks:locks ->
+    -> Ident.t -> module_presence -> T.module_declaration -> ?mode:(Mode.allowed * 'r) Mode.Value.t -> ?locks:locks ->
     t -> t
   val add_modtype: ?shape:Shape.t -> Ident.t -> T.modtype_declaration -> t -> t
 end) = struct
   open T
 
-  let add_item map mod_shape comp env =
+  let add_item map mod_shape comp mode env =
     match comp with
     | Sig_value(id, decl, _) ->
         let map, shape = proj_shape map mod_shape (Shape.Item.value id) in
-        map, M.add_value ?shape ~mode:Mode.Value.legacy id decl env
+        map, M.add_value ?shape ~mode id decl env
     | Sig_type(id, decl, _, _) ->
         let map, shape = proj_shape map mod_shape (Shape.Item.type_ id) in
         map, add_type ~check:false ?shape id decl env
@@ -2772,7 +2800,7 @@ end) = struct
         map, add_extension ~check:false ?shape ~rebind:false id ext env
     | Sig_module(id, presence, md, _, _) ->
         let map, shape = proj_shape map mod_shape (Shape.Item.module_ id) in
-        map, M.add_module_declaration ~check:false ?shape id presence md env
+        map, M.add_module_declaration ~check:false ?shape id presence md ~mode env
     | Sig_modtype(id, decl, _)  ->
         let map, shape = proj_shape map mod_shape (Shape.Item.module_type id) in
         map, M.add_modtype ?shape id decl env
@@ -2783,15 +2811,15 @@ end) = struct
         let map, shape = proj_shape map mod_shape (Shape.Item.class_type id) in
         map, add_cltype ?shape id decl env
 
-  let rec add_signature map mod_shape sg env =
+  let rec add_signature map mod_shape sg ?(mode = Mode.Value.(allow_right max)) env =
     match sg with
         [] -> map, env
     | comp :: rem ->
-        let map, env = add_item map mod_shape comp env in
-        add_signature map mod_shape rem env
+        let map, env = add_item map mod_shape comp mode env in
+        add_signature map mod_shape rem ~mode env
 end
 
-let add_signature =
+let add_signature map mod_shape sg ?mode env =
   let module M = Add_signature(Types)(struct
     let add_value ?shape ~mode id vd =
       add_value_lazy ?shape ~mode id (Subst.Lazy.of_value_description vd)
@@ -2799,32 +2827,33 @@ let add_signature =
     let add_modtype = add_modtype
   end)
   in
-  M.add_signature
+  M.add_signature map mod_shape sg ?mode env
 
 let add_signature_lazy =
   let module M = Add_signature(Subst.Lazy)(struct
     let add_value ?shape ~mode = add_value_lazy ?check:None ?shape ~mode
-    let add_module_declaration =
-      add_module_declaration_lazy ~update_summary:true
+    let add_module_declaration ?arg ?shape ~check id pres md ?mode ?locks env =
+      add_module_declaration_lazy ~update_summary:true ?arg ?shape ~check id
+        pres md ?mode ?locks env
     let add_modtype = add_modtype_lazy ~update_summary:true
   end)
   in
   M.add_signature
 
-let enter_signature_and_shape ~scope ~parent_shape mod_shape sg env =
+let enter_signature_and_shape ~scope ~parent_shape mod_shape sg ?mode env =
   let sg = Subst.signature (Rescope scope) Subst.identity sg in
-  let shape, env = add_signature parent_shape mod_shape sg env in
+  let shape, env = add_signature parent_shape mod_shape sg ?mode env in
   sg, shape, env
 
-let enter_signature ?mod_shape ~scope sg env =
+let enter_signature ?mod_shape ~scope sg ?mode env =
   let sg, _, env =
     enter_signature_and_shape ~scope ~parent_shape:Shape.Map.empty
-      mod_shape sg env
+      mod_shape sg ?mode env
   in
   sg, env
 
-let enter_signature_and_shape ~scope ~parent_shape mod_shape sg env =
-  enter_signature_and_shape ~scope ~parent_shape (Some mod_shape) sg env
+let enter_signature_and_shape ~scope ~parent_shape mod_shape sg ?mode env =
+  enter_signature_and_shape ~scope ~parent_shape (Some mod_shape) sg ?mode env
 
 let add_value_lazy = add_value_lazy ?shape:None
 let add_value ?check ~mode id vd =
@@ -2834,7 +2863,7 @@ let add_cltype = add_cltype ?shape:None
 let add_modtype_lazy = add_modtype_lazy ?shape:None
 let add_modtype = add_modtype ?shape:None
 let add_module_declaration_lazy ?(arg=false) =
-  add_module_declaration_lazy ~arg ?shape:None ~check:false ?locks:None
+  add_module_declaration_lazy ~arg ?shape:None ~check:false
 let add_signature sg env =
   let _, env = add_signature Shape.Map.empty None sg env in
   env
@@ -3156,10 +3185,13 @@ let lookup_ident_module (type a) (load : a load) ~errors ~use ~loc s env =
   match data with
   | Mod_local (mda, alias_locks) -> begin
       use_module ~use ~loc path mda;
+      let _, mode = normalize_mda_mode mda in
       let locks = alias_locks @ locks in
       match load with
-      | Load -> path, locks, (mda : a)
-      | Don't_load -> path, locks, (() : a)
+      (* CR-soon zqian: duplication of information. Should move modes out of
+         [value_data] and [module_data] *)
+      | Load -> path, (mode, locks), (mda : a)
+      | Don't_load -> path, (mode, locks), (() : a)
     end
   | Mod_unbound reason ->
       report_module_unbound ~errors ~loc env reason
@@ -3170,7 +3202,7 @@ let lookup_ident_module (type a) (load : a load) ~errors ~use ~loc s env =
       let path, a =
         lookup_global_name_module_no_locks load ~errors ~use ~loc name env
       in
-      path, locks, a
+      path, (Mode.Value.(disallow_right mode_unit), locks), a
     end
 
 let escape_mode ~errors ~env ~loc ~item ~lid vmode escaping_context =
@@ -3259,7 +3291,7 @@ let unboxed_type ~errors ~env ~loc ~lid ty =
 
     [ty] is optional as the function works on modules and classes as well, for
     which [ty] should be [None]. *)
-let walk_locks ~errors ~loc ~env ~item ~lid mode ty locks =
+let walk_locks ~errors ~env ~loc ~item ~lid mode ty locks =
   let vmode = { mode; context = None } in
   List.fold_left
     (fun vmode lock ->
@@ -3358,7 +3390,7 @@ let lookup_all_ident_constructors ~errors ~use ~loc usage s env =
 let rec lookup_module_components ~errors ~use ~loc lid env =
   match lid with
   | Lident s ->
-      let path, locks, data = lookup_ident_module Load ~errors ~use ~loc s env in
+      let path, (_, locks), data = lookup_ident_module Load ~errors ~use ~loc s env in
       path, locks, data.mda_components
   | Ldot(l, s) ->
       let path, locks, data = lookup_dot_module ~errors ~use ~loc l s env in
@@ -3451,26 +3483,29 @@ and lookup_apply ~errors ~use ~loc lid0 env =
 and lookup_module ~errors ~use ~loc lid env =
   match lid with
   | Lident s ->
-      let path, locks, data = lookup_ident_module Load ~errors ~use ~loc s env in
+      let path, mode_with_locks, data = lookup_ident_module Load ~errors ~use ~loc s env in
       let md = Subst.Lazy.force_module_decl data.mda_declaration in
-      path, md, locks
+      path, md, mode_with_locks
   | Ldot(l, s) ->
       let path, locks, data = lookup_dot_module ~errors ~use ~loc l s env in
-      let md = Subst.Lazy.force_module_decl data.mda_declaration in
-      path, md, locks
+      let md, mode = normalize_mda_mode data in
+      let md = Subst.Lazy.force_module_decl md in
+      path, md, (mode, locks)
   | Lapply _ as lid ->
       let path_f, comp_f, path_arg = lookup_apply ~errors ~use ~loc lid env in
       let md = md (modtype_of_functor_appl comp_f path_f path_arg) in
       (* [Lapply] is for [F(M).t] so nothing is closed over. *)
-      Papply(path_f, path_arg), md, locks_empty
+      Papply(path_f, path_arg), md, (Mode.alloc_as_value fcomp_res_mode, locks_empty)
 
 and lookup_dot_module ~errors ~use ~loc l s env =
-  let p, locks, comps = lookup_structure_components ~errors ~use ~loc l env in
+  let p, mode_with_locks, comps =
+    lookup_structure_components ~errors ~use ~loc l env
+  in
   match NameMap.find s comps.comp_modules with
   | mda ->
       let path = Pdot(p, s) in
       use_module ~use ~loc path mda;
-      (path, locks, mda)
+      (path, mode_with_locks, mda)
   | exception Not_found ->
       may_lookup_error errors loc env (Unbound_module (Ldot(l, s)))
 
@@ -3719,22 +3754,23 @@ let lookup_module_path ~errors ~use ~loc ~load lid env =
   match lid with
   | Lident s ->
       if !Clflags.transparent_modules && not load then
-        let path, locks, () =
+        let path, mode_with_locks, () =
           lookup_ident_module Don't_load ~errors ~use ~loc s env
         in
-        path, locks
+        path, mode_with_locks
       else
-        let path, locks, _ =
+        let path, mode_with_locks, _ =
           lookup_ident_module Load ~errors ~use ~loc s env
         in
-        path, locks
+        path, mode_with_locks
   | Ldot(l, s) ->
-      let path, locks, _ = lookup_dot_module ~errors ~use ~loc l s env in
-      path, locks
+      let path, locks, data = lookup_dot_module ~errors ~use ~loc l s env in
+      let _, mode = normalize_mda_mode data in
+      path, (mode, locks)
   | Lapply _ as lid ->
       let path_f, _comp_f, path_arg = lookup_apply ~errors ~use ~loc lid env in
       (* [Lapply] is for [F(M).t] so nothing is closed over. *)
-      Papply(path_f, path_arg), locks_empty
+      Papply(path_f, path_arg), (Mode.alloc_as_value fcomp_res_mode, locks_empty)
 
 let lookup_module_instance_path ~errors ~use ~loc ~load name env =
   (* The locks are whatever locks we would find if we went through
@@ -3767,7 +3803,7 @@ let lookup_value ~errors ~use ~loc lid env =
   in
   let vd, mode = normalize_vda_mode vda in
   let vd = Subst.Lazy.force_value_description vd in
-  path, vd, mode, locks
+  path, vd, (mode, locks)
 
 let lookup_type_full ~errors ~use ~loc lid env =
   match lid with
@@ -3910,7 +3946,7 @@ let find_module_by_name lid env =
 
 let find_value_by_name lid env =
   let loc = Location.(in_file !input_name) in
-  let path, desc, _, _ = lookup_value ~errors:false ~use:false ~loc lid env in
+  let path, desc, _ = lookup_value ~errors:false ~use:false ~loc lid env in
   path, desc
 
 let find_type_by_name lid env =
@@ -3957,7 +3993,7 @@ let find_cltype_index id env = find_index_tbl id env.cltypes
 
 (* Ordinary lookup functions *)
 
-let walk_locks ~env ~item mode ty (locks, lid, loc) =
+let walk_locks ~env ~loc lid ~item ty (mode, locks) =
   walk_locks ~errors:true ~loc ~env ~item ~lid mode ty locks
 
 let lookup_module_path ?(use=true) ~loc ~load lid env =
@@ -4342,7 +4378,6 @@ let string_of_escaping_context : escaping_context -> string =
   | Letop -> "a letop"
   | Probe -> "a probe"
   | Class -> "a class"
-  | Module -> "a module"
 
 let string_of_shared_context : shared_context -> string =
   function
@@ -4352,7 +4387,6 @@ let string_of_shared_context : shared_context -> string =
   | Closure -> "a closure that is not once"
   | Comprehension -> "a comprehension"
   | Class -> "a class"
-  | Module -> "a module"
   | Probe -> "a probe"
 
 let sharedness_hint ppf : shared_context -> _ = function
@@ -4381,10 +4415,6 @@ let sharedness_hint ppf : shared_context -> _ = function
         "@[Hint: This identifier was defined outside of the current closure.@ \
           Either this closure has to be once, or the identifier can be used only@ \
           as aliased.@]"
-  | Module ->
-    Format.fprintf ppf
-        "@[Hint: This identifier cannot be used uniquely,@ \
-          because it is defined in a module.@]"
   | Probe ->
     Format.fprintf ppf
         "@[Hint: This identifier cannot be used uniquely,@ \
@@ -4393,13 +4423,14 @@ let sharedness_hint ppf : shared_context -> _ = function
 let print_lock_item ppf (item, lid) =
   match item with
   | Module ->
-      fprintf ppf "%a is a module, and modules are always"
+      fprintf ppf "The module %a is"
         (Style.as_inline_code !print_longident) lid
   | Class ->
       fprintf ppf "%a is a class, and classes are always"
         (Style.as_inline_code !print_longident) lid
-  | Value -> fprintf ppf "The value %a is"
-      (Style.as_inline_code !print_longident) lid
+  | Value ->
+      fprintf ppf "The value %a is"
+        (Style.as_inline_code !print_longident) lid
 
 module Style = Misc.Style
 
@@ -4573,6 +4604,13 @@ let report_lookup_error _loc env ppf = function
               | _ -> fun _ppf -> ()
             in
             "function that " ^ e1, hint
+        | Functor ->
+          let s =
+            match error with
+            | Error (Areality, _) -> "functor"
+            | _ -> "functor that " ^ e1
+          in
+          s, fun _ppf -> ()
         | Lazy ->
             let s =
               match error with

--- a/typing/envaux.ml
+++ b/typing/envaux.ml
@@ -50,12 +50,12 @@ let rec env_from_summary ~allow_missing_modules sum subst =
           Env.add_extension ~check:false ~rebind:false id
             (Subst.extension_constructor subst desc)
             (env_from_summary ~allow_missing_modules s subst)
-      | Env_module(s, id, pres, desc) ->
+      | Env_module(s, id, pres, desc, mode, locks) ->
           let desc =
             Subst.Lazy.module_decl Keep subst (Subst.Lazy.of_module_decl desc)
           in
           Env.add_module_declaration_lazy ~update_summary:true id pres desc
-            (env_from_summary ~allow_missing_modules s subst)
+            ~mode ~locks (env_from_summary ~allow_missing_modules s subst)
       | Env_modtype(s, id, desc) ->
           let desc =
             Subst.Lazy.modtype_decl Keep subst (Subst.Lazy.of_modtype_decl desc)
@@ -75,13 +75,13 @@ let rec env_from_summary ~allow_missing_modules sum subst =
             (try Env.open_signature_by_path path' env with
             | Not_found -> env)
           else Env.open_signature_by_path path' env
-      | Env_functor_arg(Env_module(s, id, pres, desc), id')
+      | Env_functor_arg(Env_module(s, id, pres, desc, mode, locks), id')
             when Ident.same id id' ->
           let desc =
             Subst.Lazy.module_decl Keep subst (Subst.Lazy.of_module_decl desc)
           in
           Env.add_module_declaration_lazy ~update_summary:true id pres desc
-            ~arg:true (env_from_summary ~allow_missing_modules s subst)
+            ~mode ~locks ~arg:true (env_from_summary ~allow_missing_modules s subst)
       | Env_functor_arg _ -> assert false
       | Env_constraints(s, map) ->
           Path.Map.fold

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -51,29 +51,6 @@ type mmodes =
   | All
   | Legacy of Env.held_locks option
 
-(** Mode cross a right mode *)
-(* This is very similar to Ctype.mode_cross_right. Any bugs here are likely bugs
-   there, too. *)
-let right_mode_cross_jkind env jkind mode =
-  let jkind_of_type = Ctype.type_jkind_purely_if_principal env in
-  let crossing = Jkind.get_mode_crossing ~jkind_of_type jkind in
-  Crossing.apply_right crossing mode
-
-let right_mode_cross env ty mode =
-  if not (Ctype.is_principal ty) then mode else
-  let jkind = Ctype.type_jkind_purely env ty in
-  right_mode_cross_jkind env jkind mode
-
-let left_mode_cross_jkind env jkind mode =
-  let jkind_of_type = Ctype.type_jkind_purely_if_principal env in
-  let crossing = Jkind.get_mode_crossing ~jkind_of_type jkind in
-  Crossing.apply_left crossing mode
-
-let left_mode_cross env ty mode=
-  if not (Ctype.is_principal ty) then mode else
-  let jkind = Ctype.type_jkind_purely env ty in
-  left_mode_cross_jkind env jkind mode
-
 let native_repr_args nra1 nra2 =
   let rec loop i nra1 nra2 =
     match nra1, nra2 with
@@ -152,14 +129,14 @@ let value_descriptions ~loc env name
         match close_over_coercion with
         | Some held_locks ->
           (* Cross modes according to RHS type as it tends to be by the user. *)
-          let mode1 = left_mode_cross env vd2.val_type mode1 in
+          let mode1 = Ctype.cross_left env vd2.val_type mode1 in
           let mode1 =
             Env.walk_locks ~env ~item:Value mode1 (Some vd1.val_type) held_locks
           in
           mode1.mode
         | None -> mode1
       in
-      let mode2 = right_mode_cross env vd2.val_type mode2 in
+      let mode2 = Ctype.cross_right env vd2.val_type mode2 in
       begin match Mode.Value.submode mode1 mode2 with
       | Ok () -> ()
       | Error e -> raise (Dont_match (Mode e))

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -47,9 +47,53 @@ type value_mismatch =
 
 exception Dont_match of value_mismatch
 
+type close_over_coercion = Env.locks * Longident.t * Location.t
+
 type mmodes =
   | All
-  | Legacy of Env.held_locks option
+  | Specific of Mode.Value.l * Mode.Value.r * close_over_coercion option
+
+let child_modes id ?modalities  = function
+  | All ->
+      begin match modalities with
+      | None -> Ok All
+      | Some (moda0, moda1) ->
+        match Mode.Modality.Value.sub moda0 moda1 with
+        | Ok () -> Ok All
+        | Error e -> Error e
+      end
+  | Specific (m0, m1, c) ->
+    let c =
+      match c with
+      | None -> None
+      | Some (locks, lid, loc) -> Some (locks, Longident.Ldot (lid, id), loc)
+    in
+    match modalities with
+    | Some (moda0, moda1) ->
+        begin match Mode.Modality.Value.to_const_opt moda1 with
+        (* [wrap_constraint_with_shape] invokes inclusion check with identical
+          inferred modalities, which we workaround *)
+        | None -> Ok All
+        | Some moda1 ->
+          let m0 = Mode.Modality.Value.apply moda0 m0 in
+          let m1 = Mode.Modality.Value.(Const.apply moda1 m1) in
+          Ok (Specific (m0, m1, c))
+        end
+    | None -> Ok (Specific(m0, m1, c))
+
+let check_modes env ?(crossing = Crossing.top) ~item ?typ = function
+  | All -> Ok ()
+  | Specific (m0, m1, c) ->
+      let m0 =
+        match c with
+        | None -> m0
+        | Some (locks, lid, loc) ->
+            let m0 = Crossing.apply_left crossing m0 in
+            let m0 = Env.walk_locks ~env ~loc lid ~item typ (m0, locks) in
+            m0.mode
+      in
+      let m1 = Crossing.apply_right crossing m1 in
+      Mode.Value.submode m0 m1
 
 let native_repr_args nra1 nra2 =
   let rec loop i nra1 nra2 =
@@ -108,39 +152,16 @@ let value_descriptions ~loc env name
   | Ok () -> ()
   | Error e -> raise (Dont_match (Zero_alloc e))
   end;
-  begin match mmodes with
-  | All -> begin
-      match Mode.Modality.Value.sub vd1.val_modalities vd2.val_modalities with
-      | Ok () -> ()
-      | Error e -> raise (Dont_match (Modality e))
-      end;
-  | Legacy close_over_coercion ->
-    match Mode.Modality.Value.to_const_opt vd2.val_modalities with
-      (* [wrap_constraint_with_shape] invokes inclusion check with identical
-        inferred modalities, which we need to workaround. *)
-    | None -> ()
-    | Some val2_modalities ->
-      let mmode1, mmode2 =
-        Mode.Value.(disallow_right legacy), Mode.Value.(disallow_left legacy)
-      in
-      let mode1 = Mode.Modality.Value.apply vd1.val_modalities mmode1 in
-      let mode2 = Mode.Modality.Value.(Const.apply val2_modalities mmode2) in
-      let mode1 =
-        match close_over_coercion with
-        | Some held_locks ->
-          (* Cross modes according to RHS type as it tends to be by the user. *)
-          let mode1 = Ctype.cross_left env vd2.val_type mode1 in
-          let mode1 =
-            Env.walk_locks ~env ~item:Value mode1 (Some vd1.val_type) held_locks
-          in
-          mode1.mode
-        | None -> mode1
-      in
-      let mode2 = Ctype.cross_right env vd2.val_type mode2 in
-      begin match Mode.Value.submode mode1 mode2 with
-      | Ok () -> ()
-      | Error e -> raise (Dont_match (Mode e))
-      end
+  let crossing = Ctype.crossing_of_ty env vd2.val_type in
+  let modalities = vd1.val_modalities, vd2.val_modalities in
+  let modes =
+    match child_modes name ~modalities mmodes with
+    | Ok modes -> modes
+    | Error e -> raise (Dont_match (Modality e))
+  in
+  begin match check_modes env ~crossing ~item:Value ~typ:vd1.val_type modes with
+  | Ok () -> ()
+  | Error e -> raise (Dont_match (Mode e))
   end;
   match vd1.val_kind with
   | Val_prim p1 -> begin

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -127,28 +127,34 @@ type type_mismatch =
   | Jkind of Jkind.Violation.t
   | Unsafe_mode_crossing of unsafe_mode_crossing_mismatch
 
+(** Describes the modes of modules on both sides, passed to inclusion check. *)
 type mmodes =
   | All
-  (** Check module inclusion [M1 : MT1 @ m1 <= M2 : MT2 @ m2]
-      for all [m1 <= m2]. *)
-  | Legacy of Env.held_locks option
-  (** Check module inclusion [M1 : MT1 @ legacy <= M2 : MT2 @ legacy].
-    If [M1] is a [Pmod_ident] and the current inclusion check is for its
-    coercion into [M2], we treat all surroudning functions as not closing over
-    [M1], but closing over components in [M1] required by [MT2]. Therefore, the
-    locks for [M1] are held, to be walked by each of the components
-    individually.
+  (** Check module inclusion [M1 : MT1 @ m <= MT2 @ m] for all [m]. *)
+  | Specific of Mode.Value.l * Mode.Value.r * Typedtree.held_locks option
+  (** Check module inclusion [M1 : MT1 @ m1 <= MT2 @ m2].
 
-    This is potentially unsafe as it doesn't reflect the real runtime behavior,
-    for at least two reasons:
-    - The corecion might turn out to be [coercion_none], in which case no
-    coercion happens, and the functions will be closing over the original module.
-    - Even if the coercion happens, the functions will be closing over the
-      original module and projecting needed values out of it.
+    No prior constraint between [m1] and [m2] is given. In particular, it's
+    possible that [m1 >= m2]. For example, if [m1 = nonportable >= portable =
+    m2] and [MT2 = sig end], the inclusion check should pass. This finer
+    treatment is necessary for ergonomics.
 
-    The above concern can be resolved by the "ergonomics" discussion in
-    [typecore.type_ident].
+    Another ergonomics is wrt closing over modules. If [M1] is a [Pmod_ident],
+    all surrounding functions would naively close over [M1]. However, if [M1 =
+    nonportable] and [MT2 = sig end], surrounding functions shouldn't be forced
+    to [nonportable]. To that end, the locks leading to [M1] is not walked
+    immediately upon look-up, but held and passed to inclusion check for finer
+    treatment. This is the third constructor argument.
   *)
+
+(** Gives the modes suitable for the inclusion check of a child item. *)
+val child_modes: string ->
+  ?modalities:(Mode.Modality.Value.t * Mode.Modality.Value.t) ->
+  mmodes -> (mmodes, Mode.Modality.Value.error) Result.t
+
+(** Claim the current item is included by the RHS and its mode checked. *)
+val check_modes : Env.t -> ?crossing:Mode.Crossing.t -> item:Env.lock_item ->
+  ?typ:type_expr -> mmodes -> (unit, Mode.Value.error) Result.t
 
 val value_descriptions:
   loc:Location.t -> Env.t -> string ->
@@ -179,6 +185,9 @@ val report_type_mismatch :
   string -> string -> string ->
   Env.t ->
   Format.formatter -> type_mismatch -> unit
+
+val report_modality_sub_error :
+  string -> string -> Format.formatter -> Mode.Modality.Value.error -> unit
 
 val report_extension_constructor_mismatch :
   string -> string -> string ->

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -27,7 +27,7 @@ type pos =
 
 type modes = Includecore.mmodes =
   | All
-  | Legacy of Env.held_locks option
+  | Specific of Mode.Value.l * Mode.Value.r * held_locks option
 
 module Error = struct
 
@@ -53,6 +53,7 @@ module Error = struct
         (class_type_declaration, Ctype.class_match_failure list) diff
     | Class_declarations of
         (class_declaration, Ctype.class_match_failure list) diff
+    | Modalities of Mode.Modality.Value.error
 
   type core_module_type_symptom =
     | Not_an_alias
@@ -67,7 +68,7 @@ module Error = struct
     | Functor of functor_symptom
     | Invalid_module_alias of Path.t
     | After_alias_expansion of module_type_diff
-
+    | Mode of Mode.Value.error
 
   and module_type_diff = (module_type, module_type_symptom) diff
 
@@ -136,20 +137,86 @@ let mark_positive = function
   | Mark_both | Mark_positive -> true
   | Mark_negative | Mark_neither -> false
 
+
+let modes_unit =
+  Specific (
+    Env.mode_unit |> Mode.Value.disallow_right,
+    Env.mode_unit |> Mode.Value.disallow_left,
+    None
+  )
+
+let modes_toplevel =
+  Specific (
+    Env.mode_unit |> Mode.Value.disallow_right,
+    Env.mode_unit |> Mode.Value.disallow_left,
+    None
+  )
+
+let modes_functor_param mod_mode =
+  let m = Types.functor_param_mode |> Mode.alloc_as_value in
+  let mode, close_over_coercion = mod_mode in
+  Specific (
+    mode,
+    Mode.Value.disallow_left m,
+    close_over_coercion
+  )
+
+let modes_functor_param_legacy =
+  modes_functor_param (Mode.Value.(disallow_right legacy), None)
+
+let modes_functor_res =
+  let m = Types.functor_res_mode |> Mode.alloc_as_value in
+  Specific (
+    Mode.Value.disallow_right m,
+    Mode.Value.disallow_left m,
+    None
+  )
+
+(** The mode crossing of the memory block of a structure. *)
+let mode_crossing_structure_memaddr =
+  Mode.Crossing.of_bounds
+  { monadic = {
+      uniqueness = Unique; (* might support overwriting structure *)
+      contention = Contended
+    };
+    comonadic = {
+      areality = Global;
+      linearity = Many;
+      portability = Portable;
+      yielding = Unyielding;
+  }}
+
+(** The mode crossing of a functor. *)
+let mode_crossing_functor =
+  Mode.Crossing.of_bounds
+  { monadic = {
+      uniqueness = Aliased;
+      contention = Contended
+    };
+    comonadic = {
+      areality = Global;
+      linearity = Once;
+      portability = Nonportable;
+      yielding = Yielding;
+  }}
+
+(** The mode crossing of any module. *)
+let mode_crossing_module =
+  Mode.Crossing.of_bounds
+  { monadic = {
+      uniqueness = Unique;
+      contention = Uncontended;
+    };
+    comonadic = {
+      areality = Global;
+      linearity = Once;
+      portability = Nonportable;
+      yielding = Yielding;
+  }}
+
 (* All functions "blah env x1 x2" check that x1 is included in x2,
    i.e. that x1 is the type of an implementation that fulfills the
    specification x2. If not, Error is raised with a backtrace of the error. *)
-
-let walk_locks ~env ~item = function
-  | All | Legacy None -> ()
-  | Legacy (Some held_locks) ->
-      ignore (Env.walk_locks ~env ~item Mode.Value.(legacy |> disallow_right)
-        None held_locks)
-
-let append_ldot s = function
-  | (All | Legacy None) as t -> t
-  | Legacy (Some (locks, lid, loc)) ->
-      Legacy (Some (locks, Ldot (lid, s), loc))
 
 (* Inclusion between value descriptions *)
 
@@ -197,7 +264,11 @@ let class_type_declarations ~loc env subst decl1 decl2 =
   | reason ->
       Error Error.(Core(Class_type_declarations(diff decl1 decl2 reason)))
 
-let class_declarations env subst decl1 decl2 =
+let class_declarations env subst id ~mmodes decl1 decl2 =
+  let modes =
+    Includecore.child_modes (Ident.name id) mmodes |> Result.get_ok
+  in
+  Includecore.check_modes env ~item:Class modes |> Result.get_ok;
   let decl2 = Subst.class_declaration subst decl2 in
   match Includeclass.class_declarations env decl1 decl2 with
     []     -> Ok Tcoerce_none
@@ -541,8 +612,12 @@ and try_modtypes ~in_eq ~loc env ~mark subst ~modes mty1 mty2 orig_shape =
   in
   match mty1, mty2 with
   | _ when shallow_modtypes env subst mty1 mty2 ->
-    walk_locks ~env ~item:Module modes;
+    begin match Includecore.check_modes env ~item:Module
+      ~crossing:mode_crossing_module modes with
+    | Error e -> Error (Error.Mode e)
+    | Ok () ->
     Ok (Tcoerce_none, orig_shape)
+    end
 
   | (Mty_alias p1, _) when not (is_alias mty2) -> begin
     match
@@ -564,15 +639,24 @@ and try_modtypes ~in_eq ~loc env ~mark subst ~modes mty1 mty2 orig_shape =
         end
     end
   | (Mty_signature sig1, Mty_signature sig2) ->
+      begin match Includecore.check_modes env ~item:Module
+        ~crossing:mode_crossing_structure_memaddr modes with
+      | Error e -> Error (Error.Mode e)
+      | Ok () ->
       begin match
         signatures ~in_eq ~loc env ~mark subst ~modes sig1 sig2 orig_shape
       with
       | Ok _ as ok -> ok
       | Error e -> Error (Error.Signature e)
       end
+      end
 
   | Mty_functor (param1, res1), Mty_functor (param2, res2) ->
-      walk_locks ~env ~item:Module modes;
+      begin match
+        Includecore.check_modes env ~item:Module ~crossing:mode_crossing_functor
+        modes with
+      | Error e -> Error (Error.Mode e)
+      | Ok () ->
       let cc_arg, env, subst =
         functor_param ~in_eq ~loc env ~mark:(negate_mark mark)
           subst param1 param2
@@ -593,7 +677,7 @@ and try_modtypes ~in_eq ~loc env ~mark subst ~modes mty1 mty2 orig_shape =
       in
       let cc_res =
         modtypes ~in_eq ~loc env ~mark subst res1 res2 res_shape
-          ~modes:(Legacy None)
+          ~modes:modes_functor_res
       in
       begin match cc_arg, cc_res with
       | Ok Tcoerce_none, Ok (Tcoerce_none, final_res_shape) ->
@@ -632,6 +716,7 @@ and try_modtypes ~in_eq ~loc env ~mark subst ~modes mty1 mty2 orig_shape =
           Error Error.(Functor (Params d))
       | Ok _, Error res ->
           Error Error.(Functor (Result res))
+      end
       end
 
   | _ ->
@@ -692,7 +777,7 @@ and functor_param ~in_eq ~loc env ~mark subst param1 param2 =
       let cc_arg =
         match
           modtypes ~in_eq ~loc env ~mark Subst.identity arg2' arg1
-                Shape.dummy_mod ~modes:(Legacy None)
+                Shape.dummy_mod ~modes:modes_functor_param_legacy
         with
         | Ok (cc, _) -> Ok cc
         | Error err -> Error (Error.Mismatch err)
@@ -799,7 +884,6 @@ and signature_components :
       let id, item, shape_map, present_at_runtime =
         match sigi1, sigi2 with
         | Sig_value(id1, valdecl1, _) ,Sig_value(_id2, valdecl2, _) ->
-            let mmodes = append_ldot (Ident.name id1) mmodes in
             let item =
               value_descriptions ~loc env ~mark subst id1 ~mmodes
                 (Subst.Lazy.force_value_description valdecl1)
@@ -832,7 +916,6 @@ and signature_components :
             id1, item, shape_map, true
         | Sig_module(id1, pres1, mty1, _, _), Sig_module(_, pres2, mty2, _, _)
           -> begin
-              let mmodes = append_ldot (Ident.name id1) mmodes in
               let orig_shape =
                 Shape.(proj orig_shape (Item.module_ id1))
               in
@@ -847,7 +930,7 @@ and signature_components :
                     let mod_shape = Shape.set_uid_if_none shape mty1.md_uid in
                     Ok cc, Shape.Map.add_module shape_map id1 mod_shape
                 | Error diff ->
-                    Error (Error.Module_type diff),
+                    Error diff,
                     (* We add the original shape to the map, even though
                        there is a type error.
                        It could still be useful for merlin. *)
@@ -874,9 +957,8 @@ and signature_components :
             let item = mark_error_as_unrecoverable item in
             id1, item, shape_map, false
         | Sig_class(id1, decl1, _, _), Sig_class(_id2, decl2, _, _) ->
-            walk_locks ~env ~item:Class (append_ldot (Ident.name id1) mmodes);
             let item =
-              class_declarations env subst decl1 decl2
+              class_declarations env subst id1 ~mmodes decl1 decl2
             in
             let shape_map =
               Shape.Map.add_class_proj shape_map id1 orig_shape
@@ -937,9 +1019,13 @@ and module_declarations  ~in_eq ~loc env ~mark  subst id1 ~mmodes md1 md2 orig_s
   let p1 = Path.Pident id1 in
   if mark_positive mark then
     Env.mark_module_used md1.md_uid;
-  let modes = mmodes in
-  strengthened_modtypes  ~in_eq ~loc ~aliasable:true env ~mark subst ~modes
-    md1.md_type p1 md2.md_type orig_shape
+  let modalities = md1.md_modalities, md2.md_modalities in
+  match Includecore.child_modes (Ident.name id1) ~modalities mmodes with
+  | Error e -> Error Error.(Core (Modalities e))
+  | Ok modes ->
+      Result.map_error (fun x -> Error.Module_type x)
+        (strengthened_modtypes  ~in_eq ~loc ~aliasable:true env ~mark subst ~modes
+          md1.md_type p1 md2.md_type orig_shape)
 
 (* Inclusion between module type specifications *)
 
@@ -1001,7 +1087,7 @@ let include_functor_signatures ~loc env ~mark subst sig1 sig2 mod_shape =
   let _, _, comps1 = build_component_table (fun _pos name -> name) sig1 in
   let paired, unpaired, subst = pair_components subst comps1 sig2 in
   let d = signature_components ~in_eq:false ~loc ~mark env subst mod_shape
-            Shape.Map.empty ~mmodes:(Legacy None)
+            Shape.Map.empty ~mmodes:modes_functor_param_legacy
             (List.rev paired)
   in
   let open Sign_diff in
@@ -1050,31 +1136,34 @@ exception Apply_error of {
     env : Env.t ;
     app_name : application_name ;
     mty_f : module_type ;
-    args : (Error.functor_arg_descr * module_type) list ;
+    args : (Error.functor_arg_descr * module_type * Typedtree.mode_with_locks) list ;
   }
 
-let check_modtype_inclusion_raw ~loc env mty1 path1 mty2 =
+let check_functor_application_raw ~loc env mty1 path1 mty2 =
   let aliasable = can_alias env path1 in
   strengthened_modtypes ~in_eq:false ~loc ~aliasable env ~mark:Mark_both
-    Subst.identity ~modes:(Legacy None) mty1 path1 mty2 Shape.dummy_mod
+    Subst.identity ~modes:modes_functor_param_legacy mty1 path1 mty2 Shape.dummy_mod
   |> Result.map fst
 
-let check_modtype_inclusion ~loc env mty1 path1 mty2 =
-  match check_modtype_inclusion_raw ~loc env mty1 path1 mty2 with
+let check_functor_application ~loc env mty1 path1 mty2 =
+  match check_functor_application_raw ~loc env mty1 path1 mty2 with
   | Ok _ -> None
   | Error e -> Some (env, Error.In_Module_type e)
 
 let check_functor_application_in_path
     ~errors ~loc ~lid_whole_app ~f0_path ~args
     ~arg_path ~arg_mty ~param_mty env =
-  match check_modtype_inclusion_raw ~loc env arg_mty arg_path param_mty with
+  match check_functor_application_raw ~loc env arg_mty arg_path param_mty with
   | Ok _ -> ()
   | Error _errs ->
       if errors then
         let prepare_arg (arg_path, arg_mty) =
           let aliasable = can_alias env arg_path in
           let smd = Mtype.strengthen ~aliasable arg_mty arg_path in
-          (Error.Named arg_path, smd)
+          (* The current function is used for type checking F(M).t, which does
+          not involve modes, so we fill in the strongest modes such that error
+          messages would not mention modes. *)
+          (Error.Named arg_path, smd, Typedtree.min_mode_with_locks)
         in
         let mty_f = (Env.find_module f0_path env).md_type in
         let args = List.map prepare_arg args in
@@ -1094,7 +1183,7 @@ let compunit0
     ~comparison env ~mark impl_name impl_sig intf_name intf_sig unit_shape =
   match
     signatures ~in_eq:false ~loc:(Location.in_file impl_name) env ~mark
-      Subst.identity ~modes:(Legacy None) impl_sig intf_sig unit_shape
+      Subst.identity ~modes:modes_unit impl_sig intf_sig unit_shape
   with Result.Error reasons ->
     let diff = Error.diff impl_name intf_name reasons in
     let cdiff =
@@ -1234,7 +1323,7 @@ end
 module Functor_app_diff = struct
   module I = Functor_inclusion_diff
   module Defs= struct
-    type left = Error.functor_arg_descr * Types.module_type
+    type left = Error.functor_arg_descr * Types.module_type * Typedtree.mode_with_locks
     type right = Types.functor_parameter
     type eq = Typedtree.module_coercion
     type diff = (Error.functor_arg_descr, unit) Error.functor_param_symptom
@@ -1250,7 +1339,7 @@ module Functor_app_diff = struct
         (* We assign a small penalty to named arguments with
            non-matching names *)
         begin
-          let desc1 : Error.functor_arg_descr = fst param1 in
+          let (desc1 : Error.functor_arg_descr), _, _ = param1 in
           match desc1, I.param_name param2 with
           | (Unit | Empty_struct | Anonymous) , None
             -> 0
@@ -1266,7 +1355,7 @@ module Functor_app_diff = struct
     match d with
     | Insert (Unit|Named(None,_))
     | Delete _ (* delete is a concrete argument, not an abstract parameter*)
-    | Keep ((Unit,_),_,_) (* Keep(Unit,_) implies Keep(Unit,Unit) *)
+    | Keep ((Unit,_,_),_,_) (* Keep(Unit,_) implies Keep(Unit,Unit) *)
     | Keep (_,(Unit|Named(None,_)),_)
     | Change (_,(Unit|Named (None,_)), _ ) ->
         (* no abstract parameters to add, nor any equations *)
@@ -1279,7 +1368,7 @@ module Functor_app_diff = struct
         let mty = Subst.modtype Keep st.subst param_ty in
         let env = Env.add_module ~arg:true param Mp_present mty st.env in
         I.expand_params { st with env }
-    | Keep ((Named arg,  _mty) , Named (Some param, _param), _) ->
+    | Keep ((Named arg,  _mty, _mode) , Named (Some param, _param), _) ->
         let res =
           Option.map (fun res ->
               let scope = Ctype.create_scope () in
@@ -1290,7 +1379,7 @@ module Functor_app_diff = struct
         in
         let subst = Subst.add_module param arg st.subst in
         I.expand_params { st with subst; res }
-    | Keep (((Anonymous|Empty_struct), mty),
+    | Keep (((Anonymous|Empty_struct), mty, _mode),
             Named (Some param, _param), _) ->
         let mty' = Subst.modtype Keep st.subst mty in
         let env = Env.add_module ~arg:true param Mp_present mty' st.env in
@@ -1301,7 +1390,7 @@ module Functor_app_diff = struct
     let params, res = retrieve_functor_params env f in
     let module Compute = Diff.Right_variadic(struct
         let update = update
-        let test (state:Defs.state) (arg,arg_mty) param =
+        let test (state:Defs.state) (arg,arg_mty,arg_mode) param =
           let loc = Location.none in
           let res = match (arg:Error.functor_arg_descr), param with
             | (Unit|Empty_struct), Unit -> Ok Tcoerce_none
@@ -1310,7 +1399,7 @@ module Functor_app_diff = struct
             | ( Anonymous | Named _ | Empty_struct ), Named (_, param) ->
                 match
                   modtypes ~in_eq:false ~loc state.env ~mark:Mark_neither
-                    state.subst ~modes:(Legacy None) arg_mty param
+                    state.subst ~modes:(modes_functor_param arg_mode) arg_mty param
                     Shape.dummy_mod
                 with
                 | Error mty -> Result.Error (Error.Mismatch mty)

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -59,6 +59,7 @@ module Error: sig
         (Types.class_type_declaration, Ctype.class_match_failure list) diff
     | Class_declarations of
         (Types.class_declaration, Ctype.class_match_failure list) diff
+    | Modalities of Mode.Modality.Value.error
 
   type core_module_type_symptom =
     | Not_an_alias
@@ -73,7 +74,7 @@ module Error: sig
     | Functor of functor_symptom
     | Invalid_module_alias of Path.t
     | After_alias_expansion of module_type_diff
-
+    | Mode of Mode.Value.error
 
   and module_type_diff = (Types.module_type, module_type_symptom) diff
 
@@ -152,6 +153,20 @@ val is_runtime_component: Types.signature_item -> bool
 
 type modes = Includecore.mmodes
 
+(** The modes used for compilation unit inclusion check *)
+val modes_unit : modes
+
+(** The modes used for top-level inclusion check, where top-level is similiar to
+  a structure *)
+val modes_toplevel : modes
+
+(** Takes the mode of functor argument, returns the [modes] suitable for
+  modal inclusion check against the parameter. *)
+val modes_functor_param : Typedtree.mode_with_locks -> modes
+
+(** The modes used for functor result inclusion check *)
+val modes_functor_res : modes
+
 (* Typechecking *)
 
 val modtypes:
@@ -166,10 +181,10 @@ val strengthened_module_decl:
   loc:Location.t -> aliasable:bool -> Env.t -> mark:mark -> mmodes:modes ->
   module_declaration -> Path.t -> module_declaration -> module_coercion
 
-val check_modtype_inclusion :
+val check_functor_application :
   loc:Location.t -> Env.t -> Types.module_type -> Path.t -> Types.module_type ->
   explanation option
-(** [check_modtype_inclusion ~loc env mty1 path1 mty2] checks that the
+(** [check_functor_application ~loc env mty1 path1 mty2] checks that the
     functor application F(M) is well typed, where mty2 is the type of
     the argument of F and path1/mty1 is the path/unstrenghened type of M. *)
 
@@ -213,7 +228,8 @@ exception Apply_error of {
     env : Env.t ;
     app_name : application_name ;
     mty_f : module_type ;
-    args : (Error.functor_arg_descr * Types.module_type)  list ;
+    args : (Error.functor_arg_descr * Types.module_type *
+      Typedtree.mode_with_locks)  list ;
   }
 
 val expand_module_alias: strengthen:bool -> Env.t -> Path.t -> Types.module_type
@@ -234,7 +250,8 @@ end
 
 module Functor_app_diff: sig
   module Defs: sig
-    type left = Error.functor_arg_descr * Types.module_type
+    type left = Error.functor_arg_descr * Types.module_type *
+      Typedtree.mode_with_locks
     type right = Types.functor_parameter
     type eq = Typedtree.module_coercion
     type diff = (Error.functor_arg_descr, unit) Error.functor_param_symptom
@@ -243,6 +260,7 @@ module Functor_app_diff: sig
   val diff:
     Env.t ->
     f:Types.module_type ->
-    args:(Error.functor_arg_descr * Types.module_type) list ->
+    args:(Error.functor_arg_descr * Types.module_type *
+      Typedtree.mode_with_locks) list ->
     Diffing.Define(Defs).patch
 end

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -331,7 +331,8 @@ module With_shorthand = struct
           (Ident.name p) (pp dmodtype short_mty)
 
   let definition_of_argument ua =
-    let arg, mty = ua.item in
+    let arg, mty, _mode = ua.item in
+    (* CR zqian: print the mode *)
     match (arg: Err.functor_arg_descr) with
     | Unit -> Format.dprintf "()"
     | Empty_struct -> Format.dprintf "(struct end)"
@@ -354,7 +355,8 @@ module With_shorthand = struct
         end
 
   let arg ua =
-    let arg, mty = ua.item in
+    let arg, mty, _mode = ua.item in
+    (* CR zqian: print the mode *)
     match (arg: Err.functor_arg_descr) with
     | Unit -> Format.dprintf "()"
     | Empty_struct -> Format.dprintf "(struct end)"
@@ -502,7 +504,8 @@ module Functor_suberror = struct
         for single change difference
     *)
     let single_diff g e more =
-      let _arg, mty = g.With_shorthand.item in
+      let _arg, mty, _mode = g.With_shorthand.item in
+      (* CR zqian: also print the mode *)
       let e = match e.With_shorthand.item with
         | Types.Unit -> Format.dprintf "()"
         | Types.Named(_, mty) -> dmodtype mty
@@ -615,6 +618,11 @@ let core env id x =
            "the first" "the second" env) diff.symptom
         show_locs (diff.got.val_loc, diff.expected.val_loc)
         Printtyp.Conflicts.print_explanations
+  | Err.Modalities e ->
+      Format.dprintf "@[<v>@[<hv>%s:@;%a@]@]"
+        "Modalities do not match"
+        (Includecore.report_modality_sub_error
+            "the first" "the second") e
   | Err.Type_declarations diff ->
       Format.dprintf "@[<v>@[<hv>%s:@;<1 2>%a@ %s@;<1 2>%a@]%a%a%t@]"
         "Type declarations do not match"
@@ -715,6 +723,11 @@ let core_module_type_symptom (x:Err.core_module_type_symptom)  =
              (Style.as_inline_code Printtyp.path) path
           )
 
+let mode_mismatch (Mode.Value.Error(ax, {left; right})) =
+  Format.dprintf "%a is not included in %a"
+    (Mode.Value.Const.print_axis ax) left
+    (Mode.Value.Const.print_axis ax) right
+
 (* Construct a linearized error message from the error tree *)
 
 let rec module_type ~expansion_token ~eqmode ~env ~before ~ctx diff =
@@ -757,6 +770,7 @@ and module_type_symptom ~eqmode ~expansion_token ~env ~before ~ctx = function
           (Style.as_inline_code Printtyp.path) path
       in
       dwith_context ctx printer :: before
+  | Mode e -> dwith_context ctx (mode_mismatch e) :: before
 
 and functor_params ~expansion_token ~env ~before ~ctx {got;expected;_} =
   let d = Functor_suberror.Inclusion.patch env got expected in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3064,6 +3064,10 @@ module Crossing = struct
 
     let le (t0 : t) (t1 : t) =
       match t0, t1 with Join_const c0, Join_const c1 -> Mode.Const.le c1 c0
+
+    let top : t = Join_const Mode.Const.min
+
+    let bot : t = Join_const Mode.Const.max
   end
 
   module Comonadic = struct
@@ -3089,6 +3093,10 @@ module Crossing = struct
 
     let le (t0 : t) (t1 : t) =
       match t0, t1 with Meet_const c0, Meet_const c1 -> Mode.Const.le c0 c1
+
+    let top : t = Meet_const Mode.Const.max
+
+    let bot : t = Meet_const Mode.Const.min
   end
 
   type t = (Monadic.t, Comonadic.t) monadic_comonadic
@@ -3144,6 +3152,10 @@ module Crossing = struct
 
   let le t0 t1 =
     Monadic.le t0.monadic t1.monadic && Comonadic.le t0.comonadic t1.comonadic
+
+  let top = { monadic = Monadic.top; comonadic = Comonadic.top }
+
+  let bot = { monadic = Monadic.bot; comonadic = Comonadic.bot }
 
   let print ppf t =
     let print_atom ppf = function

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -659,8 +659,9 @@ module type S = sig
             abitrary zappings of some [m], even after further mutations to [m].
             Essentially that means [c0 = c1].
 
-         NB: zapping an inferred modality will zap both [md_mode] and [mode] that
-         it contains. The caller is reponsible for correct zapping order.
+         NB: zapping an inferred modality will mutate both [md_mode] and [mode]
+         to the degree sufficient to fix the modality, but the modes could
+         remain unfixed.
       *)
 
       (** Zap an inferred modality towards identity modality. *)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -734,6 +734,12 @@ module type S = sig
     (** [le t0 t1] returns [true] if [t0] allows more mode crossing than [t1]. *)
     val le : t -> t -> bool
 
+    (** The trivial mode crossing that crosses nothing. *)
+    val top : t
+
+    (** The mode crossing that crosses everything. *)
+    val bot : t
+
     (** Print the mode crossing by axis. Omit axes that do not cross. *)
     val print : Format.formatter -> t -> unit
   end

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -943,14 +943,16 @@ and print_out_sig_item ppf =
       fprintf ppf "@[<2>module type %s@]" name
   | Osig_modtype (name, mty) ->
       fprintf ppf "@[<2>module type %s =@ %a@]" name !out_module_type mty
-  | Osig_module (name, Omty_alias id, _) ->
-      fprintf ppf "@[<2>module %s =@ %a@]" name print_ident id
-  | Osig_module (name, mty, rs) ->
-      fprintf ppf "@[<2>%s %s :@ %a@]"
+  | Osig_module (name, Omty_alias id, moda, _) ->
+      fprintf ppf "@[<2>module %s =@ %a%a@]" name print_ident id
+        print_out_modalities_new moda
+  | Osig_module (name, mty, moda, rs) ->
+      fprintf ppf "@[<2>%s %s :@ %a%a@]"
         (match rs with Orec_not -> "module"
                      | Orec_first -> "module rec"
                      | Orec_next -> "and")
         name !out_module_type mty
+        print_out_modalities_new moda
   | Osig_type(td, rs) ->
         print_out_type_decl
           (match rs with

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -191,7 +191,7 @@ and out_sig_item =
         out_rec_status
   | Osig_typext of out_extension_constructor * out_ext_status
   | Osig_modtype of string * out_module_type
-  | Osig_module of string * out_module_type * out_rec_status
+  | Osig_module of string * out_module_type * out_modality_new list * out_rec_status
   | Osig_type of out_type_decl * out_rec_status
   | Osig_value of out_val_decl
   | Osig_ellipsis

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2597,7 +2597,7 @@ and tree_of_functor_parameter ?abbrev = function
         | None -> None, fun env -> env
         | Some id ->
             Some (Ident.name id),
-            Env.add_module ~arg:true id Mp_present ty_arg
+            fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
       Some (name, tree_of_modtype ?abbrev ty_arg), env
 
@@ -2676,7 +2676,7 @@ and tree_of_sigitem ?abbrev = function
           then Some (Abbrev.ellipsis ())
           else abbrev
       in
-      tree_of_module ?abbrev id md.md_type rs
+      tree_of_module ?abbrev id md rs
   | Sig_modtype(id, decl, _) ->
       tree_of_modtype_declaration ?abbrev id decl
   | Sig_class(id, decl, rs, _) ->
@@ -2692,8 +2692,16 @@ and tree_of_modtype_declaration ?abbrev id decl =
   in
   Osig_modtype (Ident.name id, mty)
 
-and tree_of_module ?abbrev id mty rs =
-  Osig_module (Ident.name id, tree_of_modtype ?abbrev mty, tree_of_rec rs)
+and tree_of_module ?abbrev id md rs =
+  let snap = Btype.snapshot () in
+  let moda = Mode.Modality.Value.zap_to_id md.md_modalities in
+  let r =
+    Osig_module (Ident.name id, tree_of_modtype ?abbrev md.md_type,
+    tree_of_modalities_new Immutable md.md_attributes moda,
+    tree_of_rec rs)
+  in
+  Btype.backtrack snap;
+  r
 
 let rec functor_parameters ~sep custom_printer = function
   | [] -> ignore

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -174,7 +174,7 @@ val extension_only_constructor:
 *)
 
 val tree_of_module:
-    Ident.t -> ?ellipsis:bool -> module_type -> rec_status -> out_sig_item
+    Ident.t -> ?ellipsis:bool -> module_declaration -> rec_status -> out_sig_item
 val modtype: formatter -> module_type -> unit
 val signature: formatter -> signature -> unit
 val tree_of_modtype: ?abbrev:bool -> module_type -> out_module_type

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -868,6 +868,7 @@ let rec subst_lazy_value_description s descr =
 and subst_lazy_module_decl scoping s md =
   let md_type = subst_lazy_modtype scoping s md.md_type in
   { md_type;
+    md_modalities = md.md_modalities;
     md_attributes = attrs s md.md_attributes;
     md_loc = loc s md.md_loc;
     md_uid = md.md_uid }

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -930,27 +930,9 @@ let has_poly_constraint spat =
     end
   | _ -> false
 
-(** Cross a left mode according to a type wrapped in modalities. *)
-let mode_cross_left_value env ty ?modalities mode =
-  if not (is_principal ty) then
-    Value.disallow_right mode
-  else begin
-    let jkind = type_jkind_purely env ty in
-    let jkind_of_type = type_jkind_purely_if_principal env in
-    let crossing = Jkind.get_mode_crossing ~jkind_of_type jkind in
-    let crossing =
-      match modalities with
-      | None -> crossing
-      | Some m -> Crossing.modality m crossing
-    in
-    mode
-    |> Value.disallow_right
-    |> Crossing.apply_left crossing
-  end
-
 let actual_mode_cross_left env ty (actual_mode : Env.actual_mode)
   : Env.actual_mode =
-  let mode = mode_cross_left_value env ty actual_mode.mode in
+  let mode = cross_left env ty actual_mode.mode in
   {actual_mode with mode}
 
 (** Mode cross a mode whose monadic fragment is a right mode, and whose comonadic
@@ -958,24 +940,19 @@ let actual_mode_cross_left env ty (actual_mode : Env.actual_mode)
 let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
   let monadic = Alloc.Monadic.disallow_left monadic in
   let comonadic = Alloc.Comonadic.disallow_right comonadic in
-  if not (is_principal ty) then { monadic; comonadic } else
-  let jkind = type_jkind_purely env ty in
-  let jkind_of_type = type_jkind_purely_if_principal env in
-  let crossing = Jkind.get_mode_crossing ~jkind_of_type jkind in
+  let crossing = crossing_of_ty env ty in
   Crossing.apply_left_right_alloc crossing { monadic; comonadic }
 
 (** Mode cross a right mode *)
 (* This is very similar to Ctype.mode_cross_right. Any bugs here are likely bugs
    there, too. *)
 let expect_mode_cross_jkind env jkind (expected_mode : expected_mode) =
-  let jkind_of_type = type_jkind_purely_if_principal env in
-  let crossing = Jkind.get_mode_crossing ~jkind_of_type jkind in
+  let crossing = crossing_of_jkind env jkind in
   mode_morph (Crossing.apply_right crossing) expected_mode
 
 let expect_mode_cross env ty (expected_mode : expected_mode) =
-  if not (is_principal ty) then expected_mode else
-  let jkind = type_jkind_purely env ty in
-  expect_mode_cross_jkind env jkind expected_mode
+  let crossing = crossing_of_ty env ty in
+  mode_morph (Crossing.apply_right crossing) expected_mode
 
 (** The expected mode for objects *)
 let mode_object = expect_mode_cross_jkind Env.empty Jkind.for_object mode_legacy
@@ -1018,7 +995,7 @@ let check_construct_mutability ~loc ~env mutability ty ?modalities block_mode =
   | Immutable -> ()
   | Mutable m0 ->
       let m0 = mutable_mode m0 in
-      let m0 = mode_cross_left_value env ty ?modalities m0 in
+      let m0 = cross_left env ty ?modalities m0 in
       submode ~loc ~env m0 block_mode
 
 (** The [expected_mode] of the record when projecting a mutable field. *)
@@ -2815,7 +2792,7 @@ and type_pat_aux
   | Ppat_var name ->
       let ty = instance expected_ty in
       let alloc_mode =
-        mode_cross_left_value !!penv expected_ty alloc_mode.mode
+        cross_left !!penv expected_ty alloc_mode.mode
       in
       let id, uid =
         enter_variable tps loc name alloc_mode ty sp.ppat_attributes
@@ -2858,7 +2835,7 @@ and type_pat_aux
   | Ppat_alias(sq, name) ->
       let q = type_pat tps Value sq expected_ty in
       let ty_var, mode = solve_Ppat_alias ~mode:alloc_mode.mode !!penv q in
-      let mode = mode_cross_left_value !!penv expected_ty mode in
+      let mode = cross_left !!penv expected_ty mode in
       let id, uid =
         enter_variable ~is_as_variable:true tps name.loc name mode ty_var
           sp.ppat_attributes
@@ -6052,14 +6029,14 @@ and type_expect_
         match is_float_boxing with
         | true ->
           let alloc_mode, argument_mode = register_allocation expected_mode in
-          let mode = mode_cross_left_value env Predef.type_unboxed_float mode in
+          let mode = cross_left env Predef.type_unboxed_float mode in
           submode ~loc ~env mode argument_mode;
           let uu =
             unique_use ~loc ~env mode (as_single_mode argument_mode)
           in
           Boxing (alloc_mode, uu)
         | false ->
-          let mode = mode_cross_left_value env ty_arg mode in
+          let mode = cross_left env ty_arg mode in
           submode ~loc ~env mode expected_mode;
           let uu = unique_use ~loc ~env mode (as_single_mode expected_mode) in
           Non_boxing uu
@@ -6098,7 +6075,7 @@ and type_expect_
             (Error (loc, env, Record_projection_not_rep(record.exp_type, err)))
       in
       let mode = Modality.Value.Const.apply label.lbl_modalities rmode in
-      let mode = mode_cross_left_value env ty_arg mode in
+      let mode = cross_left env ty_arg mode in
       submode ~loc ~env mode expected_mode;
       let uu = unique_use ~loc ~env mode (as_single_mode expected_mode) in
       rue {
@@ -7054,7 +7031,7 @@ and type_ident env ?(recarg=Rejected) lid =
 
   Therefore, we need to cross modes upon look-up. Ideally that should be done in
   [Env], but that is difficult due to cyclic dependency between jkind and env. *)
-  let mode = mode_cross_left_value env desc.val_type mode in
+  let mode = cross_left env desc.val_type mode in
   (* There can be locks between the definition and a use of a value. For
   example, if a function closes over a value, there will be Closure_lock between
   the value's definition and the value's use in the function. Walking the locks
@@ -7525,7 +7502,7 @@ and type_label_access
   let label =
     wrap_disambiguate "This expression has" (mk_expected ty_exp)
       (label_disambiguate record_form usage lid env expected_type) labels in
-  (record, mode, label, expected_type)
+  (record, Mode.Value.disallow_right mode, label, expected_type)
 
 (* Typing format strings for printing or reading.
    These formats are used by functions in modules Printf, Format, and Scanf.
@@ -8191,15 +8168,16 @@ and type_application env app_loc expected_mode position_and_mode
           filter_arrow_mono env (instance funct.exp_type) Nolabel
         ) ~post:(fun {ty_ret; _} -> generalize_structure ty_ret)
       in
+      let ret_mode = Alloc.disallow_right ret_mode in
       let type_sort ~why ty =
         match Ctype.type_sort ~why ~fixed:false env ty with
         | Ok sort -> sort
         | Error err -> raise (Error (app_loc, env, Function_type_not_rep (ty, err)))
       in
       let arg_sort = type_sort ~why:Function_argument ty_arg in
-      let ap_mode = Locality.disallow_right (Alloc.proj (Comonadic Areality) ret_mode) in
+      let ap_mode = Alloc.proj (Comonadic Areality) ret_mode in
       let mode_res =
-        mode_cross_left_value env ty_ret (alloc_as_value ret_mode)
+        cross_left env ty_ret (alloc_as_value ret_mode)
       in
       submode ~loc:app_loc ~env ~reason:Other
         mode_res expected_mode;
@@ -8256,9 +8234,10 @@ and type_application env app_loc expected_mode position_and_mode
           ty_ret, mode_ret, args, position_and_mode
         end ~post:(fun (ty_ret, _, _, _) -> generalize_structure ty_ret)
       in
-      let ap_mode = Locality.disallow_right (Alloc.proj (Comonadic Areality) mode_ret) in
+      let mode_ret = Alloc.disallow_right mode_ret in
+      let ap_mode = Alloc.proj (Comonadic Areality) mode_ret in
       let mode_ret =
-        mode_cross_left_value env ty_ret (alloc_as_value mode_ret)
+        cross_left env ty_ret (alloc_as_value mode_ret)
       in
       submode ~loc:app_loc ~env ~reason:(Application ty_ret)
         mode_ret expected_mode;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -300,8 +300,7 @@ let error_of_filter_arrow_failure ~explanation ~first ty_fun
 
 let type_module =
   ref ((fun _env _md -> assert false) :
-       Env.t -> Parsetree.module_expr -> Typedtree.module_expr * Shape.t *
-        Env.locks)
+       Env.t -> Parsetree.module_expr -> Typedtree.module_expr * Shape.t)
 
 (* Forward declaration, to be filled in by Typemod.type_open *)
 
@@ -1259,7 +1258,7 @@ let add_module_variables env module_variables =
          Here, on the other hand, we're calling [type_module] outside the
          raised level, so there's no extra step to take.
       *)
-      let modl, md_shape, locks =
+      let modl, md_shape =
         !type_module env
           Ast_helper.(
             Mod.unpack ~loc:mv_loc
@@ -1274,12 +1273,14 @@ let add_module_variables env module_variables =
       in
       let md =
         { md_type = modl.mod_type; md_attributes = [];
+          md_modalities = Mode.Modality.Value.id;
           md_loc = mv_name.loc;
           md_uid = mv_uid; }
       in
+      let mode = Typedtree.mode_without_locks_exn modl.mod_mode in
       Env.add_module_declaration ~shape:md_shape ~check:true mv_id pres md
         (* the [locks] is always empty, but typecore doesn't need to know *)
-        ~locks env
+        ~mode env
     end
   ) env module_variables_as_list
 
@@ -1299,7 +1300,6 @@ let enter_variable ?(is_module=false) ?(is_as_variable=false) tps loc name mode
       | Modvars_rejected ->
           raise (Error (loc, Env.empty, Modules_not_allowed));
       | Modvars_allowed { scope; module_variables } ->
-          escape ~loc ~env:Env.empty ~reason:Other mode;
           let id = Ident.create_scoped name.txt ~scope in
           let module_variables =
             { mv_id = id;
@@ -6396,7 +6396,7 @@ and type_expect_
         with_local_level begin fun () ->
           let modl, pres, id, new_env =
             Typetexp.TyVarEnv.with_local_scope begin fun () ->
-              let modl, md_shape, locks = !type_module env smodl in
+              let modl, md_shape = !type_module env smodl in
               Mtype.lower_nongen lv modl.mod_type;
               let pres =
                 match modl.mod_type with
@@ -6408,16 +6408,19 @@ and type_expect_
               let md_shape = Shape.set_uid_if_none md_shape md_uid in
               let md =
                 { md_type = modl.mod_type; md_attributes = [];
+                  md_modalities = Modality.Value.id;
                   md_loc = name.loc;
                   md_uid; }
               in
+              let mode, locks = modl.mod_mode in
+              let locks = Option.map (fun (a, _, _) -> a) locks in
               let (id, new_env) =
                 match name.txt with
                 | None -> None, env
                 | Some name ->
                     let id, env =
                       Env.enter_module_declaration
-                        ~scope ~shape:md_shape name pres md ~locks env
+                        ~scope ~shape:md_shape name pres md ~mode ?locks env
                     in
                     Some id, env
               in
@@ -6559,8 +6562,6 @@ and type_expect_
     type_newtype_expr ~loc ~env ~expected_mode ~rue ~attributes:sexp.pexp_attributes
       name jkind sbody
   | Pexp_pack m ->
-      (* CR zqian: pass [expected_mode] to [type_package] *)
-      submode ~loc ~env Value.legacy expected_mode;
       let (p, fl) =
         match get_desc (Ctype.expand_head env (instance ty_expected)) with
           Tpackage (p, fl) ->
@@ -6578,6 +6579,8 @@ and type_expect_
             raise (Error (loc, env, Not_a_packed_module ty_expected))
       in
       let (modl, fl') = !type_package env m p fl in
+      let mode = Typedtree.mode_without_locks_exn modl.mod_mode in
+      submode ~loc ~env mode expected_mode;
       rue {
         exp_desc = Texp_pack modl;
         exp_loc = loc; exp_extra = [];
@@ -7021,7 +7024,7 @@ and type_constraint_expect
   ret, ty, exp_extra
 
 and type_ident env ?(recarg=Rejected) lid =
-  let path, desc, mode, locks = Env.lookup_value ~loc:lid.loc lid.txt env in
+  let path, desc, (mode, locks) = Env.lookup_value ~loc:lid.loc lid.txt env in
   (* We cross modes when typing [Ppat_ident], before adding new variables into
   the environment. Therefore, one might think all values in the environment are
   already mode-crossed. That is not true for several reasons:
@@ -7058,8 +7061,8 @@ and type_ident env ?(recarg=Rejected) lid =
   *)
   (* CR modes: codify the above per-axis argument. *)
   let actual_mode =
-    Env.walk_locks ~env ~item:Value mode (Some desc.val_type)
-      (locks, lid.txt, lid.loc)
+    Env.walk_locks ~env ~loc:lid.loc lid.txt ~item:Value (Some desc.val_type)
+      (mode, locks)
   in
   (* We need to cross again, because the monadic fragment might have been
   weakened by the locks. Ideally, the first crossing only deals with comonadic,
@@ -9973,7 +9976,7 @@ let type_expression env jkind sexp =
       Pexp_ident lid ->
         let loc = sexp.pexp_loc in
         (* Special case for keeping type variables when looking-up a variable *)
-        let (_path, desc, _, _) =
+        let (_path, desc, _) =
           Env.lookup_value ~use:false ~loc lid.txt env
         in
         {exp with exp_type = desc.val_type}
@@ -11032,12 +11035,22 @@ let check_partial ?lev a b c cases =
 
 (* drop unnecessary arguments from the external API
    and check for uniqueness *)
-let type_expect env e ty =
-  let exp = type_expect env mode_legacy e ty in
+let type_expect env ?mode e ty =
+  let expected_mode =
+    match mode with
+    | None -> mode_legacy
+    | Some m -> mode_default m
+  in
+  let exp = type_expect env expected_mode e ty in
   maybe_check_uniqueness_exp exp; exp
 
-let type_exp env e =
-  let exp = type_exp env mode_legacy e in
+let type_exp env ?mode e =
+  let expected_mode =
+    match mode with
+    | None -> mode_legacy
+    | Some m -> mode_default m
+  in
+  let exp = type_exp env expected_mode e in
   maybe_check_uniqueness_exp exp; exp
 
 let type_argument env e t1 t2 =

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -143,9 +143,11 @@ val check_partial:
         ?lev:int -> Env.t -> type_expr ->
         Location.t -> Typedtree.value Typedtree.case list -> Typedtree.partial
 val type_expect:
-        Env.t -> Parsetree.expression -> type_expected -> Typedtree.expression
+        Env.t -> ?mode:Mode.Value.r -> Parsetree.expression -> type_expected ->
+          Typedtree.expression
 val type_exp:
-        Env.t -> Parsetree.expression -> Typedtree.expression
+        Env.t -> ?mode: Mode.Value.r -> Parsetree.expression ->
+          Typedtree.expression
 val type_approx:
         Env.t -> Parsetree.expression -> type_expr -> unit
 val type_argument:
@@ -332,8 +334,7 @@ val report_error: loc:Location.t -> Env.t -> error -> Location.error
 
 (* Forward declaration, to be filled in by Typemod.type_module *)
 val type_module:
-  (Env.t -> Parsetree.module_expr -> Typedtree.module_expr * Shape.t *
-    Env.locks) ref
+  (Env.t -> Parsetree.module_expr -> Typedtree.module_expr * Shape.t) ref
 (* Forward declaration, to be filled in by Typemod.type_open *)
 val type_open:
   (?used_slot:bool ref -> override_flag -> Env.t -> Location.t ->

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -476,12 +476,17 @@ and class_field_desc =
   | Tcf_initializer of expression
   | Tcf_attribute of attribute
 
+and held_locks = Env.locks * Longident.t * Location.t
+
+and mode_with_locks = Mode.Value.l * held_locks option
+
 (* Value expressions for the module language *)
 
 and module_expr =
   { mod_desc: module_expr_desc;
     mod_loc: Location.t;
     mod_type: Types.module_type;
+    mod_mode : mode_with_locks;
     mod_env: Env.t;
     mod_attributes: attribute list;
    }
@@ -626,6 +631,7 @@ and module_declaration =
      md_uid: Uid.t;
      md_presence: module_presence;
      md_type: module_type;
+     md_modalities: Mode.Modality.Value.t;
      md_attributes: attribute list;
      md_loc: Location.t;
     }
@@ -1347,3 +1353,9 @@ let loc_of_decl ~uid =
   | Module_substitution msd -> msd.ms_name
   | Class cd -> cd.ci_id_name
   | Class_type ctd -> ctd.ci_id_name
+
+let min_mode_with_locks = (Mode.Value.(disallow_right legacy), None)
+
+let mode_without_locks_exn = function
+  | (_, Some _) -> assert false
+  | (m, None) -> m

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -725,12 +725,23 @@ and class_field_desc =
   | Tcf_initializer of expression
   | Tcf_attribute of attribute
 
+and held_locks = Env.locks * Longident.t * Location.t
+
+and mode_with_locks = Mode.Value.l * held_locks option
+
 (* Value expressions for the module language *)
 
 and module_expr =
   { mod_desc: module_expr_desc;
     mod_loc: Location.t;
     mod_type: Types.module_type;
+    mod_mode : mode_with_locks;
+    (** The mode of the module. The second component is [Some] if [hold_locks]
+    is requested and the module is an identifier. *)
+    (* CR zqian: currently we mode-check bottom-up instead of top-down, in align
+    with the type-checking of modules. They are aligned because module type
+    inclusion check is modal. In the future both should be top-down for better
+    error messages. *)
     mod_env: Env.t;
     mod_attributes: attributes;
    }
@@ -892,6 +903,7 @@ and module_declaration =
      md_uid: Uid.t;
      md_presence: Types.module_presence;
      md_type: module_type;
+     md_modalities: Mode.Modality.Value.t;
      md_attributes: attributes;
      md_loc: Location.t;
     }
@@ -1293,3 +1305,10 @@ val function_arity : function_param list -> function_body -> int
 
 (** Given a declaration, return the location of the bound identifier *)
 val loc_of_decl : uid:Shape.Uid.t -> item_declaration -> string Location.loc
+
+(** When type checking F(M).t, which does not involve modes, we say F(M) is of
+    the strongest mode, to avoid modes in error messages. *)
+val min_mode_with_locks : mode_with_locks
+
+(** Get the mode, asserting no held locks. *)
+val mode_without_locks_exn : mode_with_locks -> Mode.Value.l

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -19,6 +19,7 @@ open Path
 open Asttypes
 open Parsetree
 open Types
+open Mode
 open Format
 
 module Style = Misc.Style
@@ -49,6 +50,24 @@ type hiding_error =
 type functor_dependency_error =
     Functor_applied
   | Functor_included
+
+type legacy_module =
+  | Compilation_unit
+  | Toplevel
+  | Functor_body
+
+let print_legacy_module ppf = function
+  | Compilation_unit -> Format.fprintf ppf "compilation unit"
+  | Functor_body -> Format.fprintf ppf "functor body"
+  | Toplevel -> Format.fprintf ppf "toplevel"
+
+type unsupported_modal_module =
+  | Functor_param
+  | Functor_res
+
+let print_unsupported_modal_module ppf = function
+  | Functor_param -> Format.fprintf ppf "functor parameters"
+  | Functor_res -> Format.fprintf ppf "functor return"
 
 type error =
     Cannot_apply of module_type
@@ -104,10 +123,42 @@ type error =
     }
   | Duplicate_parameter_name of Global_module.Name.t
   | Submode_failed of Mode.Value.error
-  | Modal_module_not_supported
+  | Value_weaker_than_module of Mode.Value.error
+  | Unsupported_modal_module of unsupported_modal_module
+  | Legacy_module of legacy_module * Mode.Value.error
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
+
+let submode ~loc ~env mode expected_mode =
+  match Value.submode mode expected_mode with
+  | Ok () -> ()
+  | Error e -> raise (Error (loc, env, Submode_failed e))
+
+let apply_mode_annots (m : Alloc.Const.Option.t) mode =
+  let min = Alloc.Const.Option.value ~default:Alloc.Const.min m in
+  let max = Alloc.Const.Option.value ~default:Alloc.Const.max m in
+  Value.submode_exn (min |> Alloc.of_const  |> alloc_as_value) mode;
+  Value.submode_exn mode (max |> Alloc.of_const |> alloc_as_value)
+
+let type_mode ~loc ~env ~(annots : Alloc.Const.Option.t) arg_mode =
+  let min =
+    Alloc.Const.Option.value ~default:Alloc.Const.min annots
+    |> Const.alloc_as_value
+  in
+  let max =
+    Alloc.Const.Option.value ~default:Alloc.Const.max annots
+    |> Const.alloc_as_value
+  in
+  submode ~loc ~env arg_mode (Value.of_const max);
+  Value.join [Value.of_const min; arg_mode]
+
+let register_allocation () =
+  let m, _ =
+    Alloc.(newvar_below
+      (max_with (Comonadic Areality) Locality.global))
+  in
+  m, alloc_as_value m
 
 open Typedtree
 
@@ -406,7 +457,7 @@ let retype_applicative_functor_type ~loc env funct arg =
     | Mty_functor (Named (_, mty_param), _) -> mty_param
     | _ -> assert false (* could trigger due to MPR#7611 *)
   in
-  Includemod.check_modtype_inclusion ~loc env mty_arg arg mty_param
+  Includemod.check_functor_application ~loc env mty_arg arg mty_param
 
 (* When doing a deep destructive substitution with type M.N.t := .., we change M
    and M.N and so we have to check that uses of the modules other than just
@@ -604,11 +655,15 @@ let rec remove_modality_and_zero_alloc_variables_sg env ~zap_modality sg =
         let desc = {desc with val_modalities; val_zero_alloc} in
         Sig_value (id, desc, vis)
     | Sig_module (id, pres, md, re, vis) ->
+        let md_modalities =
+            md.md_modalities
+            |> zap_modality |> Mode.Modality.Value.of_const
+        in
         let md_type =
           remove_modality_and_zero_alloc_variables_mty env ~zap_modality
             md.md_type
         in
-        let md = {md with md_type} in
+        let md = {md with md_type; md_modalities} in
         Sig_module (id, pres, md, re, vis)
     | item -> item
   in
@@ -834,7 +889,7 @@ let merge_constraint initial_env loc sg lid constr =
         let md'' = { md' with md_type = mty } in
         let newmd = Mtype.strengthen_decl ~aliasable:false md'' path in
         ignore(Includemod.modtypes  ~mark:Mark_both ~loc sig_env
-          ~modes:(Legacy None) newmd.md_type md.md_type);
+          ~modes:All newmd.md_type md.md_type);
         return
           ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
           (Pident id, lid, Some (Twith_module (path, lid')))
@@ -844,7 +899,7 @@ let merge_constraint initial_env loc sg lid constr =
         let aliasable = not (Env.is_functor_arg path sig_env) in
         ignore
           (Includemod.strengthened_module_decl ~loc ~mark:Mark_both
-             ~aliasable sig_env ~mmodes:(Legacy None) md' path md);
+             ~aliasable sig_env ~mmodes:All md' path md);
         real_ids := [Pident id];
         return ~replace_by:None
           (Pident id, lid, Some (Twith_modsubst (path, lid')))
@@ -1005,8 +1060,7 @@ let map_ext fn exts =
   | [] -> []
   | d1 :: dl -> fn Text_first d1 :: List.map (fn Text_next) dl
 
-let rec apply_modalities_signature ~recursive env modalities sg =
-  let env = Env.add_signature sg env in
+let apply_modalities_signature modalities sg =
   List.map (function
   | Sig_value (id, vd, vis) ->
       let val_modalities =
@@ -1017,26 +1071,17 @@ let rec apply_modalities_signature ~recursive env modalities sg =
       in
       let vd = {vd with val_modalities} in
       Sig_value (id, vd, vis)
-  | Sig_module (id, pres, md, rec_, vis) when recursive ->
-      let md_type = apply_modalities_module_type env modalities md.md_type in
-      let md = {md with md_type} in
+  | Sig_module (id, pres, md, rec_, vis) ->
+      let md_modalities =
+        md.md_modalities
+        |> Mode.Modality.Value.to_const_exn
+        |> (fun then_ -> Mode.Modality.Value.Const.concat ~then_ modalities)
+        |> Mode.Modality.Value.of_const
+      in
+      let md = {md with md_modalities} in
       Sig_module (id, pres, md, rec_, vis)
   | item -> item
   ) sg
-
-and apply_modalities_module_type env modalities = function
-  | Mty_ident p ->
-      let mtd = Env.find_modtype p env in
-      begin match mtd.mtd_type with
-      | None -> Mty_ident p
-      | Some mty -> apply_modalities_module_type env modalities mty
-      end
-  | Mty_strengthen (mty, p, alias) ->
-      Mty_strengthen (apply_modalities_module_type env modalities mty, p, alias)
-  | Mty_signature sg ->
-      let sg = apply_modalities_signature ~recursive:true env modalities sg in
-      Mty_signature sg
-  | (Mty_functor _ | Mty_alias _) as mty -> mty
 
 let loc_of_modes (modes : mode loc list) : Location.t option =
   (* CR zqian: [Parsetree.modes] should be a record with a field that is
@@ -1052,41 +1097,16 @@ let loc_of_modes (modes : mode loc list) : Location.t option =
     let loc_end = loc_end_of_modes head rest in
     Some {loc_start; loc_end; loc_ghost=false}
 
-let check_no_modal_modules ~env modes =
+let check_unsupported_modal_module ~env reason modes =
   match loc_of_modes modes with
   | None -> ()
-  | Some loc -> raise(Error(loc, env, Modal_module_not_supported))
+  | Some loc -> raise(Error(loc, env, Unsupported_modal_module reason))
 
-let apply_pmd_modalities env sig_modalities pmd_modalities mty =
-  let modalities =
-    match pmd_modalities with
-    | [] -> sig_modalities
-    | _ :: _ ->
-      Typemode.transl_modalities ~maturity:Stable Immutable [] pmd_modalities
-  in
-  (*
-  Workaround for pmd_modalities
-
-  Let [f] be the mapping representing [pmd_modalities].
-
-  In the future with proper modal modules, let [m] be the mode of the enclosing
-  structure. This module will be of mode [f m], and a value inside the module
-  will of mode [g (f m)] where [g] is the modalities on the value. Note that [m]
-  itself is of the form [f0 (f1 .. (fn legacy))] where [legacy] is the mode of
-  the file-level structure, and [fi] is the sequence of [pmd_modalities] that
-  corresponds to the enclosing structure nested inside layers of structures.
-  Therefore, the aforementioned value will be of mode
-  [g (f (f0 (f1 .. (fn legacy))))].
-
-  Currently, all modules are legacy. To simulate the above effect, we apply each
-  [pmd_modalities] of a structure deeply to all [val_modalities] in that
-  structure.
-
-  We still don't support [pmd_modalities] on functors.
-  *)
-  match Mode.Modality.Value.Const.is_id modalities with
-  | true -> mty
-  | false -> apply_modalities_module_type env modalities mty
+let transl_modalities ~sig_modalities modalities =
+  match modalities with
+  | [] -> sig_modalities
+  | _ :: _ ->
+    Typemode.transl_modalities ~maturity:Stable Immutable [] modalities
 
 (* Auxiliary for translating recursively-defined module types.
    Return a module type that approximates the shape of the given module
@@ -1114,7 +1134,7 @@ let rec approx_modtype env smty =
         match param with
         | Unit -> Types.Unit, env
         | Named (param, sarg, marg) ->
-          check_no_modal_modules ~env marg;
+          check_unsupported_modal_module ~env Functor_param marg;
           let arg = approx_modtype env sarg in
           match param.txt with
           | None -> Types.Named (None, arg), env
@@ -1166,6 +1186,7 @@ let rec approx_modtype env smty =
 and approx_module_declaration env pmd =
   {
     Types.md_type = approx_modtype env pmd.pmd_type;
+    md_modalities = Mode.Modality.Value.id;
     md_attributes = pmd.pmd_attributes;
     md_loc = pmd.pmd_loc;
     md_uid = Uid.internal_not_actually_unique;
@@ -1229,7 +1250,7 @@ and approx_sig_items env ssg=
           let newenv =
             List.fold_left
               (fun env (id, md) -> Env.add_module_declaration ~check:false
-                  id Mp_present md env)
+                  id Mp_present md ~mode:(Value.min) env)
               env decls
           in
           map_rec
@@ -1253,8 +1274,7 @@ and approx_sig_items env ssg=
       | Psig_open sod ->
           let _, env = type_open_descr env sod in
           approx_sig_items env srem
-      | Psig_include ({pincl_loc=loc; pincl_mod=mod_; pincl_kind=kind;
-            pincl_attributes=attrs}, moda) ->
+      | Psig_include ({pincl_loc=loc; pincl_mod=mod_; pincl_kind=kind; _}, moda) ->
           begin match kind with
           | Functor ->
               Language_extension.assert_enabled ~loc Include_functor ();
@@ -1270,10 +1290,7 @@ and approx_sig_items env ssg=
                   let modalities =
                     Typemode.transl_modalities ~maturity:Stable Immutable [] moda
                   in
-                  let recursive =
-                    not @@ Builtin_attributes.has_attribute "no_recursive_modalities" attrs
-                  in
-                  apply_modalities_signature ~recursive env modalities sg
+                  apply_modalities_signature modalities sg
               in
               let sg, newenv = Env.enter_signature ~scope sg env in
               sg @ approx_sig_items newenv srem
@@ -1673,12 +1690,12 @@ and transl_modtype_aux env smty =
       mkmty (Tmty_signature sg) (Mty_signature sg.sig_type) env loc
         smty.pmty_attributes
   | Pmty_functor(sarg_opt, sres, mres) ->
-      check_no_modal_modules ~env mres;
+      check_unsupported_modal_module ~env Functor_res mres;
       let t_arg, ty_arg, newenv =
         match sarg_opt with
         | Unit -> Unit, Types.Unit, env
         | Named (param, sarg, marg) ->
-          check_no_modal_modules ~env marg;
+          check_unsupported_modal_module ~env Functor_param marg;
           let arg = transl_modtype_functor_arg env sarg in
           let (id, newenv) =
             match param.txt with
@@ -1688,6 +1705,7 @@ and transl_modtype_aux env smty =
               let id, newenv =
                 let arg_md =
                   { md_type = arg.mty_type;
+                    md_modalities = Mode.Modality.Value.id;
                     md_attributes = [];
                     md_loc = param.loc;
                     md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
@@ -1731,7 +1749,7 @@ and transl_modtype_aux env smty =
       let aliasable = not (Env.is_functor_arg path env) in
       try
         ignore
-          (Includemod.modtypes ~loc env ~modes:(Legacy None)
+          (Includemod.modtypes ~loc env ~modes:All
             ~mark:Includemod.Mark_both md.md_type tmty.mty_type);
         mkmty
           (Tmty_strengthen (tmty, path, mod_id))
@@ -1770,7 +1788,8 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
   let names = Signature_names.create () in
 
   let sig_modalities =
-      Typemode.transl_modalities ~maturity:Stable Immutable [] psg_modalities
+    transl_modalities ~sig_modalities:Mode.Modality.Value.Const.id
+      psg_modalities
   in
 
   let transl_include ~loc env sig_acc sincl modalities =
@@ -1792,22 +1811,8 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
       | Structure ->
         Tincl_structure, extract_sig env smty.pmty_loc mty
     in
-    let modalities =
-      match modalities with
-      | [] -> sig_modalities
-      | _ ->
-        Typemode.transl_modalities ~maturity:Stable Immutable [] modalities
-    in
-    let sg =
-      if not @@ Mode.Modality.Value.Const.is_id modalities then
-        let recursive =
-          not @@ Builtin_attributes.has_attribute "no_recursive_modalities"
-            sincl.pincl_attributes
-        in
-        apply_modalities_signature ~recursive env modalities sg
-      else
-        sg
-    in
+    let modalities = transl_modalities ~sig_modalities modalities in
+    let sg = apply_modalities_signature modalities sg in
     let sg, newenv = Env.enter_signature ~scope sg env in
     Signature_group.iter
       (Signature_names.check_sig_item names loc)
@@ -1902,10 +1907,10 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
           Builtin_attributes.warning_scope pmd.pmd_attributes
             (fun () -> transl_modtype env pmd.pmd_type)
         in
-        let mty_type =
-          apply_pmd_modalities env sig_modalities pmd.pmd_modalities tmty.mty_type
+        let md_modalities =
+          transl_modalities ~sig_modalities pmd.pmd_modalities
+          |> Mode.Modality.Value.of_const
         in
-        let tmty = {tmty with mty_type} in
         let pres =
           match tmty.mty_type with
           | Mty_alias _ -> Mp_absent
@@ -1913,6 +1918,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
         in
         let md = {
           md_type=tmty.mty_type;
+          md_modalities;
           md_attributes=pmd.pmd_attributes;
           md_loc=pmd.pmd_loc;
           md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
@@ -1923,7 +1929,10 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
           | None -> None, env
           | Some name ->
             let id, newenv =
-              Env.enter_module_declaration ~scope name pres md env
+              (* the module is added only for its types, so we give it the
+              strongest mode to avoid false mode errors. *)
+              Env.enter_module_declaration ~scope name pres md
+                ~mode:Value.min env
             in
             Signature_names.check_module names pmd.pmd_name.loc id;
             Some id, newenv
@@ -1932,6 +1941,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
           mksig (Tsig_module {md_id=id; md_name=pmd.pmd_name;
                               md_uid=md.md_uid; md_presence=pres;
                               md_type=tmty;
+                              md_modalities=md.md_modalities;
                               md_loc=pmd.pmd_loc;
                               md_attributes=pmd.pmd_attributes})
             env loc
@@ -1953,6 +1963,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
             md
           else
             { md_type = Mty_alias path;
+              md_modalities = Mode.Modality.Value.id;
               md_attributes = pms.pms_attributes;
               md_loc = pms.pms_loc;
               md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
@@ -1979,10 +1990,11 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
         in
         sig_item, [], newenv
     | Psig_recmodule sdecls ->
+        let sdecls = List.map (fun sdecl -> (sdecl, None)) sdecls in
         let (tdecls, newenv) =
-          transl_recmodule_modtypes env sig_modalities sdecls in
+          transl_recmodule_modtypes env ~sig_modalities sdecls in
         let decls =
-          List.filter_map (fun (md, uid, _) ->
+          List.filter_map (fun (md, _, uid, _) ->
             match md.md_id with
             | None -> None
             | Some id -> Some (id, md, uid)
@@ -1994,6 +2006,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
         let sig_items =
           map_rec (fun rs (id, md, uid) ->
             let d = {Types.md_type = md.md_type.mty_type;
+                     md_modalities = md.md_modalities;
                      md_attributes = md.md_attributes;
                      md_loc = md.md_loc;
                      md_uid = uid;
@@ -2001,7 +2014,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
             Sig_module(id, Mp_present, d, rs, Exported))
             decls []
         in
-        mksig (Tsig_recmodule (List.map (fun (md, _, _) -> md) tdecls)) env loc,
+        mksig (Tsig_recmodule (List.map (fun (md, _, _, _) -> md) tdecls)) env loc,
         sig_items,
         newenv
     | Psig_modtype pmtd ->
@@ -2145,38 +2158,34 @@ and transl_modtype_decl_aux env
   in
   newenv, mtd, decl
 
-and transl_recmodule_modtypes env sig_modalities sdecls =
+and transl_recmodule_modtypes env ~sig_modalities sdecls =
   let make_env curr =
-    List.fold_left (fun env (id_shape, _, md, _) ->
+    List.fold_left (fun env (id_shape, _, md, mode, _) ->
       Option.fold ~none:env ~some:(fun (id, shape) ->
         Env.add_module_declaration ~check:true ~shape ~arg:true
-          id Mp_present md env
+          id Mp_present md ?mode:(Option.map Mode.Value.disallow_right mode) env
       ) id_shape
     ) env curr
   in
   let transition env_c curr =
     List.map2
-      (fun pmd (id_shape, id_loc, md, _) ->
+      (fun (pmd, _) (id_shape, id_loc, md, mmode, _) ->
         let tmty =
           Builtin_attributes.warning_scope pmd.pmd_attributes
             (fun () -> transl_modtype env_c pmd.pmd_type)
         in
-        let mty_type =
-          apply_pmd_modalities env sig_modalities pmd.pmd_modalities tmty.mty_type
-        in
-        let tmty = {tmty with mty_type} in
         let md = { md with Types.md_type = tmty.mty_type } in
-        (id_shape, id_loc, md, tmty))
+        (id_shape, id_loc, md, mmode, tmty))
       sdecls curr in
   let map_mtys curr =
     List.filter_map
-      (fun (id_shape, _, md, _) ->
+      (fun (id_shape, _, md, _, _) ->
          Option.map (fun (id, _) -> (id, md)) id_shape)
       curr
   in
   let scope = Ctype.create_scope () in
   let ids =
-    List.map (fun x -> Option.map (Ident.create_scoped ~scope) x.pmd_name.txt)
+    List.map (fun (x, _) -> Option.map (Ident.create_scoped ~scope) x.pmd_name.txt)
       sdecls
   in
   let approx_env =
@@ -2190,14 +2199,15 @@ and transl_recmodule_modtypes env sig_modalities sdecls =
   in
   let init =
     List.map2
-      (fun id pmd ->
+      (fun id (pmd, smmode) ->
          let md_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) in
-         let md_type =
-          approx_modtype approx_env pmd.pmd_type
-          |> apply_pmd_modalities env sig_modalities pmd.pmd_modalities
+         let md_modalities =
+            transl_modalities ~sig_modalities pmd.pmd_modalities
+            |> Mode.Modality.Value.of_const
          in
          let md =
-           { md_type;
+           { md_type = approx_modtype approx_env pmd.pmd_type;
+             md_modalities;
              md_loc = pmd.pmd_loc;
              md_attributes = pmd.pmd_attributes;
              md_uid }
@@ -2205,7 +2215,14 @@ and transl_recmodule_modtypes env sig_modalities sdecls =
          let id_shape =
            Option.map (fun id -> id, Shape.var md_uid id) id
          in
-         (id_shape, pmd.pmd_name, md, ()))
+         let mmode =
+           Option.map (fun smmode ->
+            let mmode = Value.newvar () in
+            let annots = Typemode.transl_mode_annots smmode in
+            apply_mode_annots annots mmode;
+            mmode) smmode
+          in
+         (id_shape, pmd.pmd_name, md, mmode, ()))
       ids sdecls
   in
   let env0 = make_env init in
@@ -2225,14 +2242,15 @@ and transl_recmodule_modtypes env sig_modalities sdecls =
   let env2 = make_env dcl2 in
   check_recmod_typedecls env2 (map_mtys dcl2);
   let dcl2 =
-    List.map2 (fun pmd (id_shape, id_loc, md, mty) ->
+    List.map2 (fun (pmd, _) (id_shape, id_loc, md, mmode, mty) ->
       let tmd =
         {md_id=Option.map fst id_shape; md_name=id_loc; md_type=mty;
+         md_modalities = md.Types.md_modalities;
          md_uid=md.Types.md_uid; md_presence=Mp_present;
          md_loc=pmd.pmd_loc;
          md_attributes=pmd.pmd_attributes}
       in
-      tmd, md.Types.md_uid, Option.map snd id_shape
+      tmd, mmode, md.Types.md_uid, Option.map snd id_shape
     ) sdecls dcl2
   in
   (dcl2, env2)
@@ -2384,7 +2402,7 @@ let check_recmodule_inclusion env bindings =
       let bindings1 =
         List.map
           (fun (id, _name, _mty_decl, _modl,
-                mty_actual, _attrs, _loc, shape, _uid) ->
+                mty_actual, _mmode, _attrs, _loc, shape, _uid) ->
              let ids =
                Option.map
                  (fun id -> (id, Ident.create_scoped ~scope (Ident.name id))) id
@@ -2420,20 +2438,27 @@ let check_recmodule_inclusion env bindings =
       (* Base case: check inclusion of s(mty_actual) in s(mty_decl)
          and insert coercion if needed *)
       let check_inclusion
-            (id, name, mty_decl, modl, mty_actual, attrs, loc, shape, uid) =
+            (id, name, mty_decl, modl, mty_actual, mmode, attrs, loc, shape, uid) =
         let mty_decl' = Subst.modtype (Rescope scope) s mty_decl.mty_type
         and mty_actual' = subst_and_strengthen scope s id mty_actual in
+        let modes : Includemod.modes =
+          Specific (
+            Mode.Value.disallow_right mmode,
+            Mode.Value.disallow_left mmode,
+            None)
+        in
         let coercion, shape =
           try
             Includemod.modtypes_with_shape ~shape
               ~loc:modl.mod_loc ~mark:Mark_both
-              env ~modes:(Legacy None) mty_actual' mty_decl'
+              env ~modes mty_actual' mty_decl'
           with Includemod.Error msg ->
             raise(Error(modl.mod_loc, env, Not_included msg)) in
         let modl' =
             { mod_desc = Tmod_constraint(modl, mty_decl.mty_type,
                 Tmodtype_explicit mty_decl, coercion);
               mod_type = mty_decl.mty_type;
+              mod_mode = Value.disallow_right mmode, None;
               mod_env = env;
               mod_loc = modl.mod_loc;
               mod_attributes = [];
@@ -2523,32 +2548,42 @@ let package_subtype env p1 fl1 p2 fl2 =
 
 let () = Ctype.package_subtype := package_subtype
 
-let wrap_constraint_package env mark arg held_locks mty explicit =
+let wrap_constraint_package env mark arg mty mode explicit =
   let mark = if mark then Includemod.Mark_both else Includemod.Mark_neither in
   let mty1 = Subst.modtype Keep Subst.identity arg.mod_type in
   let mty2 = Subst.modtype Keep Subst.identity mty in
+  let arg_mode, held_locks = arg.mod_mode in
+  let modes : Includemod.modes =
+    Specific (arg_mode, Value.disallow_left mode, held_locks)
+  in
   let coercion =
     try
-      Includemod.modtypes ~loc:arg.mod_loc env ~mark ~modes:(Legacy held_locks) mty1 mty2
+      Includemod.modtypes ~loc:arg.mod_loc env ~mark ~modes mty1 mty2
     with Includemod.Error msg ->
       raise(Error(arg.mod_loc, env, Not_included msg)) in
   { mod_desc = Tmod_constraint(arg, mty, explicit, coercion);
     mod_type = mty;
+    mod_mode = Value.disallow_right mode, None;
     mod_env = env;
     mod_attributes = [];
     mod_loc = arg.mod_loc }
 
-let wrap_constraint_with_shape env mark arg held_locks mty
+let wrap_constraint_with_shape env mark arg mty mode
   shape explicit =
   let mark = if mark then Includemod.Mark_both else Includemod.Mark_neither in
+  let arg_mode, held_locks = arg.mod_mode in
+  let modes : Includemod.modes =
+    Specific (arg_mode, Value.disallow_left mode, held_locks)
+  in
   let coercion, shape =
     try
       Includemod.modtypes_with_shape ~shape ~loc:arg.mod_loc env ~mark
-        ~modes:(Legacy held_locks) arg.mod_type mty
+        ~modes arg.mod_type mty
     with Includemod.Error msg ->
       raise(Error(arg.mod_loc, env, Not_included msg)) in
   { mod_desc = Tmod_constraint(arg, mty, explicit, coercion);
     mod_type = mty;
+    mod_mode = Value.disallow_right mode, None;
     mod_env = env;
     mod_attributes = [];
     mod_loc = arg.mod_loc }, shape
@@ -2560,7 +2595,6 @@ let wrap_constraint_with_shape env mark arg held_locks mty
 type argument_summary = {
   is_syntactic_unit: bool;
   arg: Typedtree.module_expr;
-  held_locks: Env.held_locks option;
   path: Path.t option;
   shape: Shape.t
 }
@@ -2574,13 +2608,14 @@ type application_summary = {
 
 let simplify_app_summary app_view = match app_view.arg with
   | None ->
-    Includemod.Error.Unit, Mty_signature []
+    Includemod.Error.Unit, Mty_signature [], Typedtree.min_mode_with_locks
   | Some arg ->
     let mty = arg.arg.mod_type in
+    let mode = arg.arg.mod_mode in
     match arg.is_syntactic_unit , arg.path with
-    | true , _      -> Includemod.Error.Empty_struct, mty
-    | false, Some p -> Includemod.Error.Named p, mty
-    | false, None   -> Includemod.Error.Anonymous, mty
+    | true , _      -> Includemod.Error.Empty_struct, mty, mode
+    | false, Some p -> Includemod.Error.Named p, mty, mode
+    | false, None   -> Includemod.Error.Anonymous, mty, mode
 
 let maybe_infer_modalities ~loc ~env ~md_mode ~mode =
   if Language_extension.(is_at_least Mode Stable) then begin
@@ -2609,22 +2644,23 @@ let maybe_infer_modalities ~loc ~env ~md_mode ~mode =
       mode.Mode.comonadic
       md_mode.Mode.comonadic with
       | Ok () -> ()
-      | Error (Error (ax, e)) -> raise (Error (loc, env, Submode_failed (Error (Comonadic ax, e))))
+      | Error (Error (ax, e)) ->
+          raise (Error (loc, env, Value_weaker_than_module
+            (Error (Comonadic ax, e))))
     end;
     Mode.Modality.Value.infer ~md_mode ~mode
   end else begin
     begin match Mode.Value.submode mode md_mode with
       | Ok () -> ()
-      | Error e -> raise (Error (loc, env, Submode_failed e))
+      | Error e -> raise (Error (loc, env, Value_weaker_than_module e))
     end;
     Mode.Modality.Value.id
   end
 
 let rec type_module ?alias sttn funct_body anchor env smod =
-  let md, shape, held_locks =
+  let md, shape =
     type_module_maybe_hold_locks ?alias ~hold_locks:false sttn funct_body anchor env smod
   in
-  assert (Option.is_none held_locks);
   md, shape
 
 and  type_module_maybe_hold_locks ?(alias=false) ~hold_locks sttn funct_body anchor env smod =
@@ -2632,18 +2668,25 @@ and  type_module_maybe_hold_locks ?(alias=false) ~hold_locks sttn funct_body anc
     (fun () -> type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod)
 
 and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
+  (* If the module is an identifier, there might be locks between the declaration
+  site and the use site.
+  - If [hold_locks] is [true], the locks are held and stored in [mod_mode].
+  - If [hold_locks] is [false], the locks are walked.
+
+  If the module is not an identifier, [hold_locks] has no effect. *)
   match smod.pmod_desc with
     Pmod_ident lid ->
-      let path, locks =
+      let path, mode_with_locks =
         Env.lookup_module_path ~load:(not alias) ~loc:smod.pmod_loc lid.txt env
       in
-      type_module_path_aux ~alias ~hold_locks sttn env path locks lid smod
+      type_module_path_aux ~alias ~hold_locks sttn env path mode_with_locks lid smod
   | Pmod_structure sstr ->
-      let (str, sg, names, shape, _finalenv) =
+      let (str, sg, mode, names, shape, _finalenv) =
         type_structure funct_body anchor env sstr in
       let md =
         { mod_desc = Tmod_structure str;
           mod_type = Mty_signature sg;
+          mod_mode = Value.disallow_right mode, None;
           mod_env = env;
           mod_attributes = smod.pmod_attributes;
           mod_loc = smod.pmod_loc }
@@ -2651,19 +2694,19 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
       let sg' = Signature_names.simplify _finalenv names sg in
       let md, shape =
         if List.length sg' = List.length sg then md, shape else
-        wrap_constraint_with_shape env false md None
-          (Mty_signature sg') shape Tmodtype_implicit
+        wrap_constraint_with_shape env false md
+          (Mty_signature sg') mode shape Tmodtype_implicit
       in
-      md, shape, None
+      md, shape
   | Pmod_functor(arg_opt, sbody) ->
-      let newenv = Env.add_escape_lock Module env in
-      let newenv = Env.add_share_lock Module newenv in
+      let _, mode = register_allocation () in
+      let newenv = Env.add_closure_lock Functor mode.comonadic env in
       let t_arg, ty_arg, newenv, funct_shape_param, funct_body =
         match arg_opt with
         | Unit ->
           Unit, Types.Unit, env, Shape.for_unnamed_functor_param, false
         | Named (param, smty, smode) ->
-          check_no_modal_modules ~env smode;
+          check_unsupported_modal_module ~env Functor_param smode;
           let mty = transl_modtype_functor_arg env smty in
           let scope = Ctype.create_scope () in
           let (id, newenv, var) =
@@ -2673,6 +2716,7 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
               let md_uid =  Uid.mk ~current_unit:(Env.get_unit_name ()) in
               let arg_md =
                 { md_type = mty.mty_type;
+                  md_modalities = Modality.Value.id;
                   md_attributes = [];
                   md_loc = param.loc;
                   md_uid;
@@ -2680,8 +2724,9 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
               in
               let id = Ident.create_scoped ~scope name in
               let shape = Shape.var md_uid id in
+              let mode = alloc_as_value functor_param_mode in
               let newenv = Env.add_module_declaration
-                ~shape ~arg:true ~check:true id Mp_present arg_md newenv
+                ~shape ~arg:true ~check:true id Mp_present arg_md ~mode newenv
               in
               Some id, newenv, id
           in
@@ -2689,35 +2734,54 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
           var, true
       in
       let body, body_shape = type_module true funct_body None newenv sbody in
+      let mode = mode_without_locks_exn body.mod_mode in
+      begin match Value.submode mode (alloc_as_value Types.functor_res_mode) with
+      | Ok () -> ()
+      | Error e -> raise (Error (sbody.pmod_loc, env,
+          Legacy_module (Functor_body, e)))
+      end;
       { mod_desc = Tmod_functor(t_arg, body);
         mod_type = Mty_functor(ty_arg, body.mod_type);
+        mod_mode = Value.disallow_right mode, None;
         mod_env = env;
         mod_attributes = smod.pmod_attributes;
         mod_loc = smod.pmod_loc },
-      Shape.abs funct_shape_param body_shape, None
+      Shape.abs funct_shape_param body_shape
   | Pmod_apply _ | Pmod_apply_unit _ ->
-      let md, shape = type_application smod.pmod_loc sttn funct_body env smod in
-      md, shape, None
+      type_application smod.pmod_loc sttn funct_body env smod
   | Pmod_constraint(sarg, smty, smode) ->
-      check_no_modal_modules ~env smode;
-      let smty = Option.get smty in
-      let arg, arg_shape, held_locks =
-        type_module_maybe_hold_locks ~alias ~hold_locks:true true funct_body anchor env sarg
+      (* Only hold locks if coercion *)
+      let hold_locks = Option.is_some smty in
+      let arg, arg_shape =
+        type_module_maybe_hold_locks ~alias ~hold_locks true funct_body
+          anchor env sarg
       in
-      let mty = transl_modtype env smty in
-      let md, final_shape =
-        wrap_constraint_with_shape env true arg held_locks mty.mty_type arg_shape
-          (Tmodtype_explicit mty)
+      let md, shape =
+        match smty with
+        | None -> arg, arg_shape
+        | Some smty ->
+          let mty = transl_modtype env smty in
+          let mode = Value.newvar () in
+          let md, final_shape =
+            wrap_constraint_with_shape env true arg mty.mty_type mode
+              arg_shape (Tmodtype_explicit mty)
+          in
+          { md with
+            mod_loc = smod.pmod_loc;
+            mod_attributes = smod.pmod_attributes;
+          },
+          final_shape
       in
-      { md with
-        mod_loc = smod.pmod_loc;
-        mod_attributes = smod.pmod_attributes;
-      },
-      final_shape, None
+      let mode = Typedtree.mode_without_locks_exn md.mod_mode in
+      let annots = Typemode.transl_mode_annots smode in
+      let mod_mode = (type_mode ~loc:smod.pmod_loc ~env ~annots mode, None) in
+      let md = {md with mod_mode} in
+      md, shape
   | Pmod_unpack sexp ->
+      let mode = Value.newvar () in
       let exp =
         Ctype.with_local_level_if_principal
-          (fun () -> Typecore.type_exp env sexp)
+          (fun () -> Typecore.type_exp env sexp ~mode:(Value.disallow_left mode))
           ~post:Typecore.generalize_structure_exp
       in
       let mty =
@@ -2743,10 +2807,11 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
         raise (Error (smod.pmod_loc, env, Not_allowed_in_functor_body));
       { mod_desc = Tmod_unpack(exp, mty);
         mod_type = mty;
+        mod_mode = Value.disallow_right mode, None;
         mod_env = env;
         mod_attributes = smod.pmod_attributes;
         mod_loc = smod.pmod_loc },
-      Shape.leaf_for_unpack, None
+      Shape.leaf_for_unpack
   | Pmod_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
   | Pmod_instance glob ->
@@ -2756,6 +2821,7 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
         Env.lookup_module_instance_path ~load:(not alias) ~loc:smod.pmod_loc
           glob env
       in
+      let mode_with_locks = (Value.disallow_right Env.mode_unit, locks) in
       let lid =
         (* Only used by [untypeast] *)
         let name =
@@ -2763,22 +2829,21 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
         in
         Location.(mkloc (Lident name) (ghostify smod.pmod_loc))
       in
-      type_module_path_aux ~alias ~hold_locks sttn env path locks lid smod
+      type_module_path_aux ~alias ~hold_locks sttn env path mode_with_locks lid
+        smod
 
-and type_module_path_aux ~alias ~hold_locks sttn env path locks (lid : _ loc) smod =
-  let held_locks =
-    let held_locks = (locks, lid.txt, lid.loc) in
-    if hold_locks then Some held_locks
+and type_module_path_aux ~alias ~hold_locks sttn env path (mode, locks) (lid : _ loc) smod =
+  let mod_mode =
+    if hold_locks then mode, Some (locks, lid.txt, lid.loc)
     else
       let vmode =
-        Env.walk_locks ~env ~item:Module Mode.Value.(legacy |> disallow_right)
-          None held_locks
+        Env.walk_locks ~env ~loc:lid.loc lid.txt ~item:Module None (mode, locks)
       in
-      Mode.Value.submode_exn vmode.mode Mode.Value.legacy;
-      None
+      vmode.mode, None
   in
   let md = { mod_desc = Tmod_ident (path, lid);
              mod_type = Mty_alias path;
+             mod_mode;
              mod_env = env;
              mod_attributes = smod.pmod_attributes;
              mod_loc = smod.pmod_loc } in
@@ -2808,13 +2873,13 @@ and type_module_path_aux ~alias ~hold_locks sttn env path locks (lid : _ loc) sm
           { md with mod_type = mty }
     end
   in
-  md, shape, held_locks
+  md, shape
 
 and type_application loc strengthen funct_body env smod =
   let rec extract_application funct_body env sargs smod =
     match smod.pmod_desc with
     | Pmod_apply(f, sarg) ->
-        let arg, shape, held_locks =
+        let arg, shape =
           type_module_maybe_hold_locks ~hold_locks:true true funct_body None env
             sarg
         in
@@ -2825,7 +2890,6 @@ and type_application loc strengthen funct_body env smod =
           arg = Some {
             is_syntactic_unit = sarg.pmod_desc = Pmod_structure [];
             arg;
-            held_locks;
             path = path_of_module arg;
             shape;
           }
@@ -2876,6 +2940,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
         raise (Error (apply_loc, env, Not_allowed_in_functor_body));
       { mod_desc = Tmod_apply_unit funct;
         mod_type = mty_res;
+        mod_mode = alloc_as_value (Alloc.disallow_right functor_res_mode), None;
         mod_env = env;
         mod_attributes = app_view.attributes;
         mod_loc = funct.mod_loc },
@@ -2893,11 +2958,11 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
       begin match app_view with
       | { arg = None; _ } -> apply_error ()
       | { loc = app_loc; attributes = app_attributes;
-          arg = Some { shape = arg_shape; path = arg_path; arg; held_locks } } ->
+          arg = Some { shape = arg_shape; path = arg_path; arg } } ->
       let coercion =
         try Includemod.modtypes
               ~loc:arg.mod_loc ~mark:Mark_both env arg.mod_type mty_param
-              ~modes:(Legacy held_locks)
+              ~modes:(Includemod.modes_functor_param arg.mod_mode)
         with Includemod.Error _ -> apply_error ()
       in
       let mty_appl =
@@ -2929,7 +2994,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
             begin match
               Includemod.modtypes
                 ~loc:app_loc ~mark:Mark_neither env mty_res nondep_mty
-                ~modes:(Legacy None)
+                ~modes:Includemod.modes_functor_res
             with
             | Tcoerce_none -> ()
             | _ ->
@@ -2946,6 +3011,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
         "the signature of this functor application" mty_appl;
       { mod_desc = Tmod_apply(funct, arg, coercion);
         mod_type = mty_appl;
+        mod_mode = alloc_as_value (Alloc.disallow_right functor_res_mode), None;
         mod_env = env;
         mod_attributes = app_attributes;
         mod_loc = app_loc },
@@ -2977,6 +3043,8 @@ and type_open_decl_aux ?used_slot ?toplevel funct_body names env od =
     in
     let md = { mod_desc = Tmod_ident (path, lid);
                mod_type = Mty_alias path;
+               mod_mode = Value.(disallow_right max), None;
+               (* CR zqian: maybe put in the correct mode and locks. *)
                mod_env = env;
                mod_attributes = od.popen_expr.pmod_attributes;
                mod_loc = od.popen_expr.pmod_loc }
@@ -2992,10 +3060,11 @@ and type_open_decl_aux ?used_slot ?toplevel funct_body names env od =
     open_descr, [], newenv
   | _ ->
     let md, mod_shape = type_module true funct_body None env od.popen_expr in
+    let mode = mode_without_locks_exn md.mod_mode in
     let scope = Ctype.create_scope () in
     let sg, newenv =
       Env.enter_signature ~scope ~mod_shape
-        (extract_sig_open env md.mod_loc md.mod_type) env
+        (extract_sig_open env md.mod_loc md.mod_type) ~mode env
     in
     let info, visibility =
       match toplevel with
@@ -3028,6 +3097,7 @@ and type_open_decl_aux ?used_slot ?toplevel funct_body names env od =
 
 and type_structure ?(toplevel = None) funct_body anchor env sstr =
   let names = Signature_names.create () in
+  let _, md_mode = register_allocation () in
 
   let type_str_include ~loc env shape_map sincl sig_acc =
     let smodl = sincl.pincl_mod in
@@ -3036,7 +3106,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
         (fun () -> type_module true funct_body None env smodl)
     in
     let scope = Ctype.create_scope () in
-    let incl_kind, sg =
+    let incl_kind, sg, mode =
       match sincl.pincl_kind with
       | Functor ->
         Language_extension.assert_enabled ~loc Include_functor ();
@@ -3044,14 +3114,15 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
           extract_sig_functor_open funct_body env smodl.pmod_loc
             modl.mod_type sig_acc
         in
-        incl_kind, sg
+        incl_kind, sg, alloc_as_value (Alloc.disallow_right functor_res_mode)
       | Structure ->
-        Tincl_structure, extract_sig_open env smodl.pmod_loc modl.mod_type
+        Tincl_structure, extract_sig_open env smodl.pmod_loc modl.mod_type,
+          (Typedtree.mode_without_locks_exn modl.mod_mode)
     in
     (* Rename all identifiers bound by this signature to avoid clashes *)
     let sg, shape, new_env =
       Env.enter_signature_and_shape ~scope ~parent_shape:shape_map
-        modl_shape sg env
+        modl_shape sg ~mode env
     in
     Signature_group.iter (Signature_names.check_sig_item names loc) sg;
     let incl =
@@ -3079,7 +3150,6 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
 
   let type_str_item
         env shape_map {pstr_loc = loc; pstr_desc = desc} sig_acc =
-    let md_mode = Mode.Value.legacy in
     match desc with
     | Pstr_eval (sexpr, attrs) ->
         let expr, sort =
@@ -3248,8 +3318,13 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
           | _ -> Mp_present
         in
         let md_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) in
+        let mode = mode_without_locks_exn modl.mod_mode in
+        let md_modalities =
+          maybe_infer_modalities ~loc:pmb_loc ~env ~md_mode ~mode
+        in
         let md =
           { md_type = enrich_module_type anchor name.txt modl.mod_type env;
+            md_modalities;
             md_attributes = attrs;
             md_loc = pmb_loc;
             md_uid;
@@ -3263,12 +3338,13 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
           | None -> None, env, []
           | Some name ->
             let id, e = Env.enter_module_declaration
-              ~scope ~shape:md_shape name pres md env
+              ~scope ~shape:md_shape name pres md ~mode:md_mode env
             in
             Signature_names.check_module names pmb_loc id;
             Some id, e,
             [Sig_module(id, pres,
                         {md_type = modl.mod_type;
+                         md_modalities;
                          md_attributes = attrs;
                          md_loc = pmb_loc;
                          md_uid;
@@ -3289,13 +3365,11 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
           List.map
             (function
               | {pmb_name = name;
-                 pmb_expr = {pmod_desc=Pmod_constraint(expr, typ, mode)};
+                 pmb_expr = {pmod_desc=Pmod_constraint(expr, Some typ, mode)};
                  pmb_attributes = attrs;
                  pmb_loc = loc;
                 } ->
-                  check_no_modal_modules ~env mode;
-                  let typ = Option.get typ in
-                  name, typ, expr, attrs, loc
+                  name, typ, mode, expr, attrs, loc
               | mb ->
                   raise (Error (mb.pmb_expr.pmod_loc, env,
                                 Recursive_module_require_explicit_type))
@@ -3303,19 +3377,21 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
             sbind
         in
         let (decls, newenv) =
-          transl_recmodule_modtypes env Mode.Modality.Value.Const.id
-            (List.map (fun (name, smty, _smodl, attrs, loc) ->
-                 {pmd_name=name; pmd_type=smty;
-                  pmd_attributes=attrs; pmd_loc=loc; pmd_modalities=[]}) sbind
+          transl_recmodule_modtypes env
+            ~sig_modalities:Mode.Modality.Value.Const.id
+            (List.map (fun (name, smty, smode, _smodl, attrs, loc) ->
+                 ({pmd_name=name; pmd_type=smty;
+                   pmd_attributes=attrs; pmd_loc=loc; pmd_modalities=[]}
+                  , Some smode)) sbind
             ) in
         List.iter
-          (fun (md, _, _) ->
+          (fun (md, _, _, _) ->
              Option.iter Signature_names.(check_module names md.md_loc) md.md_id
           ) decls;
         let bindings1 =
           List.map2
-            (fun ({md_id=id; md_type=mty}, uid, _prev_shape)
-                 (name, _, smodl, attrs, loc) ->
+            (fun ({md_id=id; md_type=mty}, mode, uid, _prev_shape)
+                 (name, _, _, smodl, attrs, loc) ->
                let modl, shape =
                  Builtin_attributes.warning_scope attrs
                    (fun () ->
@@ -3326,24 +3402,25 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
                let mty' =
                  enrich_module_type anchor name.txt modl.mod_type newenv
                in
-               (id, name, mty, modl, mty', attrs, loc, shape, uid))
+               (id, name, mty, modl, mty', Option.get mode, attrs, loc, shape, uid))
             decls sbind in
         let newenv = (* allow aliasing recursive modules from outside *)
           List.fold_left
-            (fun env (id_opt, _, mty, _, _, attrs, loc, shape, uid) ->
+            (fun env (id_opt, _, mty, _, _, mode, attrs, loc, shape, uid) ->
                match id_opt with
                | None -> env
                | Some id ->
                    let mdecl =
                      {
                        md_type = mty.mty_type;
+                       md_modalities = Modality.Value.id;
                        md_attributes = attrs;
                        md_loc = loc;
                        md_uid = uid;
                      }
                    in
                    Env.add_module_declaration ~check:true ~shape
-                     id Mp_present mdecl env
+                     id Mp_present mdecl ~mode env
             )
             env bindings1
         in
@@ -3363,6 +3440,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
         map_rec (fun rs (id, mb, uid, _shape) ->
             Sig_module(id, Mp_present, {
                 md_type=mb.mb_expr.mod_type;
+                md_modalities=Modality.Value.id;
                 md_attributes=mb.mb_attributes;
                 md_loc=mb.mb_loc;
                 md_uid = uid;
@@ -3384,6 +3462,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
         in
         Tstr_open od, sg, shape_map, newenv
     | Pstr_class cl ->
+        Value.Comonadic.(submode_exn legacy md_mode.comonadic);
         let (classes, new_env) = Typeclass.class_declarations env cl in
         let shape_map = List.fold_left (fun acc cls ->
             let open Typeclass in
@@ -3481,7 +3560,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
     let str = { str_items = items; str_type = sg; str_final_env = final_env } in
     Cmt_format.set_saved_types
       (Cmt_format.Partial_structure str :: previous_saved_types);
-    str, sg, names, Shape.str shape_map, final_env
+    str, sg, md_mode, names, Shape.str shape_map, final_env
   in
   if Option.is_some toplevel then run ()
   else Builtin_attributes.warning_scope [] run
@@ -3503,24 +3582,20 @@ let type_toplevel_phrase env sig_acc s =
   Env.reset_required_globals ();
   Env.reset_probes ();
   Typecore.reset_allocations ();
-  let (str, sg, to_remove_from_sg, shape, env) =
+  let (str, sg, mode, to_remove_from_sg, shape, env) =
     type_structure ~toplevel:(Some sig_acc) false None env s in
+  begin match Value.submode mode Value.legacy with
+  | Ok () -> ()
+  | Error e -> raise (Error (Location.none, env, (Legacy_module (Toplevel, e))))
+  end;
   remove_mode_and_jkind_variables env sg;
   remove_mode_and_jkind_variables_for_toplevel str;
   Typecore.optimise_allocations ();
   (str, sg, to_remove_from_sg, shape, env)
 
 let type_module_alias env smod =
-  let md, shape, held_locks =
-    type_module_maybe_hold_locks ~alias:true ~hold_locks:true true false
-      None env smod
-  in
-  let locks =
-    match held_locks with
-    | None -> Env.locks_empty
-    | Some (locks, _, _) -> locks
-  in
-  md, shape, locks
+  type_module_maybe_hold_locks ~alias:true ~hold_locks:true true false
+    None env smod
 
 let type_module = type_module true false None
 let type_module_maybe_hold_locks = type_module_maybe_hold_locks true false None
@@ -3549,9 +3624,12 @@ let type_module_type_of env smod =
   let tmty =
     match smod.pmod_desc with
     | Pmod_ident lid -> (* turn off strengthening in this case *)
-        let path, md, _ = Env.lookup_module ~loc:smod.pmod_loc lid.txt env in
+        let path, md, (mode, locks) =
+          Env.lookup_module ~loc:smod.pmod_loc lid.txt env
+        in
           { mod_desc = Tmod_ident (path, lid);
             mod_type = md.md_type;
+            mod_mode = mode, Some (locks, lid.txt, lid.loc);
             mod_env = env;
             mod_attributes = smod.pmod_attributes;
             mod_loc = smod.pmod_loc }
@@ -3612,15 +3690,15 @@ let type_package env m p fl =
   (* Same as Pexp_letmodule *)
   (* remember original level *)
   let outer_scope = Ctype.get_current_level () in
-  let modl, scope, held_locks =
+  let modl, scope =
     Typetexp.TyVarEnv.with_local_scope begin fun () ->
       (* type the module and create a scope in a raised level *)
       Ctype.with_local_level begin fun () ->
-        let modl, _mod_shape, held_locks =
+        let modl, _mod_shape =
           type_module_maybe_hold_locks ~hold_locks:true env m
         in
         let scope = Ctype.create_scope () in
-        modl, scope, held_locks
+        modl, scope
       end
     end
   in
@@ -3676,8 +3754,9 @@ let type_package env m p fl =
       with Ctype.Unify _ ->
         raise (Error(modl.mod_loc, env, Scoping_pack (n,ty))))
     fl';
+  let mode = Value.newvar () in
   let modl =
-    wrap_constraint_package env true modl held_locks mty Tmodtype_implicit
+    wrap_constraint_package env true modl mty mode Tmodtype_implicit
   in
   modl, fl'
 
@@ -3787,9 +3866,13 @@ let type_implementation target modulename initial_env ast =
         ignore @@ Warnings.parse_options false "-32-34-37-38-60";
       if !Clflags.as_parameter then
         error Cannot_compile_implementation_as_parameter;
-      let (str, sg, names, shape, finalenv) =
+      let (str, sg, mode, names, shape, finalenv) =
         Profile.record_call "infer" (fun () ->
           type_structure initial_env ast) in
+      begin match Value.submode mode Env.mode_unit with
+      | Ok () -> ()
+      | Error e -> error (Legacy_module (Compilation_unit, e))
+      end;
       let uid = Uid.of_compilation_unit_id modulename in
       let shape = Shape.set_uid_if_none shape uid in
       if !Clflags.binary_annotations_cms then
@@ -4011,6 +4094,7 @@ let package_signatures units =
       let sg = Subst.signature Make_local subst sg in
       let md =
         { md_type=Mty_signature sg;
+          md_modalities=Modality.Value.id;
           md_attributes=[];
           md_loc=Location.none;
           md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
@@ -4419,14 +4503,34 @@ let report_error ~loc _env = function
       Location.errorf ~loc
         "This instance has multiple arguments with the name %a."
         (Style.as_inline_code Global_module.Name.print) name
-  | Submode_failed (Error (ax, {left; right})) ->
+  | Value_weaker_than_module (Error (ax, {left; right})) ->
+      let d =
+        match ax with
+        | Comonadic Areality -> Format.dprintf "a module"
+        | _ ->
+            Format.dprintf "a %a module"
+              (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
+      in
       Location.errorf ~loc
-        "This value is %a, but expected to be %a because it is inside a module."
+        "This value is %a, but expected to be %a because it is inside %t."
         (Style.as_inline_code (Mode.Value.Const.print_axis ax)) left
         (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
-  | Modal_module_not_supported ->
+        d
+  | Submode_failed (Error (ax, {left; right})) ->
       Location.errorf ~loc
-        "Mode annotations on modules are not supported yet."
+        "This value is %a, but expected to be %a."
+        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) left
+        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
+  | Unsupported_modal_module e ->
+      Location.errorf ~loc
+        "Mode annotations on %a are not supported yet."
+        print_unsupported_modal_module e
+  | Legacy_module (reason, Error (ax, {left; right})) ->
+      Location.errorf ~loc
+        "This is %a, but expected to be %a because it is a %a."
+        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) left
+        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
+        print_legacy_module reason
 
 let report_error env ~loc err =
   Printtyp.wrap_printing_env_error env

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -32,8 +32,8 @@ val type_module:
         Env.t -> Parsetree.module_expr -> Typedtree.module_expr * Shape.t
 val type_structure:
   Env.t -> Parsetree.structure ->
-  Typedtree.structure * Types.signature * Signature_names.t * Shape.t *
-  Env.t
+  Typedtree.structure * Types.signature * Mode.Value.lr * Signature_names.t *
+  Shape.t * Env.t
 val type_toplevel_phrase:
   Env.t -> Types.signature -> Parsetree.structure ->
   Typedtree.structure * Types.signature * Signature_names.t * Shape.t *
@@ -110,6 +110,17 @@ type functor_dependency_error =
     Functor_applied
   | Functor_included
 
+(** Modules that are required to be legacy mode *)
+type legacy_module =
+  | Compilation_unit
+  | Toplevel
+  | Functor_body
+
+(** Places where modes annotations are not supported *)
+type unsupported_modal_module =
+  | Functor_param
+  | Functor_res
+
 type error =
     Cannot_apply of module_type
   | Not_included of Includemod.explanation
@@ -164,7 +175,9 @@ type error =
     }
   | Duplicate_parameter_name of Global_module.Name.t
   | Submode_failed of Mode.Value.error
-  | Modal_module_not_supported
+  | Value_weaker_than_module of Mode.Value.error
+  | Unsupported_modal_module of unsupported_modal_module
+  | Legacy_module of legacy_module * Mode.Value.error
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -755,6 +755,7 @@ module type Wrapped = sig
   and module_declaration =
   {
     md_type: module_type;
+    md_modalities: Mode.Modality.Value.t;
     md_attributes: Parsetree.attributes;
     md_loc: Location.t;
     md_uid: Uid.t;
@@ -810,9 +811,10 @@ module Map_wrapped(From : Wrapped)(To : Wrapped) = struct
       val_uid
     }
 
-  let module_declaration m {md_type; md_attributes; md_loc; md_uid} =
+  let module_declaration m {md_type; md_modalities; md_attributes; md_loc; md_uid} =
     To.{
       md_type = module_type m md_type;
+      md_modalities;
       md_attributes;
       md_loc;
       md_uid;
@@ -1683,3 +1685,6 @@ let undo_compress (changes, _old) =
             Transient_expr.set_desc ty desc; r := !next
         | _ -> ())
         log
+
+let functor_param_mode = Mode.Alloc.legacy
+let functor_res_mode = Mode.Alloc.legacy

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -972,6 +972,7 @@ module type Wrapped = sig
   and module_declaration =
   {
     md_type: module_type;
+    md_modalities : Mode.Modality.Value.t;
     md_attributes: Parsetree.attributes;
     md_loc: Location.t;
     md_uid: Uid.t;
@@ -1166,3 +1167,6 @@ val set_univar: type_expr option ref -> type_expr -> unit
 val link_kind: inside:field_kind -> field_kind -> unit
 val link_commu: inside:commutable -> commutable -> unit
 val set_commu_ok: commutable -> unit
+
+val functor_param_mode : Mode.Alloc.lr
+val functor_res_mode : Mode.Alloc.lr


### PR DESCRIPTION
Based on #3757 and #3758 

This PR adds the support for modules of non-legacy modes. Functor parameter and body are still required to be legacy.

TODO:
- [] Improve inclusion error messages
- [] Add tests reflecting subtle code changes in type checking

The room for improvement shouldn't block preliminary review and discussion. In particular, changes to the existing tests seem correct, and can serve as a good starting point.
