### PR TITLE
Statefulness and visibility axes

### DIFF
--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -89,13 +89,13 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
-          value_mode global,many,portable,unyielding;imply(unique,uncontended)(modevar#1[aliased,contended .. unique,uncontended])
+          value_mode global,many,portable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#1[aliased,contended,immutable .. unique,uncontended,read_write])
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
-          alloc_mode global,many,portable,unyielding;id(modevar#7[aliased,contended .. unique,uncontended])
+          alloc_mode global,many,portable,unyielding,stateful;id(modevar#7[aliased,contended,immutable .. unique,uncontended,read_write])
           []
           Tfunction_cases (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
-          alloc_mode global,many,nonportable,unyielding;aliased,uncontended
+          alloc_mode global,many,nonportable,unyielding,stateful;aliased,uncontended,read_write
           value
             [
               <case>
@@ -110,7 +110,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
               <case>
                 pattern (test_locations.ml[19,572+4]..test_locations.ml[19,572+5])
                   Tpat_var "n"
-                  value_mode global,many,portable,unyielding;unique,uncontended
+                  value_mode global,many,portable,unyielding,stateless;unique,uncontended,read_write
                 expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+34])
                   Texp_apply
                   apply_mode Tail

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -89,13 +89,13 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern 
           Tpat_var "fib"
-          value_mode global,many,portable,unyielding;imply(unique,uncontended)(modevar#1[aliased,contended .. unique,uncontended])
+          value_mode global,many,portable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#1[aliased,contended,immutable .. unique,uncontended,read_write])
         expression 
           Texp_function
-          alloc_mode global,many,portable,unyielding;id(modevar#7[aliased,contended .. unique,uncontended])
+          alloc_mode global,many,portable,unyielding,stateful;id(modevar#7[aliased,contended,immutable .. unique,uncontended,read_write])
           []
           Tfunction_cases 
-          alloc_mode global,many,nonportable,unyielding;aliased,uncontended
+          alloc_mode global,many,nonportable,unyielding,stateful;aliased,uncontended,read_write
           value
             [
               <case>
@@ -110,7 +110,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
               <case>
                 pattern 
                   Tpat_var "n"
-                  value_mode global,many,portable,unyielding;unique,uncontended
+                  value_mode global,many,portable,unyielding,stateless;unique,uncontended,read_write
                 expression 
                   Texp_apply
                   apply_mode Tail

--- a/testsuite/tests/templates/basic/bad_arg_impl.reference
+++ b/testsuite/tests/templates/basic/bad_arg_impl.reference
@@ -2,7 +2,7 @@ File "bad_arg_impl.ml", line 1:
 Error: The argument module bad_arg_impl.ml
        does not match the parameter signature monoid.cmi: 
        Values do not match:
-         val append : unit -> unit -> [> `Banana ] @@ portable
+         val append : unit -> unit -> [> `Banana ] @@ stateless
        is not included in
          val append : t -> t -> t
        The type "unit -> unit -> [> `Banana ]" is not compatible with the type

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -213,7 +213,7 @@ Error: The layout of type "a" is value
          because of the definition of b at line 2, characters 0-30.
 |}]
 
-type a : value mod global aliased many contended portable external_ unyielding
+type a : value mod global aliased many immutable stateless external_ unyielding
 type b : value mod local unique once contended nonportable internal = a
 [%%expect{|
 type a : immediate
@@ -273,8 +273,8 @@ Error: Layout void is more experimental than allowed by the enabled layouts exte
 |}]
 
 type a : immediate
-type b : value mod global aliased many contended portable unyielding external_ = a
-type c : value mod global aliased many contended portable unyielding external_
+type b : value mod global aliased many immutable stateless unyielding external_ = a
+type c : value mod global aliased many immutable stateless unyielding external_
 type d : immediate = c
 [%%expect{|
 type a : immediate
@@ -284,8 +284,8 @@ type d = c
 |}]
 
 type a : immediate64
-type b : value mod global aliased many contended portable unyielding external64 = a
-type c : value mod global aliased many contended portable unyielding external64
+type b : value mod global aliased many immutable stateless unyielding external64 = a
+type c : value mod global aliased many immutable stateless unyielding external64
 type d : immediate64 = c
 [%%expect{|
 type a : immediate64
@@ -295,8 +295,8 @@ type d = c
 |}]
 
 type a : float64 = float#
-type b : float64 mod global aliased many contended portable external_ = a
-type c : float64 mod global aliased many contended portable external_
+type b : float64 mod global aliased many immutable stateless external_ = a
+type c : float64 mod global aliased many immutable stateless external_
 type d : float64 = c
 [%%expect{|
 type a = float#
@@ -306,8 +306,8 @@ type d = c
 |}]
 
 type a : float32 = float32#
-type b : float32 mod global aliased many contended portable external_ = a
-type c : float32 mod global aliased many contended portable external_
+type b : float32 mod global aliased many immutable stateless external_ = a
+type c : float32 mod global aliased many immutable stateless external_
 type d : float32 = c
 [%%expect{|
 type a = float32#
@@ -352,68 +352,68 @@ type d = c
 (****************************************)
 (* Test 4: Appropriate types mode cross *)
 
-type t : any mod global aliased many contended portable external_ = int
+type t : any mod global aliased many immutable stateless external_ = int
 [%%expect{|
 type t = int
 |}]
 
-type t : any mod global aliased many contended portable external_ = float#
+type t : any mod global aliased many immutable stateless external_ = float#
 [%%expect{|
 type t = float#
 |}]
 
-type t : any mod global aliased many contended portable external_ = float32#
+type t : any mod global aliased many immutable stateless external_ = float32#
 [%%expect{|
 type t = float32#
 |}]
 
-type t : any mod global aliased many contended portable external_ = int64#
+type t : any mod global aliased many immutable stateless external_ = int64#
 [%%expect{|
 type t = int64#
 |}]
 
-type t : any mod global aliased many contended portable external_ = int32#
+type t : any mod global aliased many immutable stateless external_ = int32#
 [%%expect{|
 type t = int32#
 |}]
 
-type t : any mod global aliased many contended portable external_ = nativeint#
+type t : any mod global aliased many immutable stateless external_ = nativeint#
 [%%expect{|
 type t = nativeint#
 |}]
 
-type t : any mod global aliased many contended portable external_ = int8x16#
+type t : any mod global aliased many immutable stateless external_ = int8x16#
 [%%expect{|
 type t = int8x16#
 |}]
 
-type t : any mod global aliased many contended portable external_ = int16x8#
+type t : any mod global aliased many immutable stateless external_ = int16x8#
 [%%expect{|
 type t = int16x8#
 |}]
 
-type t : any mod global aliased many contended portable external_ = int32x4#
+type t : any mod global aliased many immutable stateless external_ = int32x4#
 [%%expect{|
 type t = int32x4#
 |}]
 
-type t : any mod global aliased many contended portable external_ = int64x2#
+type t : any mod global aliased many immutable stateless external_ = int64x2#
 [%%expect{|
 type t = int64x2#
 |}]
 
-type t : any mod global aliased many contended portable external_ = float32x4#
+type t : any mod global aliased many immutable stateless external_ = float32x4#
 [%%expect{|
 type t = float32x4#
 |}]
 
-type t : any mod global aliased many contended portable external_ = float64x2#
+type t : any mod global aliased many immutable stateless external_ = float64x2#
 [%%expect{|
 type t = float64x2#
 |}]
 
 type indirect_int = int
-type t : any mod global aliased many contended portable external_ = indirect_int
+type t : any mod global aliased many immutable stateless external_ = indirect_int
 [%%expect{|
 type indirect_int = int
 type t = indirect_int
@@ -1173,12 +1173,12 @@ type 'a t = { x : 'a @@ global many portable aliased contended; } [@@unboxed]
    [layout_of], we'll be able to give a better jkind to [@@unboxed] types, and
    this will likely improve. *)
 
-type 'a t : value mod global portable contended many aliased unyielding =
-  Foo of 'a @@ global portable contended many aliased [@@unboxed]
+type 'a t : value mod global immutable stateless many aliased unyielding =
+  Foo of 'a @@ global immutable stateless many aliased [@@unboxed]
 [%%expect {|
-Lines 1-2, characters 0-65:
-1 | type 'a t : value mod global portable contended many aliased unyielding =
-2 |   Foo of 'a @@ global portable contended many aliased [@@unboxed]
+Lines 1-2, characters 0-66:
+1 | type 'a t : value mod global immutable stateless many aliased unyielding =
+2 |   Foo of 'a @@ global immutable stateless many aliased [@@unboxed]
 Error: The kind of type "t" is value
          because it instantiates an unannotated type parameter of t,
          chosen to have kind value.
@@ -1271,7 +1271,7 @@ Error: The kind of type "t" is immutable_data with 'a @@ unyielding
 type ('a : value mod aliased) t = ('a : value mod global)
 type ('a : immediate) t = ('a : value)
 type ('a : value) t = ('a : immediate)
-type ('a : value mod external_ portable many unyielding) t = ('a : value mod contended global aliased)
+type ('a : value mod external_ stateless many unyielding) t = ('a : value mod immutable global aliased)
 type ('a : value) t = ('a : any)
 type ('a : value) t = ('a : value)
 type ('a : bits32 mod aliased) t = ('a : any mod global)

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -196,6 +196,8 @@ Error: This type "int ref" should be an instance of type "('a : immutable_data)"
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
          portability: mod portable with int ≰ mod portable
+         statefulness: mod stateless with int ≰ mod stateless
+         visibility: mod read_write ≰ mod immutable
 |}]
 
 let foo (t : int t @ local) = use_global t [@nontail]
@@ -346,6 +348,8 @@ Error: This type "int ref" should be an instance of type "('a : immutable_data)"
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
          portability: mod portable with int ≰ mod portable
+         statefulness: mod stateless with int ≰ mod stateless
+         visibility: mod read_write ≰ mod immutable
 |}]
 
 let foo (t : int t @ aliased) = use_unique t

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -94,7 +94,7 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) option" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) option is value mod contended
+       The kind of (unit -> unit) option is value mod immutable
          because it's a boxed variant type.
        But the kind of (unit -> unit) option must be a subkind of
          value mod portable
@@ -182,6 +182,7 @@ Error: The kind of type "'a ref" is mutable_data with 'a @@ many unyielding.
 
        The first mode-crosses less than the second along:
          portability: mod portable with 'a ≰ mod portable
+         statefulness: mod stateless with 'a ≰ mod stateless
 |}]
 
 type t_test = int ref require_portable
@@ -311,7 +312,7 @@ Line 1, characters 14-33:
                   ^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) list" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) list is value mod contended
+       The kind of (unit -> unit) list is value mod immutable
          because it's a boxed variant type.
        But the kind of (unit -> unit) list must be a subkind of
          value mod portable
@@ -522,7 +523,7 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) iarray" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) iarray is value mod contended
+       The kind of (unit -> unit) iarray is value mod immutable
          because it is the primitive value type iarray.
        But the kind of (unit -> unit) iarray must be a subkind of
          value mod portable

--- a/testsuite/tests/typing-jkind-bounds/printing.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing.ml
@@ -52,6 +52,8 @@ Error: The kind of type "t" is immutable_data with 'a @@ portable
          linearity: mod many with 'a ≰ mod many
          contention: mod contended with 'a ≰ mod contended
          yielding: mod unyielding with 'a ≰ mod unyielding
+         statefulness: mod stateless with 'a ≰ mod stateless
+         visibility: mod immutable with 'a ≰ mod immutable
 |}]
 
 module M : sig
@@ -103,6 +105,8 @@ Error: Signature mismatch:
        The first mode-crosses less than the second along:
          portability: mod portable with 'a ≰ mod portable
          yielding: mod unyielding with 'a ≰ mod unyielding
+         statefulness: mod stateless with 'a ≰ mod stateless
+         visibility: mod immutable with 'a ≰ mod immutable
 |}]
 
 module M : sig
@@ -182,6 +186,8 @@ Error: This type "a" = "int ref" should be an instance of type
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
          portability: mod portable with int ≰ mod portable
+         statefulness: mod stateless with int ≰ mod stateless
+         visibility: mod read_write ≰ mod immutable
 |}]
 
 type 'a u = Foo of 'a @@ portable
@@ -195,7 +201,7 @@ Line 3, characters 11-25:
                ^^^^^^^^^^^^^^
 Error: This type "(int -> int) u" should be an instance of type
          "('a : immutable_data)"
-       The kind of (int -> int) u is value mod contended portable
+       The kind of (int -> int) u is value mod portable immutable
          because of the definition of u at line 1, characters 0-33.
        But the kind of (int -> int) u must be a subkind of immutable_data
          because of the definition of t at line 2, characters 0-28.
@@ -217,6 +223,8 @@ Error: This type "(int -> int) u" should be an instance of type
          linearity: mod many with int -> int ≰ mod many
          contention: mod contended with int -> int ≰ mod contended
          yielding: mod unyielding with int -> int ≰ mod unyielding
+         statefulness: mod stateless with int -> int ≰ mod stateless
+         visibility: mod immutable with int -> int ≰ mod immutable
 |}]
 
 module M : sig
@@ -429,4 +437,5 @@ Error: Signature mismatch:
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         visibility: mod read_write ≰ mod immutable with 'a
 |}]

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -136,6 +136,8 @@ Error: The kind of type "t" is mutable_data with 'a @@ many unyielding
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
          portability: mod portable with 'a ≰ mod portable
+         statefulness: mod stateless with 'a ≰ mod stateless
+         visibility: mod read_write ≰ mod immutable
 |}]
 
 type t : immutable_data = { x : int ref }
@@ -154,7 +156,7 @@ type t : immutable_data = { x : unit -> unit }
 Line 1, characters 0-46:
 1 | type t : immutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod contended
+Error: The kind of type "t" is value mod immutable
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -187,7 +189,7 @@ type t : mutable_data = { x : unit -> unit }
 Line 1, characters 0-44:
 1 | type t : mutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod contended
+Error: The kind of type "t" is value mod immutable
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -275,6 +277,7 @@ Error: The kind of type "t" is mutable_data with 'a @@ many unyielding
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         visibility: mod read_write ≰ mod immutable with 'a
 |}]
 
 type 'a t : immutable_data with 'a = { x : 'a -> 'a }
@@ -282,7 +285,7 @@ type 'a t : immutable_data with 'a = { x : 'a -> 'a }
 Line 1, characters 0-53:
 1 | type 'a t : immutable_data with 'a = { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod contended
+Error: The kind of type "t" is value mod immutable
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.
@@ -622,7 +625,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is value mod contended
+       The kind of (unit -> unit) t is value mod immutable
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable
@@ -647,7 +650,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is value mod contended
+       The kind of (unit -> unit) t is value mod immutable
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod external_
@@ -742,7 +745,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is value mod contended
+       The kind of (unit -> unit) t is value mod immutable
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
@@ -148,6 +148,7 @@ Error: Signature mismatch:
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'b
+         visibility: mod read_write ≰ mod immutable with 'b
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
@@ -67,6 +67,7 @@ Error: The kind of type "'a F(Ref).t" is mutable_data
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         visibility: mod read_write ≰ mod immutable with 'a
 |}]
 
 module Ref = struct
@@ -86,6 +87,7 @@ Error: The kind of type "'a F(Ref).t" is mutable_data
 
        The first mode-crosses less than the second along:
          portability: mod portable with 'a ≰ mod portable
+         statefulness: mod stateless with 'a ≰ mod stateless
 |}]
 
 module F (M : sig

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -124,7 +124,8 @@ end = struct
   type 'a t : immediate with 'a @@ aliased many contended global portable
 end
 [%%expect {|
-module M : sig type 'a t : immutable_data mod global aliased yielding end
+module M :
+  sig type 'a t : value mod global aliased many contended portable end
 |}]
 
 module M : sig
@@ -369,7 +370,7 @@ end
 module M : sig type 'a t : immutable_data with 'a @@ portable end
 |}]
 
-type t : immutable_data with int ref @@ contended
+type t : immutable_data with int ref @@ immutable
 
 module type S = sig
   type t : immutable_data

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -140,6 +140,8 @@ Error: The kind of type "t" is mutable_data with 'a @@ many unyielding
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
          portability: mod portable with 'a ≰ mod portable
+         statefulness: mod stateless with 'a ≰ mod stateless
+         visibility: mod read_write ≰ mod immutable
 |}]
 
 type t : immutable_data = Foo | Bar of int ref
@@ -158,7 +160,7 @@ type t : immutable_data = Foo of (unit -> unit)
 Line 1, characters 0-47:
 1 | type t : immutable_data = Foo of (unit -> unit)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod contended
+Error: The kind of type "t" is value mod immutable
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -191,7 +193,7 @@ type t : mutable_data = Foo of { x : unit -> unit }
 Line 1, characters 0-51:
 1 | type t : mutable_data = Foo of { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod contended
+Error: The kind of type "t" is value mod immutable
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -279,6 +281,7 @@ Error: The kind of type "t" is mutable_data with 'a @@ many unyielding
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         visibility: mod read_write ≰ mod immutable with 'a
 |}]
 
 type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
@@ -286,7 +289,7 @@ type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
 Line 1, characters 0-60:
 1 | type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod contended
+Error: The kind of type "t" is value mod immutable
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.
@@ -625,7 +628,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is value mod contended
+       The kind of (unit -> unit) t is value mod immutable
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable
@@ -650,7 +653,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is value mod contended
+       The kind of (unit -> unit) t is value mod immutable
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod external_
@@ -745,7 +748,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is value mod contended
+       The kind of (unit -> unit) t is value mod immutable
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -216,7 +216,7 @@ Line 1, characters 19-32:
 Error: This type "float or_null" should be an instance of type
          "('a : any_non_null)"
        The kind of float or_null is
-         value_or_null mod many contended portable unyielding
+         value_or_null mod many unyielding stateless immutable
          because it is the primitive immediate_or_null type or_null.
        But the kind of float or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
@@ -270,7 +270,7 @@ Line 1, characters 19-32:
 Error: This type "float or_null" should be an instance of type
          "('a : any_non_null)"
        The kind of float or_null is
-         value_or_null mod many contended portable unyielding
+         value_or_null mod many unyielding stateless immutable
          because it is the primitive immediate_or_null type or_null.
        But the kind of float or_null must be a subkind of any_non_null
          because it's the type argument to the array type.

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -770,7 +770,7 @@ Line 1, characters 0-61:
 1 | type q : any mod portable = #{ x : int -> int; y : int -> q }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "q" is
-         value mod aliased contended & value mod aliased contended
+         value mod aliased immutable & value mod aliased immutable
          because it is an unboxed record.
        But the kind of type "q" must be a subkind of
          value_or_null mod portable & value_or_null mod portable

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -313,7 +313,7 @@ module B = struct
   let a t = t.a
 end
 [%%expect{|
-module A : sig type t : mutable_data mod global external_ yielding end
+module A : sig type t : value mod global many portable external_ end
 module B :
   sig
     type t : value mod contended portable = { a : A.t; }
@@ -385,8 +385,10 @@ Lines 1-2, characters 0-34:
 Error: This variant or record definition does not match that of type "'a t"
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their bounds are not equal
-         the original has: mod many portable unyielding contended with 'a
-         but this has: mod many portable unyielding contended
+         the original has: mod many portable unyielding stateless contended
+         immutable with 'a
+         but this has: mod many portable unyielding stateless contended
+         immutable
 |}]
 
 type ('a, 'b) arity_2 : immutable_data with 'b = { x : 'a }
@@ -404,8 +406,10 @@ Error: This variant or record definition does not match that of type
          "('a, 'b) arity_2"
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their bounds are not equal
-         the original has: mod many portable unyielding contended with 'b
-         but this has: mod many portable unyielding contended with 'a
+         the original has: mod many portable unyielding stateless contended
+         immutable with 'b
+         but this has: mod many portable unyielding stateless contended
+         immutable with 'a
 |}]
 
 (* mcomp *)

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -1886,7 +1886,7 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value mod aliased contended
+       The kind of 'a -> 'b is value mod aliased immutable
          because it's a function type.
        But the kind of 'a -> 'b must be a subkind of immediate
          because of the definition of t35 at line 1, characters 0-30.
@@ -2876,7 +2876,7 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression is used as a function, but its type "'a"
        has kind "bits64", which cannot be the kind of a function.
-       (Functions always have kind "value mod aliased contended".)
+       (Functions always have kind "value mod aliased immutable".)
 |}]
 
 let f (x : ('a : value mod portable)) = x ()
@@ -2887,7 +2887,7 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression is used as a function, but its type "'a"
        has kind "value mod portable", which cannot be the kind of a function.
-       (Functions always have kind "value mod aliased contended".)
+       (Functions always have kind "value mod aliased immutable".)
 |}]
 
 let f (x : ('a : value)) = x ()

--- a/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -1812,7 +1812,7 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value mod aliased contended
+       The kind of 'a -> 'b is value mod aliased immutable
          because it's a function type.
        But the kind of 'a -> 'b must be a subkind of immediate
          because of the definition of t35 at line 1, characters 0-30.

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -22,7 +22,7 @@ Line 1, characters 26-27:
 1 | let foo (r @ contended) = r.a <- 42
                               ^
 Error: This value is "contended" but expected to be "uncontended".
-  Hint: In order to write into the mutable fields,
+  Hint: In order to write into its mutable fields,
   this record needs to be uncontended.
 |}]
 
@@ -32,7 +32,7 @@ Line 1, characters 26-27:
 1 | let foo (r @ contended) = r.a
                               ^
 Error: This value is "contended" but expected to be "shared".
-  Hint: In order to read from the mutable fields,
+  Hint: In order to read from its mutable fields,
   this record needs to be at least shared.
 |}]
 
@@ -47,7 +47,7 @@ Line 1, characters 27-28:
 1 | let foo (r @ contended) = {r with b = best_bytes ()}
                                ^
 Error: This value is "contended" but expected to be "shared".
-  Hint: In order to read from the mutable fields,
+  Hint: In order to read from its mutable fields,
   this record needs to be at least shared.
 |}]
 
@@ -58,7 +58,7 @@ Line 1, characters 23-24:
 1 | let foo (r @ shared) = r.a <- 42
                            ^
 Error: This value is "shared" but expected to be "uncontended".
-  Hint: In order to write into the mutable fields,
+  Hint: In order to write into its mutable fields,
   this record needs to be uncontended.
 |}]
 
@@ -191,7 +191,7 @@ Line 3, characters 6-16:
 3 |     | [| x; y |] -> ()
           ^^^^^^^^^^
 Error: This value is "contended" but expected to be "shared".
-  Hint: In order to read from the mutable fields,
+  Hint: In order to read from its mutable fields,
   this record needs to be at least shared.
 |}]
 (* CR modes: Error message should mention array, not record. *)

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -3,8 +3,7 @@
 *)
 
 (** In this file, we test the dual relationship between [visibility] and [statefulness]
-    axes, [visibility] requirements over mutable record fields,
-    and the kind [atomically_mutable_data]. *)
+    axes, [visibility] requirements over mutable record fields, and the kind [sync_data]. *)
 
 (* Visibility requirements over mutable record fields.
    [uncontended] to avoid contention errors printed first. *)
@@ -161,16 +160,16 @@ let foo (x @ read_write) a = x := a
 val foo : 'a ref -> 'a -> unit = <fun>
 |}]
 
-(* API that uses the [atomically_mutable_data] layout kind. *)
+(* API that uses the [sync_data] kind. *)
 
 module Atomic : sig @@ stateless
-  type !'a t : atomically_mutable_data with 'a @@ contended
+  type !'a t : sync_data with 'a @@ contended
 
   val make : 'a -> 'a t
   val get : 'a t @ read -> 'a
   val set : 'a t -> 'a -> unit
 end = struct
-  type !'a t : atomically_mutable_data with 'a @@ contended
+  type !'a t : sync_data with 'a @@ contended
 
   external make : 'a -> 'a t @@ stateless = "%makemutable"
   external get : 'a t @ read -> 'a @@ stateless = "%atomic_load"
@@ -181,7 +180,7 @@ end
 [%%expect{|
 module Atomic :
   sig
-    type !'a t : atomically_mutable_data with 'a @@ contended
+    type !'a t : sync_data with 'a @@ contended
     val make : 'a -> 'a t @@ stateless
     val get : 'a t @ read -> 'a @@ stateless
     val set : 'a t -> 'a -> unit @@ stateless

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -25,7 +25,7 @@ Line 1, characters 35-36:
 1 | let foo (x @ read uncontended) a = x.a <- a
                                        ^
 Error: This value is "read" but expected to be "read_write".
-  Hint: In order to write into the mutable fields,
+  Hint: In order to write into its mutable fields,
   this record needs to have read_write visibility.
 |}]
 
@@ -35,7 +35,7 @@ Line 1, characters 40-41:
 1 | let foo (x @ immutable uncontended) a = x.a <- a
                                             ^
 Error: This value is "immutable" but expected to be "read_write".
-  Hint: In order to write into the mutable fields,
+  Hint: In order to write into its mutable fields,
   this record needs to have read_write visibility.
 |}]
 
@@ -50,7 +50,7 @@ Line 1, characters 38-39:
 1 | let foo (x @ immutable uncontended) = x.a
                                           ^
 Error: This value is "immutable" but expected to be "read".
-  Hint: In order to read from the mutable fields,
+  Hint: In order to read from its mutable fields,
   this record needs to have read visibility.
 |}]
 
@@ -72,7 +72,7 @@ Line 1, characters 44-45:
 1 | let foo (x @ immutable uncontended) upd = { x with b = upd }
                                                 ^
 Error: This value is "immutable" but expected to be "read".
-  Hint: In order to read from the mutable fields,
+  Hint: In order to read from its mutable fields,
   this record needs to have read visibility.
 |}]
 
@@ -84,7 +84,7 @@ Line 1, characters 33-34:
 1 | let foo (x @ read contended) a = x.a <- a
                                      ^
 Error: This value is "contended" but expected to be "uncontended".
-  Hint: In order to write into the mutable fields,
+  Hint: In order to write into its mutable fields,
   this record needs to be uncontended.
 |}]
 
@@ -94,7 +94,7 @@ Line 1, characters 33-34:
 1 | let foo (x @ contended read) a = x.a <- a
                                      ^
 Error: This value is "contended" but expected to be "uncontended".
-  Hint: In order to write into the mutable fields,
+  Hint: In order to write into its mutable fields,
   this record needs to be uncontended.
 |}]
 
@@ -104,7 +104,7 @@ Line 1, characters 30-31:
 1 | let foo (x @ read shared) a = x.a <- a
                                   ^
 Error: This value is "shared" but expected to be "uncontended".
-  Hint: In order to write into the mutable fields,
+  Hint: In order to write into its mutable fields,
   this record needs to be uncontended.
 |}]
 
@@ -114,7 +114,7 @@ Line 1, characters 38-39:
 1 | let foo (x @ immutable contended) a = x.a
                                           ^
 Error: This value is "contended" but expected to be "shared".
-  Hint: In order to read from the mutable fields,
+  Hint: In order to read from its mutable fields,
   this record needs to be at least shared.
 |}]
 
@@ -126,7 +126,7 @@ Line 1, characters 26-27:
 1 | let foo (x @ immutable) = x.contents
                               ^
 Error: This value is "contended" but expected to be "shared".
-  Hint: In order to read from the mutable fields,
+  Hint: In order to read from its mutable fields,
   this record needs to be at least shared.
 |}]
 
@@ -442,7 +442,7 @@ Line 1, characters 42-43:
 1 | let foo (x : int ref) @ stateless = lazy (x.contents)
                                               ^
 Error: This value is "immutable" but expected to be "read".
-  Hint: In order to read from the mutable fields,
+  Hint: In order to read from its mutable fields,
   this record needs to have read visibility.
 |}]
 
@@ -454,7 +454,7 @@ Line 1, characters 42-43:
 1 | let bat (x : int ref) @ observing = lazy (x.contents <- 4)
                                               ^
 Error: This value is "read" but expected to be "read_write".
-  Hint: In order to write into the mutable fields,
+  Hint: In order to write into its mutable fields,
   this record needs to have read_write visibility.
 |}]
 
@@ -525,7 +525,7 @@ Line 4, characters 4-5:
 4 |     x.contents <- 42;
         ^
 Error: This value is "immutable" but expected to be "read_write".
-  Hint: In order to write into the mutable fields,
+  Hint: In order to write into its mutable fields,
   this record needs to have read_write visibility.
 |}]
 
@@ -547,6 +547,6 @@ Line 5, characters 4-5:
 5 |     y.contents <- 24
         ^
 Error: This value is "read" but expected to be "read_write".
-  Hint: In order to write into the mutable fields,
+  Hint: In order to write into its mutable fields,
   this record needs to have read_write visibility.
 |}]

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -129,14 +129,64 @@ Error: This value is "contended" but expected to be "shared".
   this record needs to be at least shared.
 |}]
 
+let foo (x @ immutable shared) = x.contents
+[%%expect{|
+Line 1, characters 33-34:
+1 | let foo (x @ immutable shared) = x.contents
+                                     ^
+Error: This value is "immutable" but expected to be "read".
+  Hint: In order to read from its mutable fields,
+  this record needs to have read visibility.
+|}]
+
+let foo (x @ immutable uncontended) = x.contents
+[%%expect{|
+Line 1, characters 38-39:
+1 | let foo (x @ immutable uncontended) = x.contents
+                                          ^
+Error: This value is "immutable" but expected to be "read".
+  Hint: In order to read from its mutable fields,
+  this record needs to have read visibility.
+|}]
+
 let foo (x @ read) = x.contents
 [%%expect{|
 val foo : 'a ref @ read -> 'a @ read = <fun>
 |}]
 
+let foo (x @ read contended) = x.contents
+[%%expect{|
+Line 1, characters 31-32:
+1 | let foo (x @ read contended) = x.contents
+                                   ^
+Error: This value is "contended" but expected to be "shared".
+  Hint: In order to read from its mutable fields,
+  this record needs to be at least shared.
+|}]
+
+let foo (x @ read uncontended) = x.contents
+[%%expect{|
+val foo : 'a ref @ uncontended read -> 'a @ uncontended read = <fun>
+|}]
+
 let foo (x @ read_write) = x.contents
 [%%expect{|
 val foo : 'a ref -> 'a = <fun>
+|}]
+
+let foo (x @ read_write contended) = x.contents
+[%%expect{|
+Line 1, characters 37-38:
+1 | let foo (x @ read_write contended) = x.contents
+                                         ^
+Error: This value is "contended" but expected to be "shared".
+  Hint: In order to read from its mutable fields,
+  this record needs to be at least shared.
+|}]
+
+let foo (x @ read_write shared) = x.contents
+[%%expect{|
+val foo : 'a ref @ shared -> 'a @ shared = <fun>
 |}]
 
 let foo (x @ immutable) a = x := a
@@ -147,6 +197,22 @@ Line 1, characters 28-29:
 Error: This value is "contended" but expected to be "uncontended".
 |}]
 
+let foo (x @ immutable shared) a = x := a
+[%%expect{|
+Line 1, characters 35-36:
+1 | let foo (x @ immutable shared) a = x := a
+                                       ^
+Error: This value is "shared" but expected to be "uncontended".
+|}]
+
+let foo (x @ immutable uncontended) a = x := a
+[%%expect{|
+Line 1, characters 40-41:
+1 | let foo (x @ immutable uncontended) a = x := a
+                                            ^
+Error: This value is "immutable" but expected to be "read_write".
+|}]
+
 let foo (x @ read) a = x := a
 [%%expect{|
 Line 1, characters 23-24:
@@ -155,9 +221,112 @@ Line 1, characters 23-24:
 Error: This value is "shared" but expected to be "uncontended".
 |}]
 
+let foo (x @ read contended) a = x := a
+[%%expect{|
+Line 1, characters 33-34:
+1 | let foo (x @ read contended) a = x := a
+                                     ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let foo (x @ read uncontended) a = x := a
+[%%expect{|
+Line 1, characters 35-36:
+1 | let foo (x @ read uncontended) a = x := a
+                                       ^
+Error: This value is "read" but expected to be "read_write".
+|}]
+
 let foo (x @ read_write) a = x := a
 [%%expect{|
 val foo : 'a ref -> 'a -> unit = <fun>
+|}]
+
+let foo (x @ read_write contended) a = x := a
+[%%expect{|
+Line 1, characters 39-40:
+1 | let foo (x @ read_write contended) a = x := a
+                                           ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let foo (x @ read_write shared) a = x := a
+[%%expect{|
+Line 1, characters 36-37:
+1 | let foo (x @ read_write shared) a = x := a
+                                        ^
+Error: This value is "shared" but expected to be "uncontended".
+|}]
+
+let foo (x @ immutable) = !x
+[%%expect{|
+Line 1, characters 27-28:
+1 | let foo (x @ immutable) = !x
+                               ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+(* CR dkalinichenko: update Stdlib to reflect required visibility and contention. *)
+
+let foo (x @ immutable shared) = !x
+[%%expect{|
+Line 1, characters 34-35:
+1 | let foo (x @ immutable shared) = !x
+                                      ^
+Error: This value is "shared" but expected to be "uncontended".
+|}]
+
+let foo (x @ immutable uncontended) = !x
+[%%expect{|
+Line 1, characters 39-40:
+1 | let foo (x @ immutable uncontended) = !x
+                                           ^
+Error: This value is "immutable" but expected to be "read_write".
+|}]
+
+let foo (x @ read) = !x
+[%%expect{|
+Line 1, characters 22-23:
+1 | let foo (x @ read) = !x
+                          ^
+Error: This value is "shared" but expected to be "uncontended".
+|}]
+
+let foo (x @ read contended) = !x
+[%%expect{|
+Line 1, characters 32-33:
+1 | let foo (x @ read contended) = !x
+                                    ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let foo (x @ read uncontended) = !x
+[%%expect{|
+Line 1, characters 34-35:
+1 | let foo (x @ read uncontended) = !x
+                                      ^
+Error: This value is "read" but expected to be "read_write".
+|}]
+
+let foo (x @ read_write) = !x
+[%%expect{|
+val foo : 'a ref -> 'a = <fun>
+|}]
+
+let foo (x @ read_write contended) = !x
+[%%expect{|
+Line 1, characters 38-39:
+1 | let foo (x @ read_write contended) = !x
+                                          ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let foo (x @ read_write shared) = !x
+[%%expect{|
+Line 1, characters 35-36:
+1 | let foo (x @ read_write shared) = !x
+                                       ^
+Error: This value is "shared" but expected to be "uncontended".
 |}]
 
 (* API that uses the [sync_data] kind. *)
@@ -265,6 +434,41 @@ Line 2, characters 25-26:
 Error: This value is "immutable" but expected to be "read_write".
 |}]
 
+(* Closing over a stateful value also gives stateful. *)
+
+let foo (f : (unit -> unit) @ stateful) @ stateful = fun () -> f ()
+[%%expect{|
+val foo : (unit -> unit) -> unit -> unit = <fun>
+|}]
+
+let foo (f : (unit -> unit) @ stateful portable) @ stateless = fun () -> f ()
+[%%expect{|
+Line 1, characters 73-74:
+1 | let foo (f : (unit -> unit) @ stateful portable) @ stateless = fun () -> f ()
+                                                                             ^
+Error: The value "f" is stateful, so cannot be used inside a function that may not capture state.
+|}]
+
+(* The error for [portable] is displayed first. *)
+
+let foo (f : (unit -> unit) @ stateful) @ stateless = fun () -> f ()
+[%%expect{|
+Line 1, characters 64-65:
+1 | let foo (f : (unit -> unit) @ stateful) @ stateless = fun () -> f ()
+                                                                    ^
+Error: The value "f" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+(* CR modes: fix the error message. *)
+
+let foo (f : (unit -> unit) @ observing portable) @ stateless = fun () -> f ()
+[%%expect{|
+Line 1, characters 74-75:
+1 | let foo (f : (unit -> unit) @ observing portable) @ stateless = fun () -> f ()
+                                                                              ^
+Error: The value "f" is stateful, so cannot be used inside a function that may not capture state.
+|}]
+
 (* Closing over use of read gives observing *)
 let foo () =
     let a = Atomic.make 0 in
@@ -286,6 +490,28 @@ Line 4, characters 22-25:
 4 |   let _ @ stateless = bar in
                           ^^^
 Error: This value is "observing" but expected to be "stateless".
+|}]
+
+(* Closing over a observing value also gives observing. *)
+
+let foo (f : (unit -> unit) @ observing) @ observing = fun () -> f ()
+[%%expect{|
+val foo : (unit -> unit) @ observing -> (unit -> unit) @ observing = <fun>
+|}]
+
+let foo (f : (unit -> unit) @ observing) @ stateful = fun () -> f ()
+[%%expect{|
+val foo : (unit -> unit) @ observing -> unit -> unit = <fun>
+|}]
+
+(* CR modes: fix the error message. *)
+
+let foo (f : (unit -> unit) @ stateful) @ observing = fun () -> f ()
+[%%expect{|
+Line 1, characters 64-65:
+1 | let foo (f : (unit -> unit) @ stateful) @ observing = fun () -> f ()
+                                                                    ^
+Error: The value "f" is stateful, so cannot be used inside a function that may not capture state.
 |}]
 
 (* Testing defaulting  *)
@@ -369,6 +595,11 @@ Error: This value is "contended" but expected to be "shared".
 
 (* [read] => [shared]. *)
 
+let default : 'a @ shared -> ('a @ read -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+val default : 'a @ shared -> ('a @ read -> 'b) -> 'b = <fun>
+|}]
+
 let default : 'a @ contended -> ('a @ read -> 'b) -> 'b = fun x f -> f x
 [%%expect{|
 Line 1, characters 71-72:
@@ -409,9 +640,30 @@ Line 1, characters 82-83:
 Error: This value is "contended" but expected to be "shared".
 |}]
 
+let fails : 'a @ contended -> ('a @ read_write -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+Line 1, characters 75-76:
+1 | let fails : 'a @ contended -> ('a @ read_write -> 'b) -> 'b = fun x f -> f x
+                                                                               ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let fails : 'a @ shared -> ('a @ read_write -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+Line 1, characters 72-73:
+1 | let fails : 'a @ shared -> ('a @ read_write -> 'b) -> 'b = fun x f -> f x
+                                                                            ^
+Error: This value is "shared" but expected to be "uncontended".
+|}]
+
 let succeeds : 'a @ contended -> ('a @ read_write contended -> 'b) -> 'b = fun x f -> f x
 [%%expect{|
 val succeeds : 'a @ contended -> ('a @ contended -> 'b) -> 'b = <fun>
+|}]
+
+let succeeds : 'a @ shared -> ('a @ read_write shared -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+val succeeds : 'a @ shared -> ('a @ shared -> 'b) -> 'b = <fun>
 |}]
 
 (* Modalities. *)
@@ -420,14 +672,14 @@ type 'a t1 = { y : 'a @@ immutable }
 
 let get : 'a @ contended -> 'a t1 = fun y -> {y}
 
-type 'a t2 = { z : 'a @@ shared }
+type 'a t2 = { z : 'a @@ read }
 
 let get : 'a @ shared -> 'a t2 = fun z -> {z}
 
 [%%expect{|
 type 'a t1 = { y : 'a @@ immutable; }
 val get : 'a @ contended -> 'a t1 = <fun>
-type 'a t2 = { z : 'a @@ shared; }
+type 'a t2 = { z : 'a @@ read; }
 val get : 'a @ shared -> 'a t2 = <fun>
 |}]
 
@@ -443,6 +695,16 @@ Line 1, characters 42-43:
 Error: This value is "immutable" but expected to be "read".
   Hint: In order to read from its mutable fields,
   this record needs to have read visibility.
+|}]
+
+let zap (x : int ref) @ stateless = lazy (x.contents <- 3)
+[%%expect{|
+Line 1, characters 42-43:
+1 | let zap (x : int ref) @ stateless = lazy (x.contents <- 3)
+                                              ^
+Error: This value is "immutable" but expected to be "read_write".
+  Hint: In order to write into its mutable fields,
+  this record needs to have read_write visibility.
 |}]
 
 (* [lazy_t @ observing] capture values at [read]. *)

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -1,0 +1,433 @@
+(* TEST
+   expect;
+*)
+
+(** In this file, we test the dual relationship between [visibility] and [statefulness]
+    axes, [visibility] requirements over mutable record fields,
+    and the kind [atomically_mutable_data]. *)
+
+(* Visibility requirements over mutable record fields.
+   [uncontended] to avoid contention errors printed first. *)
+
+type 'a myref = { mutable a : 'a; b : 'a }
+[%%expect{|
+type 'a myref = { mutable a : 'a; b : 'a; }
+|}]
+
+let foo x a = x.a <- a
+[%%expect{|
+val foo : 'a myref -> 'a -> unit = <fun>
+|}]
+
+let foo (x @ read uncontended) a = x.a <- a
+[%%expect{|
+Line 1, characters 35-36:
+1 | let foo (x @ read uncontended) a = x.a <- a
+                                       ^
+Error: This value is "read" but expected to be "read_write".
+  Hint: In order to write into the mutable fields,
+  this record needs to have read_write visibility.
+|}]
+
+let foo (x @ immutable uncontended) a = x.a <- a
+[%%expect{|
+Line 1, characters 40-41:
+1 | let foo (x @ immutable uncontended) a = x.a <- a
+                                            ^
+Error: This value is "immutable" but expected to be "read_write".
+  Hint: In order to write into the mutable fields,
+  this record needs to have read_write visibility.
+|}]
+
+let foo (x @ read uncontended) = x.a
+[%%expect{|
+val foo : 'a myref @ uncontended read -> 'a @ uncontended read = <fun>
+|}]
+
+let foo (x @ immutable uncontended) = x.a
+[%%expect{|
+Line 1, characters 38-39:
+1 | let foo (x @ immutable uncontended) = x.a
+                                          ^
+Error: This value is "immutable" but expected to be "read".
+  Hint: In order to read from the mutable fields,
+  this record needs to have read visibility.
+|}]
+
+let foo (x @ read uncontended) upd = { x with a = upd }
+[%%expect{|
+val foo : 'a myref @ uncontended read -> 'a -> 'a myref @ uncontended read =
+  <fun>
+|}]
+
+let foo (x @ immutable uncontended) upd = { x with a = upd }
+[%%expect{|
+val foo : 'a myref @ uncontended immutable -> 'a -> 'a myref @ immutable =
+  <fun>
+|}]
+
+let foo (x @ immutable uncontended) upd = { x with b = upd }
+[%%expect{|
+Line 1, characters 44-45:
+1 | let foo (x @ immutable uncontended) upd = { x with b = upd }
+                                                ^
+Error: This value is "immutable" but expected to be "read".
+  Hint: In order to read from the mutable fields,
+  this record needs to have read visibility.
+|}]
+
+(* Errors when mutating a record field prints contention before visibility errors *)
+
+let foo (x @ read contended) a = x.a <- a
+[%%expect{|
+Line 1, characters 33-34:
+1 | let foo (x @ read contended) a = x.a <- a
+                                     ^
+Error: This value is "contended" but expected to be "uncontended".
+  Hint: In order to write into the mutable fields,
+  this record needs to be uncontended.
+|}]
+
+let foo (x @ contended read) a = x.a <- a
+[%%expect{|
+Line 1, characters 33-34:
+1 | let foo (x @ contended read) a = x.a <- a
+                                     ^
+Error: This value is "contended" but expected to be "uncontended".
+  Hint: In order to write into the mutable fields,
+  this record needs to be uncontended.
+|}]
+
+let foo (x @ read shared) a = x.a <- a
+[%%expect{|
+Line 1, characters 30-31:
+1 | let foo (x @ read shared) a = x.a <- a
+                                  ^
+Error: This value is "shared" but expected to be "uncontended".
+  Hint: In order to write into the mutable fields,
+  this record needs to be uncontended.
+|}]
+
+let foo (x @ immutable contended) a = x.a
+[%%expect{|
+Line 1, characters 38-39:
+1 | let foo (x @ immutable contended) a = x.a
+                                          ^
+Error: This value is "contended" but expected to be "shared".
+  Hint: In order to read from the mutable fields,
+  this record needs to be at least shared.
+|}]
+
+(* visibility requirements over refs *)
+
+let foo (x @ immutable) = x.contents
+[%%expect{|
+Line 1, characters 26-27:
+1 | let foo (x @ immutable) = x.contents
+                              ^
+Error: This value is "contended" but expected to be "shared".
+  Hint: In order to read from the mutable fields,
+  this record needs to be at least shared.
+|}]
+
+let foo (x @ read) = x.contents
+[%%expect{|
+val foo : 'a ref @ read -> 'a @ read = <fun>
+|}]
+
+let foo (x @ read_write) = x.contents
+[%%expect{|
+val foo : 'a ref -> 'a = <fun>
+|}]
+
+let foo (x @ immutable) a = x := a
+[%%expect{|
+Line 1, characters 28-29:
+1 | let foo (x @ immutable) a = x := a
+                                ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let foo (x @ read) a = x := a
+[%%expect{|
+Line 1, characters 23-24:
+1 | let foo (x @ read) a = x := a
+                           ^
+Error: This value is "shared" but expected to be "uncontended".
+|}]
+
+let foo (x @ read_write) a = x := a
+[%%expect{|
+val foo : 'a ref -> 'a -> unit = <fun>
+|}]
+
+(* API that uses the [atomically_mutable_data] layout kind. *)
+
+module Atomic : sig @@ stateless
+  type !'a t : atomically_mutable_data with 'a @@ contended
+
+  val make : 'a -> 'a t
+  val get : 'a t @ read -> 'a
+  val set : 'a t -> 'a -> unit
+end = struct
+  type !'a t : atomically_mutable_data with 'a @@ contended
+
+  external make : 'a -> 'a t @@ stateless = "%makemutable"
+  external get : 'a t @ read -> 'a @@ stateless = "%atomic_load"
+  external ignore : 'a -> unit @@ stateless = "%ignore"
+  external exchange : 'a t -> 'a -> 'a @@ stateless = "%atomic_exchange"
+  let set r x = ignore (exchange r x)
+end
+[%%expect{|
+module Atomic :
+  sig
+    type !'a t : atomically_mutable_data with 'a @@ contended
+    val make : 'a -> 'a t @@ stateless
+    val get : 'a t @ read -> 'a @@ stateless
+    val set : 'a t -> 'a -> unit @@ stateless
+  end
+|}]
+
+
+(* Simple checks of Atomic API *)
+let foo (a @ read) = Atomic.set a 42
+[%%expect{|
+Line 1, characters 32-33:
+1 | let foo (a @ read) = Atomic.set a 42
+                                    ^
+Error: This value is "read" but expected to be "read_write".
+|}]
+
+let foo (a @ read_write) = Atomic.set a 0
+[%%expect{|
+val foo : int Atomic.t -> unit = <fun>
+|}]
+
+let foo (a @ immutable) = Atomic.set a 9
+[%%expect{|
+Line 1, characters 37-38:
+1 | let foo (a @ immutable) = Atomic.set a 9
+                                         ^
+Error: This value is "immutable" but expected to be "read_write".
+|}]
+
+let foo (a @ read) = Atomic.get a
+[%%expect{|
+val foo : 'a Atomic.t @ read -> 'a = <fun>
+|}]
+
+let foo (a @ read_write) = Atomic.get a
+[%%expect{|
+val foo : 'a Atomic.t -> 'a = <fun>
+|}]
+
+let foo (a @ immutable) = Atomic.get a
+[%%expect{|
+Line 1, characters 37-38:
+1 | let foo (a @ immutable) = Atomic.get a
+                                         ^
+Error: This value is "immutable" but expected to be "read".
+|}]
+
+(* Closing over use of read_write gives stateful *)
+let foo () =
+    let a = Atomic.make 42 in
+    let bar () = Atomic.set a 1 in
+    let _ @ stateless = bar in
+    ()
+[%%expect{|
+Line 4, characters 24-27:
+4 |     let _ @ stateless = bar in
+                            ^^^
+Error: This value is "stateful" but expected to be "stateless".
+|}]
+
+let foo : int Atomic.t @ read_write -> (unit -> unit) @ stateless =
+    fun a () -> Atomic.set a 2
+[%%expect{|
+Line 2, characters 4-30:
+2 |     fun a () -> Atomic.set a 2
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This function when partially applied returns a value which is "stateful",
+       but expected to be "stateless".
+|}]
+
+let a @ read_write = Atomic.make 42
+[%%expect{|
+val a : int Atomic.t = <abstr>
+|}]
+
+let foo @ stateless =
+    fun () -> Atomic.set a 0
+[%%expect{|
+Line 2, characters 25-26:
+2 |     fun () -> Atomic.set a 0
+                             ^
+Error: This value is "immutable" but expected to be "read_write".
+|}]
+
+(* Closing over use of read gives observing *)
+let foo () =
+    let a = Atomic.make 0 in
+    let bar () = Atomic.get a in
+    let _ @ observing = bar in
+    ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let foo () =
+  let a = Atomic.make 0 in
+  let bar () = Atomic.get a in
+  let _ @ stateless = bar in
+  ()
+
+[%%expect{|
+Line 4, characters 22-25:
+4 |   let _ @ stateless = bar in
+                          ^^^
+Error: This value is "observing" but expected to be "stateless".
+|}]
+
+(* Testing defaulting  *)
+
+(* [stateless] => [portable]. *)
+
+let default : 'a @ stateless -> 'a @ portable = fun x -> x
+[%%expect{|
+val default : 'a @ stateless -> 'a @ portable = <fun>
+|}]
+
+let override : 'a @ stateless nonportable -> 'a @ portable = fun x -> x
+[%%expect{|
+Line 1, characters 70-71:
+1 | let override : 'a @ stateless nonportable -> 'a @ portable = fun x -> x
+                                                                          ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+(* [observing] or [stateful] don't change the default. *)
+
+let fails : 'a @ observing -> 'a @ portable = fun x -> x
+[%%expect{|
+Line 1, characters 55-56:
+1 | let fails : 'a @ observing -> 'a @ portable = fun x -> x
+                                                           ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+let succeeds : 'a @ observing portable -> 'a @ portable = fun x -> x
+[%%expect{|
+val succeeds : 'a @ portable observing -> 'a @ portable = <fun>
+|}]
+
+let fails : 'a @ stateful -> 'a @ portable = fun x -> x
+[%%expect{|
+Line 1, characters 54-55:
+1 | let fails : 'a @ stateful -> 'a @ portable = fun x -> x
+                                                          ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+let succeeds : 'a @ stateful portable -> 'a @ portable = fun x -> x
+[%%expect{|
+val succeeds : 'a @ portable -> 'a @ portable = <fun>
+|}]
+
+(* Modalities. *)
+
+type 'a t = { x : 'a @@ stateless }
+
+let get : 'a t -> 'a @ portable = fun t -> t.x
+
+[%%expect{|
+type 'a t = { x : 'a @@ stateless; }
+val get : 'a t -> 'a @ portable = <fun>
+|}]
+
+(* [immutable] => [contended]. *)
+
+let default : 'a @ contended -> ('a @ immutable -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+val default : 'a @ contended -> ('a @ immutable -> 'b) -> 'b = <fun>
+|}]
+
+let override : 'a @ contended -> ('a @ immutable uncontended -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+Line 1, characters 89-90:
+1 | let override : 'a @ contended -> ('a @ immutable uncontended -> 'b) -> 'b = fun x f -> f x
+                                                                                             ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let override : 'a @ contended -> ('a @ immutable shared -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+Line 1, characters 84-85:
+1 | let override : 'a @ contended -> ('a @ immutable shared -> 'b) -> 'b = fun x f -> f x
+                                                                                        ^
+Error: This value is "contended" but expected to be "shared".
+|}]
+
+(* [read] => [shared]. *)
+
+let default : 'a @ contended -> ('a @ read -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+Line 1, characters 71-72:
+1 | let default : 'a @ contended -> ('a @ read -> 'b) -> 'b = fun x f -> f x
+                                                                           ^
+Error: This value is "contended" but expected to be "shared".
+|}]
+
+let override : 'a @ contended -> ('a @ read uncontended -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+Line 1, characters 84-85:
+1 | let override : 'a @ contended -> ('a @ read uncontended -> 'b) -> 'b = fun x f -> f x
+                                                                                        ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let override : 'a @ contended -> ('a @ read contended -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+val override : 'a @ contended -> ('a @ contended read -> 'b) -> 'b = <fun>
+|}]
+
+(* [read_write] doesn't change the default. *)
+
+
+let fails : 'a @ contended -> ('a @ read_write uncontended -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+Line 1, characters 87-88:
+1 | let fails : 'a @ contended -> ('a @ read_write uncontended -> 'b) -> 'b = fun x f -> f x
+                                                                                           ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let fails : 'a @ contended -> ('a @ read_write shared -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+Line 1, characters 82-83:
+1 | let fails : 'a @ contended -> ('a @ read_write shared -> 'b) -> 'b = fun x f -> f x
+                                                                                      ^
+Error: This value is "contended" but expected to be "shared".
+|}]
+
+let succeeds : 'a @ contended -> ('a @ read_write contended -> 'b) -> 'b = fun x f -> f x
+[%%expect{|
+val succeeds : 'a @ contended -> ('a @ contended -> 'b) -> 'b = <fun>
+|}]
+
+(* Modalities. *)
+
+type 'a t1 = { y : 'a @@ immutable }
+
+let get : 'a @ contended -> 'a t1 = fun y -> {y}
+
+type 'a t2 = { z : 'a @@ shared }
+
+let get : 'a @ shared -> 'a t2 = fun z -> {z}
+
+[%%expect{|
+type 'a t1 = { y : 'a @@ immutable; }
+val get : 'a @ contended -> 'a t1 = <fun>
+type 'a t2 = { z : 'a @@ shared; }
+val get : 'a @ shared -> 'a t2 = <fun>
+|}]

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -446,7 +446,7 @@ let foo (f : (unit -> unit) @ stateful portable) @ stateless = fun () -> f ()
 Line 1, characters 73-74:
 1 | let foo (f : (unit -> unit) @ stateful portable) @ stateless = fun () -> f ()
                                                                              ^
-Error: The value "f" is stateful, so cannot be used inside a function that may not capture state.
+Error: The value "f" is stateful, so cannot be used inside a function that is stateless.
 |}]
 
 (* The error for [portable] is displayed first. *)
@@ -459,14 +459,12 @@ Line 1, characters 64-65:
 Error: The value "f" is nonportable, so cannot be used inside a function that is portable.
 |}]
 
-(* CR modes: fix the error message. *)
-
 let foo (f : (unit -> unit) @ observing portable) @ stateless = fun () -> f ()
 [%%expect{|
 Line 1, characters 74-75:
 1 | let foo (f : (unit -> unit) @ observing portable) @ stateless = fun () -> f ()
                                                                               ^
-Error: The value "f" is stateful, so cannot be used inside a function that may not capture state.
+Error: The value "f" is observing, so cannot be used inside a function that is stateless.
 |}]
 
 (* Closing over use of read gives observing *)
@@ -504,14 +502,12 @@ let foo (f : (unit -> unit) @ observing) @ stateful = fun () -> f ()
 val foo : (unit -> unit) @ observing -> unit -> unit = <fun>
 |}]
 
-(* CR modes: fix the error message. *)
-
 let foo (f : (unit -> unit) @ stateful) @ observing = fun () -> f ()
 [%%expect{|
 Line 1, characters 64-65:
 1 | let foo (f : (unit -> unit) @ stateful) @ observing = fun () -> f ()
                                                                     ^
-Error: The value "f" is stateful, so cannot be used inside a function that may not capture state.
+Error: The value "f" is stateful, so cannot be used inside a function that is observing.
 |}]
 
 (* Testing defaulting  *)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -4578,6 +4578,7 @@ let report_lookup_error _loc env ppf = function
         | Error (Linearity, _) -> "once", "is many"
         | Error (Portability, _) -> "nonportable", "is portable"
         | Error (Yielding, _) -> "yielding", "may not yield"
+        | Error (Statefulness, _) -> "stateful", "may not capture state"
       in
       let s, hint =
         match context with

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -4578,7 +4578,9 @@ let report_lookup_error _loc env ppf = function
         | Error (Linearity, _) -> "once", "is many"
         | Error (Portability, _) -> "nonportable", "is portable"
         | Error (Yielding, _) -> "yielding", "may not yield"
-        | Error (Statefulness, _) -> "stateful", "may not capture state"
+        | Error (Statefulness, {left; right}) ->
+          asprintf "%a" Mode.Statefulness.Const.print left,
+          asprintf "is %a" Mode.Statefulness.Const.print right
       in
       let s, hint =
         match context with

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -421,12 +421,14 @@ module Mod_bounds = struct
     create ~locality:Locality.min ~linearity:Linearity.min
       ~uniqueness:Uniqueness.min ~portability:Portability.min
       ~contention:Contention.min ~yielding:Yielding.min
+      ~statefulness:Statefulness.min ~visibility:Visibility.min
       ~externality:Externality.min ~nullability:Nullability.min
 
   let max =
     create ~locality:Locality.max ~linearity:Linearity.max
       ~uniqueness:Uniqueness.max ~portability:Portability.max
       ~contention:Contention.max ~yielding:Yielding.max
+      ~statefulness:Statefulness.max ~visibility:Visibility.max
       ~externality:Externality.max ~nullability:Nullability.max
 
   let join t1 t2 =
@@ -436,10 +438,12 @@ module Mod_bounds = struct
     let portability = Portability.join (portability t1) (portability t2) in
     let contention = Contention.join (contention t1) (contention t2) in
     let yielding = Yielding.join (yielding t1) (yielding t2) in
+    let statefulness = Statefulness.join (statefulness t1) (statefulness t2) in
+    let visibility = Visibility.join (visibility t1) (visibility t2) in
     let externality = Externality.join (externality t1) (externality t2) in
     let nullability = Nullability.join (nullability t1) (nullability t2) in
     create ~locality ~linearity ~uniqueness ~portability ~contention ~yielding
-      ~externality ~nullability
+      ~statefulness ~visibility ~externality ~nullability
 
   let meet t1 t2 =
     let locality = Locality.meet (locality t1) (locality t2) in
@@ -448,10 +452,12 @@ module Mod_bounds = struct
     let portability = Portability.meet (portability t1) (portability t2) in
     let contention = Contention.meet (contention t1) (contention t2) in
     let yielding = Yielding.meet (yielding t1) (yielding t2) in
+    let statefulness = Statefulness.meet (statefulness t1) (statefulness t2) in
+    let visibility = Visibility.meet (visibility t1) (visibility t2) in
     let externality = Externality.meet (externality t1) (externality t2) in
     let nullability = Nullability.meet (nullability t1) (nullability t2) in
     create ~locality ~linearity ~uniqueness ~portability ~contention ~yielding
-      ~externality ~nullability
+      ~statefulness ~visibility ~externality ~nullability
 
   let less_or_equal t1 t2 =
     let[@inline] axis_less_or_equal ~le ~axis a b : Sub_result.t =
@@ -484,6 +490,14 @@ module Mod_bounds = struct
             ~axis:(Pack (Modal (Comonadic Yielding))) (yielding t1)
             (yielding t2))
     @@ Sub_result.combine
+         (axis_less_or_equal ~le:Statefulness.le
+            ~axis:(Pack (Modal (Comonadic Statefulness))) (statefulness t1)
+            (statefulness t2))
+    @@ Sub_result.combine
+         (axis_less_or_equal ~le:Visibility.le
+            ~axis:(Pack (Modal (Monadic Visibility))) (visibility t1)
+            (visibility t2))
+    @@ Sub_result.combine
          (axis_less_or_equal ~le:Externality.le
             ~axis:(Pack (Nonmodal Externality)) (externality t1)
             (externality t2))
@@ -497,6 +511,8 @@ module Mod_bounds = struct
     && Portability.equal (portability t1) (portability t2)
     && Contention.equal (contention t1) (contention t2)
     && Yielding.equal (yielding t1) (yielding t2)
+    && Statefulness.equal (statefulness t1) (statefulness t2)
+    && Visibility.equal (visibility t1) (visibility t2)
     && Externality.equal (externality t1) (externality t2)
     && Nullability.equal (nullability t1) (nullability t2)
 
@@ -508,6 +524,8 @@ module Mod_bounds = struct
     | Modal (Comonadic Linearity) -> linearity t
     | Modal (Comonadic Portability) -> portability t
     | Modal (Comonadic Yielding) -> yielding t
+    | Modal (Comonadic Statefulness) -> statefulness t
+    | Modal (Monadic Visibility) -> visibility t
     | Nonmodal Externality -> externality t
     | Nonmodal Nullability -> nullability t
 
@@ -536,6 +554,12 @@ module Mod_bounds = struct
          (Yielding.le Yielding.max (yielding t))
          (Modal (Comonadic Yielding))
     |> add_if
+         (Statefulness.le Statefulness.max (statefulness t))
+         (Modal (Comonadic Statefulness))
+    |> add_if
+         (Visibility.le Visibility.max (visibility t))
+         (Modal (Monadic Visibility))
+    |> add_if
          (Externality.le Externality.max (externality t))
          (Nonmodal Externality)
     |> add_if
@@ -546,6 +570,7 @@ module Mod_bounds = struct
     create ~linearity:Linearity.max ~locality:Locality.max
       ~uniqueness:Uniqueness.min ~portability:Portability.max
       ~contention:Contention.min ~yielding:Yielding.max
+      ~statefulness:Statefulness.max ~visibility:Visibility.min
       ~externality:Externality.max ~nullability:Nullability.Non_null
 
   let to_mode_crossing t =
@@ -555,9 +580,14 @@ module Mod_bounds = struct
             { areality = locality t;
               linearity = linearity t;
               portability = portability t;
-              yielding = yielding t
+              yielding = yielding t;
+              statefulness = statefulness t
             };
-          monadic = { uniqueness = uniqueness t; contention = contention t }
+          monadic =
+            { uniqueness = uniqueness t;
+              contention = contention t;
+              visibility = visibility t
+            }
         }
 end
 
@@ -985,6 +1015,9 @@ module Layout_and_axes = struct
                   (value_for_axis ~axis:(Modal (Comonadic Portability)))
                 ~contention:(value_for_axis ~axis:(Modal (Monadic Contention)))
                 ~yielding:(value_for_axis ~axis:(Modal (Comonadic Yielding)))
+                ~statefulness:
+                  (value_for_axis ~axis:(Modal (Comonadic Statefulness)))
+                ~visibility:(value_for_axis ~axis:(Modal (Monadic Visibility)))
                 ~externality:(value_for_axis ~axis:(Nonmodal Externality))
                 ~nullability:(value_for_axis ~axis:(Nonmodal Nullability))
             in
@@ -1271,11 +1304,30 @@ module Const = struct
                 ~linearity:Linearity.Const.min
                 ~portability:Portability.Const.min ~yielding:Yielding.Const.min
                 ~uniqueness:Uniqueness.Const_op.max
-                ~contention:Contention.Const_op.min ~externality:Externality.max
+                ~contention:Contention.Const_op.min
+                ~statefulness:Statefulness.Const.min
+                ~visibility:Visibility.Const_op.min ~externality:Externality.max
                 ~nullability:Nullability.Non_null;
             with_bounds = No_with_bounds
           };
         name = "immutable_data"
+      }
+
+    let atomically_mutable_data =
+      { jkind =
+          { layout = Base Value;
+            mod_bounds =
+              Mod_bounds.create ~locality:Locality.Const.max
+                ~linearity:Linearity.Const.min
+                ~portability:Portability.Const.min ~yielding:Yielding.Const.min
+                ~uniqueness:Uniqueness.Const_op.max
+                ~contention:Contention.Const_op.min
+                ~statefulness:Statefulness.Const.min
+                ~visibility:Visibility.Const_op.max ~externality:Externality.max
+                ~nullability:Nullability.Non_null;
+            with_bounds = No_with_bounds
+          };
+        name = "atomically_mutable_data"
       }
 
     let mutable_data =
@@ -1286,7 +1338,9 @@ module Const = struct
                 ~linearity:Linearity.Const.min
                 ~portability:Portability.Const.min ~yielding:Yielding.Const.min
                 ~contention:Contention.Const_op.max
-                ~uniqueness:Uniqueness.Const_op.max ~externality:Externality.max
+                ~uniqueness:Uniqueness.Const_op.max
+                ~statefulness:Statefulness.Const.min
+                ~visibility:Visibility.Const_op.max ~externality:Externality.max
                 ~nullability:Nullability.Non_null;
             with_bounds = No_with_bounds
           };
@@ -1438,6 +1492,7 @@ module Const = struct
         value_or_null_mod_everything;
         value;
         immutable_data;
+        atomically_mutable_data;
         mutable_data;
         void;
         immediate;
@@ -1509,16 +1564,37 @@ module Const = struct
            (Some [])
       |> function
       | None -> None
-      | Some modes -> (
-        match List.mem "global" modes, List.mem "unyielding" modes with
-        | true, true ->
-          (* We default [mod global] to [mod global unyielding],
-             so we don't want to print the latter. *)
-          Some (List.filter (fun m -> m <> "unyielding") modes)
-        | true, false ->
-          (* Otherwise, print [mod global yielding] to indicate [yielding]. *)
-          Some (modes @ ["yielding"])
-        | _, _ -> Some modes)
+      | Some modes ->
+        (* Handle all the mode implications *)
+        let modes =
+          match List.mem "global" modes, List.mem "unyielding" modes with
+          | true, true ->
+            (* [global] implies [unyielding], omit it. *)
+            List.filter (fun m -> m <> "unyielding") modes
+          | true, false ->
+            (* Otherwise, print [mod global yielding] to indicate [yielding]. *)
+            modes @ ["yielding"]
+          | _, _ -> modes
+        in
+        let modes =
+          (* Likewise for [stateless] and [portable]. *)
+          match List.mem "stateless" modes, List.mem "portable" modes with
+          | true, true -> List.filter (fun m -> m <> "portable") modes
+          | true, false -> modes @ ["portable"]
+          | _, _ -> modes
+        in
+        (* Likewise for [immutable] and [contended], or [read] and [shared]. *)
+        let modes =
+          match List.mem "immutable" modes, List.mem "contended" modes with
+          | true, true -> List.filter (fun m -> m <> "contended") modes
+          | true, false -> modes @ ["contended"]
+          | _, _ -> (
+            match List.mem "read" modes, List.mem "shared" modes with
+            | true, true -> List.filter (fun m -> m <> "shared") modes
+            | true, false -> modes @ ["shared"]
+            | _, _ -> modes)
+        in
+        Some modes
 
     let modality_to_ignore_axes axes_to_ignore =
       (* The modality is constant along axes to ignore and id along others *)
@@ -1697,6 +1773,7 @@ module Const = struct
       | "bits64" -> Builtin.bits64.jkind
       | "vec128" -> Builtin.vec128.jkind
       | "immutable_data" -> Builtin.immutable_data.jkind
+      | "atomically_mutable_data" -> Builtin.atomically_mutable_data.jkind
       | "mutable_data" -> Builtin.mutable_data.jkind
       | _ -> raise ~loc:jkind.pjkind_loc (Unknown_jkind jkind))
       |> allow_left |> allow_right
@@ -1723,6 +1800,8 @@ module Const = struct
           ~portability:(value_for_axis ~axis:(Modal (Comonadic Portability)))
           ~contention:(value_for_axis ~axis:(Modal (Monadic Contention)))
           ~yielding:(value_for_axis ~axis:(Modal (Comonadic Yielding)))
+          ~statefulness:(value_for_axis ~axis:(Modal (Comonadic Statefulness)))
+          ~visibility:(value_for_axis ~axis:(Modal (Monadic Visibility)))
           ~externality:(value_for_axis ~axis:(Nonmodal Externality))
           ~nullability:(value_for_axis ~axis:(Nonmodal Nullability))
       in
@@ -1896,6 +1975,9 @@ module Jkind_desc = struct
 
     let immutable_data = of_const Const.Builtin.immutable_data.jkind
 
+    let atomically_mutable_data =
+      of_const Const.Builtin.atomically_mutable_data.jkind
+
     let mutable_data = of_const Const.Builtin.mutable_data.jkind
 
     let void = of_const Const.Builtin.void.jkind
@@ -1990,6 +2072,11 @@ module Builtin = struct
   let immutable_data ~(why : History.value_creation_reason) =
     fresh_jkind Jkind_desc.Builtin.immutable_data
       ~annotation:(mk_annot "immutable_data")
+      ~why:(Value_creation why)
+
+  let atomically_mutable_data ~(why : History.value_creation_reason) =
+    fresh_jkind Jkind_desc.Builtin.atomically_mutable_data
+      ~annotation:(mk_annot "atomically_mutable_data")
       ~why:(Value_creation why)
 
   let mutable_data ~(why : History.value_creation_reason) =
@@ -2240,19 +2327,19 @@ let for_object =
   (* The crossing of objects are based on the fact that they are
      produced/defined/allocated at legacy, which applies to only the
      comonadic axes. *)
-  let ({ linearity; areality = locality; portability; yielding }
+  let ({ linearity; areality = locality; portability; yielding; statefulness }
         : Mode.Alloc.Comonadic.Const.t) =
     Alloc.Comonadic.Const.legacy
   in
-  let ({ contention; uniqueness } : Mode.Alloc.Monadic.Const_op.t) =
+  let ({ contention; uniqueness; visibility } : Mode.Alloc.Monadic.Const_op.t) =
     Alloc.Monadic.Const_op.max
   in
   fresh_jkind
     { layout = Sort (Base Value);
       mod_bounds =
         Mod_bounds.create ~linearity ~locality ~uniqueness ~portability
-          ~contention ~yielding ~externality:Externality.max
-          ~nullability:Non_null;
+          ~contention ~yielding ~statefulness ~visibility
+          ~externality:Externality.max ~nullability:Non_null;
       with_bounds = No_with_bounds
     }
     ~annotation:None ~why:(Value_creation Object)
@@ -2320,11 +2407,13 @@ let get_modal_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) =
         { areality = locality mod_bounds;
           linearity = linearity mod_bounds;
           portability = portability mod_bounds;
-          yielding = yielding mod_bounds
+          yielding = yielding mod_bounds;
+          statefulness = statefulness mod_bounds
         };
       monadic =
         { uniqueness = uniqueness mod_bounds;
-          contention = contention mod_bounds
+          contention = contention mod_bounds;
+          visibility = visibility mod_bounds
         }
     }
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1313,7 +1313,7 @@ module Const = struct
         name = "immutable_data"
       }
 
-    let atomically_mutable_data =
+    let sync_data =
       { jkind =
           { layout = Base Value;
             mod_bounds =
@@ -1327,7 +1327,7 @@ module Const = struct
                 ~nullability:Nullability.Non_null;
             with_bounds = No_with_bounds
           };
-        name = "atomically_mutable_data"
+        name = "sync_data"
       }
 
     let mutable_data =
@@ -1492,7 +1492,7 @@ module Const = struct
         value_or_null_mod_everything;
         value;
         immutable_data;
-        atomically_mutable_data;
+        sync_data;
         mutable_data;
         void;
         immediate;
@@ -1773,7 +1773,7 @@ module Const = struct
       | "bits64" -> Builtin.bits64.jkind
       | "vec128" -> Builtin.vec128.jkind
       | "immutable_data" -> Builtin.immutable_data.jkind
-      | "atomically_mutable_data" -> Builtin.atomically_mutable_data.jkind
+      | "sync_data" -> Builtin.sync_data.jkind
       | "mutable_data" -> Builtin.mutable_data.jkind
       | _ -> raise ~loc:jkind.pjkind_loc (Unknown_jkind jkind))
       |> allow_left |> allow_right
@@ -1975,8 +1975,7 @@ module Jkind_desc = struct
 
     let immutable_data = of_const Const.Builtin.immutable_data.jkind
 
-    let atomically_mutable_data =
-      of_const Const.Builtin.atomically_mutable_data.jkind
+    let sync_data = of_const Const.Builtin.sync_data.jkind
 
     let mutable_data = of_const Const.Builtin.mutable_data.jkind
 
@@ -2074,9 +2073,8 @@ module Builtin = struct
       ~annotation:(mk_annot "immutable_data")
       ~why:(Value_creation why)
 
-  let atomically_mutable_data ~(why : History.value_creation_reason) =
-    fresh_jkind Jkind_desc.Builtin.atomically_mutable_data
-      ~annotation:(mk_annot "atomically_mutable_data")
+  let sync_data ~(why : History.value_creation_reason) =
+    fresh_jkind Jkind_desc.Builtin.sync_data ~annotation:(mk_annot "sync_data")
       ~why:(Value_creation why)
 
   let mutable_data ~(why : History.value_creation_reason) =

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -277,7 +277,7 @@ module Const : sig
     val immutable_data : t
 
     (** Atomically mutable values that don't contain functions. *)
-    val atomically_mutable_data : t
+    val sync_data : t
 
     (** Mutable values that don't contain functions. *)
     val mutable_data : t
@@ -352,8 +352,7 @@ module Builtin : sig
   val immutable_data : why:History.value_creation_reason -> 'd Types.jkind
 
   (** This is suitable for records or variants with atomically mutable fields. *)
-  val atomically_mutable_data :
-    why:History.value_creation_reason -> 'd Types.jkind
+  val sync_data : why:History.value_creation_reason -> 'd Types.jkind
 
   (** This is suitable for records or variants with mutable fields. *)
   val mutable_data : why:History.value_creation_reason -> 'd Types.jkind

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -276,6 +276,9 @@ module Const : sig
     (** Immutable values that don't contain functions. *)
     val immutable_data : t
 
+    (** Atomically mutable values that don't contain functions. *)
+    val atomically_mutable_data : t
+
     (** Mutable values that don't contain functions. *)
     val mutable_data : t
 
@@ -347,6 +350,10 @@ module Builtin : sig
 
   (** This is suitable for records or variants without mutable fields. *)
   val immutable_data : why:History.value_creation_reason -> 'd Types.jkind
+
+  (** This is suitable for records or variants with atomically mutable fields. *)
+  val atomically_mutable_data :
+    why:History.value_creation_reason -> 'd Types.jkind
 
   (** This is suitable for records or variants with mutable fields. *)
   val mutable_data : why:History.value_creation_reason -> 'd Types.jkind

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -153,6 +153,8 @@ module Axis = struct
       Pack (Modal (Monadic Contention));
       Pack (Modal (Comonadic Portability));
       Pack (Modal (Comonadic Yielding));
+      Pack (Modal (Comonadic Statefulness));
+      Pack (Modal (Monadic Visibility));
       Pack (Nonmodal Externality);
       Pack (Nonmodal Nullability) ]
 
@@ -168,6 +170,8 @@ module Axis = struct
     | Modal (Comonadic Portability) -> true
     | Modal (Monadic Contention) -> true
     | Modal (Comonadic Yielding) -> true
+    | Modal (Comonadic Statefulness) -> true
+    | Modal (Monadic Visibility) -> true
     | Nonmodal Externality -> true
     | Nonmodal Nullability -> false
 end
@@ -188,8 +192,10 @@ module Axis_set = struct
     | Modal (Comonadic Portability) -> 3
     | Modal (Monadic Contention) -> 4
     | Modal (Comonadic Yielding) -> 5
-    | Nonmodal Externality -> 6
-    | Nonmodal Nullability -> 7
+    | Modal (Comonadic Statefulness) -> 6
+    | Modal (Monadic Visibility) -> 7
+    | Nonmodal Externality -> 8
+    | Nonmodal Nullability -> 9
 
   let[@inline] axis_mask ax = 1 lsl axis_index ax
 
@@ -215,6 +221,8 @@ module Axis_set = struct
     |> set_axis (Modal (Comonadic Portability))
     |> set_axis (Modal (Monadic Contention))
     |> set_axis (Modal (Comonadic Yielding))
+    |> set_axis (Modal (Comonadic Statefulness))
+    |> set_axis (Modal (Monadic Visibility))
     |> set_axis (Nonmodal Externality)
     |> set_axis (Nonmodal Nullability)
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -293,16 +293,70 @@ module type S = sig
     val unyielding : lr
   end
 
+  module Statefulness : sig
+    module Const : sig
+      type t =
+        | Stateless
+        | Observing
+        | Stateful
+
+      include Lattice with type t := t
+    end
+
+    type error = Const.t Solver.error
+
+    include
+      Common
+        with module Const := Const
+         and type error := error
+         and type 'd t = (Const.t, 'd) mode_comonadic
+
+    val stateless : lr
+
+    val observing : lr
+
+    val stateful : lr
+  end
+
+  module Visibility : sig
+    module Const : sig
+      type t =
+        | Immutable
+        | Read
+        | Read_write
+
+      include Lattice with type t := t
+    end
+
+    module Const_op : Lattice with type t = Const.t
+
+    type error = Const.t Solver.error
+
+    include
+      Common
+        with module Const := Const
+         and type error := error
+         and type 'd t = (Const.t, 'd) mode_monadic
+
+    val immutable : lr
+
+    val read : lr
+
+    val read_write : lr
+  end
+
   type 'a comonadic_with =
     { areality : 'a;
       linearity : Linearity.Const.t;
       portability : Portability.Const.t;
-      yielding : Yielding.Const.t
+      yielding : Yielding.Const.t;
+      statefulness : Statefulness.Const.t
     }
 
   type monadic =
     { uniqueness : Uniqueness.Const.t;
-      contention : Contention.Const.t
+      contention : Contention.Const.t;
+      visibility : Visibility.Const.t
     }
 
   module Axis : sig
@@ -313,8 +367,10 @@ module type S = sig
       | Linearity : ('areality comonadic_with, Linearity.Const.t) t
       | Portability : ('areality comonadic_with, Portability.Const.t) t
       | Yielding : ('areality comonadic_with, Yielding.Const.t) t
+      | Statefulness : ('areality comonadic_with, Statefulness.Const.t) t
       | Uniqueness : (monadic, Uniqueness.Const.t) t
       | Contention : (monadic, Contention.Const.t) t
+      | Visibility : (monadic, Visibility.Const.t) t
 
     val print : Format.formatter -> ('p, 'r) t -> unit
 
@@ -380,13 +436,15 @@ module type S = sig
 
     val all_axes : ('l * 'r) axis_packed list
 
-    type ('a, 'b, 'c, 'd, 'e, 'f) modes =
+    type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) modes =
       { areality : 'a;
         linearity : 'b;
         uniqueness : 'c;
         portability : 'd;
         contention : 'e;
-        yielding : 'f
+        yielding : 'f;
+        statefulness : 'g;
+        visibility : 'h
       }
 
     module Const : sig
@@ -398,7 +456,9 @@ module type S = sig
               Uniqueness.Const.t,
               Portability.Const.t,
               Contention.Const.t,
-              Yielding.Const.t )
+              Yielding.Const.t,
+              Statefulness.Const.t,
+              Visibility.Const.t )
             modes
 
       module Option : sig
@@ -410,7 +470,9 @@ module type S = sig
             Uniqueness.Const.t option,
             Portability.Const.t option,
             Contention.Const.t option,
-            Yielding.Const.t option )
+            Yielding.Const.t option,
+            Statefulness.Const.t option,
+            Visibility.Const.t option )
           modes
 
         val none : t

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -10243,11 +10243,11 @@ let contention_hint _fail_reason _submode_reason context =
   match (context : contention_context option) with
   | Some Read_mutable ->
       [Location.msg
-        "@[Hint: In order to read from the mutable fields,@ \
+        "@[Hint: In order to read from its mutable fields,@ \
         this record needs to be at least shared.@]"]
   | Some Write_mutable ->
       [Location.msg
-        "@[Hint: In order to write into the mutable fields,@ \
+        "@[Hint: In order to write into its mutable fields,@ \
         this record needs to be uncontended.@]"]
   | Some Force_lazy ->
       [Location.msg
@@ -10259,11 +10259,11 @@ let visibility_hint _fail_reason _submode_reason context =
   match (context : visibility_context option) with
   | Some Read_mutable ->
       [Location.msg
-        "@[Hint: In order to read from the mutable fields,@ \
+        "@[Hint: In order to read from its mutable fields,@ \
         this record needs to have read visibility.@]"]
   | Some Write_mutable ->
       [Location.msg
-        "@[Hint: In order to write into the mutable fields,@ \
+        "@[Hint: In order to write into its mutable fields,@ \
         this record needs to have read_write visibility.@]"]
   | None -> []
 

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -188,6 +188,10 @@ type contention_context =
   | Write_mutable
   | Force_lazy
 
+type visibility_context =
+  | Read_mutable
+  | Write_mutable
+
 type unsupported_stack_allocation =
   | Lazy
   | Module
@@ -299,6 +303,7 @@ type error =
       Mode.Value.error * submode_reason *
       Env.locality_context option *
       contention_context option *
+      visibility_context option *
       Env.shared_context option
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -63,6 +63,19 @@ module Axis_pair = struct
       Any_axis_pair (Modal (Comonadic Yielding), Yielding.Const.Yielding)
     | "unyielding" ->
       Any_axis_pair (Modal (Comonadic Yielding), Yielding.Const.Unyielding)
+    | "stateless" ->
+      Any_axis_pair
+        (Modal (Comonadic Statefulness), Statefulness.Const.Stateless)
+    | "observing" ->
+      Any_axis_pair
+        (Modal (Comonadic Statefulness), Statefulness.Const.Observing)
+    | "stateful" ->
+      Any_axis_pair (Modal (Comonadic Statefulness), Statefulness.Const.Stateful)
+    | "immutable" ->
+      Any_axis_pair (Modal (Monadic Visibility), Visibility.Const.Immutable)
+    | "read" -> Any_axis_pair (Modal (Monadic Visibility), Visibility.Const.Read)
+    | "read_write" ->
+      Any_axis_pair (Modal (Monadic Visibility), Visibility.Const.Read_write)
     | "everything" -> Everything_but_nullability
     | _ -> raise Not_found
 end
@@ -95,6 +108,8 @@ module Transled_modifiers = struct
       portability : Mode.Portability.Const.t Location.loc option;
       contention : Mode.Contention.Const.t Location.loc option;
       yielding : Mode.Yielding.Const.t Location.loc option;
+      statefulness : Mode.Statefulness.Const.t Location.loc option;
+      visibility : Mode.Visibility.Const.t Location.loc option;
       externality : Jkind_axis.Externality.t Location.loc option;
       nullability : Jkind_axis.Nullability.t Location.loc option
     }
@@ -106,6 +121,8 @@ module Transled_modifiers = struct
       portability = None;
       contention = None;
       yielding = None;
+      statefulness = None;
+      visibility = None;
       externality = None;
       nullability = None
     }
@@ -118,6 +135,8 @@ module Transled_modifiers = struct
     | Modal (Comonadic Portability) -> t.portability
     | Modal (Monadic Contention) -> t.contention
     | Modal (Comonadic Yielding) -> t.yielding
+    | Modal (Comonadic Statefulness) -> t.statefulness
+    | Modal (Monadic Visibility) -> t.visibility
     | Nonmodal Externality -> t.externality
     | Nonmodal Nullability -> t.nullability
 
@@ -130,6 +149,8 @@ module Transled_modifiers = struct
     | Modal (Comonadic Portability) -> { t with portability = value }
     | Modal (Monadic Contention) -> { t with contention = value }
     | Modal (Comonadic Yielding) -> { t with yielding = value }
+    | Modal (Comonadic Statefulness) -> { t with statefulness = value }
+    | Modal (Monadic Visibility) -> { t with visibility = value }
     | Nonmodal Externality -> { t with externality = value }
     | Nonmodal Nullability -> { t with nullability = value }
 end
@@ -164,6 +185,8 @@ let transl_modifier_annots annots =
           contention = Some { txt = Contention.Const_op.min; loc };
           yielding = Some { txt = Yielding.Const.min; loc };
           externality = Some { txt = Externality.min; loc };
+          statefulness = Some { txt = Statefulness.Const.min; loc };
+          visibility = Some { txt = Visibility.Const_op.min; loc };
           nullability =
             Transled_modifiers.get ~axis:(Nonmodal Nullability) modifiers_so_far
         }
@@ -172,25 +195,71 @@ let transl_modifier_annots annots =
   let modifiers = List.fold_left step empty_modifiers annots in
   (* Since [yielding] is the default mode in presence of [local],
      the [global] modifier must also apply [unyielding] unless specified. *)
-  match
-    ( Transled_modifiers.get ~axis:(Modal (Comonadic Yielding)) modifiers,
-      Transled_modifiers.get ~axis:(Modal (Comonadic Areality)) modifiers )
-  with
-  | None, Some { txt = Locality.Const.Global; _ } ->
-    Transled_modifiers.set ~axis:(Modal (Comonadic Yielding)) modifiers
-      (Some { txt = Yielding.Const.Unyielding; loc = Location.none })
-  | _, _ -> modifiers
+  let modifiers =
+    match
+      ( Transled_modifiers.get ~axis:(Modal (Comonadic Yielding)) modifiers,
+        Transled_modifiers.get ~axis:(Modal (Comonadic Areality)) modifiers )
+    with
+    | None, Some { txt = Locality.Const.Global; _ } ->
+      Transled_modifiers.set ~axis:(Modal (Comonadic Yielding)) modifiers
+        (Some { txt = Yielding.Const.Unyielding; loc = Location.none })
+    | _, _ -> modifiers
+  in
+  (* Likewise, [immutable] => [contended], [read] => [shared]. *)
+  let modifiers =
+    match
+      ( Transled_modifiers.get ~axis:(Modal (Monadic Contention)) modifiers,
+        Transled_modifiers.get ~axis:(Modal (Monadic Visibility)) modifiers )
+    with
+    | None, Some { txt = Visibility.Const.Immutable; _ } ->
+      Transled_modifiers.set ~axis:(Modal (Monadic Contention)) modifiers
+        (Some { txt = Contention.Const.Contended; loc = Location.none })
+    | None, Some { txt = Visibility.Const.Read; _ } ->
+      Transled_modifiers.set ~axis:(Modal (Monadic Contention)) modifiers
+        (Some { txt = Contention.Const.Shared; loc = Location.none })
+    | _, _ -> modifiers
+  in
+  (* Likewise, [stateless] => [portable]. *)
+  let modifiers =
+    match
+      ( Transled_modifiers.get ~axis:(Modal (Comonadic Portability)) modifiers,
+        Transled_modifiers.get ~axis:(Modal (Comonadic Statefulness)) modifiers
+      )
+    with
+    | None, Some { txt = Statefulness.Const.Stateless; _ } ->
+      Transled_modifiers.set ~axis:(Modal (Comonadic Portability)) modifiers
+        (Some { txt = Portability.Const.Portable; loc = Location.none })
+    | _, _ -> modifiers
+  in
+  modifiers
 
 let default_mode_annots (annots : Alloc.Const.Option.t) =
-  (* Unlike all other modes, [yielding] has a different default
-     depending on whether [areality] is [Global] or [Local]. *)
+  (* [yielding] has a different default depending on whether [areality]
+     is [global] or [local]. *)
   let yielding =
     match annots.yielding, annots.areality with
     | (Some _ as y), _ | y, None -> y
     | None, Some Locality.Const.Global -> Some Yielding.Const.Unyielding
     | None, Some Locality.Const.Local -> Some Yielding.Const.Yielding
   in
-  { annots with yielding }
+  (* Likewise for [contention]. *)
+  let contention =
+    match annots.contention, annots.visibility with
+    | (Some _ as c), _ | c, None -> c
+    | None, Some Visibility.Const.Immutable -> Some Contention.Const.Contended
+    | None, Some Visibility.Const.Read -> Some Contention.Const.Shared
+    | None, Some Visibility.Const.Read_write ->
+      Some Contention.Const.Uncontended
+  in
+  (* Likewise for [portability]. *)
+  let portability =
+    match annots.portability, annots.statefulness with
+    | (Some _ as p), _ | p, None -> p
+    | None, Some Statefulness.Const.Stateless -> Some Portability.Const.Portable
+    | None, Some Statefulness.Const.(Observing | Stateful) ->
+      Some Portability.Const.Nonportable
+  in
+  { annots with yielding; contention; portability }
 
 let transl_mode_annots annots : Alloc.Const.Option.t =
   let step modifiers_so_far annot =
@@ -215,24 +284,15 @@ let transl_mode_annots annots : Alloc.Const.Option.t =
       uniqueness = Option.map get_txt modes.uniqueness;
       portability = Option.map get_txt modes.portability;
       contention = Option.map get_txt modes.contention;
-      yielding = Option.map get_txt modes.yielding
+      yielding = Option.map get_txt modes.yielding;
+      statefulness = Option.map get_txt modes.statefulness;
+      visibility = Option.map get_txt modes.visibility
     }
 
 let untransl_mode_annots (modes : Mode.Alloc.Const.Option.t) =
   let print_to_string_opt print a = Option.map (Format.asprintf "%a" print) a in
+  (* Untranslate [areality] and [yielding]. *)
   let areality = print_to_string_opt Mode.Locality.Const.print modes.areality in
-  let uniqueness =
-    print_to_string_opt Mode.Uniqueness.Const.print modes.uniqueness
-  in
-  let linearity =
-    print_to_string_opt Mode.Linearity.Const.print modes.linearity
-  in
-  let portability =
-    print_to_string_opt Mode.Portability.Const.print modes.portability
-  in
-  let contention =
-    print_to_string_opt Mode.Contention.Const.print modes.contention
-  in
   let yielding =
     (* Since [yielding] has non-standard defaults, we special-case
        whether we want to print it here. *)
@@ -242,10 +302,48 @@ let untransl_mode_annots (modes : Mode.Alloc.Const.Option.t) =
       None
     | _, _ -> print_to_string_opt Mode.Yielding.Const.print modes.yielding
   in
+  (* Untranslate [visibility] and [contention]. *)
+  let visibility =
+    print_to_string_opt Mode.Visibility.Const.print modes.visibility
+  in
+  let contention =
+    match modes.visibility, modes.contention with
+    | Some Visibility.Const.Immutable, Some Contention.Const.Contended
+    | Some Visibility.Const.Read, Some Contention.Const.Shared
+    | Some Visibility.Const.Read_write, Some Contention.Const.Uncontended ->
+      None
+    | _, _ -> print_to_string_opt Mode.Contention.Const.print modes.contention
+  in
+  (* Untranslate [statefulness] and [portability]. *)
+  let statefulness =
+    print_to_string_opt Mode.Statefulness.Const.print modes.statefulness
+  in
+  let portability =
+    match modes.statefulness, modes.portability with
+    | Some Statefulness.Const.Stateless, Some Portability.Const.Portable
+    | ( Some Statefulness.Const.(Observing | Stateful),
+        Some Portability.Const.Nonportable ) ->
+      None
+    | _, _ -> print_to_string_opt Mode.Portability.Const.print modes.portability
+  in
+  (* Untranslate remaining modes. *)
+  let uniqueness =
+    print_to_string_opt Mode.Uniqueness.Const.print modes.uniqueness
+  in
+  let linearity =
+    print_to_string_opt Mode.Linearity.Const.print modes.linearity
+  in
   List.filter_map
     (fun x ->
       Option.map (fun s -> { txt = Parsetree.Mode s; loc = Location.none }) x)
-    [areality; uniqueness; linearity; portability; contention; yielding]
+    [ areality;
+      uniqueness;
+      linearity;
+      portability;
+      contention;
+      yielding;
+      statefulness;
+      visibility ]
 
 let transl_modality ~maturity { txt = Parsetree.Modality modality; loc } =
   let axis_pair =
@@ -266,6 +364,10 @@ let transl_modality ~maturity { txt = Parsetree.Modality modality; loc } =
     Modality.Atom (Monadic Contention, Join_with mode)
   | Modal_axis_pair (Comonadic Yielding, mode) ->
     Modality.Atom (Comonadic Yielding, Meet_with mode)
+  | Modal_axis_pair (Comonadic Statefulness, mode) ->
+    Modality.Atom (Comonadic Statefulness, Meet_with mode)
+  | Modal_axis_pair (Monadic Visibility, mode) ->
+    Modality.Atom (Monadic Visibility, Join_with mode)
 
 let untransl_modality (a : Modality.t) : Parsetree.modality loc =
   let s =
@@ -288,6 +390,17 @@ let untransl_modality (a : Modality.t) : Parsetree.modality loc =
     | Atom (Comonadic Yielding, Meet_with Yielding.Const.Yielding) -> "yielding"
     | Atom (Comonadic Yielding, Meet_with Yielding.Const.Unyielding) ->
       "unyielding"
+    | Atom (Comonadic Statefulness, Meet_with Statefulness.Const.Stateless) ->
+      "stateless"
+    | Atom (Comonadic Statefulness, Meet_with Statefulness.Const.Observing) ->
+      "observing"
+    | Atom (Comonadic Statefulness, Meet_with Statefulness.Const.Stateful) ->
+      "stateful"
+    | Atom (Monadic Visibility, Join_with Visibility.Const.Immutable) ->
+      "immutable"
+    | Atom (Monadic Visibility, Join_with Visibility.Const.Read) -> "read"
+    | Atom (Monadic Visibility, Join_with Visibility.Const.Read_write) ->
+      "read_write"
     | _ -> failwith "BUG: impossible modality atom"
   in
   { txt = Modality s; loc = Location.none }
@@ -303,11 +416,13 @@ let mutable_implied_modalities (mut : Types.mutability) attrs =
     [ Atom (Comonadic Areality, Meet_with Regionality.Const.legacy);
       Atom (Comonadic Linearity, Meet_with Linearity.Const.legacy);
       Atom (Comonadic Portability, Meet_with Portability.Const.legacy);
-      Atom (Comonadic Yielding, Meet_with Yielding.Const.legacy) ]
+      Atom (Comonadic Yielding, Meet_with Yielding.Const.legacy);
+      Atom (Comonadic Statefulness, Meet_with Statefulness.Const.legacy) ]
   in
   let monadic : Modality.t list =
     [ Atom (Monadic Uniqueness, Join_with Uniqueness.Const.legacy);
-      Atom (Monadic Contention, Join_with Contention.Const.legacy) ]
+      Atom (Monadic Contention, Join_with Contention.Const.legacy);
+      Atom (Monadic Visibility, Join_with Visibility.Const.legacy) ]
   in
   match mut with
   | Immutable -> []
@@ -317,7 +432,9 @@ let mutable_implied_modalities (mut : Types.mutability) attrs =
     else monadic @ comonadic
 
 (* Since [yielding] is the default mode in presence of [local],
-   the [global] modality must also apply [unyielding] unless specified. *)
+   the [global] modality must also apply [unyielding] unless specified.
+
+   Similarly for [visibility]/[contention] and [statefulness]/[portability]. *)
 let default_modalities (modalities : Modality.t list) =
   let areality =
     List.find_map
@@ -335,10 +452,56 @@ let default_modalities (modalities : Modality.t list) =
         | _ -> None)
       modalities
   in
+  let visibility =
+    List.find_map
+      (function
+        | Modality.Atom (Monadic Visibility, Join_with a) ->
+          Some (a : Visibility.Const.t)
+        | _ -> None)
+      modalities
+  in
+  let statefulness =
+    List.find_map
+      (function
+        | Modality.Atom (Comonadic Statefulness, Meet_with s) ->
+          Some (s : Statefulness.Const.t)
+        | _ -> None)
+      modalities
+  in
+  let contention =
+    List.find_map
+      (function
+        | Modality.Atom (Monadic Contention, Join_with c) ->
+          Some (c : Contention.Const.t)
+        | _ -> None)
+      modalities
+  in
+  let portability =
+    List.find_map
+      (function
+        | Modality.Atom (Comonadic Portability, Meet_with p) ->
+          Some (p : Portability.Const.t)
+        | _ -> None)
+      modalities
+  in
+  (* Build the list of extra modalities *)
   let extra =
-    match areality, yielding with
+    (match areality, yielding with
     | Some Global, None ->
       [Modality.Atom (Comonadic Yielding, Meet_with Yielding.Const.Unyielding)]
+    | _, _ -> [])
+    @ (match visibility, contention with
+      | Some Visibility.Const.Immutable, None ->
+        [ Modality.Atom
+            (Monadic Contention, Join_with Contention.Const.Contended) ]
+      | Some Visibility.Const.Read, None ->
+        [Modality.Atom (Monadic Contention, Join_with Contention.Const.Shared)]
+      | _, _ -> [])
+    @
+    match statefulness, portability with
+    | Some Statefulness.Const.Stateless, None ->
+      [ Modality.Atom
+          (Comonadic Portability, Meet_with Portability.Const.Portable) ]
     | _, _ -> []
   in
   modalities @ extra
@@ -382,6 +545,56 @@ let untransl_yielding l =
   | _, Some yld -> Some (Modality.Atom (Comonadic Yielding, Meet_with yld))
   | _, None -> None
 
+let untransl_contention l =
+  let visibility =
+    List.find_map
+      (function
+        | Modality.Atom (Monadic Visibility, Join_with a) ->
+          Some (a : Visibility.Const.t)
+        | _ -> None)
+      l
+  in
+  let contention =
+    List.find_map
+      (function
+        | Modality.Atom (Monadic Contention, Join_with c) ->
+          Some (c : Contention.Const.t)
+        | _ -> None)
+      l
+  in
+  match visibility, contention with
+  | Some Visibility.Const.Immutable, Some Contention.Const.Contended
+  | Some Visibility.Const.Read, Some Contention.Const.Shared
+  | Some Visibility.Const.Read_write, Some Contention.Const.Uncontended ->
+    None
+  | _, Some cnt -> Some (Modality.Atom (Monadic Contention, Join_with cnt))
+  | _, None -> None
+
+let untransl_portability l =
+  let statefulness =
+    List.find_map
+      (function
+        | Modality.Atom (Comonadic Statefulness, Meet_with s) ->
+          Some (s : Statefulness.Const.t)
+        | _ -> None)
+      l
+  in
+  let portability =
+    List.find_map
+      (function
+        | Modality.Atom (Comonadic Portability, Meet_with p) ->
+          Some (p : Portability.Const.t)
+        | _ -> None)
+      l
+  in
+  match statefulness, portability with
+  | Some Statefulness.Const.Stateless, Some Portability.Const.Portable
+  | ( Some Statefulness.Const.(Observing | Stateful),
+      Some Portability.Const.Nonportable ) ->
+    None
+  | _, Some port -> Some (Modality.Atom (Comonadic Portability, Meet_with port))
+  | _, None -> None
+
 let untransl_modalities mut attrs t =
   let l = Modality.Value.Const.to_list t in
   let l =
@@ -389,6 +602,8 @@ let untransl_modalities mut attrs t =
     List.filter_map
       (function
         | Modality.Atom (Comonadic Yielding, _) -> untransl_yielding l
+        | Modality.Atom (Monadic Contention, _) -> untransl_contention l
+        | Modality.Atom (Comonadic Portability, _) -> untransl_portability l
         | a when Modality.is_id a -> None
         | a -> Some a)
       l

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -37,6 +37,8 @@ module Transled_modifiers : sig
       portability : Mode.Portability.Const.t Location.loc option;
       contention : Mode.Contention.Const.t Location.loc option;
       yielding : Mode.Yielding.Const.t Location.loc option;
+      statefulness : Mode.Statefulness.Const.t Location.loc option;
+      visibility : Mode.Visibility.Const.t Location.loc option;
       externality : Jkind_axis.Externality.t Location.loc option;
       nullability : Jkind_axis.Nullability.t Location.loc option
     }

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -35,6 +35,8 @@ module Jkind_mod_bounds = struct
   module Portability = Mode.Portability.Const
   module Contention = Mode.Contention.Const_op
   module Yielding = Mode.Yielding.Const
+  module Statefulness = Mode.Statefulness.Const
+  module Visibility = Mode.Visibility.Const_op
   module Externality = Jkind_axis.Externality
   module Nullability = Jkind_axis.Nullability
 
@@ -45,6 +47,8 @@ module Jkind_mod_bounds = struct
     portability: Portability.t;
     contention: Contention.t;
     yielding: Yielding.t;
+    statefulness: Statefulness.t;
+    visibility: Visibility.t;
     externality: Externality.t;
     nullability: Nullability.t;
   }
@@ -55,6 +59,8 @@ module Jkind_mod_bounds = struct
   let[@inline] portability t = t.portability
   let[@inline] contention t = t.contention
   let[@inline] yielding t = t.yielding
+  let[@inline] statefulness t = t.statefulness
+  let[@inline] visibility t = t.visibility
   let[@inline] externality t = t.externality
   let[@inline] nullability t = t.nullability
 
@@ -65,6 +71,8 @@ module Jkind_mod_bounds = struct
       ~portability
       ~contention
       ~yielding
+      ~statefulness
+      ~visibility
       ~externality
       ~nullability =
     {
@@ -74,6 +82,8 @@ module Jkind_mod_bounds = struct
       portability;
       contention;
       yielding;
+      statefulness;
+      visibility;
       externality;
       nullability;
     }
@@ -84,6 +94,8 @@ module Jkind_mod_bounds = struct
   let[@inline] set_portability portability t = { t with portability }
   let[@inline] set_contention contention t = { t with contention }
   let[@inline] set_yielding yielding t = { t with yielding }
+  let[@inline] set_statefulness statefulness t = { t with statefulness }
+  let[@inline] set_visibility visibility t = { t with visibility }
   let[@inline] set_externality externality t = { t with externality }
   let[@inline] set_nullability nullability t = { t with nullability }
 
@@ -121,6 +133,16 @@ module Jkind_mod_bounds = struct
       then Yielding.max
       else t.yielding
     in
+    let statefulness =
+      if mem max_axes (Modal (Comonadic Statefulness))
+      then Statefulness.max
+      else t.statefulness
+    in
+    let visibility =
+      if mem max_axes (Modal (Monadic Visibility))
+      then Visibility.max
+      else t.visibility
+    in
     let externality =
       if mem max_axes (Nonmodal Externality)
       then Externality.max
@@ -138,6 +160,8 @@ module Jkind_mod_bounds = struct
       portability;
       contention;
       yielding;
+      statefulness;
+      visibility;
       externality;
       nullability;
     }
@@ -176,6 +200,16 @@ module Jkind_mod_bounds = struct
       then Yielding.min
       else t.yielding
     in
+    let statefulness =
+      if mem min_axes (Modal (Comonadic Statefulness))
+      then Statefulness.min
+      else t.statefulness
+    in
+    let visibility =
+      if mem min_axes (Modal (Monadic Visibility))
+      then Visibility.min
+      else t.visibility
+    in
     let externality =
       if mem min_axes (Nonmodal Externality)
       then Externality.min
@@ -192,6 +226,8 @@ module Jkind_mod_bounds = struct
       uniqueness;
       portability;
       contention;
+      statefulness;
+      visibility;
       yielding;
       externality;
       nullability;
@@ -211,6 +247,10 @@ module Jkind_mod_bounds = struct
      Contention.(le max (contention t))) &&
     (not (mem axes (Modal (Comonadic Yielding))) ||
      Yielding.(le max (yielding t))) &&
+    (not (mem axes (Modal (Comonadic Statefulness))) ||
+     Statefulness.(le max (statefulness t))) &&
+    (not (mem axes (Modal (Monadic Visibility))) ||
+     Visibility.(le max (visibility t))) &&
     (not (mem axes (Nonmodal Externality)) ||
      Externality.(le max (externality t))) &&
     (not (mem axes (Nonmodal Nullability)) ||
@@ -223,6 +263,8 @@ module Jkind_mod_bounds = struct
         portability = Portable;
         contention = Uncontended;
         yielding = Yielding;
+        statefulness = Stateful;
+        visibility = Read_write;
         externality = External;
         nullability = Maybe_null } -> true
     | _ -> false
@@ -234,17 +276,21 @@ module Jkind_mod_bounds = struct
           portability;
           contention;
           yielding;
+          statefulness;
+          visibility;
           externality;
           nullability } =
     Format.fprintf ppf "@[{ locality = %a;@ linearity = %a;@ uniqueness = %a;@ \
-      portability = %a;@ contention = %a;@ yielding = %a;@ externality = %a;@ \
-      nullability = %a }@]"
+      portability = %a;@ contention = %a;@ yielding = %a;@ statefulness = %a;@ \
+      visibility = %a;@ externality = %a;@ nullability = %a }@]"
       Locality.print locality
       Linearity.print linearity
       Uniqueness.print uniqueness
       Portability.print portability
       Contention.print contention
       Yielding.print yielding
+      Statefulness.print statefulness
+      Visibility.print visibility
       Externality.print externality
       Nullability.print nullability
 end

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -76,6 +76,8 @@ module Jkind_mod_bounds : sig
   module Portability = Mode.Portability.Const
   module Contention = Mode.Contention.Const_op
   module Yielding = Mode.Yielding.Const
+  module Statefulness = Mode.Statefulness.Const
+  module Visibility = Mode.Visibility.Const_op
   module Externality = Jkind_axis.Externality
   module Nullability = Jkind_axis.Nullability
 
@@ -88,6 +90,8 @@ module Jkind_mod_bounds : sig
     portability:Portability.t ->
     contention:Contention.t ->
     yielding:Yielding.t ->
+    statefulness:Statefulness.t ->
+    visibility:Visibility.t ->
     externality:Externality.t ->
     nullability:Nullability.t ->
     t
@@ -98,6 +102,8 @@ module Jkind_mod_bounds : sig
   val portability : t -> Portability.t
   val contention : t -> Contention.t
   val yielding : t -> Yielding.t
+  val statefulness : t -> Statefulness.t
+  val visibility : t -> Visibility.t
   val externality : t -> Externality.t
   val nullability : t -> Nullability.t
 
@@ -107,6 +113,8 @@ module Jkind_mod_bounds : sig
   val set_portability : Portability.t -> t -> t
   val set_contention : Contention.t -> t -> t
   val set_yielding : Yielding.t -> t -> t
+  val set_statefulness : Statefulness.t -> t -> t
+  val set_visibility : Visibility.t -> t -> t
   val set_externality : Externality.t -> t -> t
   val set_nullability : Nullability.t -> t -> t
 


### PR DESCRIPTION
Rebase of https://github.com/ocaml-flambda/flambda-backend/pull/3098 with updated naming: statefulness going `stateless < observing < stateful` and access going `immutable < read < read_write`.  Similarly to the defaulting for `yielding`, `stateless` implies `portable`, `immutable` implies `contended`, and `read` implies `shared`. Also adds a new kind `atomic_immutable_data`.

Subsequent PRs will update Stdlib, Capsule API, etc, to use those.