### PR TITLE
Avoid uncaught `Not_found` arising from free vars in probes

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -30,6 +30,7 @@ type error =
     Free_super_var
   | Unreachable_reached
   | Bad_probe_layout of Ident.t
+  | Unknown_probe_layout of Ident.t
   | Illegal_void_record_field
   | Illegal_product_record_field of Jkind.Sort.Const.t
   | Void_sort of type_expr
@@ -1120,9 +1121,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
 
            It's really hacky to be doing this kind of jkind check this late.
            The middle-end folks have plans to eliminate the need for it by
-           reworking the way probes are compiled.  For that reason, I haven't
-           bothered to give a particularly good error or handle the Not_found
-           case from env.
+           reworking the way probes are compiled.
 
            (We could probably calculate the jkinds of these variables here
            rather than requiring them all to be value, but that would be even
@@ -1146,9 +1145,15 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
             | Ok _ -> ()
             | Error _ -> raise (Error (e.exp_loc, Bad_probe_layout id))
           end
-        | exception Not_found ->
-          (* Might be a module, which are all values.  Otherwise raise. *)
-          ignore (Env.find_module_lazy path e.exp_env)
+        | exception Not_found -> begin
+            (* Might be a module, which are all values.  Otherwise raise. *)
+            match Env.find_module_lazy path e.exp_env with
+            | _ -> ()
+            | exception Not_found ->
+                (* Might still be a module if it's bound to a runtime parameter. *)
+                if not (Env.is_bound_to_runtime_parameter id) then
+                  raise (Error (e.exp_loc, Unknown_probe_layout id))
+          end
       ) arg_idents;
       let make_param name = {
         name;
@@ -2430,6 +2435,11 @@ let report_error ppf = function
   | Bad_probe_layout id ->
       fprintf ppf "Variables in probe handlers must have jkind value, \
                    but %s in this handler does not." (Ident.name id)
+  | Unknown_probe_layout id ->
+      fprintf ppf
+        "Unknown variable %a appearing in probe:@ Please \
+         report this error to the Jane Street compilers team."
+        Ident.print id
   | Illegal_void_record_field ->
       fprintf ppf
         "Void sort detected where value was expected in a record field:@ Please \

--- a/lambda/translcore.mli
+++ b/lambda/translcore.mli
@@ -48,6 +48,7 @@ type error =
     Free_super_var
   | Unreachable_reached
   | Bad_probe_layout of Ident.t
+  | Unknown_probe_layout of Ident.t
   | Illegal_void_record_field
   | Illegal_product_record_field of Jkind.Sort.Const.t
   | Void_sort of Types.type_expr

--- a/testsuite/tests/templates/basic/probe.ml
+++ b/testsuite/tests/templates/basic/probe.ml
@@ -1,0 +1,37 @@
+(* TEST
+ readonly_files="monoid_utils.ml monoid_utils.mli monoid.mli";
+ {
+   setup-ocamlc.byte-build-env;
+
+   flags = "-as-parameter";
+   module = "monoid.mli";
+   ocamlc.byte;
+
+   flags = "-parameter Monoid";
+   module = "monoid_utils.mli monoid_utils.ml";
+   ocamlc.byte;
+
+   flags = "-parameter Monoid";
+   module = "probe.ml";
+   ocamlc.byte;
+ }
+ {
+   setup-ocamlopt.byte-build-env;
+
+   flags = "-as-parameter";
+   module = "monoid.mli";
+   ocamlopt.byte;
+
+   flags = "-parameter Monoid";
+   module = "monoid_utils.mli monoid_utils.ml";
+   ocamlopt.byte;
+
+   flags = "-parameter Monoid";
+   module = "probe.ml";
+   ocamlopt.byte;
+ }
+*)
+
+let () =
+  [%probe "probe" (ignore (Monoid_utils.concat []))];
+  print_endline "Hello world!"

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1140,6 +1140,9 @@ let import_crcs ~source crcs =
 let runtime_parameter_bindings () =
   Persistent_env.runtime_parameter_bindings !persistent_env
 
+let is_bound_to_runtime_parameter id =
+  Persistent_env.is_bound_to_runtime_parameter !persistent_env id
+
 let parameters () = Persistent_env.parameters !persistent_env
 
 let read_pers_mod modname cmi =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -554,6 +554,9 @@ val import_crcs: source:string -> Import_info.t array -> unit
    [Persistent_env.runtime_parameter_bindings] for details) *)
 val runtime_parameter_bindings: unit -> (Global_module.t * Ident.t) list
 
+(* Return whether an ident appears in [runtime_parameter_bindings] *)
+val is_bound_to_runtime_parameter: Ident.t -> bool
+
 (* Return the list of parameters specified for the current unit, in
    alphabetical order *)
 val parameters: unit -> Global_module.Name.t list

--- a/typing/persistent_env.mli
+++ b/typing/persistent_env.mli
@@ -183,6 +183,10 @@ val imports : 'a t -> Import_info.Intf.t list
    world. In fact we aim to inline away all passing of runtime parameters. *)
 val runtime_parameter_bindings : 'a t -> (Global_module.t * Ident.t) list
 
+(* Return whether the given identifier is a local that appears in
+   [runtime_parameter_bindings]. *)
+val is_bound_to_runtime_parameter : 'a t -> Ident.t -> bool
+
 (* Find whether a module has been imported as a parameter. This means that it
    is a registered parameter import (see [register_parameter_import]) _and_ it has
    been actually imported (i.e., it has occurred at least once). *)


### PR DESCRIPTION
We have a check that the free variables in a probe are all values. Unfortunately, this check runs _after_ translation to lambda, which means it considers the free variables of the lambda code. This is bad if the probe has a reference to a compilation unit that takes a parameter, since that will get translated to a local variable that doesn't appear in the environment and therefore we can't check its jkind.

Also, the error one gets in this situation is an uncaught `Not_found` with a backtrace, which is unpleasant and hard to debug.

Other improvements are possible, but for the moment we can just remember which lambda-level locals refer to runtime parameters, since those will always have value jkinds. Additionally, I've added a nicer error message for any other `Not_found`s that might arise from this check.