### PR TITLE
Cfg_selectgen emit_expr tidyups etc

### DIFF
--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1073,7 +1073,6 @@ class virtual selector_generic =
       Never_returns
 
     method emit_expr_op env sub_cfg bound_name op args dbg =
-      let ret res = Or_never_returns.Ok res in
       match self#emit_parts_list env sub_cfg args with
       | Never_returns -> Never_returns
       | Ok (simple_args, env) -> (
@@ -1155,14 +1154,14 @@ class virtual selector_generic =
           add_naming_op_for_bound_name sub_cfg loc_res;
           self#insert_move_results env sub_cfg loc_res rd stack_ofs;
           Select_utils.set_traps_for_raise env;
-          ret rd
+          Ok rd
         | Terminator (Prim { op = Probe _; label_after } as term) ->
           let r1 = self#emit_tuple env sub_cfg new_args in
           let rd = self#regs_for ty in
           let rd = self#insert_op_debug' env sub_cfg term dbg r1 rd in
           Select_utils.set_traps_for_raise env;
           Sub_cfg.add_never_block sub_cfg ~label:label_after;
-          ret rd
+          Ok rd
         | Terminator (Call_no_return ({ func_symbol; ty_args; _ } as r)) ->
           let loc_arg, stack_ofs =
             self#emit_extcall_args env sub_cfg ty_args new_args
@@ -1190,7 +1189,7 @@ class virtual selector_generic =
           if returns
           then (
             Sub_cfg.add_never_block sub_cfg ~label;
-            ret rd)
+            Ok rd)
           else Never_returns
         | Basic (Op (Alloc { bytes = _; mode; dbginfo = [placeholder] })) ->
           let rd = self#regs_for typ_val in
@@ -1207,7 +1206,7 @@ class virtual selector_generic =
           add_naming_op_for_bound_name sub_cfg rd;
           self#emit_stores env sub_cfg dbg new_args rd;
           Select_utils.set_traps_for_raise env;
-          ret rd
+          Ok rd
         | Basic (Op (Alloc { bytes = _; mode = _; dbginfo })) ->
           Misc.fatal_errorf
             "Selection Alloc: expected a single placehold in dbginfo, found %d"
@@ -1216,7 +1215,7 @@ class virtual selector_generic =
           let r1 = self#emit_tuple env sub_cfg new_args in
           let rd = self#regs_for ty in
           add_naming_op_for_bound_name sub_cfg rd;
-          ret (self#insert_op_debug env sub_cfg op dbg r1 rd)
+          Ok (self#insert_op_debug env sub_cfg op dbg r1 rd)
         | Basic basic ->
           Misc.fatal_errorf "unexpected basic (%a)" Cfg.dump_basic basic
         | Terminator term ->

--- a/backend/cfg_selectgen.mli
+++ b/backend/cfg_selectgen.mli
@@ -205,14 +205,14 @@ class virtual selector_generic :
       bound_name:Backend_var.With_provenance.t option ->
       Reg.t array Select_utils.Or_never_returns.t
 
-    method emit_expr_aux :
+    method emit_expr :
       environment ->
       Sub_cfg.t ->
       Cmm.expression ->
       bound_name:Backend_var.With_provenance.t option ->
       Reg.t array Select_utils.Or_never_returns.t
 
-    method emit_expr_aux_raise :
+    method emit_expr_raise :
       environment ->
       Sub_cfg.t ->
       Lambda.raise_kind ->
@@ -220,7 +220,7 @@ class virtual selector_generic :
       Debuginfo.t ->
       Reg.t array Select_utils.Or_never_returns.t
 
-    method emit_expr_aux_op :
+    method emit_expr_op :
       environment ->
       Sub_cfg.t ->
       Backend_var.With_provenance.t option ->
@@ -229,7 +229,7 @@ class virtual selector_generic :
       Debuginfo.t ->
       Reg.t array Select_utils.Or_never_returns.t
 
-    method emit_expr_aux_ifthenelse :
+    method emit_expr_ifthenelse :
       environment ->
       Sub_cfg.t ->
       Backend_var.With_provenance.t option ->
@@ -242,7 +242,7 @@ class virtual selector_generic :
       Cmm.kind_for_unboxing ->
       Reg.t array Select_utils.Or_never_returns.t
 
-    method emit_expr_aux_switch :
+    method emit_expr_switch :
       environment ->
       Sub_cfg.t ->
       Backend_var.With_provenance.t option ->
@@ -253,7 +253,7 @@ class virtual selector_generic :
       Cmm.kind_for_unboxing ->
       Reg.t array Select_utils.Or_never_returns.t
 
-    method emit_expr_aux_catch :
+    method emit_expr_catch :
       environment ->
       Sub_cfg.t ->
       Backend_var.With_provenance.t option ->
@@ -268,7 +268,7 @@ class virtual selector_generic :
       Cmm.kind_for_unboxing ->
       Reg.t array Select_utils.Or_never_returns.t
 
-    method emit_expr_aux_exit :
+    method emit_expr_exit :
       environment ->
       Sub_cfg.t ->
       Cmm.exit_label ->
@@ -276,7 +276,7 @@ class virtual selector_generic :
       Cmm.trap_action list ->
       Reg.t array Select_utils.Or_never_returns.t
 
-    method emit_expr_aux_trywith :
+    method emit_expr_trywith :
       environment ->
       Sub_cfg.t ->
       Backend_var.With_provenance.t option ->


### PR DESCRIPTION
The first commit is #3798 .
After that:
* Remove unnecessary `_aux` suffixes from translation functions; these date from the days when region handling was done in `Selectgen`
* Remove the `ret` function in `emit_expr`, likewise
* Rename `emit_sequence` and `emit_tail_sequence` since they have nothing to do with sequences.