### PR TITLE
Mark Obj_dup as not having effects and handle in Cfg

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -429,6 +429,8 @@ let can_raise_terminator (i : terminator) =
 (* CR gyorsh: [is_pure_terminator] is not the same as [can_raise_terminator]
    because of [Tailcal Self] which is not pure but marked as cannot raise at the
    moment, which we might want to reconsider later. *)
+(* CR mshinwell/gyorsh: maybe this function could be made more precise e.g.
+   taking into account [effects] on extcalls *)
 let is_pure_terminator desc =
   match (desc : terminator) with
   | Return | Raise _ | Call_no_return _ | Tailcall_func _ | Tailcall_self _

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -858,8 +858,8 @@ let unary_primitive env res dbg f arg =
     ( None,
       res,
       C.extcall ~dbg ~alloc:true ~returns:true ~is_c_builtin:false
-        ~effects:Arbitrary_effects ~coeffects:Has_coeffects ~ty_args:[]
-        "caml_obj_dup" Cmm.typ_val [arg] )
+        ~effects:No_effects ~coeffects:Has_coeffects ~ty_args:[] "caml_obj_dup"
+        Cmm.typ_val [arg] )
   | Is_int _ -> None, res, C.and_int arg (C.int ~dbg 1) dbg
   | Is_null -> None, res, C.eq ~dbg arg (C.nativeint ~dbg 0n)
   | Get_tag -> None, res, C.get_tag arg dbg

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -154,15 +154,22 @@ CAMLprim value caml_obj_with_tag(value new_tag_v, value arg)
   tag_t tag_for_alloc;
   uintnat infix_offset = 0;
 
-  tag_t new_tag = (tag_t)Long_val(new_tag_v);
-  tag_t existing_tag = Tag_val(arg);
+  // This function must not raise exceptions (except asynchronous exceptions).
+  // It behaves just like an allocation function, which has generative effects,
+  // but not arbitrary effects.  (See the [Obj_dup] case in [To_cmm].)
 
-  if ((existing_tag == Closure_tag || existing_tag == Infix_tag
+  tag_t new_tag = (tag_t)Long_val(new_tag_v);
+#ifdef DEBUG
+  tag_t existing_tag = Tag_val(arg);
+#endif
+
+  CAMLassert (
+    !(
+      (existing_tag == Closure_tag || existing_tag == Infix_tag
        || new_tag == Closure_tag || new_tag == Infix_tag)
-      && existing_tag != new_tag) {
-    caml_failwith("Cannot change tags of existing closures or create \
-      new closures using [caml_obj_with_tag]");
-  }
+      && existing_tag != new_tag));
+  // Cannot change tags of existing closures or create new closures using
+  // [caml_obj_with_tag].
 
   if (new_tag == Infix_tag) {
     // If we received an infix block, we must return the same; but the whole

--- a/testsuite/tests/exception-extra-args/obj_dup.ml
+++ b/testsuite/tests/exception-extra-args/obj_dup.ml
@@ -1,0 +1,20 @@
+(* TEST *)
+
+[@@@ocaml.flambda_o3]
+
+let[@inline never] bar _ _ = ()
+
+let[@inline never] baz () = ()
+
+let foo size (x : int) arr y =
+  let extra_arg_array = ref arr in
+  let extra_arg_int = ref 0 in
+  (try
+    for i = 0 to size - 1 do
+      if i > 20 then (
+        let _ = Sys.opaque_identity (Obj.dup y) in
+        baz ()
+      )
+    done
+  with _exn -> ());
+  bar !extra_arg_array !extra_arg_int


### PR DESCRIPTION
This marks `Obj_dup` as not having effects in the primitive translation out of Flambda 2.  Then `Cfg.can_raise_terminator` is modified to take account of the new `effects` propagation from #3765.  The result is that the included test case now passes, whereas before it failed, by virtue of `To_cmm` not having wrapped the `C.extcall` for `Obj_dup` with an extra argument wrapper (such wrapper always being redundant).

This PR has to change the C stub `caml_obj_dup` so it never has effects: prior to this PR there is a corner case where an exception may be raised, but I think it's fine for this to change to a `CAMLassert`.  Otherwise it is just like an allocation, which never raises (except for asynchronous effects, but that isn't relevant here).

Based on #3765, only the second commit here is new.