### PR TITLE
Use caml_modify_local on runtime4 for atomics

### DIFF
--- a/runtime4/misc.c
+++ b/runtime4/misc.c
@@ -256,7 +256,7 @@ CAMLprim value caml_atomic_compare_exchange(value ref, value oldv, value newv)
 {
   value* p = Op_val(ref);
   if (*p == oldv) {
-    caml_modify(p, newv);
+    caml_modify_local(ref, 0, newv);
     return oldv;
   } else {
     return *p;
@@ -275,7 +275,7 @@ CAMLprim value caml_atomic_cas(value ref, value oldv, value newv)
 CAMLprim value caml_atomic_exchange(value ref, value v)
 {
   value ret = Field(ref, 0);
-  caml_modify(Op_val(ref), v);
+  caml_modify_local(ref, 0, v);
   return ret;
 }
 


### PR DESCRIPTION
The C implementations of atomics on runtime4 (as used on arm64, and on x86-64 in cases where specialization has not happened) incorrectly call `caml_modify` rather than `caml_modify_local`.  This causes failures as seen on #3744.  The structure of the code on runtime5 looks correct already.