### PR TITLE
Print if we ran out of fuel as part of the jkind violation error

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -532,6 +532,8 @@ list list list list list list
                             list list list list list" must be a subkind of
          immutable_data
          because of the definition of t at line 1, characters 0-149.
+       Note: I gave up trying to find the simplest kind for the first,
+       as it is very large or deeply recursive.
 |}]
 
 type t = int list list list list list list list list list list list list list list list list list list list list list list list list
@@ -597,6 +599,8 @@ Error: The kind of type "t" is immutable_data with 'a t t t t t t t t t t t
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
+       Note: I gave up trying to find the simplest kind for the first,
+       as it is very large or deeply recursive.
 |}]
 
 let foo (t : _ t @@ contended) = use_uncontended t
@@ -643,6 +647,8 @@ Error: The kind of type "t" is immutable_data
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
+       Note: I gave up trying to find the simplest kind for the first,
+       as it is very large or deeply recursive.
 |}]
 
 let foo (t : int t @@ contended) = use_uncontended t

--- a/testsuite/tests/typing-jkind-bounds/subsumption/fuel.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/fuel.ml
@@ -28,6 +28,8 @@ Error: The kind of type "int list list list list list" is immutable_data
        But the kind of type "int list list list list list" must be a subkind of
          immutable_data
          because of the definition of t at line 1, characters 0-54.
+       Note: I gave up trying to find the simplest kind for the first,
+       as it is very large or deeply recursive.
 |}]
 
 (* Differences in fuel consumption do not cause errors for module inclusion check

--- a/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/recursive.ml
@@ -24,7 +24,6 @@ and 'a foo = 'a my_list
 type 'a my_list : immutable_data with 'a =
   | Nil
   | Cons of 'a * 'a my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list
-(* CR layouts v2.8: consider making the error message say something about running out of fuel *)
 [%%expect {|
 Line 3, characters 17-115:
 3 |   | Cons of 'a * 'a my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list my_list
@@ -336,6 +335,8 @@ degenerate
        But the kind of type "degenerate" must be a subkind of immutable_data
          with 'a
          because of the annotation on the declaration of the type degenerate.
+       Note: I gave up trying to find the simplest kind for the first,
+       as it is very large or deeply recursive.
 |}]
 
 type ('a, 'b) zipped_list : immutable_data with 'a with 'b = Nil | Cons of 'a * 'b * ('a, 'b) zipped_list
@@ -507,4 +508,6 @@ Error: The kind of type "t2" is immutable_data with 'a with t1 with t1 t2
        But the kind of type "t2" must be a subkind of immutable_data with 'a
          with t1
          because of the annotation on the declaration of the type t2.
+       Note: I gave up trying to find the simplest kind for the first,
+       as it is very large or deeply recursive.
 |}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1135,6 +1135,7 @@ let fresh_jkind jkind ~annotation ~why =
     annotation;
     history = Creation why;
     has_warned = false;
+    ran_out_of_fuel_during_normalize = false;
     quality = Not_best
   }
   |> allow_left |> allow_right
@@ -1145,6 +1146,7 @@ let fresh_jkind_poly jkind ~annotation ~why =
     annotation;
     history = Creation why;
     has_warned = false;
+    ran_out_of_fuel_during_normalize = false;
     quality = Not_best
   }
 
@@ -1868,6 +1870,7 @@ module Builtin = struct
       (* this should never get printed: it's a dummy *)
       history = Creation (Any_creation Dummy_jkind);
       has_warned = false;
+      ran_out_of_fuel_during_normalize = false;
       quality = Not_best
     }
 
@@ -1886,6 +1889,7 @@ module Builtin = struct
       annotation = mk_annot "value";
       history = Creation (Value_or_null_creation V1_safety_check);
       has_warned = false;
+      ran_out_of_fuel_during_normalize = false;
       quality = Not_best
     }
 
@@ -1988,6 +1992,7 @@ let of_const (type l r) ~annotation ~why ~(quality : (l * r) jkind_quality)
     annotation;
     history = Creation why;
     has_warned = false;
+    ran_out_of_fuel_during_normalize = false;
     quality
   }
 
@@ -2194,7 +2199,11 @@ let[@inline] normalize ~mode ~jkind_of_type t =
     quality =
       (match t.quality, fuel_result with
       | Not_best, _ | _, Ran_out_of_fuel -> Not_best
-      | Best, Sufficient_fuel -> Best)
+      | Best, Sufficient_fuel -> Best);
+    ran_out_of_fuel_during_normalize =
+      (match fuel_result with
+      | Ran_out_of_fuel -> true
+      | _ -> t.ran_out_of_fuel_during_normalize)
   }
 
 let get_layout_defaulting_to_value { jkind = { layout; _ }; _ } =
@@ -2847,6 +2856,23 @@ module Violation = struct
                  pp_bound sub.jkind pp_bound super.jkind))
     | No_intersection _ -> ()
 
+  let report_fuel ppf violation =
+    let report_fuel_for_type which =
+      fprintf ppf
+        "@;\
+         @[Note: I gave up trying to find the simplest kind for the %s,@,\
+         as it is very large or deeply recursive.@]" which
+    in
+    let first_ran_out, second_ran_out =
+      match violation with
+      | Not_a_subjkind (k1, k2, _) ->
+        k1.ran_out_of_fuel_during_normalize, k2.ran_out_of_fuel_during_normalize
+      | No_intersection (k1, k2) ->
+        k1.ran_out_of_fuel_during_normalize, k2.ran_out_of_fuel_during_normalize
+    in
+    if first_ran_out then report_fuel_for_type "first";
+    if second_ran_out then report_fuel_for_type "second"
+
   let report_general preamble pp_former former ppf t =
     let mismatch_type =
       match t.violation with
@@ -2935,7 +2961,8 @@ module Violation = struct
       fprintf ppf "@[<hov 2>%s%a has %t,@ which %t.@]" preamble pp_former former
         fmt_k1 fmt_k2;
     report_missing_cmi ppf missing_cmi_option;
-    report_reason ppf t.violation
+    report_reason ppf t.violation;
+    report_fuel ppf t.violation
 
   let pp_t ppf x = fprintf ppf "%t" x
 
@@ -2951,9 +2978,20 @@ end
 (* relations *)
 
 let equate_or_equal ~allow_mutation
-    { jkind = jkind1; annotation = _; history = _; has_warned = _; quality = _ }
-    { jkind = jkind2; annotation = _; history = _; has_warned = _; quality = _ }
-    =
+    { jkind = jkind1;
+      annotation = _;
+      history = _;
+      has_warned = _;
+      ran_out_of_fuel_during_normalize = _;
+      quality = _
+    }
+    { jkind = jkind2;
+      annotation = _;
+      history = _;
+      has_warned = _;
+      ran_out_of_fuel_during_normalize = _;
+      quality = _
+    } =
   Jkind_desc.equate_or_equal ~allow_mutation jkind1 jkind2
 
 (* CR layouts v2.8: Switch this back to ~allow_mutation:false *)
@@ -3023,6 +3061,9 @@ let intersection_or_error ~type_equal ~jkind_of_type ~reason t1 t2 =
           combine_histories ~type_equal ~jkind_of_type reason (Pack_jkind t1)
             (Pack_jkind t2);
         has_warned = t1.has_warned || t2.has_warned;
+        ran_out_of_fuel_during_normalize =
+          t1.ran_out_of_fuel_during_normalize
+          || t2.ran_out_of_fuel_during_normalize;
         quality =
           Not_best (* As required by the fact that this is a [jkind_r] *)
       }
@@ -3386,16 +3427,23 @@ module Debug_printers = struct
     | Creation c -> fprintf ppf "Creation (%a)" creation_reason c
 
   let t (type l r) ppf
-      ({ jkind; annotation = a; history = h; has_warned = _; quality = q } :
+      ({ jkind;
+         annotation = a;
+         history = h;
+         has_warned = _;
+         ran_out_of_fuel_during_normalize = roofdn;
+         quality = q
+       } :
         (l * r) jkind) : unit =
     fprintf ppf
       "@[<v 2>{ jkind = %a@,\
        ; annotation = %a@,\
        ; history = %a@,\
+       ; ran_out_of_fuel_during_normalize = %a@,\
        ; quality = %s@,\
       \ }@]" Jkind_desc.Debug_printers.t jkind
       (pp_print_option Pprintast.jkind_annotation)
-      a history h
+      a history h pp_print_bool roofdn
       (match q with Best -> "Best" | Not_best -> "Not_best")
 
   module Const = struct

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -365,6 +365,7 @@ and 'd jkind =
     annotation : Parsetree.jkind_annotation option;
     history : jkind_history;
     has_warned : bool;
+    ran_out_of_fuel_during_normalize : bool;
     quality : 'd jkind_quality;
   }
   constraint 'd = 'l * 'r

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -354,6 +354,7 @@ and 'd jkind =
     annotation : Parsetree.jkind_annotation option;
     history : jkind_history;
     has_warned : bool;
+    ran_out_of_fuel_during_normalize : bool;
     quality : 'd jkind_quality;
   }
   constraint 'd = 'l * 'r


### PR DESCRIPTION
Remember on a jkind if we ran out of fuel during normalize, and print that as
part of jkind violation errors, to give users a little bit more to go on.