### PR TITLE
Add new interface for target-specific selection code

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -24,6 +24,7 @@ vectorize_utils.ml
 vectorize_utils.mli
 cfg_selectgen.ml
 cfg_selectgen.mli
+cfg_selectgen_target_intf.ml
 cfg_selection.mli
 cmm_builtins.ml
 cmm_builtins.mli

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -127,7 +127,7 @@ let is_immediate_natint n =
 
 let specific x =
   assert (not (Arch.operation_can_raise x));
-  Cfg_selectgen.Basic (Op (Specific x))
+  Cfg.Basic (Op (Specific x))
 
 let pseudoregs_for_operation op arg res =
   match (op : Operation.t) with
@@ -411,7 +411,7 @@ class selector =
     (* Recognize float arithmetic with mem *)
 
     method select_floatarith commutative width regular_op mem_op args
-        : Cfg_selectgen.basic_or_terminator * Cmm.expression list =
+        : Cfg.basic_or_terminator * Cmm.expression list =
       let open Cmm in
       match width, args with
       | ( Float64,

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -63,12 +63,10 @@ let select_bitwidth : Cmm.bswap_bitwidth -> Arch.bswap_bitwidth = function
   | Thirtytwo -> Thirtytwo
   | Sixtyfour -> Sixtyfour
 
-let specific x ~label_after =
+let specific x ~label_after : Cfg.basic_or_terminator =
   if Arch.operation_can_raise x
-  then
-    Cfg_selectgen.Terminator
-      (Cfg.Specific_can_raise { Cfg.op = x; label_after })
-  else Cfg_selectgen.Basic Cfg.(Op (Specific x))
+  then Terminator (Specific_can_raise { op = x; label_after })
+  else Basic (Op (Specific x))
 
 class selector =
   object (self)

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -154,6 +154,10 @@ module S = struct
     | Call of func_call_operation with_label_after
     | Prim of prim_call_operation with_label_after
     | Specific_can_raise of Arch.specific_operation with_label_after
+
+  type basic_or_terminator =
+    | Basic of basic
+    | Terminator of terminator
 end
 
 (* CR-someday gyorsh: Switch can be translated to Branch. *)

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -303,11 +303,7 @@ let join_array env rs ~bound_name : _ Or_never_returns.t =
 
 type environment = Select_utils.environment
 
-type basic_or_terminator =
-  | Basic of Cfg.basic
-  | Terminator of Cfg.terminator
-
-let basic_op x = Basic (Op x)
+let basic_op x : Cfg.basic_or_terminator = Basic (Op x)
 
 class virtual selector_generic =
   object (self : 'self)
@@ -541,7 +537,7 @@ class virtual selector_generic =
 
     method select_operation (op : Cmm.operation) (args : Cmm.expression list)
         (dbg : Debuginfo.t) ~label_after
-        : basic_or_terminator * Cmm.expression list =
+        : Cfg.basic_or_terminator * Cmm.expression list =
       let wrong_num_args n =
         Misc.fatal_errorf
           "Selection.select_operation: expected %d argument(s) for@ %s" n
@@ -686,8 +682,8 @@ class virtual selector_generic =
         Misc.fatal_error "Selection.select_oper"
 
     method private select_arith_comm (op : Simple_operation.integer_operation)
-        (args : Cmm.expression list) : basic_or_terminator * Cmm.expression list
-        =
+        (args : Cmm.expression list)
+        : Cfg.basic_or_terminator * Cmm.expression list =
       match args with
       | [arg; Cconst_int (n, _)] when self#is_immediate op n ->
         basic_op (Intop_imm (op, n)), [arg]
@@ -696,16 +692,16 @@ class virtual selector_generic =
       | _ -> basic_op (Intop op), args
 
     method private select_arith (op : Simple_operation.integer_operation)
-        (args : Cmm.expression list) : basic_or_terminator * Cmm.expression list
-        =
+        (args : Cmm.expression list)
+        : Cfg.basic_or_terminator * Cmm.expression list =
       match args with
       | [arg; Cconst_int (n, _)] when self#is_immediate op n ->
         basic_op (Intop_imm (op, n)), [arg]
       | _ -> basic_op (Intop op), args
 
     method private select_arith_comp (cmp : Simple_operation.integer_comparison)
-        (args : Cmm.expression list) : basic_or_terminator * Cmm.expression list
-        =
+        (args : Cmm.expression list)
+        : Cfg.basic_or_terminator * Cmm.expression list =
       match args with
       | [arg; Cconst_int (n, _)]
         when self#is_immediate (Simple_operation.Icomp cmp) n ->

--- a/backend/cfg_selectgen.mli
+++ b/backend/cfg_selectgen.mli
@@ -20,10 +20,6 @@
 
 type environment = Select_utils.environment
 
-type basic_or_terminator =
-  | Basic of Cfg.basic
-  | Terminator of Cfg.terminator
-
 class virtual selector_generic :
   object
     method is_store : Operation.t -> bool
@@ -84,7 +80,7 @@ class virtual selector_generic :
       Cmm.expression list ->
       Debuginfo.t ->
       label_after:Label.t ->
-      basic_or_terminator * Cmm.expression list
+      Cfg.basic_or_terminator * Cmm.expression list
     (* Can be overridden to deal with special arithmetic instructions *)
 
     method select_condition :

--- a/backend/cfg_selectgen_target_intf.ml
+++ b/backend/cfg_selectgen_target_intf.ml
@@ -1,0 +1,100 @@
+(* -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** Interface to be satisfied by target-specific code, for instruction
+    selection. *)
+
+type is_immediate_result =
+  | Is_immediate of bool
+  | Use_default
+
+type is_simple_expr_result =
+  | Simple_if_all_expressions_are of Cmm.expression list
+  | Use_default
+
+type effects_of_result =
+  | Effects_of_all_expressions of Cmm.expression list
+  | Use_default
+
+type select_operation_then_rewrite_result =
+  | Rewritten of Cfg.basic_or_terminator * Cmm.expression list
+  | Use_default
+
+type select_operation_result =
+  | Rewritten of Cfg.basic_or_terminator * Cmm.expression list
+  | Select_operation_then_rewrite of
+      Cmm.operation
+      * Cmm.expression list
+      * Debuginfo.t
+      * (Cfg.basic_or_terminator ->
+        args:Cmm.expression list ->
+        select_operation_then_rewrite_result)
+  | Use_default
+
+type select_store_result =
+  | Maybe_out_of_range
+  | Rewritten of Operation.t * Cmm.expression
+  | Use_default
+
+type is_store_out_of_range_result =
+  | Within_range
+  | Out_of_range
+
+type insert_move_extcall_arg_result =
+  | Rewritten of Cfg.basic * Reg.t array * Reg.t array
+  | Use_default
+
+module type S = sig
+  val is_immediate :
+    Simple_operation.integer_operation -> int -> is_immediate_result
+
+  val is_immediate_test :
+    Simple_operation.integer_comparison -> int -> is_immediate_result
+
+  val is_simple_expr : Cmm.expression -> is_simple_expr_result
+
+  val effects_of : Cmm.expression -> effects_of_result
+
+  val select_addressing :
+    Cmm.memory_chunk -> Cmm.expression -> Arch.addressing_mode * Cmm.expression
+
+  val select_operation :
+    Cmm.operation ->
+    Cmm.expression list ->
+    label_after:Label.t ->
+    select_operation_result
+
+  val select_store :
+    is_assign:bool ->
+    Arch.addressing_mode ->
+    Cmm.expression ->
+    select_store_result
+
+  val is_store_out_of_range :
+    Cmm.memory_chunk -> byte_offset:int -> is_store_out_of_range_result
+
+  val insert_move_extcall_arg :
+    Cmm.exttype -> Reg.t array -> Reg.t array -> insert_move_extcall_arg_result
+end

--- a/dune
+++ b/dune
@@ -435,6 +435,7 @@
   branch_relaxation
   branch_relaxation_intf
   cfg_selectgen
+  cfg_selectgen_target_intf
   cfg_selection
   cfg_invariants
   cmm_helpers


### PR DESCRIPTION
In the new world without objects, this interface is what must be provided by the target-specific selection code, in order to allow instantiation of the generic instruction selection functor.