### PR TITLE
Revert "Avoid checking pending actions in Condition.wait (#3741)"

### DIFF
--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -168,10 +168,7 @@ CAMLprim value caml_ml_condition_wait(value wcond, value wmut)
   sync_retcode retcode;
 
   CAML_EV_BEGIN(EV_DOMAIN_CONDITION_WAIT);
-  /* no_pending here: we don't want to delay releasing the mutex.
-     (We're waiting for another thread to wake us up anyway: they
-     can handle any pending actions)) */
-  caml_enter_blocking_section_no_pending();
+  caml_enter_blocking_section();
   retcode = sync_condvar_wait(cond, mut);
   caml_leave_blocking_section();
   sync_check_error(retcode, "Condition.wait");


### PR DESCRIPTION
#3741 removed a pending signals check from `Condition.wait`, on the basis that POSIX specifies that `pthread_cond_wait` (which this function wraps) never returns `EINTR` and cannot portably be interrupted by a signal, so there's no need to have an additional signal check beforehand.

However, on Linux, signals arriving during `pthread_cond_wait` cause a spurious wakeup (that is, the function returns early, but with `0` rather than `EINTR`), a behaviour permitted but not required by POSIX. It turns out that some programs rely on this signal-catching behaviour of `Condition.wait` on Linux, and dropping the signal check here can cause such programs to hang.

(I think OCaml 5 safepoint checks would typically be sufficient to avoid this hang, but we're building in configurations that disable those, hence hanging)