### PR TITLE
Propagate effects info to Cfg.external_call_operation

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -626,8 +626,8 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
     if fp then [| rbp |] else [||]
   | Switch _ ->
     [| rax; rdx |]
-  | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; }
-  | Prim {op = External { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; }; _} ->
+  | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; effects = _; }
+  | Prim {op = External { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; effects = _; }; _} ->
     assert (stack_ofs >= 0);
     if alloc || stack_ofs > 0 then all_phys_regs else destroyed_at_c_call
   | Call {op = Indirect | Direct _; _} -> all_phys_regs
@@ -653,8 +653,8 @@ let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_int
     false
   | Switch _ ->
     false
-  | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; }
-  | Prim {op = External { func_symbol = _; alloc; ty_res = _; ty_args = _; }; _} ->
+  | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; _ }
+  | Prim {op = External { func_symbol = _; alloc; ty_res = _; ty_args = _; _ }; _} ->
     if more_destruction_points then
       true
     else

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -419,8 +419,8 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
   | Tailcall_func _ | Prim {op = Probe _; _}
   | Specific_can_raise _ ->
     [||]
-  | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; }
-  | Prim {op  = External { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; }; _} ->
+  | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; _ }
+  | Prim {op  = External { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; _ }; _} ->
     if alloc || stack_ofs > 0 then all_phys_regs else destroyed_at_c_noalloc_call
 
 (* CR-soon xclerc for xclerc: consider having more destruction points.
@@ -438,8 +438,8 @@ let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_int
   | Tailcall_func _ | Prim {op = Probe _; _}
   | Specific_can_raise _ ->
     false
-  | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs = _}
-  | Prim {op  = External { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs = _}; _} ->
+  | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs = _; _}
+  | Prim {op  = External { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs = _; _}; _} ->
     if more_destruction_points then
       true
     else

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -357,7 +357,9 @@ let dump_terminator' ?(print_reg = Printreg.reg) ?(res = [||]) ?(args = [||])
   | Prim { op = prim; label_after } ->
     Format.fprintf ppf "%t%a" print_res dump_linear_call_op
       (match prim with
-      | External { func_symbol = func; ty_res; ty_args; alloc; stack_ofs } ->
+      | External
+          { func_symbol = func; ty_res; ty_args; alloc; stack_ofs; effects = _ }
+        ->
         Linear.Lextcall
           { func; ty_res; ty_args; returns = true; alloc; stack_ofs }
       | Probe { name; handler_code_sym; enabled_at_init } ->

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -37,6 +37,8 @@ module S = struct
   type external_call_operation =
     { func_symbol : string;
       alloc : bool;
+      (* CR mshinwell: rename [alloc] -> [needs_caml_c_call] *)
+      effects : Cmm.effects;
       ty_res : Cmm.machtype;
       ty_args : Cmm.exttype list;
       stack_ofs : int

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -268,7 +268,13 @@ let add_calls_terminator :
   | Tailcall_self _ | Tailcall_func _ -> (Function_call, term.dbg) :: points
   | Call _ -> (Function_call, term.dbg) :: points
   | Call_no_return
-      { alloc = false; func_symbol = _; ty_res = _; ty_args = _; stack_ofs = _ }
+      { alloc = false;
+        func_symbol = _;
+        ty_res = _;
+        ty_args = _;
+        stack_ofs = _;
+        effects = _
+      }
   | Prim
       { op =
           External
@@ -276,13 +282,20 @@ let add_calls_terminator :
               func_symbol = _;
               ty_res = _;
               ty_args = _;
-              stack_ofs = _
+              stack_ofs = _;
+              effects = _
             };
         label_after = _
       } ->
     points
   | Call_no_return
-      { alloc = true; func_symbol = _; ty_res = _; ty_args = _; stack_ofs = _ }
+      { alloc = true;
+        func_symbol = _;
+        ty_res = _;
+        ty_args = _;
+        stack_ofs = _;
+        effects = _
+      }
   | Prim
       { op =
           External
@@ -290,7 +303,8 @@ let add_calls_terminator :
               func_symbol = _;
               ty_res = _;
               ty_args = _;
-              stack_ofs = _
+              stack_ofs = _;
+              effects = _
             };
         label_after = _
       } ->

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -161,7 +161,8 @@ let linearize_terminator cfg_with_layout (func : string) start
             (Ltailcall_imm { func = { sym_name = func; sym_global = Local } })
         ],
         Some destination )
-    | Call_no_return { func_symbol; alloc; ty_args; ty_res; stack_ofs } ->
+    | Call_no_return
+        { func_symbol; alloc; ty_args; ty_res; stack_ofs; effects = _ } ->
       single
         (L.Lcall_op
            (Lextcall
@@ -182,7 +183,8 @@ let linearize_terminator cfg_with_layout (func : string) start
     | Prim { op; label_after } ->
       let op : Linear.call_operation =
         match op with
-        | External { func_symbol; alloc; ty_args; ty_res; stack_ofs } ->
+        | External
+            { func_symbol; alloc; ty_args; ty_res; stack_ofs; effects = _ } ->
           Lextcall
             { func = func_symbol;
               alloc;

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -190,10 +190,12 @@ class virtual selector_generic =
       | Cextcall { func; builtin = true } ->
         Misc.fatal_errorf
           "Selection.select_operation: builtin not recognized %s" func ()
-      | Cextcall { func; alloc; ty; ty_args; returns; builtin = false } ->
+      | Cextcall
+          { func; alloc; ty; ty_args; returns; builtin = false; effects; _ } ->
         let external_call =
           { Cfg.func_symbol = func;
             alloc;
+            effects;
             ty_res = ty;
             ty_args;
             stack_ofs = -1


### PR DESCRIPTION
This should be a no-op, but propagates the `effects` information on external calls into `Cfg`.  It will be used in a follow-up PR to fix a problem with `caml_obj_dup` and #3688 .