### PR TITLE
Have errors suggest "shared or uncontended" rather than "shared"

### DIFF
--- a/testsuite/tests/typing-modes/crossing.ml
+++ b/testsuite/tests/typing-modes/crossing.ml
@@ -206,7 +206,7 @@ let cross_shared2 (x : cross_shared @@ contended) : _ @@ shared = x
 Line 1, characters 66-67:
 1 | let cross_shared2 (x : cross_shared @@ contended) : _ @@ shared = x
                                                                       ^
-Error: This value is "contended" but expected to be "shared".
+Error: This value is "contended" but expected to be "shared" or "uncontended".
 |}]
 
 let cross_uncontended1 (x : cross_uncontended @@ shared) : _ @@ uncontended = x
@@ -222,7 +222,7 @@ let cross_uncontended2 (x : cross_uncontended @@ contended) : _ @@ shared = x
 Line 1, characters 76-77:
 1 | let cross_uncontended2 (x : cross_uncontended @@ contended) : _ @@ shared = x
                                                                                 ^
-Error: This value is "contended" but expected to be "shared".
+Error: This value is "contended" but expected to be "shared" or "uncontended".
 |}]
 
 (* Check that all modalities cross modes *)

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -31,7 +31,7 @@ let foo (r @ contended) = r.a
 Line 1, characters 26-27:
 1 | let foo (r @ contended) = r.a
                               ^
-Error: This value is "contended" but expected to be "shared".
+Error: This value is "contended" but expected to be "shared" or "uncontended".
   Hint: In order to read from the mutable fields,
   this record needs to be at least shared.
 |}]
@@ -46,7 +46,7 @@ let foo (r @ contended) = {r with b = best_bytes ()}
 Line 1, characters 27-28:
 1 | let foo (r @ contended) = {r with b = best_bytes ()}
                                ^
-Error: This value is "contended" but expected to be "shared".
+Error: This value is "contended" but expected to be "shared" or "uncontended".
   Hint: In order to read from the mutable fields,
   this record needs to be at least shared.
 |}]
@@ -190,7 +190,7 @@ let foo (r @ contended) =
 Line 3, characters 6-16:
 3 |     | [| x; y |] -> ()
           ^^^^^^^^^^
-Error: This value is "contended" but expected to be "shared".
+Error: This value is "contended" but expected to be "shared" or "uncontended".
   Hint: In order to read from the mutable fields,
   this record needs to be at least shared.
 |}]


### PR DESCRIPTION
The error message
```
Error: This value is contended but expected to be shared.
```
is unhelpful for users that know about `uncontended` but not `shared` (which will likely be many users if not most). In particular, it won't be obvious to them that it suffices to make the value `uncontended`. This changes the message to
```
Error: This value is contended but expected to be shared or uncontended.
```
which hopefully is useful even if the word `shared` is mysterious.