### PR TITLE
Simplify the logging logic (register allocators)

### DIFF
--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -168,7 +168,7 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
     let { Prio_queue.priority; data = reg, interval } =
       Prio_queue.get_and_remove prio_queue
     in
-    if gi_debug
+    if debug
     then (
       indent ();
       log "got register %a (prio=%d)" Printreg.reg reg priority);
@@ -224,7 +224,7 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
       if debug then log "spilling %a" Printreg.reg reg;
       reg.Reg.spill <- true;
       spilling := (reg, interval) :: !spilling);
-    if gi_debug then dedent ()
+    if debug then dedent ()
   done;
   dedent ();
   match !spilling with

--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -270,6 +270,7 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
 
 let run : Cfg_with_infos.t -> Cfg_with_infos.t =
  fun cfg_with_infos ->
+  if debug then reset_indentation ();
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
   let cfg_infos, stack_slots =
     Regalloc_rewrite.prelude

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -12,6 +12,8 @@ let indent () = (Lazy.force log_function).indent ()
 
 let dedent () = (Lazy.force log_function).dedent ()
 
+let reset_indentation () = (Lazy.force log_function).reset_indentation ()
+
 let log : type a. ?no_eol:unit -> (a, Format.formatter, unit) format -> a =
  fun ?no_eol fmt -> (Lazy.force log_function).log ?no_eol fmt
 

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -680,7 +680,7 @@ module Hardware_registers = struct
           if overlap_hard
           then acc
           else (
-            if gi_debug then indent ();
+            if debug then indent ();
             let overlaping : Hardware_register.assigned list =
               List.filter hardware_reg.assigned
                 ~f:(fun
@@ -707,7 +707,7 @@ module Hardware_registers = struct
                    ->
                   acc_cost + actual_cost pseudo_reg, acc_evictable && evictable)
             in
-            if gi_debug then dedent ();
+            if debug then dedent ();
             if not evictable
             then acc
             else

--- a/backend/regalloc/regalloc_gi_utils.mli
+++ b/backend/regalloc/regalloc_gi_utils.mli
@@ -2,10 +2,6 @@
 
 open Regalloc_utils
 
-val gi_debug : bool
-
-val gi_invariants : bool Lazy.t
-
 val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
 
 val indent : unit -> unit

--- a/backend/regalloc/regalloc_gi_utils.mli
+++ b/backend/regalloc/regalloc_gi_utils.mli
@@ -8,6 +8,8 @@ val indent : unit -> unit
 
 val dedent : unit -> unit
 
+val reset_indentation : unit -> unit
+
 val log_body_and_terminator :
   Cfg.basic_instruction_list ->
   Cfg.terminator Cfg.instruction ->

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -94,14 +94,14 @@ let build : State.t -> Cfg_with_infos.t -> unit =
 
 let make_work_list : State.t -> unit =
  fun state ->
-  if irc_debug then log "make_work_list";
+ if irc_debug then (log "make_work_list"; indent ());
   State.iter_and_clear_initial state ~f:(fun reg ->
       let deg = reg.Reg.degree in
       if irc_debug
       then
-        log "- %a has degree=%s (k=%d)" Printreg.reg reg (Degree.to_string deg)
-          (k reg);
-      if deg >= k reg
+        (log "- %a has degree=%s (k=%d)" Printreg.reg reg (Degree.to_string deg)
+           (k reg); indent());
+      (if deg >= k reg
       then (
         if irc_debug then log "~> spill_work_list";
         State.add_spill_work_list state reg)
@@ -111,7 +111,8 @@ let make_work_list : State.t -> unit =
         State.add_freeze_work_list state reg)
       else (
         if irc_debug then log "~> simplify_work_list";
-        State.add_simplify_work_list state reg))
+        State.add_simplify_work_list state reg)); if irc_debug then dedent ());
+ if irc_debug then dedent ()
 
 let simplify : State.t -> unit =
  fun state ->
@@ -181,7 +182,7 @@ let add_work_list : State.t -> Reg.t -> unit =
 
 let coalesce : State.t -> unit =
  fun state ->
-  if irc_debug then log "coalesce";
+ if irc_debug then (log "coalesce"; indent ());
   let m = State.choose_and_remove_work_list_moves state in
   let x = m.res.(0) in
   let y = m.arg.(0) in
@@ -191,7 +192,7 @@ let coalesce : State.t -> unit =
   if irc_debug then log "x=%a y=%a" Printreg.reg x Printreg.reg y;
   let u, v = if State.is_precolored state y then y, x else x, y in
   if irc_debug then log "u=%a v=%a" Printreg.reg u Printreg.reg v;
-  if Reg.same u v
+  (if Reg.same u v
   then (
     if irc_debug then log "case #1/4";
     State.add_coalesced_moves state m;
@@ -218,7 +219,8 @@ let coalesce : State.t -> unit =
     add_work_list state u)
   else (
     if irc_debug then log "case #4/4";
-    State.add_active_moves state m)
+    State.add_active_moves state m));
+  if irc_debug then dedent ()
 
 let freeze_moves : State.t -> Reg.t -> unit =
  fun state u ->
@@ -292,7 +294,7 @@ let select_spilling_register_using_heuristics : State.t -> Reg.t =
 
 let select_spill : State.t -> unit =
  fun state ->
-  if irc_debug then log "select_spill";
+ if irc_debug then (log "select_spill"; indent());
   let reg = select_spilling_register_using_heuristics state in
   if irc_debug
   then
@@ -300,13 +302,14 @@ let select_spill : State.t -> unit =
       Spilling_heuristics.(to_string @@ Lazy.force value);
   State.remove_spill_work_list state reg;
   State.add_simplify_work_list state reg;
-  freeze_moves state reg
+  freeze_moves state reg;
+  if irc_debug then dedent ()
 
 let assign_colors : State.t -> Cfg_with_layout.t -> unit =
  fun state _cfg_with_layout ->
-  if irc_debug then log "assign_colors";
+ if irc_debug then (log "assign_colors"; indent ());
   State.iter_and_clear_select_stack state ~f:(fun n ->
-      if irc_debug then log "%a" Printreg.reg n;
+   if irc_debug then (log "%a" Printreg.reg n; indent ());
       let reg_class = Proc.register_class n in
       let reg_num_avail =
         Array.unsafe_get Proc.num_available_registers reg_class
@@ -349,7 +352,7 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
       let first_avail =
         mark_adjacent_colors_and_get_first_available (State.adj_list state n)
       in
-      if first_avail = reg_num_avail
+      (if first_avail = reg_num_avail
       then (
         if irc_debug then log "spilling";
         State.add_spilled_nodes state n)
@@ -357,10 +360,11 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
         State.add_colored_nodes state n;
         let c = first_avail + reg_first_avail in
         if irc_debug then log "coloring with %d" c;
-        n.Reg.irc_color <- Some c));
+        n.Reg.irc_color <- Some c)); if irc_debug then dedent ());
   State.iter_coalesced_nodes state ~f:(fun n ->
       let alias = State.find_alias state n in
-      n.Reg.irc_color <- alias.Reg.irc_color)
+      n.Reg.irc_color <- alias.Reg.irc_color);
+   if irc_debug then dedent ()
 
 module Utils = struct
   include Regalloc_irc_utils
@@ -419,7 +423,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
   then
     fatal "register allocation was not succesful after %d rounds (%s)"
       max_rounds (Cfg_with_infos.cfg cfg_with_infos).fun_name;
-  if irc_debug then log "main, round #%d" round;
+  if irc_debug then (log "main, round #%d" round; indent ());
   let work_lists_desc state (name, f) =
     Printf.sprintf "%s:%s" name (if f state then "{}" else "...")
   in
@@ -477,6 +481,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
   if irc_debug then log "(after loop)";
   assign_colors state cfg_with_layout;
   State.invariant state;
+  if irc_debug then dedent ();
   match State.spilled_nodes state with
   | [] -> if irc_debug then log "(end of main)"
   | _ :: _ as spilled_nodes -> (

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -34,13 +34,13 @@ let filter_unavailable : Reg.t array -> Reg.t array =
 
 let build : State.t -> Cfg_with_infos.t -> unit =
  fun state cfg_with_infos ->
-  if irc_debug then log "build";
+  if debug then log "build";
   let liveness = Cfg_with_infos.liveness cfg_with_infos in
   let add_edges_live (id : InstructionId.t) ~(def : Reg.t array)
       ~(move_src : Reg.t) ~(destroyed : Reg.t array) : unit =
     let destroyed = filter_unavailable destroyed in
     let live = InstructionId.Tbl.find liveness id in
-    if irc_debug && Reg.set_has_collisions live.across
+    if debug && Reg.set_has_collisions live.across
     then fatal "live set has physical register collisions";
     if Array.length def > 0
     then
@@ -94,35 +94,35 @@ let build : State.t -> Cfg_with_infos.t -> unit =
 
 let make_work_list : State.t -> unit =
  fun state ->
-  if irc_debug
+  if debug
   then (
     log "make_work_list";
     indent ());
   State.iter_and_clear_initial state ~f:(fun reg ->
       let deg = reg.Reg.degree in
-      if irc_debug
+      if debug
       then (
         log "- %a has degree=%s (k=%d)" Printreg.reg reg (Degree.to_string deg)
           (k reg);
         indent ());
       if deg >= k reg
       then (
-        if irc_debug then log "~> spill_work_list";
+        if debug then log "~> spill_work_list";
         State.add_spill_work_list state reg)
       else if State.is_move_related state reg
       then (
-        if irc_debug then log "~> freeze_work_list";
+        if debug then log "~> freeze_work_list";
         State.add_freeze_work_list state reg)
       else (
-        if irc_debug then log "~> simplify_work_list";
+        if debug then log "~> simplify_work_list";
         State.add_simplify_work_list state reg);
-      if irc_debug then dedent ());
-  if irc_debug then dedent ()
+      if debug then dedent ());
+  if debug then dedent ()
 
 let simplify : State.t -> unit =
  fun state ->
   let reg = State.choose_and_remove_simplify_work_list state in
-  if irc_debug then log "simplify %a" Printreg.reg reg;
+  if debug then log "simplify %a" Printreg.reg reg;
   State.push_select_stack state reg;
   State.iter_adjacent state reg ~f:(fun adj -> State.decr_degree state adj)
 
@@ -158,7 +158,7 @@ let conservative : State.t -> Reg.t -> Reg.t -> bool =
 
 let combine : State.t -> Reg.t -> Reg.t -> unit =
  fun state u v ->
-  if irc_debug then log "combine u=%a v=%a" Printreg.reg u Printreg.reg v;
+  if debug then log "combine u=%a v=%a" Printreg.reg u Printreg.reg v;
   if State.mem_freeze_work_list state v
   then State.remove_freeze_work_list state v
   else State.remove_spill_work_list state v;
@@ -187,22 +187,22 @@ let add_work_list : State.t -> Reg.t -> unit =
 
 let coalesce : State.t -> unit =
  fun state ->
-  if irc_debug
+  if debug
   then (
     log "coalesce";
     indent ());
   let m = State.choose_and_remove_work_list_moves state in
   let x = m.res.(0) in
   let y = m.arg.(0) in
-  if irc_debug then log "x=%a y=%a" Printreg.reg x Printreg.reg y;
+  if debug then log "x=%a y=%a" Printreg.reg x Printreg.reg y;
   let x = State.find_alias state x in
   let y = State.find_alias state y in
-  if irc_debug then log "x=%a y=%a" Printreg.reg x Printreg.reg y;
+  if debug then log "x=%a y=%a" Printreg.reg x Printreg.reg y;
   let u, v = if State.is_precolored state y then y, x else x, y in
-  if irc_debug then log "u=%a v=%a" Printreg.reg u Printreg.reg v;
+  if debug then log "u=%a v=%a" Printreg.reg u Printreg.reg v;
   if Reg.same u v
   then (
-    if irc_debug then log "case #1/4";
+    if debug then log "case #1/4";
     State.add_coalesced_moves state m;
     add_work_list state u)
   else if State.is_precolored state v
@@ -213,7 +213,7 @@ let coalesce : State.t -> unit =
                 float, and vec128) as disjoint. *)
           State.interferes_with_adj state v u
   then (
-    if irc_debug then log "case #2/4";
+    if debug then log "case #2/4";
     State.add_constrained_moves state m;
     add_work_list state u;
     add_work_list state v)
@@ -221,18 +221,18 @@ let coalesce : State.t -> unit =
           | true -> all_adjacent_are_ok state u v
           | false -> conservative state u v
   then (
-    if irc_debug then log "case #3/4";
+    if debug then log "case #3/4";
     State.add_coalesced_moves state m;
     combine state u v;
     add_work_list state u)
   else (
-    if irc_debug then log "case #4/4";
+    if debug then log "case #4/4";
     State.add_active_moves state m);
-  if irc_debug then dedent ()
+  if debug then dedent ()
 
 let freeze_moves : State.t -> Reg.t -> unit =
  fun state u ->
-  if irc_debug then log "freeze_moves %a" Printreg.reg u;
+  if debug then log "freeze_moves %a" Printreg.reg u;
   State.iter_node_moves state u ~f:(fun m ->
       let x = m.res.(0) in
       let y = m.arg.(0) in
@@ -252,7 +252,7 @@ let freeze_moves : State.t -> Reg.t -> unit =
 let freeze : State.t -> unit =
  fun state ->
   let reg = State.choose_and_remove_freeze_work_list state in
-  if irc_debug then log "freeze %a" Printreg.reg reg;
+  if debug then log "freeze %a" Printreg.reg reg;
   State.add_simplify_work_list state reg;
   freeze_moves state reg
 
@@ -278,7 +278,7 @@ let select_spilling_register_using_heuristics : State.t -> Reg.t =
        similarly cached because it depends on the degree (which does not need a
        call to `rewrite` to change). *)
     let weighted_cost (reg : Reg.t) =
-      if irc_debug
+      if debug
       then
         log "register %a has spill cost %d" Printreg.reg reg reg.Reg.spill_cost;
       (float reg.Reg.spill_cost /. float reg.Reg.degree)
@@ -293,7 +293,7 @@ let select_spilling_register_using_heuristics : State.t -> Reg.t =
       State.fold_spill_work_list state ~init:(Reg.dummy, Float.max_float)
         ~f:(fun ((_curr_reg, curr_min_cost) as acc) reg ->
           let reg_cost = weighted_cost reg in
-          if irc_debug
+          if debug
           then log "register %a has weighted cost %f" Printreg.reg reg reg_cost;
           if Float.compare reg_cost curr_min_cost < 0
           then reg, reg_cost
@@ -302,28 +302,28 @@ let select_spilling_register_using_heuristics : State.t -> Reg.t =
 
 let select_spill : State.t -> unit =
  fun state ->
-  if irc_debug
+  if debug
   then (
     log "select_spill";
     indent ());
   let reg = select_spilling_register_using_heuristics state in
-  if irc_debug
+  if debug
   then
     log "chose %a using heuristics %S" Printreg.reg reg
       Spilling_heuristics.(to_string @@ Lazy.force value);
   State.remove_spill_work_list state reg;
   State.add_simplify_work_list state reg;
   freeze_moves state reg;
-  if irc_debug then dedent ()
+  if debug then dedent ()
 
 let assign_colors : State.t -> Cfg_with_layout.t -> unit =
  fun state _cfg_with_layout ->
-  if irc_debug
+  if debug
   then (
     log "assign_colors";
     indent ());
   State.iter_and_clear_select_stack state ~f:(fun n ->
-      if irc_debug
+      if debug
       then (
         log "%a" Printreg.reg n;
         indent ());
@@ -355,7 +355,7 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
             match alias.Reg.irc_color with
             | None -> assert false
             | Some color ->
-              if irc_debug then log "color %d is not available" color;
+              if debug then log "color %d is not available" color;
               if Array.unsafe_get ok_colors (color - reg_first_avail)
               then (
                 Array.unsafe_set ok_colors (color - reg_first_avail) false;
@@ -371,29 +371,25 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
       in
       if first_avail = reg_num_avail
       then (
-        if irc_debug then log "spilling";
+        if debug then log "spilling";
         State.add_spilled_nodes state n)
       else (
         State.add_colored_nodes state n;
         let c = first_avail + reg_first_avail in
-        if irc_debug then log "coloring with %d" c;
+        if debug then log "coloring with %d" c;
         n.Reg.irc_color <- Some c);
-      if irc_debug then dedent ());
+      if debug then dedent ());
   State.iter_coalesced_nodes state ~f:(fun n ->
       let alias = State.find_alias state n in
       n.Reg.irc_color <- alias.Reg.irc_color);
-  if irc_debug then dedent ()
+  if debug then dedent ()
 
 module Utils = struct
   include Regalloc_irc_utils
 
-  let debug = irc_debug
+  let debug = debug
 
-  let invariants = irc_invariants
-
-  let log = log
-
-  let log_body_and_terminator = log_body_and_terminator
+  let invariants = invariants
 
   let is_spilled reg = Reg.equal_irc_work_list reg.Reg.irc_work_list Reg.Spilled
 
@@ -441,7 +437,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
   then
     fatal "register allocation was not succesful after %d rounds (%s)"
       max_rounds (Cfg_with_infos.cfg cfg_with_infos).fun_name;
-  if irc_debug
+  if debug
   then (
     log "main, round #%d" round;
     indent ());
@@ -457,11 +453,11 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
            "spill_wl", State.is_empty_spill_work_list ])
   in
   let log_work_list_desc prefix =
-    if irc_debug then log "%s -- %s" prefix (work_lists_desc state)
+    if debug then log "%s -- %s" prefix (work_lists_desc state)
   in
   build state cfg_with_infos;
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
-  if irc_debug
+  if debug
   then (
     let adj_set = State.adj_set state in
     log "(%d pairs in adj_set)" (RegisterStamp.PairSet.cardinal adj_set);
@@ -474,7 +470,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
           log "(%d, %d) <- adj_set" (RegisterStamp.fst p) (RegisterStamp.snd p)));
   make_work_list state;
   State.invariant state;
-  if irc_debug then log_work_list_desc "before loop";
+  if debug then log_work_list_desc "before loop";
   let spill_cost_is_up_to_date = ref false in
   let continue = ref true in
   while !continue do
@@ -496,17 +492,17 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
         spill_cost_is_up_to_date := true);
       select_spill state)
     else continue := false;
-    if irc_debug then log_work_list_desc "end of loop";
+    if debug then log_work_list_desc "end of loop";
     State.invariant state
   done;
-  if irc_debug then log "(after loop)";
+  if debug then log "(after loop)";
   assign_colors state cfg_with_layout;
   State.invariant state;
-  if irc_debug then dedent ();
+  if debug then dedent ();
   match State.spilled_nodes state with
-  | [] -> if irc_debug then log "(end of main)"
+  | [] -> if debug then log "(end of main)"
   | _ :: _ as spilled_nodes -> (
-    if irc_debug
+    if debug
     then
       List.iter spilled_nodes ~f:(fun reg ->
           log "/!\\ register %a needs to be spilled" Printreg.reg reg);
@@ -514,7 +510,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
       rewrite state cfg_with_infos ~spilled_nodes ~reset:true
         ~block_temporaries:(round = 1)
     with
-    | false -> if irc_debug then log "(end of main)"
+    | false -> if debug then log "(end of main)"
     | true ->
       State.invariant state;
       main ~round:(succ round) state cfg_with_infos)
@@ -531,7 +527,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
   (* CR xclerc for xclerc: consider moving the computation of temporaries and
      the creation of the state to `prelude`. *)
   let all_temporaries = Reg.Set.union cfg_infos.arg cfg_infos.res in
-  if irc_debug then log "#temporaries=%d" (Reg.Set.cardinal all_temporaries);
+  if debug then log "#temporaries=%d" (Reg.Set.cardinal all_temporaries);
   let state =
     State.make
       ~initial:(Reg.Set.elements all_temporaries)
@@ -550,7 +546,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
     in
     ());
   main ~round:1 state cfg_with_infos;
-  if irc_debug then log_cfg_with_infos cfg_with_infos;
+  if debug then log_cfg_with_infos cfg_with_infos;
   Regalloc_rewrite.postlude
     (module State)
     (module Utils)

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -94,14 +94,18 @@ let build : State.t -> Cfg_with_infos.t -> unit =
 
 let make_work_list : State.t -> unit =
  fun state ->
- if irc_debug then (log "make_work_list"; indent ());
+  if irc_debug
+  then (
+    log "make_work_list";
+    indent ());
   State.iter_and_clear_initial state ~f:(fun reg ->
       let deg = reg.Reg.degree in
       if irc_debug
-      then
-        (log "- %a has degree=%s (k=%d)" Printreg.reg reg (Degree.to_string deg)
-           (k reg); indent());
-      (if deg >= k reg
+      then (
+        log "- %a has degree=%s (k=%d)" Printreg.reg reg (Degree.to_string deg)
+          (k reg);
+        indent ());
+      if deg >= k reg
       then (
         if irc_debug then log "~> spill_work_list";
         State.add_spill_work_list state reg)
@@ -111,8 +115,9 @@ let make_work_list : State.t -> unit =
         State.add_freeze_work_list state reg)
       else (
         if irc_debug then log "~> simplify_work_list";
-        State.add_simplify_work_list state reg)); if irc_debug then dedent ());
- if irc_debug then dedent ()
+        State.add_simplify_work_list state reg);
+      if irc_debug then dedent ());
+  if irc_debug then dedent ()
 
 let simplify : State.t -> unit =
  fun state ->
@@ -182,7 +187,10 @@ let add_work_list : State.t -> Reg.t -> unit =
 
 let coalesce : State.t -> unit =
  fun state ->
- if irc_debug then (log "coalesce"; indent ());
+  if irc_debug
+  then (
+    log "coalesce";
+    indent ());
   let m = State.choose_and_remove_work_list_moves state in
   let x = m.res.(0) in
   let y = m.arg.(0) in
@@ -192,7 +200,7 @@ let coalesce : State.t -> unit =
   if irc_debug then log "x=%a y=%a" Printreg.reg x Printreg.reg y;
   let u, v = if State.is_precolored state y then y, x else x, y in
   if irc_debug then log "u=%a v=%a" Printreg.reg u Printreg.reg v;
-  (if Reg.same u v
+  if Reg.same u v
   then (
     if irc_debug then log "case #1/4";
     State.add_coalesced_moves state m;
@@ -219,7 +227,7 @@ let coalesce : State.t -> unit =
     add_work_list state u)
   else (
     if irc_debug then log "case #4/4";
-    State.add_active_moves state m));
+    State.add_active_moves state m);
   if irc_debug then dedent ()
 
 let freeze_moves : State.t -> Reg.t -> unit =
@@ -294,7 +302,10 @@ let select_spilling_register_using_heuristics : State.t -> Reg.t =
 
 let select_spill : State.t -> unit =
  fun state ->
- if irc_debug then (log "select_spill"; indent());
+  if irc_debug
+  then (
+    log "select_spill";
+    indent ());
   let reg = select_spilling_register_using_heuristics state in
   if irc_debug
   then
@@ -307,9 +318,15 @@ let select_spill : State.t -> unit =
 
 let assign_colors : State.t -> Cfg_with_layout.t -> unit =
  fun state _cfg_with_layout ->
- if irc_debug then (log "assign_colors"; indent ());
+  if irc_debug
+  then (
+    log "assign_colors";
+    indent ());
   State.iter_and_clear_select_stack state ~f:(fun n ->
-   if irc_debug then (log "%a" Printreg.reg n; indent ());
+      if irc_debug
+      then (
+        log "%a" Printreg.reg n;
+        indent ());
       let reg_class = Proc.register_class n in
       let reg_num_avail =
         Array.unsafe_get Proc.num_available_registers reg_class
@@ -352,7 +369,7 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
       let first_avail =
         mark_adjacent_colors_and_get_first_available (State.adj_list state n)
       in
-      (if first_avail = reg_num_avail
+      if first_avail = reg_num_avail
       then (
         if irc_debug then log "spilling";
         State.add_spilled_nodes state n)
@@ -360,11 +377,12 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
         State.add_colored_nodes state n;
         let c = first_avail + reg_first_avail in
         if irc_debug then log "coloring with %d" c;
-        n.Reg.irc_color <- Some c)); if irc_debug then dedent ());
+        n.Reg.irc_color <- Some c);
+      if irc_debug then dedent ());
   State.iter_coalesced_nodes state ~f:(fun n ->
       let alias = State.find_alias state n in
       n.Reg.irc_color <- alias.Reg.irc_color);
-   if irc_debug then dedent ()
+  if irc_debug then dedent ()
 
 module Utils = struct
   include Regalloc_irc_utils
@@ -423,7 +441,10 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
   then
     fatal "register allocation was not succesful after %d rounds (%s)"
       max_rounds (Cfg_with_infos.cfg cfg_with_infos).fun_name;
-  if irc_debug then (log "main, round #%d" round; indent ());
+  if irc_debug
+  then (
+    log "main, round #%d" round;
+    indent ());
   let work_lists_desc state (name, f) =
     Printf.sprintf "%s:%s" name (if f state then "{}" else "...")
   in

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -517,6 +517,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
 
 let run : Cfg_with_infos.t -> Cfg_with_infos.t =
  fun cfg_with_infos ->
+  if debug then reset_indentation ();
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
   let cfg_infos, stack_slots =
     Regalloc_rewrite.prelude

--- a/backend/regalloc/regalloc_irc_state.ml
+++ b/backend/regalloc/regalloc_irc_state.ml
@@ -368,7 +368,7 @@ let[@inline] add_edge state u v =
     let add_adj_list x y = x.Reg.interf <- y :: x.Reg.interf in
     let incr_degree x =
       let deg = x.Reg.degree in
-      if irc_debug && deg = Degree.infinite
+      if debug && deg = Degree.infinite
       then fatal "trying to increment the degree of a precolored node";
       x.Reg.degree <- succ deg
     in
@@ -565,7 +565,7 @@ let reg_set_of_doubly_linked_list (l : Reg.t Doubly_linked_list.t) : Reg.Set.t =
 
 let[@inline] invariant state =
   (* CR xclerc for xclerc: avoid multiple conversions to sets. *)
-  if irc_debug && Lazy.force irc_invariants
+  if debug && Lazy.force invariants
   then (
     (* interf (list) is morally a set *)
     List.iter (Reg.all_registers ()) ~f:check_inter_has_no_duplicates;

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -3,13 +3,6 @@
 open! Int_replace_polymorphic_compare
 open! Regalloc_utils
 
-let irc_debug = false
-
-let bool_of_param param_name =
-  bool_of_param ~guard:(irc_debug, "irc_debug") param_name
-
-let irc_invariants : bool Lazy.t = bool_of_param "IRC_INVARIANTS"
-
 let log_function = lazy (make_log_function ~label:"irc")
 
 let indent () = (Lazy.force log_function).indent ()
@@ -145,7 +138,7 @@ let k reg = Proc.num_available_registers.(Proc.register_class reg)
 
 let update_register_locations : unit -> unit =
  fun () ->
-  if irc_debug then log "update_register_locations";
+  if debug then log "update_register_locations";
   List.iter (Reg.all_registers ()) ~f:(fun reg ->
       match reg.Reg.loc with
       | Reg _ -> ()
@@ -156,7 +149,7 @@ let update_register_locations : unit -> unit =
           (* because of rewrites, the register may no longer be present *)
           ()
         | Some color ->
-          if irc_debug then log "updating %a to %d" Printreg.reg reg color;
+          if debug then log "updating %a to %d" Printreg.reg reg color;
           reg.Reg.loc <- Reg color))
 
 module Spilling_heuristics = struct

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -9,6 +9,8 @@ let indent () = (Lazy.force log_function).indent ()
 
 let dedent () = (Lazy.force log_function).dedent ()
 
+let reset_indentation () = (Lazy.force log_function).reset_indentation ()
+
 let log : type a. ?no_eol:unit -> (a, Format.formatter, unit) format -> a =
  fun ?no_eol fmt -> (Lazy.force log_function).log ?no_eol fmt
 

--- a/backend/regalloc/regalloc_irc_utils.mli
+++ b/backend/regalloc/regalloc_irc_utils.mli
@@ -6,6 +6,8 @@ val indent : unit -> unit
 
 val dedent : unit -> unit
 
+val reset_indentation : unit -> unit
+
 val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
 
 val log_body_and_terminator :

--- a/backend/regalloc/regalloc_irc_utils.mli
+++ b/backend/regalloc/regalloc_irc_utils.mli
@@ -2,10 +2,6 @@
 
 open Regalloc_utils
 
-val irc_debug : bool
-
-val irc_invariants : bool Lazy.t
-
 val indent : unit -> unit
 
 val dedent : unit -> unit

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -264,6 +264,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
 
 let run : Cfg_with_infos.t -> Cfg_with_infos.t =
  fun cfg_with_infos ->
+  if debug then reset_indentation ();
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
   let cfg_infos, stack_slots =
     Regalloc_rewrite.prelude

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -307,7 +307,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
         indent ();
         iter_cfg_dfs (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun block ->
             log "(block %a)" Label.format block.start;
-            log_body_and_terminator block.body block.terminator liveness); dedent ());
-      )
+            log_body_and_terminator block.body block.terminator liveness);
+        dedent ()))
     cfg_with_infos;
   cfg_with_infos

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -307,7 +307,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
         indent ();
         iter_cfg_dfs (Cfg_with_layout.cfg cfg_with_layout) ~f:(fun block ->
             log "(block %a)" Label.format block.start;
-            log_body_and_terminator block.body block.terminator liveness));
-      dedent ())
+            log_body_and_terminator block.body block.terminator liveness); dedent ());
+      )
     cfg_with_infos;
   cfg_with_infos

--- a/backend/regalloc/regalloc_ls_state.ml
+++ b/backend/regalloc/regalloc_ls_state.ml
@@ -38,14 +38,14 @@ let[@inline] update_intervals state map =
          map []
        |> List.sort ~cmp:(fun (left : Interval.t) (right : Interval.t) ->
               Int.compare left.begin_ right.begin_);
-  if ls_debug then log_intervals ~kind:"regular" state.intervals;
+  if debug then log_intervals ~kind:"regular" state.intervals;
   Array.iter active ~f:(fun (intervals : ClassIntervals.t) ->
       intervals.fixed
         <- List.sort
              ~cmp:(fun (left : Interval.t) (right : Interval.t) ->
                Int.compare right.end_ left.end_)
              intervals.fixed;
-      if ls_debug then log_intervals ~kind:"fixed" intervals.fixed)
+      if debug then log_intervals ~kind:"fixed" intervals.fixed)
 
 let[@inline] iter_intervals state ~f = List.iter state.intervals ~f
 
@@ -104,7 +104,7 @@ let rec is_in_a_range ls_order (cell : Range.t DLL.cell option) : bool =
     || is_in_a_range ls_order (DLL.next cell)
 
 let[@inline] invariant_intervals state cfg_with_infos =
-  if ls_debug && Lazy.force ls_invariants
+  if debug && Lazy.force invariants
   then (
     (match state.intervals with [] -> () | hd :: tl -> check_intervals hd tl);
     let interval_map : Interval.t Reg.Map.t =
@@ -168,7 +168,7 @@ let invariant_active_field (reg_class : int) (field_name : string)
   match l with [] -> () | hd :: tl -> is hd tl
 
 let[@inline] invariant_active state =
-  if ls_debug && Lazy.force ls_invariants
+  if debug && Lazy.force invariants
   then
     Array.iteri state.active ~f:(fun reg_class intervals ->
         invariant_active_field reg_class "fixed " intervals.ClassIntervals.fixed;

--- a/backend/regalloc/regalloc_ls_utils.ml
+++ b/backend/regalloc/regalloc_ls_utils.ml
@@ -10,6 +10,8 @@ let indent () = (Lazy.force log_function).indent ()
 
 let dedent () = (Lazy.force log_function).dedent ()
 
+let reset_indentation () = (Lazy.force log_function).reset_indentation ()
+
 let log : type a. ?no_eol:unit -> (a, Format.formatter, unit) format -> a =
  fun ?no_eol fmt -> (Lazy.force log_function).log ?no_eol fmt
 

--- a/backend/regalloc/regalloc_ls_utils.ml
+++ b/backend/regalloc/regalloc_ls_utils.ml
@@ -4,13 +4,6 @@ open! Int_replace_polymorphic_compare
 open! Regalloc_utils
 module DLL = Flambda_backend_utils.Doubly_linked_list
 
-let ls_debug = false
-
-let bool_of_param param_name =
-  bool_of_param ~guard:(ls_debug, "ls_debug") param_name
-
-let ls_invariants : bool Lazy.t = bool_of_param "LS_INVARIANTS"
-
 let log_function = lazy (make_log_function ~label:"ls")
 
 let indent () = (Lazy.force log_function).indent ()

--- a/backend/regalloc/regalloc_ls_utils.mli
+++ b/backend/regalloc/regalloc_ls_utils.mli
@@ -9,6 +9,8 @@ val indent : unit -> unit
 
 val dedent : unit -> unit
 
+val reset_indentation : unit -> unit
+
 val log_body_and_terminator :
   Cfg.basic_instruction_list ->
   Cfg.terminator Cfg.instruction ->

--- a/backend/regalloc/regalloc_ls_utils.mli
+++ b/backend/regalloc/regalloc_ls_utils.mli
@@ -3,10 +3,6 @@
 open Regalloc_utils
 module DLL = Flambda_backend_utils.Doubly_linked_list
 
-val ls_debug : bool
-
-val ls_invariants : bool Lazy.t
-
 val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
 
 val indent : unit -> unit

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -353,14 +353,14 @@ end = struct
             let destroyed : Reg.Set.t =
               Reg.Set.filter
                 (fun (reg : Reg.t) ->
-                  if split_debug then log "register %a" Printreg.reg reg;
+                  if debug then log "register %a" Printreg.reg reg;
                   let keep =
                     match Reg.Tbl.find_opt num_sets reg with
                     | None | Some Maybe_more_than_once -> true
                     | Some At_most_once -> (
                       match Reg.Map.find_opt reg !already_spilled with
                       | None ->
-                        if split_debug
+                        if debug
                         then (
                           indent ();
                           log "case/2";
@@ -373,7 +373,7 @@ end = struct
                                (Cfg_dominators.is_strictly_dominating doms
                                   spilled_at tree.label)
                           then fatal "inconsistent dominator tree";
-                        if split_debug
+                        if debug
                         then (
                           indent ();
                           log "case/3 (already spilled at %a)" Label.format
@@ -385,7 +385,7 @@ end = struct
                   then
                     already_spilled
                       := Reg.Map.add reg tree.label !already_spilled;
-                  if split_debug
+                  if debug
                   then (
                     indent ();
                     log "keep? %B" keep;
@@ -421,11 +421,11 @@ end = struct
     let res =
       List.fold_left tree.children ~init:destructions_at_end
         ~f:(fun destructions_at_end (child : Cfg_dominators.dominator_tree) ->
-          if split_debug then log "child %a" Label.format child.label;
+          if debug then log "child %a" Label.format child.label;
           remove_dominated_spills doms child ~num_sets
             ~already_spilled:!already_spilled ~destructions_at_end)
     in
-    if split_debug then dedent ();
+    if debug then dedent ();
     res
 
   let optimize cfg_with_infos ~destructions_at_end =

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -75,7 +75,7 @@ end = struct
       definitions_at_beginning:definitions_at_beginning ->
       definitions_at_beginning * Label.t Stack.t =
    fun cfg_with_infos ~definitions_at_beginning ->
-    if split_debug
+    if debug
     then (
       log "MoveSpillsAndReloads.move_definitions_at_beginning_down";
       indent ());
@@ -117,7 +117,7 @@ end = struct
                 in
                 if not (Reg.Set.is_empty to_move)
                 then (
-                  if split_debug
+                  if debug
                   then
                     log "moving %a from block %a to block %a" Printreg.regset
                       to_move Label.format label Label.format successor_label;
@@ -134,7 +134,7 @@ end = struct
                            | Some set -> Some (Reg.Set.union set to_move))
                          !definitions_at_beginning)
             | _ -> ()));
-    if split_debug then dedent ();
+    if debug then dedent ();
     !definitions_at_beginning, stack
 
   (** A destruction at the end of a block can be move up if:
@@ -153,7 +153,7 @@ end = struct
       destructions_at_end:destructions_at_end ->
       destructions_at_end =
    fun cfg_with_infos stack ~definitions_at_beginning ~destructions_at_end ->
-    if split_debug
+    if debug
     then (
       log "MoveSpillsAndReloads.move_destructions_at_end_up";
       indent ());
@@ -197,7 +197,7 @@ end = struct
             in
             if not (Reg.Set.is_empty to_move)
             then (
-              if split_debug
+              if debug
               then
                 log "moving %a from block %a to block %a" Printreg.regset
                   to_move Label.format label Label.format predecessor_label;
@@ -216,11 +216,11 @@ end = struct
                          Some (destruction_kind, Reg.Set.union set to_move))
                      !destructions_at_end)
     done;
-    if split_debug then dedent ();
+    if debug then dedent ();
     !destructions_at_end
 
   let optimize cfg_with_infos ~destructions_at_end ~definitions_at_beginning =
-    if split_debug
+    if debug
     then (
       log "MoveSpillsAndReloads.optimize";
       indent ());
@@ -232,7 +232,7 @@ end = struct
       move_destructions_at_end_up cfg_with_infos stack ~definitions_at_beginning
         ~destructions_at_end
     in
-    if split_debug then dedent ();
+    if debug then dedent ();
     destructions_at_end, definitions_at_beginning
 end
 
@@ -247,7 +247,7 @@ module RemoveReloadSpillInSameBlock : sig
     destructions_at_end * definitions_at_beginning
 end = struct
   let optimize cfg_with_infos ~destructions_at_end ~definitions_at_beginning =
-    if split_debug
+    if debug
     then (
       log "RemoveReloadSpillInSameBlock.optimize";
       indent ());
@@ -255,7 +255,7 @@ end = struct
     let definitions_at_beginning =
       Label.Map.mapi
         (fun (label : Label.t) (definitions : Reg.Set.t) ->
-          if split_debug
+          if debug
           then (
             log "block %a" Label.format label;
             indent ());
@@ -263,7 +263,7 @@ end = struct
           | None -> definitions
           | Some (Destruction_only_on_exceptional_path, _) -> definitions
           | Some (Destruction_on_all_paths, destructions) -> (
-            if split_debug
+            if debug
             then (
               log "definitions: %a" Printreg.regset definitions;
               log "destructions: %a" Printreg.regset destructions;
@@ -271,21 +271,21 @@ end = struct
             let can_be_removed : Reg.Set.t =
               Reg.Set.filter
                 (fun (reg : Reg.t) ->
-                  if split_debug then log "register %a" Printreg.reg reg;
+                  if debug then log "register %a" Printreg.reg reg;
                   match Reg.Set.mem reg destructions with
                   | false ->
-                    if split_debug then log "(not among destructions)";
+                    if debug then log "(not among destructions)";
                     false
                   | true ->
                     let block =
                       Cfg_with_infos.get_block_exn cfg_with_infos label
                     in
                     let occurs = occurs_block block reg in
-                    if split_debug then log "occurs? %B" occurs;
+                    if debug then log "occurs? %B" occurs;
                     not occurs)
                 definitions
             in
-            if split_debug
+            if debug
             then (
               dedent ();
               log "can be removed: %a" Printreg.regset can_be_removed);
@@ -302,7 +302,7 @@ end = struct
               Reg.Set.diff definitions can_be_removed))
         definitions_at_beginning
     in
-    if split_debug
+    if debug
     then (
       dedent ();
       dedent ());
@@ -341,7 +341,7 @@ end = struct
       destructions_at_end:destructions_at_end ->
       destructions_at_end =
    fun doms tree ~num_sets ~already_spilled ~destructions_at_end ->
-    if split_debug
+    if debug
     then (
       log "remove_dominated_spills %a" Label.format tree.label;
       indent ());
@@ -367,7 +367,7 @@ end = struct
                           dedent ());
                         true
                       | Some spilled_at ->
-                        if split_debug && Lazy.force split_invariants
+                        if debug && Lazy.force invariants
                         then
                           if not
                                (Cfg_dominators.is_strictly_dominating doms
@@ -395,7 +395,7 @@ end = struct
             in
             if Reg.Set.is_empty destroyed
             then (
-              if split_debug
+              if debug
               then (
                 indent ();
                 log "(the destroyed set is empty)";
@@ -403,14 +403,14 @@ end = struct
               None)
             else Some (Destruction_on_all_paths, destroyed)
           | Some (Destruction_only_on_exceptional_path, _) as existing ->
-            if split_debug
+            if debug
             then (
               indent ();
               log "(ignored as a half-destruction point)";
               dedent ());
             existing
           | None ->
-            if split_debug
+            if debug
             then (
               indent ();
               log "(not a destruction point)";
@@ -429,7 +429,7 @@ end = struct
     res
 
   let optimize cfg_with_infos ~destructions_at_end =
-    if split_debug
+    if debug
     then (
       log "RemoveDominatedSpillsForConstants.optimize";
       indent ());
@@ -448,14 +448,13 @@ end = struct
       Cfg_with_infos.fold_blocks cfg_with_infos ~init:(Reg.Tbl.create 123)
         ~f:(fun label block acc ->
           let in_loop : bool = is_in_loop loops label in
-          if split_debug
-          then log "block %a in_loop? %B" Label.format label in_loop;
+          if debug then log "block %a in_loop? %B" Label.format label in_loop;
           incr_set acc block.terminator.res ~in_loop;
           DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
               incr_set acc instr.res ~in_loop);
           acc)
     in
-    if split_debug
+    if debug
     then (
       log "num_sets:";
       indent ();
@@ -549,7 +548,7 @@ let compute_definitions :
           let definitions_at_beginning =
             Label.Set.fold
               (fun successor_label definitions_at_beginning ->
-                (if split_debug && Lazy.force split_invariants
+                (if debug && Lazy.force invariants
                 then
                   let successor_block =
                     Cfg_with_infos.get_block_exn cfg_with_infos successor_label

--- a/backend/regalloc/regalloc_split_utils.ml
+++ b/backend/regalloc/regalloc_split_utils.ml
@@ -3,18 +3,11 @@
 open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
 open! Regalloc_utils
 
-let split_debug = false
-
 let split_live_ranges : bool Lazy.t =
   bool_of_param ~default:true "SPLIT_LIVE_RANGES"
 
 let split_more_destruction_points : bool Lazy.t =
   bool_of_param "SPLIT_MORE_DESTR_POINTS"
-
-let bool_of_param param_name =
-  bool_of_param ~guard:(split_debug, "split_debug") param_name
-
-let split_invariants : bool Lazy.t = bool_of_param "SPLIT_INVARIANTS"
 
 let log_function = lazy (make_log_function ~label:"split")
 

--- a/backend/regalloc/regalloc_split_utils.mli
+++ b/backend/regalloc/regalloc_split_utils.mli
@@ -4,10 +4,6 @@ open Regalloc_utils
 
 val split_live_ranges : bool Lazy.t
 
-val split_debug : bool
-
-val split_invariants : bool Lazy.t
-
 val indent : unit -> unit
 
 val dedent : unit -> unit

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -48,6 +48,11 @@ let bool_of_param ?guard ?(default = false) param_name =
          then fatal "%s is set but %s is not" param_name guard_name);
      res)
 
+let debug = false
+
+let invariants : bool Lazy.t =
+  bool_of_param ~guard:(debug, "debug") "INVARIANTS"
+
 let validator_debug = bool_of_param "VALIDATOR_DEBUG"
 
 let block_temporaries = bool_of_param "BLOCK_TEMPORARIES"

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -72,6 +72,7 @@ let make_indent n = String.make (2 * n) ' '
 type log_function =
   { indent : unit -> unit;
     dedent : unit -> unit;
+    reset_indentation : unit -> unit;
     log : 'a. ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a;
     enabled : bool
   }
@@ -82,6 +83,7 @@ let make_log_function : label:string -> log_function =
   let indent_level = ref 0 in
   let indent () = incr indent_level in
   let dedent () = decr indent_level in
+  let reset_indentation () = indent_level := 0 in
   let log =
     if enabled
     then
@@ -92,7 +94,7 @@ let make_log_function : label:string -> log_function =
         (make_indent !indent_level)
     else fun ?no_eol:_ fmt -> Format.(ifprintf err_formatter) fmt
   in
-  { indent; dedent; log; enabled }
+  { indent; dedent; reset_indentation; log; enabled }
 
 module Instruction = struct
   type id = InstructionId.t
@@ -193,8 +195,8 @@ let make_log_body_and_terminator :
     Cfg.terminator Cfg.instruction ->
     liveness ->
     unit =
- fun { log; enabled; indent = _; dedent = _ } ~instr_prefix ~term_prefix body
-     term liveness ->
+ fun { log; enabled; indent = _; dedent = _; reset_indentation = _ }
+     ~instr_prefix ~term_prefix body term liveness ->
   DLL.iter body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
       log ~no_eol:() "%s " (instr_prefix instr);
       if enabled then Cfg.dump_basic Format.err_formatter instr.Cfg.desc;
@@ -210,8 +212,8 @@ let make_log_cfg_with_infos :
     term_prefix:(Cfg.terminator Cfg.instruction -> string) ->
     Cfg_with_infos.t ->
     unit =
- fun ({ indent; dedent; log; enabled } as log_function) ~instr_prefix
-     ~term_prefix cfg_with_infos ->
+ fun ({ indent; dedent; log; enabled; reset_indentation = _ } as log_function)
+     ~instr_prefix ~term_prefix cfg_with_infos ->
   if enabled
   then
     let liveness = Cfg_with_infos.liveness cfg_with_infos in

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -28,6 +28,7 @@ type liveness = Cfg_with_infos.liveness
 type log_function =
   { indent : unit -> unit;
     dedent : unit -> unit;
+    reset_indentation : unit -> unit;
     log : 'a. ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a;
     enabled : bool
   }

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -10,8 +10,12 @@ val fatal : ('a, Format.formatter, unit, 'b) format4 -> 'a
 
 val find_param_value : string -> string option
 
+val debug : bool
+
 val bool_of_param :
   ?guard:bool * string -> ?default:bool -> string -> bool Lazy.t
+
+val invariants : bool Lazy.t
 
 val verbose : bool Lazy.t
 


### PR DESCRIPTION
Based on https://github.com/ocaml-flambda/flambda-backend/pull/3775.

This pull request simplifies the register
allocator logging logic, only using a
single couple of value for `debug` /
`invariants` rather than one per allocator.