### PR TITLE
Tweak logging code of register allocators

### DIFF
--- a/backend/cfg/sub_cfg.ml
+++ b/backend/cfg/sub_cfg.ml
@@ -123,8 +123,8 @@ let dump sub_cfg =
   let liveness = InstructionId.Tbl.create 32 in
   DLL.iter sub_cfg.layout ~f:(fun (block : Cfg.basic_block) ->
       Format.eprintf "Block %a@." Label.print block.start;
-      Regalloc_irc_utils.log_body_and_terminator ~indent:0 block.body
-        block.terminator liveness)
+      Regalloc_irc_utils.log_body_and_terminator block.body block.terminator
+        liveness)
 
 (* note: `dump` is for debugging, and thus not always in use. *)
 let (_ : t -> unit) = dump

--- a/backend/regalloc/regalloc_gi_utils.mli
+++ b/backend/regalloc/regalloc_gi_utils.mli
@@ -6,17 +6,19 @@ val gi_debug : bool
 
 val gi_invariants : bool Lazy.t
 
-val log :
-  indent:int -> ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
+val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
+
+val indent : unit -> unit
+
+val dedent : unit -> unit
 
 val log_body_and_terminator :
-  indent:int ->
   Cfg.basic_instruction_list ->
   Cfg.terminator Cfg.instruction ->
   liveness ->
   unit
 
-val log_cfg_with_infos : indent:int -> Cfg_with_infos.t -> unit
+val log_cfg_with_infos : Cfg_with_infos.t -> unit
 
 module Priority_heuristics : sig
   type t =

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -94,14 +94,14 @@ let build : State.t -> Cfg_with_infos.t -> unit =
 
 let make_work_list : State.t -> unit =
  fun state ->
-  if irc_debug then log "make_work_list";
+ if irc_debug then (log "make_work_list"; indent ());
   State.iter_and_clear_initial state ~f:(fun reg ->
       let deg = reg.Reg.degree in
       if irc_debug
       then
-        log "- %a has degree=%s (k=%d)" Printreg.reg reg (Degree.to_string deg)
-          (k reg);
-      if deg >= k reg
+        (log "- %a has degree=%s (k=%d)" Printreg.reg reg (Degree.to_string deg)
+           (k reg); indent());
+      (if deg >= k reg
       then (
         if irc_debug then log "~> spill_work_list";
         State.add_spill_work_list state reg)
@@ -111,7 +111,8 @@ let make_work_list : State.t -> unit =
         State.add_freeze_work_list state reg)
       else (
         if irc_debug then log "~> simplify_work_list";
-        State.add_simplify_work_list state reg))
+        State.add_simplify_work_list state reg)); if irc_debug then dedent ());
+ if irc_debug then dedent ()
 
 let simplify : State.t -> unit =
  fun state ->
@@ -181,7 +182,7 @@ let add_work_list : State.t -> Reg.t -> unit =
 
 let coalesce : State.t -> unit =
  fun state ->
-  if irc_debug then log "coalesce";
+ if irc_debug then (log "coalesce"; indent ());
   let m = State.choose_and_remove_work_list_moves state in
   let x = m.res.(0) in
   let y = m.arg.(0) in
@@ -191,7 +192,7 @@ let coalesce : State.t -> unit =
   if irc_debug then log "x=%a y=%a" Printreg.reg x Printreg.reg y;
   let u, v = if State.is_precolored state y then y, x else x, y in
   if irc_debug then log "u=%a v=%a" Printreg.reg u Printreg.reg v;
-  if Reg.same u v
+  (if Reg.same u v
   then (
     if irc_debug then log "case #1/4";
     State.add_coalesced_moves state m;
@@ -218,7 +219,8 @@ let coalesce : State.t -> unit =
     add_work_list state u)
   else (
     if irc_debug then log "case #4/4";
-    State.add_active_moves state m)
+    State.add_active_moves state m));
+  if irc_debug then dedent ()
 
 let freeze_moves : State.t -> Reg.t -> unit =
  fun state u ->
@@ -292,7 +294,7 @@ let select_spilling_register_using_heuristics : State.t -> Reg.t =
 
 let select_spill : State.t -> unit =
  fun state ->
-  if irc_debug then log "select_spill";
+ if irc_debug then (log "select_spill"; indent());
   let reg = select_spilling_register_using_heuristics state in
   if irc_debug
   then
@@ -300,13 +302,14 @@ let select_spill : State.t -> unit =
       Spilling_heuristics.(to_string @@ Lazy.force value);
   State.remove_spill_work_list state reg;
   State.add_simplify_work_list state reg;
-  freeze_moves state reg
+  freeze_moves state reg;
+  if irc_debug then dedent ()
 
 let assign_colors : State.t -> Cfg_with_layout.t -> unit =
  fun state _cfg_with_layout ->
-  if irc_debug then log "assign_colors";
+ if irc_debug then (log "assign_colors"; indent ());
   State.iter_and_clear_select_stack state ~f:(fun n ->
-      if irc_debug then log "%a" Printreg.reg n;
+   if irc_debug then (log "%a" Printreg.reg n; indent ());
       let reg_class = Proc.register_class n in
       let reg_num_avail =
         Array.unsafe_get Proc.num_available_registers reg_class
@@ -349,7 +352,7 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
       let first_avail =
         mark_adjacent_colors_and_get_first_available (State.adj_list state n)
       in
-      if first_avail = reg_num_avail
+      (if first_avail = reg_num_avail
       then (
         if irc_debug then log "spilling";
         State.add_spilled_nodes state n)
@@ -357,10 +360,11 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
         State.add_colored_nodes state n;
         let c = first_avail + reg_first_avail in
         if irc_debug then log "coloring with %d" c;
-        n.Reg.irc_color <- Some c));
+        n.Reg.irc_color <- Some c)); if irc_debug then dedent ());
   State.iter_coalesced_nodes state ~f:(fun n ->
       let alias = State.find_alias state n in
-      n.Reg.irc_color <- alias.Reg.irc_color)
+      n.Reg.irc_color <- alias.Reg.irc_color);
+   if irc_debug then dedent ()
 
 module Utils = struct
   include Regalloc_irc_utils
@@ -419,7 +423,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
   then
     fatal "register allocation was not succesful after %d rounds (%s)"
       max_rounds (Cfg_with_infos.cfg cfg_with_infos).fun_name;
-  if irc_debug then log "main, round #%d" round;
+  if irc_debug then (log "main, round #%d" round; indent ());
   let work_lists_desc state (name, f) =
     Printf.sprintf "%s:%s" name (if f state then "{}" else "...")
   in
@@ -477,6 +481,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
   if irc_debug then log "(after loop)";
   assign_colors state cfg_with_layout;
   State.invariant state;
+  if irc_debug then dedent ();
   match State.spilled_nodes state with
   | [] -> if irc_debug then log "(end of main)"
   | _ :: _ as spilled_nodes -> (

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -94,14 +94,18 @@ let build : State.t -> Cfg_with_infos.t -> unit =
 
 let make_work_list : State.t -> unit =
  fun state ->
- if irc_debug then (log "make_work_list"; indent ());
+  if irc_debug
+  then (
+    log "make_work_list";
+    indent ());
   State.iter_and_clear_initial state ~f:(fun reg ->
       let deg = reg.Reg.degree in
       if irc_debug
-      then
-        (log "- %a has degree=%s (k=%d)" Printreg.reg reg (Degree.to_string deg)
-           (k reg); indent());
-      (if deg >= k reg
+      then (
+        log "- %a has degree=%s (k=%d)" Printreg.reg reg (Degree.to_string deg)
+          (k reg);
+        indent ());
+      if deg >= k reg
       then (
         if irc_debug then log "~> spill_work_list";
         State.add_spill_work_list state reg)
@@ -111,8 +115,9 @@ let make_work_list : State.t -> unit =
         State.add_freeze_work_list state reg)
       else (
         if irc_debug then log "~> simplify_work_list";
-        State.add_simplify_work_list state reg)); if irc_debug then dedent ());
- if irc_debug then dedent ()
+        State.add_simplify_work_list state reg);
+      if irc_debug then dedent ());
+  if irc_debug then dedent ()
 
 let simplify : State.t -> unit =
  fun state ->
@@ -182,7 +187,10 @@ let add_work_list : State.t -> Reg.t -> unit =
 
 let coalesce : State.t -> unit =
  fun state ->
- if irc_debug then (log "coalesce"; indent ());
+  if irc_debug
+  then (
+    log "coalesce";
+    indent ());
   let m = State.choose_and_remove_work_list_moves state in
   let x = m.res.(0) in
   let y = m.arg.(0) in
@@ -192,7 +200,7 @@ let coalesce : State.t -> unit =
   if irc_debug then log "x=%a y=%a" Printreg.reg x Printreg.reg y;
   let u, v = if State.is_precolored state y then y, x else x, y in
   if irc_debug then log "u=%a v=%a" Printreg.reg u Printreg.reg v;
-  (if Reg.same u v
+  if Reg.same u v
   then (
     if irc_debug then log "case #1/4";
     State.add_coalesced_moves state m;
@@ -219,7 +227,7 @@ let coalesce : State.t -> unit =
     add_work_list state u)
   else (
     if irc_debug then log "case #4/4";
-    State.add_active_moves state m));
+    State.add_active_moves state m);
   if irc_debug then dedent ()
 
 let freeze_moves : State.t -> Reg.t -> unit =
@@ -294,7 +302,10 @@ let select_spilling_register_using_heuristics : State.t -> Reg.t =
 
 let select_spill : State.t -> unit =
  fun state ->
- if irc_debug then (log "select_spill"; indent());
+  if irc_debug
+  then (
+    log "select_spill";
+    indent ());
   let reg = select_spilling_register_using_heuristics state in
   if irc_debug
   then
@@ -307,9 +318,15 @@ let select_spill : State.t -> unit =
 
 let assign_colors : State.t -> Cfg_with_layout.t -> unit =
  fun state _cfg_with_layout ->
- if irc_debug then (log "assign_colors"; indent ());
+  if irc_debug
+  then (
+    log "assign_colors";
+    indent ());
   State.iter_and_clear_select_stack state ~f:(fun n ->
-   if irc_debug then (log "%a" Printreg.reg n; indent ());
+      if irc_debug
+      then (
+        log "%a" Printreg.reg n;
+        indent ());
       let reg_class = Proc.register_class n in
       let reg_num_avail =
         Array.unsafe_get Proc.num_available_registers reg_class
@@ -352,7 +369,7 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
       let first_avail =
         mark_adjacent_colors_and_get_first_available (State.adj_list state n)
       in
-      (if first_avail = reg_num_avail
+      if first_avail = reg_num_avail
       then (
         if irc_debug then log "spilling";
         State.add_spilled_nodes state n)
@@ -360,11 +377,12 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
         State.add_colored_nodes state n;
         let c = first_avail + reg_first_avail in
         if irc_debug then log "coloring with %d" c;
-        n.Reg.irc_color <- Some c)); if irc_debug then dedent ());
+        n.Reg.irc_color <- Some c);
+      if irc_debug then dedent ());
   State.iter_coalesced_nodes state ~f:(fun n ->
       let alias = State.find_alias state n in
       n.Reg.irc_color <- alias.Reg.irc_color);
-   if irc_debug then dedent ()
+  if irc_debug then dedent ()
 
 module Utils = struct
   include Regalloc_irc_utils
@@ -423,7 +441,10 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
   then
     fatal "register allocation was not succesful after %d rounds (%s)"
       max_rounds (Cfg_with_infos.cfg cfg_with_infos).fun_name;
-  if irc_debug then (log "main, round #%d" round; indent ());
+  if irc_debug
+  then (
+    log "main, round #%d" round;
+    indent ());
   let work_lists_desc state (name, f) =
     Printf.sprintf "%s:%s" name (if f state then "{}" else "...")
   in

--- a/backend/regalloc/regalloc_irc_state.ml
+++ b/backend/regalloc/regalloc_irc_state.ml
@@ -655,15 +655,14 @@ let[@inline] invariant state =
           if not (Int.equal degree cardinal)
           then (
             List.iter u.Reg.interf ~f:(fun r ->
-                log ~indent:0 "%a <- interf[%a]" Printreg.reg r Printreg.reg u);
+                log "%a <- interf[%a]" Printreg.reg r Printreg.reg u);
             Reg.Set.iter
-              (fun r ->
-                log ~indent:0 "%a <- adj_list[%a]" Printreg.reg r Printreg.reg u)
+              (fun r -> log "%a <- adj_list[%a]" Printreg.reg r Printreg.reg u)
               adj_list;
             Reg.Set.iter
               (fun r ->
-                log ~indent:0 "%a <- work_lists_or_precolored[%a]" Printreg.reg
-                  r Printreg.reg u)
+                log "%a <- work_lists_or_precolored[%a]" Printreg.reg r
+                  Printreg.reg u)
               (Reg.Set.inter adj_list work_lists_or_precolored);
             fatal
               "invariant expected degree for %a to be %d but got %d\n\

--- a/backend/regalloc/regalloc_irc_utils.mli
+++ b/backend/regalloc/regalloc_irc_utils.mli
@@ -6,17 +6,19 @@ val irc_debug : bool
 
 val irc_invariants : bool Lazy.t
 
-val log :
-  indent:int -> ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
+val indent : unit -> unit
+
+val dedent : unit -> unit
+
+val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
 
 val log_body_and_terminator :
-  indent:int ->
   Cfg.basic_instruction_list ->
   Cfg.terminator Cfg.instruction ->
   liveness ->
   unit
 
-val log_cfg_with_infos : indent:int -> Cfg_with_infos.t -> unit
+val log_cfg_with_infos : Cfg_with_infos.t -> unit
 
 module Color : sig
   type t = int

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -307,7 +307,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
         indent ();
         iter_cfg_dfs (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun block ->
             log "(block %a)" Label.format block.start;
-            log_body_and_terminator block.body block.terminator liveness); dedent ());
-      )
+            log_body_and_terminator block.body block.terminator liveness);
+        dedent ()))
     cfg_with_infos;
   cfg_with_infos

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -307,7 +307,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
         indent ();
         iter_cfg_dfs (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun block ->
             log "(block %a)" Label.format block.start;
-            log_body_and_terminator block.body block.terminator liveness));
-      dedent ())
+            log_body_and_terminator block.body block.terminator liveness); dedent ());
+      )
     cfg_with_infos;
   cfg_with_infos

--- a/backend/regalloc/regalloc_ls_state.ml
+++ b/backend/regalloc/regalloc_ls_state.ml
@@ -38,14 +38,14 @@ let[@inline] update_intervals state map =
          map []
        |> List.sort ~cmp:(fun (left : Interval.t) (right : Interval.t) ->
               Int.compare left.begin_ right.begin_);
-  if ls_debug then log_intervals ~indent:1 ~kind:"regular" state.intervals;
+  if ls_debug then log_intervals ~kind:"regular" state.intervals;
   Array.iter active ~f:(fun (intervals : ClassIntervals.t) ->
       intervals.fixed
         <- List.sort
              ~cmp:(fun (left : Interval.t) (right : Interval.t) ->
                Int.compare right.end_ left.end_)
              intervals.fixed;
-      if ls_debug then log_intervals ~indent:1 ~kind:"fixed" intervals.fixed)
+      if ls_debug then log_intervals ~kind:"fixed" intervals.fixed)
 
 let[@inline] iter_intervals state ~f = List.iter state.intervals ~f
 

--- a/backend/regalloc/regalloc_ls_utils.mli
+++ b/backend/regalloc/regalloc_ls_utils.mli
@@ -7,17 +7,19 @@ val ls_debug : bool
 
 val ls_invariants : bool Lazy.t
 
-val log :
-  indent:int -> ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
+val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
+
+val indent : unit -> unit
+
+val dedent : unit -> unit
 
 val log_body_and_terminator :
-  indent:int ->
   Cfg.basic_instruction_list ->
   Cfg.terminator Cfg.instruction ->
   liveness ->
   unit
 
-val log_cfg_with_infos : indent:int -> Cfg_with_infos.t -> unit
+val log_cfg_with_infos : Cfg_with_infos.t -> unit
 
 val iter_cfg_dfs : Cfg.t -> f:(Cfg.basic_block -> unit) -> unit
 
@@ -93,6 +95,6 @@ module ClassIntervals : sig
   val release_expired_intervals : t -> pos:int -> unit
 end
 
-val log_interval : indent:int -> kind:string -> Interval.t -> unit
+val log_interval : kind:string -> Interval.t -> unit
 
-val log_intervals : indent:int -> kind:string -> Interval.t list -> unit
+val log_intervals : kind:string -> Interval.t list -> unit

--- a/backend/regalloc/regalloc_rewrite.mli
+++ b/backend/regalloc/regalloc_rewrite.mli
@@ -15,11 +15,13 @@ module type Utils = sig
 
   val invariants : bool Lazy.t
 
-  val log :
-    indent:int -> ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
+  val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
+
+  val indent : unit -> unit
+
+  val dedent : unit -> unit
 
   val log_body_and_terminator :
-    indent:int ->
     Cfg.basic_instruction_list ->
     Cfg.terminator Cfg.instruction ->
     liveness ->

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -25,8 +25,7 @@ let[@inline] remove_from_bindings :
     Reg.Map.filter
       (fun reg _ ->
         let remove = Reg.Set.mem reg regs in
-        if split_debug
-        then if remove then log ~indent:3 "removing %a" Printreg.reg reg;
+        if split_debug then if remove then log "removing %a" Printreg.reg reg;
         not remove)
       bindings
 
@@ -44,14 +43,16 @@ let rec compute_substitution_tree :
  fun state substs bindings tree ->
   let label = tree.label in
   if split_debug
-  then log ~indent:1 "compute_substitution_tree %a" Label.format label;
+  then (
+    log "compute_substitution_tree %a" Label.format label;
+    indent ());
   (* First, remove the phi and definitions from the bindings. *)
-  if split_debug then log ~indent:2 "removing from phis";
+  if split_debug then log "removing from phis";
   let bindings =
     remove_from_bindings state label ~field:State.phi_at_beginning
       ~extract:Fun.id bindings
   in
-  if split_debug then log ~indent:2 "removing from definitions";
+  if split_debug then log "removing from definitions";
   (* note: it is possible to have two definitions in a row (i.e. without any
      destruction or phi between them), since we delete the dominated
      destructions of constant values. *)
@@ -62,15 +63,22 @@ let rec compute_substitution_tree :
   let subst = Reg.Tbl.create 17 in
   Label.Tbl.replace substs label subst;
   (* Second, add the bindings to the substitution. *)
-  if split_debug then log ~indent:2 "adding from bindings";
+  if split_debug
+  then (
+    log "adding from bindings";
+    indent ());
   Reg.Map.iter
     (fun old_reg new_reg ->
       if split_debug
-      then log ~indent:3 "%a -> %a" Printreg.reg old_reg Printreg.reg new_reg;
+      then log "%a -> %a" Printreg.reg old_reg Printreg.reg new_reg;
       Reg.Tbl.replace subst old_reg new_reg)
     bindings;
   (* Third, add the definitions to the substitution and bindings. *)
-  if split_debug then log ~indent:2 "adding from definitions";
+  if split_debug
+  then (
+    dedent ();
+    log "adding from definitions";
+    indent ());
   let bindings =
     match Label.Map.find_opt label (State.definitions_at_beginning state) with
     | None -> bindings
@@ -83,28 +91,33 @@ let rec compute_substitution_tree :
           Regalloc_stack_slots.use_same_slot_or_fatal slots new_reg
             ~existing:old_reg;
           if split_debug
-          then
-            log ~indent:3 "renaming %a to %a" Printreg.reg old_reg Printreg.reg
-              new_reg;
+          then log "renaming %a to %a" Printreg.reg old_reg Printreg.reg new_reg;
           Reg.Tbl.replace subst old_reg new_reg;
           Reg.Map.add old_reg new_reg bindings)
         renames bindings
   in
   (* Fourth, remove the destroyed registers from the bindings. *)
-  if split_debug then log ~indent:2 "removing from destructions";
+  if split_debug
+  then (
+    dedent ();
+    log "removing from destructions");
   let bindings =
     remove_from_bindings state label ~field:State.destructions_at_end
       ~extract:snd bindings
   in
   (* Finally, propagate the bindings to the children. *)
   List.iter tree.children ~f:(fun child ->
-      compute_substitution_tree state substs bindings child)
+      compute_substitution_tree state substs bindings child);
+  if split_debug then dedent ()
 
 (* Computes the substitutions for all blocks, by introducing new registers at
    reload points and then propagating names until new ones take over. *)
 let compute_substitutions : State.t -> Cfg_with_infos.t -> Substitution.map =
  fun state cfg_with_infos ->
-  if split_debug then log ~indent:0 "compute_substitutions";
+  if split_debug
+  then (
+    log "compute_substitutions";
+    indent ());
   let cfg = Cfg_with_infos.cfg cfg_with_infos in
   let dom_forest =
     Cfg_dominators.dominator_forest (Cfg_with_infos.dominators cfg_with_infos)
@@ -112,6 +125,7 @@ let compute_substitutions : State.t -> Cfg_with_infos.t -> Substitution.map =
   let substs = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
   List.iter dom_forest ~f:(fun dom_tree ->
       compute_substitution_tree state substs Reg.Map.empty dom_tree);
+  if split_debug then dedent ();
   substs
 
 let apply_substitutions : Cfg_with_infos.t -> Substitution.map -> unit =
@@ -147,8 +161,7 @@ let make_spill : type a. a make_operation =
       stack
   in
   if split_debug
-  then
-    log ~indent:3 "spill %a -> %a" Printreg.reg new_reg Printreg.reg stack_reg;
+  then log "spill %a -> %a" Printreg.reg new_reg Printreg.reg stack_reg;
   Move.make_instr Move.Store
     ~id:(State.get_and_incr_instruction_id state)
     ~copy ~from:new_reg ~to_:stack_reg
@@ -246,17 +259,21 @@ let insert_spills_in_block :
 let insert_spills :
     State.t -> Cfg_with_infos.t -> Substitution.map -> Substitution.t =
  fun state cfg_with_infos substs ->
-  if split_debug then log ~indent:0 "insert_spills";
+  if split_debug
+  then (
+    log "insert_spills";
+    indent ());
   let destructions_at_end = State.destructions_at_end state in
   let stack_subst = Reg.Tbl.create (Label.Map.cardinal destructions_at_end) in
   Label.Map.iter
     (fun label (_, live_at_destruction_point) ->
-      if split_debug then log ~indent:1 "block %a" Label.format label;
+      if split_debug then log "block %a" Label.format label;
       let block = Cfg_with_infos.get_block_exn cfg_with_infos label in
       let block_subst = Substitution.for_label substs label in
       insert_spills_in_block state ~block_subst ~stack_subst block
         (DLL.last_cell block.body) live_at_destruction_point)
     destructions_at_end;
+  if split_debug then dedent ();
   stack_subst
 
 (* Creates a reload instruction for the register named `old_reg` before
@@ -280,8 +297,7 @@ let make_reload : type a. a make_operation =
       stack
   in
   if split_debug
-  then
-    log ~indent:3 "reload %a -> %a" Printreg.reg stack_reg Printreg.reg new_reg;
+  then log "reload %a -> %a" Printreg.reg stack_reg Printreg.reg new_reg;
   Move.make_instr Move.Load
     ~id:(State.get_and_incr_instruction_id state)
     ~copy ~from:stack_reg ~to_:new_reg
@@ -308,15 +324,19 @@ let insert_reloads_in_block :
 let insert_reloads :
     State.t -> Cfg_with_infos.t -> Substitution.map -> Substitution.t -> unit =
  fun state cfg_with_infos substs stack_subst ->
-  if split_debug then log ~indent:0 "insert_reloads";
+  if split_debug
+  then (
+    log "insert_reloads";
+    indent ());
   Label.Map.iter
     (fun label live_at_definition_point ->
-      if split_debug then log ~indent:1 "block %a" Label.format label;
+      if split_debug then log "block %a" Label.format label;
       let block = Cfg_with_infos.get_block_exn cfg_with_infos label in
       let block_subst = Substitution.for_label substs label in
       insert_reloads_in_block state ~block_subst ~stack_subst block
         (DLL.hd_cell block.body) live_at_definition_point)
-    (State.definitions_at_beginning state)
+    (State.definitions_at_beginning state);
+  if split_debug then dedent ()
 
 let add_phi_moves_to_instr_list :
     State.t ->
@@ -337,11 +357,11 @@ let add_phi_moves_to_instr_list :
       | true ->
         if split_debug
         then
-          log ~indent:3 "(no phi necessary because %a == %a)" Printreg.reg from
+          log "(no phi necessary because %a == %a)" Printreg.reg from
             Printreg.reg to_
       | false ->
         if split_debug
-        then log ~indent:3 "phi %a -> %a" Printreg.reg from Printreg.reg to_;
+        then log "phi %a -> %a" Printreg.reg from Printreg.reg to_;
         let phi_move =
           Move.make_instr Move.Plain
             ~id:(State.get_and_incr_instruction_id state)
@@ -361,7 +381,7 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
       let block = Cfg_with_infos.get_block_exn cfg_with_infos label in
       if split_debug
       then
-        log ~indent:1 "insert_phi_moves for block %a: %a" Label.format label
+        log "insert_phi_moves for block %a: %a" Label.format label
           Printreg.regset to_unify;
       if block.is_trap_handler
       then fatal "phi block %a is a trap handler" Label.format label;
@@ -417,8 +437,9 @@ let split_at_destruction_points :
  fun cfg_with_infos cfg_infos ->
   if split_debug
   then (
-    log ~indent:0 "split_at_destruction_points";
-    Regalloc_irc_utils.log_cfg_with_infos ~indent:1 cfg_with_infos);
+    log "split_at_destruction_points";
+    indent ();
+    Regalloc_irc_utils.log_cfg_with_infos cfg_with_infos);
   let state =
     Profile.record ~accumulate:true "state"
       (fun () ->
@@ -428,20 +449,20 @@ let split_at_destruction_points :
   if split_debug
   then (
     let doms = Cfg_with_infos.dominators cfg_with_infos in
-    log_dominance_frontier ~indent:1 (Cfg_with_infos.cfg cfg_with_infos) doms;
-    log_dominator_forest ~indent:1 (Cfg_dominators.dominator_forest doms));
+    log_dominance_frontier (Cfg_with_infos.cfg cfg_with_infos) doms;
+    log_dominator_forest (Cfg_dominators.dominator_forest doms));
   match Label.Map.is_empty (State.definitions_at_beginning state) with
   | true ->
-    log ~indent:1 "renaming_infos is empty (no new names introduced)";
+    log "renaming_infos is empty (no new names introduced)";
     None
   | false ->
-    if split_debug then State.log_renaming_info ~indent:1 state;
+    if split_debug then State.log_renaming_info state;
     let substs =
       Profile.record ~accumulate:true "compute_substitutions"
         (fun () -> compute_substitutions state cfg_with_infos)
         ()
     in
-    if split_debug then log_substitutions ~indent:1 substs;
+    if split_debug then log_substitutions substs;
     Profile.record ~accumulate:true "apply_substitutions"
       (fun () -> apply_substitutions cfg_with_infos substs)
       ();
@@ -450,7 +471,7 @@ let split_at_destruction_points :
         (fun () -> insert_spills state cfg_with_infos substs)
         ()
     in
-    if split_debug then log_stack_subst ~indent:1 stack_subst;
+    if split_debug then log_stack_subst stack_subst;
     Profile.record ~accumulate:true "insert_reloads"
       (fun () -> insert_reloads state cfg_with_infos substs stack_subst)
       ();
@@ -460,7 +481,9 @@ let split_at_destruction_points :
         ()
     in
     if split_debug
-    then Regalloc_irc_utils.log_cfg_with_infos ~indent:1 cfg_with_infos;
+    then (
+      Regalloc_irc_utils.log_cfg_with_infos cfg_with_infos;
+      dedent ());
     Some (State.stack_slots state, block_inserted)
 
 let split_live_ranges : Cfg_with_infos.t -> cfg_infos -> Regalloc_stack_slots.t

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -19,30 +19,38 @@ type t =
     instruction_id : InstructionId.sequence
   }
 
-let log_renaming_info : indent:int -> t -> unit =
- fun ~indent state ->
-  log ~indent "renaming_infos";
-  log ~indent:(indent + 1) "destructions:";
+let log_renaming_info : t -> unit =
+ fun state ->
+  log "renaming_infos";
+  indent ();
+  log "destructions:";
+  indent ();
   Label.Map.iter
     (fun label (kind, regset) ->
-      log ~indent:(indent + 2) " - end of block %a %s (%a)" Label.format label
+      log " - end of block %a %s (%a)" Label.format label
         (match kind with
         | Destruction_on_all_paths -> "[all-paths]"
         | Destruction_only_on_exceptional_path -> "[exn-only]")
         Printreg.regset regset)
     state.destructions_at_end;
-  log ~indent:(indent + 1) "definitions:";
+  dedent ();
+  log "definitions:";
+  indent ();
   Label.Map.iter
     (fun label regset ->
-      log ~indent:(indent + 2) " - beginning of block %a (%a)" Label.format
-        label Printreg.regset regset)
+      log " - beginning of block %a (%a)" Label.format label Printreg.regset
+        regset)
     state.definitions_at_beginning;
-  log ~indent:1 "phi:";
+  dedent ();
+  log "phi:";
+  indent ();
   Label.Map.iter
     (fun label regset ->
-      log ~indent:(indent + 2) " - beginning of block %a (%a)" Label.format
-        label Printreg.regset regset)
-    state.phi_at_beginning
+      log " - beginning of block %a (%a)" Label.format label Printreg.regset
+        regset)
+    state.phi_at_beginning;
+  dedent ();
+  dedent ()
 
 (* Optimizes `destructions_at_end` and `definitions_at_beginning`, by moving
    definitions down and destructions up. Doing so create more opportunities for
@@ -68,7 +76,9 @@ end = struct
       definitions_at_beginning * Label.t Stack.t =
    fun cfg_with_infos ~definitions_at_beginning ->
     if split_debug
-    then log ~indent:1 "MoveSpillsAndReloads.move_definitions_at_beginning_down";
+    then (
+      log "MoveSpillsAndReloads.move_definitions_at_beginning_down";
+      indent ());
     let definitions_at_beginning = ref definitions_at_beginning in
     let doms = Cfg_with_infos.dominators cfg_with_infos in
     let stack = Stack.create () in
@@ -109,9 +119,8 @@ end = struct
                 then (
                   if split_debug
                   then
-                    log ~indent:2 "moving %a from block %a to block %a"
-                      Printreg.regset to_move Label.format label Label.format
-                      successor_label;
+                    log "moving %a from block %a to block %a" Printreg.regset
+                      to_move Label.format label Label.format successor_label;
                   definitions_at_beginning
                     := Label.Map.update label
                          (function
@@ -125,6 +134,7 @@ end = struct
                            | Some set -> Some (Reg.Set.union set to_move))
                          !definitions_at_beginning)
             | _ -> ()));
+    if split_debug then dedent ();
     !definitions_at_beginning, stack
 
   (** A destruction at the end of a block can be move up if:
@@ -144,7 +154,9 @@ end = struct
       destructions_at_end =
    fun cfg_with_infos stack ~definitions_at_beginning ~destructions_at_end ->
     if split_debug
-    then log ~indent:1 "MoveSpillsAndReloads.move_destructions_at_end_up";
+    then (
+      log "MoveSpillsAndReloads.move_destructions_at_end_up";
+      indent ());
     let destructions_at_end = ref destructions_at_end in
     while not (Stack.is_empty stack) do
       let label = Stack.pop stack in
@@ -187,9 +199,8 @@ end = struct
             then (
               if split_debug
               then
-                log ~indent:2 "moving %a from block %a to block %a"
-                  Printreg.regset to_move Label.format label Label.format
-                  predecessor_label;
+                log "moving %a from block %a to block %a" Printreg.regset
+                  to_move Label.format label Label.format predecessor_label;
               destructions_at_end
                 := Label.Map.update label
                      (function
@@ -205,10 +216,14 @@ end = struct
                          Some (destruction_kind, Reg.Set.union set to_move))
                      !destructions_at_end)
     done;
+    if split_debug then dedent ();
     !destructions_at_end
 
   let optimize cfg_with_infos ~destructions_at_end ~definitions_at_beginning =
-    if split_debug then log ~indent:0 "MoveSpillsAndReloads.optimize";
+    if split_debug
+    then (
+      log "MoveSpillsAndReloads.optimize";
+      indent ());
     let definitions_at_beginning, stack =
       move_definitions_at_beginning_down cfg_with_infos
         ~definitions_at_beginning
@@ -217,6 +232,7 @@ end = struct
       move_destructions_at_end_up cfg_with_infos stack ~definitions_at_beginning
         ~destructions_at_end
     in
+    if split_debug then dedent ();
     destructions_at_end, definitions_at_beginning
 end
 
@@ -231,41 +247,48 @@ module RemoveReloadSpillInSameBlock : sig
     destructions_at_end * definitions_at_beginning
 end = struct
   let optimize cfg_with_infos ~destructions_at_end ~definitions_at_beginning =
-    if split_debug then log ~indent:0 "RemoveReloadSpillInSameBlock.optimize";
+    if split_debug
+    then (
+      log "RemoveReloadSpillInSameBlock.optimize";
+      indent ());
     let destructions_at_end = ref destructions_at_end in
     let definitions_at_beginning =
       Label.Map.mapi
         (fun (label : Label.t) (definitions : Reg.Set.t) ->
-          if split_debug then log ~indent:1 "block %a" Label.format label;
+          if split_debug
+          then (
+            log "block %a" Label.format label;
+            indent ());
           match Label.Map.find_opt label !destructions_at_end with
           | None -> definitions
           | Some (Destruction_only_on_exceptional_path, _) -> definitions
           | Some (Destruction_on_all_paths, destructions) -> (
             if split_debug
             then (
-              log ~indent:2 "definitions: %a" Printreg.regset definitions;
-              log ~indent:2 "destructions: %a" Printreg.regset destructions);
+              log "definitions: %a" Printreg.regset definitions;
+              log "destructions: %a" Printreg.regset destructions;
+              indent ());
             let can_be_removed : Reg.Set.t =
               Reg.Set.filter
                 (fun (reg : Reg.t) ->
-                  if split_debug
-                  then log ~indent:3 "register %a" Printreg.reg reg;
+                  if split_debug then log "register %a" Printreg.reg reg;
                   match Reg.Set.mem reg destructions with
                   | false ->
-                    if split_debug then log ~indent:3 "(not among destructions)";
+                    if split_debug then log "(not among destructions)";
                     false
                   | true ->
                     let block =
                       Cfg_with_infos.get_block_exn cfg_with_infos label
                     in
                     let occurs = occurs_block block reg in
-                    if split_debug then log ~indent:3 "occurs? %B" occurs;
+                    if split_debug then log "occurs? %B" occurs;
                     not occurs)
                 definitions
             in
             if split_debug
-            then
-              log ~indent:2 "can be removed: %a" Printreg.regset can_be_removed;
+            then (
+              dedent ();
+              log "can be removed: %a" Printreg.regset can_be_removed);
             match Reg.Set.is_empty can_be_removed with
             | true -> definitions
             | false ->
@@ -279,6 +302,10 @@ end = struct
               Reg.Set.diff definitions can_be_removed))
         definitions_at_beginning
     in
+    if split_debug
+    then (
+      dedent ();
+      dedent ());
     !destructions_at_end, definitions_at_beginning
 end
 
@@ -315,7 +342,9 @@ end = struct
       destructions_at_end =
    fun doms tree ~num_sets ~already_spilled ~destructions_at_end ->
     if split_debug
-    then log ~indent:1 "remove_dominated_spills %a" Label.format tree.label;
+    then (
+      log "remove_dominated_spills %a" Label.format tree.label;
+      indent ());
     let already_spilled = ref already_spilled in
     let destructions_at_end : (destruction_kind * Reg.Set.t) Label.Map.t =
       Label.Map.update tree.label
@@ -325,14 +354,16 @@ end = struct
               Reg.Set.filter
                 (fun (reg : Reg.t) ->
                   if split_debug
-                  then log ~indent:2 "register %a" Printreg.reg reg;
+                  then (
+                    log "register %a" Printreg.reg reg;
+                    indent ());
                   let keep =
                     match Reg.Tbl.find_opt num_sets reg with
                     | None | Some Maybe_more_than_once -> true
                     | Some At_most_once -> (
                       match Reg.Map.find_opt reg !already_spilled with
                       | None ->
-                        if split_debug then log ~indent:3 "case/2";
+                        if split_debug then log "case/2";
                         true
                       | Some spilled_at ->
                         if split_debug && Lazy.force split_invariants
@@ -343,41 +374,51 @@ end = struct
                           then fatal "inconsistent dominator tree";
                         if split_debug
                         then
-                          log ~indent:3 "case/3 (already spilled at %a)"
-                            Label.format spilled_at;
+                          log "case/3 (already spilled at %a)" Label.format
+                            spilled_at;
                         false)
                   in
                   if keep
                   then
                     already_spilled
                       := Reg.Map.add reg tree.label !already_spilled;
-                  if split_debug then log ~indent:3 "keep? %B" keep;
+                  if split_debug then log "keep? %B" keep;
                   keep)
                 destroyed
             in
             if Reg.Set.is_empty destroyed
             then (
-              if split_debug then log ~indent:3 "(the destroyed set is empty)";
+              if split_debug
+              then (
+                log "(the destroyed set is empty)";
+                dedent ());
               None)
             else Some (Destruction_on_all_paths, destroyed)
           | Some (Destruction_only_on_exceptional_path, _) as existing ->
             if split_debug
-            then log ~indent:2 "(ignored as a half-destruction point)";
+            then (
+              dedent ();
+              log "(ignored as a half-destruction point)");
             existing
           | None ->
-            if split_debug then log ~indent:2 "(not a destruction point)";
+            if split_debug
+            then (
+              dedent ();
+              log "(not a destruction point)");
             None)
         destructions_at_end
     in
     List.fold_left tree.children ~init:destructions_at_end
       ~f:(fun destructions_at_end (child : Cfg_dominators.dominator_tree) ->
-        if split_debug then log ~indent:2 "child %a" Label.format child.label;
+        if split_debug then log "child %a" Label.format child.label;
         remove_dominated_spills doms child ~num_sets
           ~already_spilled:!already_spilled ~destructions_at_end)
 
   let optimize cfg_with_infos ~destructions_at_end =
     if split_debug
-    then log ~indent:0 "RemoveDominatedSpillsForConstants.optimize";
+    then (
+      log "RemoveDominatedSpillsForConstants.optimize";
+      indent ());
     let loops = Cfg_with_infos.loop_infos cfg_with_infos in
     let incr_set (tbl : set Reg.Tbl.t) (arr : Reg.t array) ~(in_loop : bool) :
         unit =
@@ -394,7 +435,7 @@ end = struct
         ~f:(fun label block acc ->
           let in_loop : bool = is_in_loop loops label in
           if split_debug
-          then log ~indent:1 "block %a in_loop? %B" Label.format label in_loop;
+          then log "block %a in_loop? %B" Label.format label in_loop;
           incr_set acc block.terminator.res ~in_loop;
           DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
               incr_set acc instr.res ~in_loop);
@@ -402,17 +443,23 @@ end = struct
     in
     if split_debug
     then (
-      log ~indent:1 "num_sets:";
+      log "num_sets:";
+      indent ();
       Reg.Tbl.iter
         (fun reg num_set ->
-          log ~indent:2 "%a ~> %s" Printreg.reg reg (string_of_set num_set))
-        num_sets);
+          log "%a ~> %s" Printreg.reg reg (string_of_set num_set))
+        num_sets;
+      dedent ());
     let doms = Cfg_with_infos.dominators cfg_with_infos in
     let forest = Cfg_dominators.dominator_forest doms in
-    List.fold_left forest ~init:destructions_at_end
-      ~f:(fun destructions_at_end dominator_tree ->
-        remove_dominated_spills doms dominator_tree ~num_sets
-          ~already_spilled:Reg.Map.empty ~destructions_at_end)
+    let res =
+      List.fold_left forest ~init:destructions_at_end
+        ~f:(fun destructions_at_end dominator_tree ->
+          remove_dominated_spills doms dominator_tree ~num_sets
+            ~already_spilled:Reg.Map.empty ~destructions_at_end)
+    in
+    dedent ();
+    res
 end
 
 let add_destruction_point_at_end :

--- a/backend/regalloc/regalloc_split_state.mli
+++ b/backend/regalloc/regalloc_split_state.mli
@@ -10,7 +10,7 @@ type phi_at_beginning = Reg.Set.t Label.Map.t
 
 type t
 
-val log_renaming_info : indent:int -> t -> unit
+val log_renaming_info : t -> unit
 
 (** Constructs the renaming information necessary to split the live ranges.
 

--- a/backend/regalloc/regalloc_split_utils.mli
+++ b/backend/regalloc/regalloc_split_utils.mli
@@ -8,21 +8,23 @@ val split_debug : bool
 
 val split_invariants : bool Lazy.t
 
-val log :
-  indent:int -> ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
+val indent : unit -> unit
 
-val log_dominance_frontier : indent:int -> Cfg.t -> Cfg_dominators.t -> unit
+val dedent : unit -> unit
 
-val log_dominator_tree : indent:int -> Cfg_dominators.dominator_tree -> unit
+val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
 
-val log_dominator_forest :
-  indent:int -> Cfg_dominators.dominator_tree list -> unit
+val log_dominance_frontier : Cfg.t -> Cfg_dominators.t -> unit
 
-val log_substitution : indent:int -> Substitution.t -> unit
+val log_dominator_tree : Cfg_dominators.dominator_tree -> unit
 
-val log_substitutions : indent:int -> Substitution.map -> unit
+val log_dominator_forest : Cfg_dominators.dominator_tree list -> unit
 
-val log_stack_subst : indent:int -> Substitution.t -> unit
+val log_substitution : Substitution.t -> unit
+
+val log_substitutions : Substitution.map -> unit
+
+val log_stack_subst : Substitution.t -> unit
 
 val live_at_block_beginning : Cfg_with_infos.t -> Label.t -> Reg.Set.t
 

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -22,9 +22,9 @@ val block_temporaries : bool Lazy.t
 type liveness = Cfg_with_infos.liveness
 
 type log_function =
-  { log :
-      'a.
-      indent:int -> ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a;
+  { indent : unit -> unit;
+    dedent : unit -> unit;
+    log : 'a. ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a;
     enabled : bool
   }
 
@@ -64,7 +64,6 @@ val make_log_body_and_terminator :
   log_function ->
   instr_prefix:(Cfg.basic Cfg.instruction -> string) ->
   term_prefix:(Cfg.terminator Cfg.instruction -> string) ->
-  indent:int ->
   Cfg.basic_instruction_list ->
   Cfg.terminator Cfg.instruction ->
   liveness ->
@@ -74,7 +73,6 @@ val make_log_cfg_with_infos :
   log_function ->
   instr_prefix:(Cfg.basic Cfg.instruction -> string) ->
   term_prefix:(Cfg.terminator Cfg.instruction -> string) ->
-  indent:int ->
   Cfg_with_infos.t ->
   unit
 


### PR DESCRIPTION
Based on https://github.com/ocaml-flambda/flambda-backend/pull/3769.

Removes the `indent:int` parameter passed
to every single logging function, and uses
`indent` / `dedent` functions to increment /
decrement the indentation.

(I have tried to be very careful, although
not aiming for a 1:1 change, but even if
everything is not exactly right, it is only
about logging code.)