### PR TITLE
Introduce Or_never_returns in Cfg_selectgen

### DIFF
--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -223,8 +223,8 @@ class selector =
       List.iter
         (fun arg ->
           match self#emit_expr env sub_cfg arg ~bound_name:None with
-          | None -> assert false
-          | Some regs ->
+          | Never_returns -> assert false
+          | Ok regs ->
             for i = 0 to Array.length regs - 1 do
               let r = regs.(i) in
               let kind : Cmm.memory_chunk =

--- a/backend/cfg_selectgen.mli
+++ b/backend/cfg_selectgen.mli
@@ -203,14 +203,14 @@ class virtual selector_generic :
       Sub_cfg.t ->
       Cmm.expression ->
       bound_name:Backend_var.With_provenance.t option ->
-      Reg.t array option
+      Reg.t array Select_utils.Or_never_returns.t
 
     method emit_expr_aux :
       environment ->
       Sub_cfg.t ->
       Cmm.expression ->
       bound_name:Backend_var.With_provenance.t option ->
-      Reg.t array option
+      Reg.t array Select_utils.Or_never_returns.t
 
     method emit_expr_aux_raise :
       environment ->
@@ -218,7 +218,7 @@ class virtual selector_generic :
       Lambda.raise_kind ->
       Cmm.expression list ->
       Debuginfo.t ->
-      Reg.t array option
+      Reg.t array Select_utils.Or_never_returns.t
 
     method emit_expr_aux_op :
       environment ->
@@ -227,7 +227,7 @@ class virtual selector_generic :
       Cmm.operation ->
       Cmm.expression list ->
       Debuginfo.t ->
-      Reg.t array option
+      Reg.t array Select_utils.Or_never_returns.t
 
     method emit_expr_aux_ifthenelse :
       environment ->
@@ -240,7 +240,7 @@ class virtual selector_generic :
       Cmm.expression ->
       Debuginfo.t ->
       Cmm.kind_for_unboxing ->
-      Reg.t array option
+      Reg.t array Select_utils.Or_never_returns.t
 
     method emit_expr_aux_switch :
       environment ->
@@ -251,7 +251,7 @@ class virtual selector_generic :
       (Cmm.expression * Debuginfo.t) array ->
       Debuginfo.t ->
       Cmm.kind_for_unboxing ->
-      Reg.t array option
+      Reg.t array Select_utils.Or_never_returns.t
 
     method emit_expr_aux_catch :
       environment ->
@@ -266,7 +266,7 @@ class virtual selector_generic :
       list ->
       Cmm.expression ->
       Cmm.kind_for_unboxing ->
-      Reg.t array option
+      Reg.t array Select_utils.Or_never_returns.t
 
     method emit_expr_aux_exit :
       environment ->
@@ -274,7 +274,7 @@ class virtual selector_generic :
       Cmm.exit_label ->
       Cmm.expression list ->
       Cmm.trap_action list ->
-      Reg.t array option
+      Reg.t array Select_utils.Or_never_returns.t
 
     method emit_expr_aux_trywith :
       environment ->
@@ -287,7 +287,7 @@ class virtual selector_generic :
       Cmm.expression ->
       Debuginfo.t ->
       Cmm.kind_for_unboxing ->
-      Reg.t array option
+      Reg.t array Select_utils.Or_never_returns.t
 
     method emit_tail : environment -> Sub_cfg.t -> Cmm.expression -> unit
 

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -25,6 +25,12 @@ module Int = Numbers.Int
 module V = Backend_var
 module VP = Backend_var.With_provenance
 
+module Or_never_returns = struct
+  type 'a t =
+    | Ok of 'a
+    | Never_returns
+end
+
 type trap_stack_info =
   | Unreachable
   | Reachable of Simple_operation.trap_stack

--- a/backend/select_utils.mli
+++ b/backend/select_utils.mli
@@ -18,6 +18,12 @@
 
 [@@@ocaml.warning "+a-4-9-40-41-42"]
 
+module Or_never_returns : sig
+  type 'a t =
+    | Ok of 'a
+    | Never_returns
+end
+
 type trap_stack_info =
   | Unreachable
   | Reachable of Simple_operation.trap_stack


### PR DESCRIPTION
This should help make the selection code clearer, especially since it seems like we may need to enhance it to handle cases of `Invalid` being generated in contexts that they are not currently (cc @Gbury ).  We may also need to think about a proper "invalid" operation in Cfg.