### PR TITLE
Fix sorts of record operations

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -214,7 +214,7 @@ let iter_on_occurrences
           f ~namespace:Value exp_env path lid
       | Texp_construct (lid, constr_desc, _, _) ->
           add_constructor_description exp_env lid constr_desc
-      | Texp_field (_, lid, label_desc, _, _)
+      | Texp_field (_, _, lid, label_desc, _, _)
       | Texp_setfield (_, _, lid, label_desc, _) ->
           add_label ~namespace:Label exp_env lid label_desc
       | Texp_unboxed_field (_, _, lid, label_desc, _) ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -760,7 +760,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         | Record_inlined (_, _, Variant_with_null) -> assert false
       in
       let sort_arg =
-        (* We know the record is boxed because unboxed records don't have
+        (* We know the record is boxed because [@@unboxed] records don't have
            mutable fields, and this is double checked by the assert in [access]
            above. *)
         Jkind.Sort.Const.for_boxed_record

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -759,7 +759,13 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
             Psetmixedfield(lbl.lbl_pos, shape, mode)
         | Record_inlined (_, _, Variant_with_null) -> assert false
       in
-      Lprim(access, [transl_exp ~scopes Jkind.Sort.Const.for_record arg;
+      let sort_arg =
+        (* We know the record is boxed because unboxed records don't have
+           mutable fields, and this is double checked by the assert in [access]
+           above. *)
+        Jkind.Sort.Const.for_boxed_record
+      in
+      Lprim(access, [transl_exp ~scopes sort_arg arg;
                      transl_exp ~scopes lbl.lbl_sort newval],
             of_location ~scopes e.exp_loc)
   | Texp_array (amut, element_sort, expr_list, alloc_mode) ->
@@ -1884,7 +1890,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     | Some m -> is_heap_mode m
   in
   match opt_init_expr with
-  | Some (init_expr, _) when on_heap && size >= Config.max_young_wosize ->
+  | Some (init_expr, init_expr_sort, _)
+    when on_heap && size >= Config.max_young_wosize ->
     (* Take a shallow copy of the init record, then mutate the fields
        of the copy *)
     let copy_id = Ident.create_local "newrecord" in
@@ -1942,10 +1949,13 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                           of_location ~scopes loc),
                     cont)
     in
+    let init_expr_sort =
+      Jkind.Sort.default_for_transl_and_get init_expr_sort
+    in
     assert (is_heap_mode (Option.get mode)); (* Pduprecord must be Alloc_heap and not unboxed *)
     Llet(Strict, Lambda.layout_block, copy_id,
          Lprim(Pduprecord (repres, size),
-               [transl_exp ~scopes Jkind.Sort.Const.for_record init_expr],
+               [transl_exp ~scopes init_expr_sort init_expr],
                of_location ~scopes loc),
          Array.fold_left update_field (Lvar copy_id) fields)
   | Some _ | None ->
@@ -1963,7 +1973,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                  if Types.is_mutable mut then Reads_vary else Reads_agree
                in
                let unique_barrier = match opt_init_expr with
-                 | Some (_, ubr) -> Translmode.transl_unique_barrier ubr
+                 | Some (_, _, ubr) -> Translmode.transl_unique_barrier ubr
                  | None -> assert false (* Kept fields only exist on extended records *)
                in
                let sem = add_barrier_to_read unique_barrier sem in
@@ -2114,8 +2124,12 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     in
     begin match opt_init_expr with
       None -> lam
-    | Some (init_expr, _) -> Llet(Strict, Lambda.layout_block, init_id,
-                             transl_exp ~scopes Jkind.Sort.Const.for_record init_expr, lam)
+    | Some (init_expr, init_expr_sort, _) ->
+        let init_expr_sort =
+          Jkind.Sort.default_for_transl_and_get init_expr_sort
+        in
+        Llet(Strict, Lambda.layout_block, init_id,
+             transl_exp ~scopes init_expr_sort init_expr, lam)
     end
 
 and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -636,8 +636,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         {fields; representation; extended_expression } ->
       transl_record_unboxed_product ~scopes e.exp_loc e.exp_env
         fields representation extended_expression
-  | Texp_field(arg, id, lbl, float, ubr) ->
-      let targ = transl_exp ~scopes Jkind.Sort.Const.for_record arg in
+  | Texp_field(arg, arg_sort, id, lbl, float, ubr) ->
+      let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
+      let targ = transl_exp ~scopes arg_sort arg in
       let sem =
         if Types.is_mutable lbl.lbl_mut then Reads_vary else Reads_agree
       in

--- a/testsuite/tests/typing-layouts/datatypes.ml
+++ b/testsuite/tests/typing-layouts/datatypes.ml
@@ -529,13 +529,5 @@ val zero : unit -> int64# = <fun>
 let zero x = { (id x) with l = #0L } [@@warning "-23"]
 
 [%%expect {|
-Line 1, characters 15-21:
-1 | let zero x = { (id x) with l = #0L } [@@warning "-23"]
-                   ^^^^^^
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of 'a r is bits64
-         because of the definition of r at line 1, characters 0-45.
-       But the layout of 'a r must be a sublayout of value
-         because it has to be value for the V1 safety check.
+val zero : ('a : bits64). 'a r -> int64# r = <fun>
 |}]

--- a/testsuite/tests/typing-layouts/datatypes.ml
+++ b/testsuite/tests/typing-layouts/datatypes.ml
@@ -525,3 +525,17 @@ type ('a : bits64) r = { l : 'a; } [@@unboxed]
 val id : ('a : bits64). 'a -> 'a = <fun>
 val zero : unit -> int64# = <fun>
 |}]
+
+let zero x = { (id x) with l = #0L } [@@warning "-23"]
+
+[%%expect {|
+Line 1, characters 15-21:
+1 | let zero x = { (id x) with l = #0L } [@@warning "-23"]
+                   ^^^^^^
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of 'a r is bits64
+         because of the definition of r at line 1, characters 0-45.
+       But the layout of 'a r must be a sublayout of value
+         because it has to be value for the V1 safety check.
+|}]

--- a/testsuite/tests/typing-layouts/datatypes.ml
+++ b/testsuite/tests/typing-layouts/datatypes.ml
@@ -509,3 +509,27 @@ Error: This type "t_any M.t2" should be an instance of type "'a M.t2"
          because of the definition of t1 at line 3, characters 2-42.
 |}]
 
+
+(*************************************************)
+(* Test 11: Projecting from an @@unboxed record. *)
+
+(* This is a regression test. We previously had a bug where transl would assume
+   the record in a Texp_field operation has layout value. *)
+
+type ('a : bits64) r = { l : 'a } [@@unboxed]
+let id (x : (_ : bits64)) = x
+let zero () = (id { l = #0L }).l
+
+[%%expect{|
+type ('a : bits64) r = { l : 'a; } [@@unboxed]
+val id : ('a : bits64). 'a -> 'a = <fun>
+Line 3, characters 14-30:
+3 | let zero () = (id { l = #0L }).l
+                  ^^^^^^^^^^^^^^^^
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of int64# r is bits64
+         because of the definition of r at line 1, characters 0-45.
+       But the layout of int64# r must be a sublayout of value
+         because it has to be value for the V1 safety check.
+|}]

--- a/testsuite/tests/typing-layouts/datatypes.ml
+++ b/testsuite/tests/typing-layouts/datatypes.ml
@@ -523,13 +523,5 @@ let zero () = (id { l = #0L }).l
 [%%expect{|
 type ('a : bits64) r = { l : 'a; } [@@unboxed]
 val id : ('a : bits64). 'a -> 'a = <fun>
-Line 3, characters 14-30:
-3 | let zero () = (id { l = #0L }).l
-                  ^^^^^^^^^^^^^^^^
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of int64# r is bits64
-         because of the definition of r at line 1, characters 0-45.
-       But the layout of int64# r must be a sublayout of value
-         because it has to be value for the V1 safety check.
+val zero : unit -> int64# = <fun>
 |}]

--- a/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -445,3 +445,8 @@ Error: Layout mismatch in final type declaration consistency check.
 (* Test 10: Constraints and parameter kind inference *)
 
 (* Doesn't need layouts_alpha. *)
+
+(*************************************************)
+(* Test 11: Projecting from an @@unboxed record. *)
+
+(* Doesn't need layouts_alpha. *)

--- a/testsuite/tests/typing-missing-cmi-3/user.ml
+++ b/testsuite/tests/typing-missing-cmi-3/user.ml
@@ -91,7 +91,17 @@ Error: Type "Middle.pack2" = "(module Middle.T with type M.t = int)"
 (* Check the detection of type kind in type-directed disambiguation . *)
 let t = Middle.r.Middle.x
 [%%expect {|
-val t : unit = ()
+Line 1, characters 8-16:
+1 | let t = Middle.r.Middle.x
+            ^^^^^^^^
+Error: This expression has type "Original.r"
+       but an expression was expected of type "('a : '_representable_layout_1)"
+       The layout of Original.r is any
+         because the .cmi file for Original.r is missing.
+       But the layout of Original.r must be representable
+         because it's the record type used in a projection.
+       No .cmi file found containing Original.r.
+       Hint: Adding "original" to your dependencies might help.
 |}]
 
 let k = match Middle.s with Middle.S -> ()

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -80,7 +80,7 @@ module type Sort = sig
 
     val for_variant_arg : t
 
-    val for_record : t
+    val for_boxed_record : t
 
     val for_block_element : t
 

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -126,7 +126,7 @@ module Sort = struct
 
     let for_poly_variant = value
 
-    let for_record = value
+    let for_boxed_record = value
 
     let for_object = value
 

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -554,7 +554,7 @@ and expression i ppf x =
       record_unboxed_product_representation (i+1) ppf representation;
       line i ppf "extended_expression =\n";
       option (i+1) expression ppf (Option.map fst extended_expression);
-  | Texp_field (e, li, _, _, _) ->
+  | Texp_field (e, _, li, _, _, _) ->
       line i ppf "Texp_field\n";
       expression i ppf e;
       longident i ppf li;

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -543,7 +543,7 @@ and expression i ppf x =
       line i ppf "representation =\n";
       record_representation (i+1) ppf representation;
       line i ppf "extended_expression =\n";
-      option (i+1) expression ppf (Option.map fst extended_expression);
+      option (i+1) expression ppf (Option.map Misc.fst3 extended_expression);
   | Texp_record_unboxed_product
         { fields; representation; extended_expression } ->
       line i ppf "Texp_record_unboxed_product\n";

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -363,7 +363,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
       Option.iter (fun (expr, _) -> sub.expr sub expr) expo
   | Texp_record { fields; extended_expression; _} ->
       iter_fields fields;
-      Option.iter (fun (exp, _) -> sub.expr sub exp) extended_expression;
+      Option.iter (fun (exp, _, _) -> sub.expr sub exp) extended_expression;
   | Texp_record_unboxed_product { fields; extended_expression; _} ->
       iter_fields fields;
       Option.iter (fun (exp, _) -> sub.expr sub exp) extended_expression;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -367,7 +367,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
   | Texp_record_unboxed_product { fields; extended_expression; _} ->
       iter_fields fields;
       Option.iter (fun (exp, _) -> sub.expr sub exp) extended_expression;
-  | Texp_field (exp, lid, _, _, _) ->
+  | Texp_field (exp, _, lid, _, _, _) ->
       iter_loc sub lid;
       sub.expr sub exp
   | Texp_unboxed_field (exp, _, lid, _, _) ->

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -498,7 +498,8 @@ let expr sub x =
         Texp_record {
           fields = map_fields fields; representation;
           extended_expression =
-            Option.map (fun (exp, ubr) -> (sub.expr sub exp, ubr)) extended_expression;
+            Option.map (fun (exp, sort, ubr) -> (sub.expr sub exp, sort, ubr))
+              extended_expression;
           alloc_mode
         }
     | Texp_record_unboxed_product

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -509,8 +509,8 @@ let expr sub x =
             Option.map
               (fun (exp, sort) -> (sub.expr sub exp, sort)) extended_expression
         }
-    | Texp_field (exp, lid, ld, float, ubr) ->
-        Texp_field (sub.expr sub exp, map_loc sub lid, ld, float, ubr)
+    | Texp_field (exp, sort, lid, ld, float, ubr) ->
+        Texp_field (sub.expr sub exp, sort, map_loc sub lid, ld, float, ubr)
     | Texp_unboxed_field (exp, sort, lid, ld, uu) ->
         Texp_unboxed_field (sub.expr sub exp, sort, map_loc sub lid, ld, uu)
     | Texp_setfield (exp1, am, lid, ld, exp2) ->

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -236,7 +236,7 @@ and expression_desc =
   | Texp_record of {
       fields : ( Types.label_description * record_label_definition ) array;
       representation : Types.record_representation;
-      extended_expression : (expression * Unique_barrier.t) option;
+      extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
       alloc_mode : alloc_mode option
     }
   | Texp_record_unboxed_product of {

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -246,8 +246,8 @@ and expression_desc =
       extended_expression : (expression * Jkind.sort) option;
     }
   | Texp_field of
-      expression * Longident.t loc * label_description * texp_field_boxing *
-        Unique_barrier.t
+      expression * Jkind.sort * Longident.t loc * label_description *
+        texp_field_boxing * Unique_barrier.t
   | Texp_unboxed_field of
       expression * Jkind.sort * Longident.t loc * unboxed_label_description *
         unique_use
@@ -1314,7 +1314,7 @@ let rec exp_is_nominal exp =
   | Texp_variant (_, None)
   | Texp_construct (_, _, [], _) ->
       true
-  | Texp_field (parent, _, _, _, _) | Texp_send (parent, _, _) ->
+  | Texp_field (parent, _, _, _, _, _) | Texp_send (parent, _, _) ->
       exp_is_nominal parent
   | _ -> false
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -444,10 +444,12 @@ and expression_desc =
               { fields = [| l1, Kept t1; l2 Override P2 |]; representation;
                 extended_expression = Some E0 }
           *)
-  | Texp_field of expression * Longident.t loc * Types.label_description *
-      texp_field_boxing * Unique_barrier.t
-    (** [texp_field_boxing] provides extra information depending on if the
-        projection requires boxing. *)
+  | Texp_field of expression * Jkind.sort * Longident.t loc *
+      Types.label_description * texp_field_boxing * Unique_barrier.t
+    (** - The sort is the sort of the whole record (which may be non-value if
+          the record is @@unboxed).
+        - [texp_field_boxing] provides extra information depending on if the
+          projection requires boxing. *)
   | Texp_unboxed_field of
       expression * Jkind.sort * Longident.t loc * Types.unboxed_label_description *
         unique_use

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -411,7 +411,7 @@ and expression_desc =
   | Texp_record of {
       fields : ( Types.label_description * record_label_definition ) array;
       representation : Types.record_representation;
-      extended_expression : (expression * Unique_barrier.t) option;
+      extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
       alloc_mode : alloc_mode option
     }
         (** { l1=P1; ...; ln=Pn }           (extended_expression = None)

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2426,7 +2426,7 @@ and check_uniqueness_exp_as_value ienv exp : Value.t * UF.t =
       | Some value -> value
     in
     value, UF.unused
-  | Texp_field (e, _, l, float, unique_barrier) -> (
+  | Texp_field (e, _, _, l, float, unique_barrier) -> (
     let value, uf = check_uniqueness_exp_as_value ienv e in
     match Value.paths value with
     | None ->

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2236,7 +2236,7 @@ let rec check_uniqueness_exp ~overwrite (ienv : Ienv.t) exp : UF.t =
     let value, uf_ext =
       match extended_expression with
       | None -> Value.fresh, UF.unused
-      | Some (exp, unique_barrier) ->
+      | Some (exp, _, unique_barrier) ->
         let value, uf_exp = check_uniqueness_exp_as_value ienv exp in
         Unique_barrier.enable unique_barrier;
         let uf_read =

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -598,7 +598,7 @@ let expression sub exp =
         Pexp_record_unboxed_product
           (list,
            Option.map (fun (exp, _) -> sub.expr sub exp) extended_expression)
-    | Texp_field (exp, lid, _label, _, _) ->
+    | Texp_field (exp, _sort, lid, _label, _, _) ->
         Pexp_field (sub.expr sub exp, map_loc sub lid)
     | Texp_unboxed_field (exp, _, lid, _label, _) ->
         Pexp_unboxed_field (sub.expr sub exp, map_loc sub lid)

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -587,7 +587,7 @@ let expression sub exp =
             | _, Overridden (lid, exp) -> (lid, sub.expr sub exp) :: l)
             [] fields
         in
-        Pexp_record (list, Option.map (fun (exp, _) -> sub.expr sub exp)
+        Pexp_record (list, Option.map (fun (exp, _, _) -> sub.expr sub exp)
                              extended_expression)
     | Texp_record_unboxed_product { fields; extended_expression; _ } ->
         let list = Array.fold_left (fun l -> function

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -865,7 +865,7 @@ let rec expression : Typedtree.expression -> term_judg =
       join [
         expression e1 << Dereference
       ]
-    | Texp_field (e, _, _, _, _) ->
+    | Texp_field (e, _, _, _, _, _) ->
       (*
         G |- e: m[Dereference]
         -----------------------

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -782,7 +782,7 @@ let rec expression : Typedtree.expression -> term_judg =
         in
         join [
           array field es;
-          option expression (Option.map fst eo) << Dereference
+          option expression (Option.map Misc.fst3 eo) << Dereference
         ]
     | Texp_record_unboxed_product { fields = es; extended_expression = eo;
                                     representation = rep } ->


### PR DESCRIPTION
Not all records are values, now that we allow unboxed types in `@@unboxed` records.  Yet, `Jkind.Sort.Const.for_record` exists, and as a result there are two bugs that this PR fixes (both caught by the value kind sanity check, so no miscompilation in practice).

There are four commits, probably best reviewed individually.
1) Demonstrate a bug where we assume the record in a record projection is a value.
2) Fix this by storing the sort of the record in `Texp_field`. This mirrors what we do for unboxed records. Perhaps it would be better to stick it in the `record_representation`, but for now being uniform seemed clearer - we can change this later if desired.
3) Demonstrate a bug where we assume the initial expression in a functional record update is a value.
4) Fix this by storing the sort of the record alongside the initial expression. This again mirrors what we do for unboxed records. This commit also renames `Jkind.Sort.Const.for_record` to `Jkind.Sort.Const.for_boxed_record` - one use remains, and I wrote a comment explaining why I think it's fine.

Review: @rtjoa 

Thanks to @nmatschke for reporting the first bug.