### PR TITLE
New version of Cfg_selectgen.emit_stores

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -448,6 +448,15 @@ class selector =
         self#insert_moves env sub_cfg rdst rd;
         rd
       with Use_default -> super#insert_op_debug env sub_cfg op dbg rs rd
+
+    method select_store_new is_assign addr exp
+        : Cfg_selectgen_target_intf.select_store_result =
+      let op, args = self#select_store is_assign addr exp in
+      Rewritten (op, args)
+
+    method is_store_out_of_range _chunk ~byte_offset:_
+        : Cfg_selectgen_target_intf.is_store_out_of_range_result =
+      Misc.fatal_error "is_store_out_of_range should not be called on x86-64"
   end
 
 let fundecl ~future_funcnames f =

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -93,9 +93,12 @@ let division_crashes_on_overflow = false
 
 let identity_addressing = Iindexed 0
 
-let offset_addressing _addr _delta =
-  (* Resulting offset might not be representable.  *)
-  Misc.fatal_error "Arch.offset_addressing not supported"
+let offset_addressing addr delta =
+  (* Resulting offset might not be representable, but that is the
+     responsibility of the caller. *)
+  match addr with
+  | Iindexed i -> Iindexed (i + delta)
+  | Ibased (sym, i) -> Ibased (sym, i + delta)
 
 let num_args_addressing = function
   | Iindexed _ -> 1

--- a/backend/cfg_selectgen.mli
+++ b/backend/cfg_selectgen.mli
@@ -92,6 +92,17 @@ class virtual selector_generic :
       Operation.t * Cmm.expression
     (* Can be overridden to deal with special store constant instructions *)
 
+    method virtual select_store_new :
+      bool ->
+      Arch.addressing_mode ->
+      Cmm.expression ->
+      Cfg_selectgen_target_intf.select_store_result
+
+    method virtual is_store_out_of_range :
+      Cmm.memory_chunk ->
+      byte_offset:int ->
+      Cfg_selectgen_target_intf.is_store_out_of_range_result
+
     method regs_for : Cmm.machtype -> Reg.t array
     (* Return an array of fresh registers of the given type. Default
        implementation is like Reg.createv. Can be overridden if float values are


### PR DESCRIPTION
The aim here is to remove the arm64-specific version of this, as discussed with @gretay-js and @xclerc earlier this week.

Only the newest changeset here pertains to this PR, the rest are from other PRs.