### PR TITLE
Actually call relax_poll in Branch_relaxation

### DIFF
--- a/backend/arm64/CSE.ml
+++ b/backend/arm64/CSE.ml
@@ -30,7 +30,7 @@ class cfg_cse = object
     match op with
     | Specific spec ->
       (match spec with
-       | Ifar_poll _
+       | Ifar_poll
        | Ifar_alloc _
        | Ishiftarith _
        | Imuladd

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -53,7 +53,7 @@ type cmm_label = Label.t
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
 type specific_operation =
-  | Ifar_poll of { return_label: cmm_label option }
+  | Ifar_poll
   | Ifar_alloc of { bytes : int; dbginfo : Cmm.alloc_dbginfo }
   | Ishiftarith of arith_operation * int
   | Imuladd       (* multiply and add *)
@@ -120,7 +120,7 @@ let int_of_bswap_bitwidth = function
 
 let print_specific_operation printreg op ppf arg =
   match op with
-  | Ifar_poll _ ->
+  | Ifar_poll ->
     fprintf ppf "(far) poll"
   | Ifar_alloc { bytes; dbginfo = _ } ->
     fprintf ppf "(far) alloc %i" bytes
@@ -221,7 +221,7 @@ let equal_specific_operation left right =
   | Imove32, Imove32 -> true
   | Isignext left, Isignext right -> Int.equal left right
   | Isimd left, Isimd right -> Simd.equal_operation left right
-  | (Ifar_alloc _  | Ifar_poll _  | Ishiftarith _
+  | (Ifar_alloc _  | Ifar_poll  | Ishiftarith _
     | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf
     | Inegmulsubf | Isqrtf | Ibswap _ | Imove32 | Isignext _ | Isimd _), _ -> false
 
@@ -299,7 +299,7 @@ let is_logical_immediate x =
 (* Specific operations that are pure *)
 
 let operation_is_pure : specific_operation -> bool = function
-  | Ifar_alloc _ | Ifar_poll _ -> false
+  | Ifar_alloc _ | Ifar_poll -> false
   | Ishiftarith _ -> true
   | Imuladd -> true
   | Imulsub -> true
@@ -318,7 +318,7 @@ let operation_is_pure : specific_operation -> bool = function
 
 let operation_can_raise = function
   | Ifar_alloc _
-  | Ifar_poll _ -> true
+  | Ifar_poll -> true
   | Imuladd
   | Imulsub
   | Inegmulf
@@ -335,7 +335,7 @@ let operation_can_raise = function
 
 let operation_allocates = function
   | Ifar_alloc _ -> true
-  | Ifar_poll _
+  | Ifar_poll
   | Imuladd
   | Imulsub
   | Inegmulf

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -43,7 +43,7 @@ type cmm_label = Label.t
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
 type specific_operation =
-  | Ifar_poll of { return_label: cmm_label option }
+  | Ifar_poll
   | Ifar_alloc of { bytes : int; dbginfo : Cmm.alloc_dbginfo }
   | Ishiftarith of arith_operation * int
   | Imuladd       (* multiply and add *)

--- a/backend/arm64/emit.mlp
+++ b/backend/arm64/emit.mlp
@@ -448,7 +448,7 @@ let num_call_gc_points instr =
     (* The following four should never be seen, since this function is run
        before branch relaxation. *)
     | Lop (Specific (Ifar_alloc _))
-    | Lop (Specific (Ifar_poll _)) -> assert false
+    | Lop (Specific Ifar_poll) -> assert false
     | Lop (Alloc { mode = (Local | Heap); _ })
     | Lop (Specific
              (Imuladd|Imulsub|Inegmulf|Imuladdf|Inegmuladdf|Imulsubf|Inegmulsubf|
@@ -822,7 +822,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Alloc { mode = Heap;_ }) when !fastcode_flag -> 5
     | Lop (Specific (Ifar_alloc _)) when !fastcode_flag -> 6
     | Lop Poll -> 3
-    | Lop (Specific (Ifar_poll _)) -> 4
+    | Lop (Specific Ifar_poll) -> 4
     | Lop (Alloc { mode = Heap; bytes = num_bytes; _ })
     | Lop (Specific (Ifar_alloc { bytes = num_bytes; _ })) ->
       begin match num_bytes with
@@ -905,8 +905,8 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Specific (Isimd simd)) ->
       DSL.simd_instr_size simd
 
-  let relax_poll ~return_label =
-    Lop (Specific (Ifar_poll { return_label }))
+  let relax_poll () =
+    Lop (Specific Ifar_poll)
 
   let relax_allocation ~num_bytes ~dbginfo =
     Lop (Specific (Ifar_alloc { bytes = num_bytes; dbginfo }))
@@ -1391,8 +1391,8 @@ let emit_instr i =
         `	str	{emit_reg i.arg.(0)}, [{emit_reg reg_domain_state_ptr}, #{emit_int offset}]\n`
     | Lop(Poll) ->
         assembly_code_for_poll i ~far:false ~return_label:None
-    | Lop(Specific (Ifar_poll { return_label })) ->
-        assembly_code_for_poll i ~far:true ~return_label
+    | Lop(Specific Ifar_poll) ->
+        assembly_code_for_poll i ~far:true ~return_label:None
     | Lop(Intop_imm(Iadd, n)) ->
         emit_addimm i.res.(0) i.arg.(0) n
     | Lop(Intop_imm(Isub, n)) ->

--- a/backend/arm64/vectorize_specific.ml
+++ b/backend/arm64/vectorize_specific.ml
@@ -12,7 +12,7 @@ let memory_access : Arch.specific_operation -> Memory_access.t option =
     Some (Memory_access.create ?first_memory_arg_index desc)
   in
   match op with
-  | Ifar_poll _ ->
+  | Ifar_poll ->
     (* Conservative, don't reorder across poll instructions. In practice, there
        are not many poll instructions present at this stage, because poll
        insertion pass currently happens after vectorize. *)
@@ -27,7 +27,7 @@ let memory_access : Arch.specific_operation -> Memory_access.t option =
 
 let is_seed_store (op : Arch.specific_operation) =
   match op with
-  | Ifar_poll _ | Ifar_alloc _ | Ishiftarith _ | Imuladd | Imulsub | Inegmulf
+  | Ifar_poll | Ifar_alloc _ | Ishiftarith _ | Imuladd | Imulsub | Inegmulf
   | Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf | Isqrtf | Ibswap _
   | Imove32 | Isignext _ | Isimd _ ->
     None

--- a/backend/branch_relaxation.ml
+++ b/backend/branch_relaxation.ml
@@ -87,7 +87,8 @@ module Make (T : Branch_relaxation_intf.S) = struct
         else
           match instr.desc with
           | Lop (Poll) ->
-             fixup true (pc + T.instr_size instr.desc) instr.next
+            instr.desc <- T.relax_poll ();
+            fixup true (pc + T.instr_size instr.desc) instr.next
           | Lop (Alloc { bytes = num_bytes; dbginfo }) ->
             instr.desc <- T.relax_allocation ~num_bytes ~dbginfo;
             fixup true (pc + T.instr_size instr.desc) instr.next

--- a/backend/branch_relaxation_intf.mli
+++ b/backend/branch_relaxation_intf.mli
@@ -65,6 +65,6 @@ module type S = sig
     -> Linear.instruction_desc
 
   val relax_poll
-     : return_label:Cmm.label option
+     : unit
     -> Linear.instruction_desc
 end


### PR DESCRIPTION
The `Branch_relaxation` module is only used on arm64.  It was missing a call to replace potentially out-of-range poll instructions with "far poll" instructions.  This patch fixes that.

Fixing this revealed that the `return_label` argument, which I think was generally removed some time ago, was still languishing on `Ifar_poll`.  It is removed by this PR.