### PR TITLE
Use the same verbose parameter for all register allocators

### DIFF
--- a/backend/regalloc/NOTES.md
+++ b/backend/regalloc/NOTES.md
@@ -14,8 +14,17 @@ should be run; it must be followed by either `on` or `off`.
 In addition to these two main command-line parameters, each allocator provides a
 number of additional parameters to control its behaviour. These parameters are
 passed through the `-regalloc-param` command-line parameter followed by a
-`NAME:VALUE` binding. The parameters available for the various allocators are
-described in the sections below.
+`NAME:VALUE` binding. Some parameters are specific to a given allocator, and are
+described in the sections below. Other parameters are common to all allocators:
+
+- `BLOCK_TEMPORARIES` (`on` or `off`): whether to use block rather than instruction
+  temporaries when "rewriting" (See next section);
+- `SPLIT_LIVE_RANGES` (`on` or `off`): whether to split live ranges before allocation;
+- `SPLIT_MORE_DESTR_POINTS` (`on` or `off`): whether to treat a non-allocating
+   external call as a destruction point;
+- `VALIDATOR_DEBUG` (`on` or `off`): whether to enable debugging for the validator;
+- `VERBOSE` (`on` or `off`): whether to produce a log describing each and
+  every step of the algorithm.
 
 
 ## Common elements
@@ -134,8 +143,6 @@ resources. It can be controlled by the following parameters:
   options selecting the temporary with the lowest estimated spilling cost (both
   are counting the number of uses, the hierarchical option using the information
   about loops to give more weight to a use inside a loop);
-- `IRC_VERBOSE` (`on` or `off`): whether to produce a log describing each and
-  every step of the algorithm;
 - `IRC_INVARIANTS` (`on` or `off`): whether to check the invariants.
 
 
@@ -157,8 +164,6 @@ The implementation is a direct port of upstream's algorithm (`Interval` and
 use of the `Regalloc_rewrite.rewrite_gen` function (from IRC) when temporaries
 need to be spilled. It can be controlled by the following parameters:
 
-- `LS_VERBOSE` (`on` or `off`): whether to produce a log describing each and
-  every step of the algorithm;
 - `LS_INVARIANTS` (`on` or `off`): whether to check the invariants.
 
 
@@ -215,8 +220,6 @@ It can be controlled by the following parameters:
   the strategy to use when trying to find a free register;
 - `GI_SPILLING_HEURISTICS` (`flat-uses`, or `hierarchical-uses`), with the same
   semantics as with IRC (See above);
-- `GI_VERBOSE` (`on` or `off`): whether to produce a log describing each and
-  every step of the algorithm;
 - `GI_INVARIANTS` (`on` or `off`): whether to check the invariants.
 
 

--- a/backend/regalloc/NOTES.md
+++ b/backend/regalloc/NOTES.md
@@ -59,7 +59,7 @@ for a list of registers the allocator has decided should be spilled. This
 means that the registers will have their values stored on the stack. In turn,
 it implies that before each read (resp. after each write) of the value, a reload
 (resp. spill) instruction needs to be inserted. The value is reloaded into
-(resp. spilled from) a fresh *temporary*, whose live range is covers only
+(resp. spilled from) a fresh *temporary*, whose live range covers only
 the instruction reading and/or writing the value. After rewrite, the spilled
 registers no longer appear in the CFG. All occurrences have been replaced with
 temporaries with very short live ranges, thus making the allocation problem

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -11,12 +11,9 @@ let gi_rng = Random.State.make [| 4; 6; 2 |]
 let bool_of_param param_name =
   bool_of_param ~guard:(gi_debug, "gi_debug") param_name
 
-let gi_verbose : bool Lazy.t = bool_of_param "GI_VERBOSE"
-
 let gi_invariants : bool Lazy.t = bool_of_param "GI_INVARIANTS"
 
-let log_function =
-  lazy (make_log_function ~verbose:(Lazy.force gi_verbose) ~label:"gi")
+let log_function = lazy (make_log_function ~label:"gi")
 
 let log :
     type a.
@@ -520,7 +517,7 @@ let build_intervals : Cfg_with_infos.t -> Interval.t Reg.Tbl.t =
     (fun _reg (interval : Interval.t) ->
       interval.ranges <- List.rev interval.ranges)
     past_ranges;
-  if gi_debug && Lazy.force gi_verbose
+  if gi_debug && Lazy.force verbose
   then
     iter_cfg_layout cfg_with_layout ~f:(fun block ->
         log ~indent:2 "(block %a)" Label.format block.start;

--- a/backend/regalloc/regalloc_gi_utils.mli
+++ b/backend/regalloc/regalloc_gi_utils.mli
@@ -4,8 +4,6 @@ open Regalloc_utils
 
 val gi_debug : bool
 
-val gi_verbose : bool Lazy.t
-
 val gi_invariants : bool Lazy.t
 
 val log :

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -8,12 +8,9 @@ let irc_debug = false
 let bool_of_param param_name =
   bool_of_param ~guard:(irc_debug, "irc_debug") param_name
 
-let irc_verbose : bool Lazy.t = bool_of_param "IRC_VERBOSE"
-
 let irc_invariants : bool Lazy.t = bool_of_param "IRC_INVARIANTS"
 
-let log_function =
-  lazy (make_log_function ~verbose:(Lazy.force irc_verbose) ~label:"irc")
+let log_function = lazy (make_log_function ~label:"irc")
 
 let log :
     type a.

--- a/backend/regalloc/regalloc_irc_utils.mli
+++ b/backend/regalloc/regalloc_irc_utils.mli
@@ -4,8 +4,6 @@ open Regalloc_utils
 
 val irc_debug : bool
 
-val irc_verbose : bool Lazy.t
-
 val irc_invariants : bool Lazy.t
 
 val log :

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -105,7 +105,7 @@ let build_intervals : State.t -> Cfg_with_infos.t -> unit =
          present at the end of every "block". *)
       incr pos);
   Reg.Tbl.iter (fun reg (range : Range.t) -> add_range reg range) current_ranges;
-  if ls_debug && Lazy.force ls_verbose
+  if ls_debug && Lazy.force verbose
   then
     iter_cfg_dfs (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun block ->
         log ~indent:2 "(block %a)" Label.format block.start;
@@ -283,7 +283,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
     (module Utils)
     state
     ~f:(fun () ->
-      if ls_debug && Lazy.force ls_verbose
+      if ls_debug && Lazy.force verbose
       then
         let liveness = Cfg_with_infos.liveness cfg_with_infos in
         iter_cfg_dfs (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun block ->

--- a/backend/regalloc/regalloc_ls_utils.ml
+++ b/backend/regalloc/regalloc_ls_utils.ml
@@ -9,12 +9,9 @@ let ls_debug = false
 let bool_of_param param_name =
   bool_of_param ~guard:(ls_debug, "ls_debug") param_name
 
-let ls_verbose : bool Lazy.t = bool_of_param "LS_VERBOSE"
-
 let ls_invariants : bool Lazy.t = bool_of_param "LS_INVARIANTS"
 
-let log_function =
-  lazy (make_log_function ~verbose:(Lazy.force ls_verbose) ~label:"ls")
+let log_function = lazy (make_log_function ~label:"ls")
 
 let log :
     type a.

--- a/backend/regalloc/regalloc_ls_utils.mli
+++ b/backend/regalloc/regalloc_ls_utils.mli
@@ -5,8 +5,6 @@ module DLL = Flambda_backend_utils.Doubly_linked_list
 
 val ls_debug : bool
 
-val ls_verbose : bool Lazy.t
-
 val ls_invariants : bool Lazy.t
 
 val log :

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -14,12 +14,9 @@ let split_more_destruction_points : bool Lazy.t =
 let bool_of_param param_name =
   bool_of_param ~guard:(split_debug, "split_debug") param_name
 
-let split_verbose : bool Lazy.t = bool_of_param "SPLIT_VERBOSE"
-
 let split_invariants : bool Lazy.t = bool_of_param "SPLIT_INVARIANTS"
 
-let log_function =
-  lazy (make_log_function ~verbose:(Lazy.force split_verbose) ~label:"split")
+let log_function = lazy (make_log_function ~label:"split")
 
 let log :
     type a.

--- a/backend/regalloc/regalloc_split_utils.mli
+++ b/backend/regalloc/regalloc_split_utils.mli
@@ -6,8 +6,6 @@ val split_live_ranges : bool Lazy.t
 
 val split_debug : bool
 
-val split_verbose : bool Lazy.t
-
 val split_invariants : bool Lazy.t
 
 val log :

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -52,6 +52,8 @@ let validator_debug = bool_of_param "VALIDATOR_DEBUG"
 
 let block_temporaries = bool_of_param "BLOCK_TEMPORARIES"
 
+let verbose : bool Lazy.t = bool_of_param "VERBOSE"
+
 type liveness = Cfg_with_infos.liveness
 
 let make_indent n = String.make (2 * n) ' '
@@ -63,10 +65,11 @@ type log_function =
     enabled : bool
   }
 
-let make_log_function : verbose:bool -> label:string -> log_function =
- fun ~verbose ~label ->
+let make_log_function : label:string -> log_function =
+ fun ~label ->
+  let enabled = Lazy.force verbose in
   let log =
-    if verbose
+    if enabled
     then
       fun ~indent ?no_eol fmt ->
       Format.eprintf
@@ -74,7 +77,7 @@ let make_log_function : verbose:bool -> label:string -> log_function =
         label (make_indent indent)
     else fun ~indent:_ ?no_eol:_ fmt -> Format.(ifprintf err_formatter) fmt
   in
-  { log; enabled = verbose }
+  { log; enabled }
 
 module Instruction = struct
   type id = InstructionId.t

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -13,6 +13,8 @@ val find_param_value : string -> string option
 val bool_of_param :
   ?guard:bool * string -> ?default:bool -> string -> bool Lazy.t
 
+val verbose : bool Lazy.t
+
 val validator_debug : bool Lazy.t
 
 val block_temporaries : bool Lazy.t
@@ -26,7 +28,7 @@ type log_function =
     enabled : bool
   }
 
-val make_log_function : verbose:bool -> label:string -> log_function
+val make_log_function : label:string -> log_function
 
 module Instruction : sig
   type id = InstructionId.t


### PR DESCRIPTION
As per title; it is no longer useful to be
able to enable logging for only a usbset
of allocators.