### PR TITLE
Reset logging at the start of register allocation

### DIFF
--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -264,6 +264,7 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
 
 let run : Cfg_with_infos.t -> Cfg_with_infos.t =
  fun cfg_with_infos ->
+  if debug then reset_indentation ();
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
   let cfg_infos, stack_slots =
     Regalloc_rewrite.prelude

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -12,6 +12,8 @@ let indent () = (Lazy.force log_function).indent ()
 
 let dedent () = (Lazy.force log_function).dedent ()
 
+let reset_indentation () = (Lazy.force log_function).reset_indentation ()
+
 let log : type a. ?no_eol:unit -> (a, Format.formatter, unit) format -> a =
  fun ?no_eol fmt -> (Lazy.force log_function).log ?no_eol fmt
 

--- a/backend/regalloc/regalloc_gi_utils.mli
+++ b/backend/regalloc/regalloc_gi_utils.mli
@@ -8,6 +8,8 @@ val indent : unit -> unit
 
 val dedent : unit -> unit
 
+val reset_indentation : unit -> unit
+
 val log_body_and_terminator :
   Cfg.basic_instruction_list ->
   Cfg.terminator Cfg.instruction ->

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -517,6 +517,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
 
 let run : Cfg_with_infos.t -> Cfg_with_infos.t =
  fun cfg_with_infos ->
+  if debug then reset_indentation ();
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
   let cfg_infos, stack_slots =
     Regalloc_rewrite.prelude

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -9,6 +9,8 @@ let indent () = (Lazy.force log_function).indent ()
 
 let dedent () = (Lazy.force log_function).dedent ()
 
+let reset_indentation () = (Lazy.force log_function).reset_indentation ()
+
 let log : type a. ?no_eol:unit -> (a, Format.formatter, unit) format -> a =
  fun ?no_eol fmt -> (Lazy.force log_function).log ?no_eol fmt
 

--- a/backend/regalloc/regalloc_irc_utils.mli
+++ b/backend/regalloc/regalloc_irc_utils.mli
@@ -6,6 +6,8 @@ val indent : unit -> unit
 
 val dedent : unit -> unit
 
+val reset_indentation : unit -> unit
+
 val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
 
 val log_body_and_terminator :

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -264,6 +264,7 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
 
 let run : Cfg_with_infos.t -> Cfg_with_infos.t =
  fun cfg_with_infos ->
+  if debug then reset_indentation ();
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
   let cfg_infos, stack_slots =
     Regalloc_rewrite.prelude

--- a/backend/regalloc/regalloc_ls_utils.ml
+++ b/backend/regalloc/regalloc_ls_utils.ml
@@ -10,6 +10,8 @@ let indent () = (Lazy.force log_function).indent ()
 
 let dedent () = (Lazy.force log_function).dedent ()
 
+let reset_indentation () = (Lazy.force log_function).reset_indentation ()
+
 let log : type a. ?no_eol:unit -> (a, Format.formatter, unit) format -> a =
  fun ?no_eol fmt -> (Lazy.force log_function).log ?no_eol fmt
 

--- a/backend/regalloc/regalloc_ls_utils.mli
+++ b/backend/regalloc/regalloc_ls_utils.mli
@@ -9,6 +9,8 @@ val indent : unit -> unit
 
 val dedent : unit -> unit
 
+val reset_indentation : unit -> unit
+
 val log_body_and_terminator :
   Cfg.basic_instruction_list ->
   Cfg.terminator Cfg.instruction ->

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -28,6 +28,7 @@ type liveness = Cfg_with_infos.liveness
 type log_function =
   { indent : unit -> unit;
     dedent : unit -> unit;
+    reset_indentation : unit -> unit;
     log : 'a. ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a;
     enabled : bool
   }


### PR DESCRIPTION
Based on https://github.com/ocaml-flambda/flambda-backend/pull/3777.

This is defensive, to be sure the indentation
level is not unbounded if there is a bug
in the refactoring of the pull requests in
this chain.