### PR TITLE
Clean up regalloc jobs (CI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,15 +157,15 @@ jobs:
           - name: gi
             config: --enable-middle-end=flambda2
             os: ubuntu-latest
-            build_ocamlparam: '_,w=-46,regalloc=gi,cfg-cse-optimize=1'
-            ocamlparam: '_,w=-46,regalloc=gi,cfg-cse-optimize=1'
+            build_ocamlparam: '_,w=-46,regalloc=gi'
+            ocamlparam: '_,w=-46,regalloc=gi'
             check_arch: true
 
-          - name: cfg-selection
+          - name: cfg-invariants
             config: --enable-middle-end=flambda2
             os: ubuntu-latest
-            build_ocamlparam: '_,w=-46,regalloc=cfg,cfg-cse-optimize=1,cfg-selection=1,cfg-zero-alloc-checker=1'
-            ocamlparam: '_,w=-46,regalloc=cfg,cfg-cse-optimize=1,cfg-selection=1,cfg-zero-alloc-checker=1,cfg-invariants=1'
+            build_ocamlparam: '_,w=-46,regalloc=cfg'
+            ocamlparam: '_,w=-46,regalloc=cfg,cfg-invariants=1'
             check_arch: true
 
           - name: vectorizer


### PR DESCRIPTION
Now that CFG is the only pipeline, a couple
of CI jobs can be slightly simplified. This
pull request also renames the `cfg-selection`
job to `cfg-invariants`, since CFG selection
is the only alternative anyway...