### PR TITLE
Remove objects from CSE code

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -313,6 +313,7 @@ let available_regs ~stack_slots ~f x =
 
 let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
   let register_allocator = register_allocator fd_cmm in
+  let module CSE = Cfg_cse.Cse_generic (CSE) in
   let cfg_with_infos =
     cfg_with_layout
     ++ (fun cfg_with_layout ->

--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -12,7 +12,7 @@
 (*   special exception on linking described in the file LICENSE.          *)
 (*                                                                        *)
 (**************************************************************************)
-[@@@ocaml.warning "+4"]
+[@@@ocaml.warning "+a-30-40-41-42"]
 
 open! Int_replace_polymorphic_compare
 

--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -14,7 +14,7 @@
 (**************************************************************************)
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-open! Int_replace_polymorphic_compare
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
 
 (* CSE for the AMD64 *)
 

--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -20,37 +20,32 @@ open! Int_replace_polymorphic_compare
 
 open Arch
 
-let of_simd_class (cl : Simd.operation_class) : Cfg_cse.op_class =
+let of_simd_class (cl : Simd.operation_class) : Cfg_cse_target_intf.op_class =
   match cl with
   | Pure -> Op_pure
   | Load { is_mutable = true } -> Op_load Mutable
   | Load { is_mutable = false } -> Op_load Immutable
 
-class cfg_cse = object
-
-  inherit Cfg_cse.cse_generic as super
-
-  method! class_of_operation
-  : Operation.t -> Cfg_cse.op_class
-  = fun op ->
+let class_of_operation (op : Operation.t)
+    : Cfg_cse_target_intf.class_of_operation_result =
   match op with
-    | Specific spec ->
+  | Specific spec ->
     begin match spec with
-    | Ilea _ | Isextend32 | Izextend32 -> Op_pure
-    | Istore_int(_, _, is_asg) -> Op_store is_asg
-    | Ioffset_loc(_, _) -> Op_store true
-    | Ifloatarithmem _ -> Op_load Mutable
-    | Ibswap _ -> super#class_of_operation op
+    | Ilea _ | Isextend32 | Izextend32 -> Class Op_pure
+    | Istore_int(_, _, is_asg) -> Class (Op_store is_asg)
+    | Ioffset_loc(_, _) -> Class (Op_store true)
+    | Ifloatarithmem _ -> Class (Op_load Mutable)
+    | Ibswap _ -> Use_default
     | Irdtsc | Irdpmc
-    | Ilfence | Isfence | Imfence -> Op_other
+    | Ilfence | Isfence | Imfence -> Class Op_other
     | Isimd op ->
-      of_simd_class (Simd.class_of_operation op)
+      Class (of_simd_class (Simd.class_of_operation op))
     | Isimd_mem (op,_addr) ->
-      of_simd_class (Simd.Mem.class_of_operation op)
+      Class (of_simd_class (Simd.Mem.class_of_operation op))
     | Ipause
     | Icldemote _
-    | Iprefetch _ -> Op_other
-      end
+    | Iprefetch _ -> Class Op_other
+    end
   | Move | Spill | Reload
   | Floatop _
   | Csel _
@@ -61,9 +56,8 @@ class cfg_cse = object
   | Intop _ | Intop_imm _ | Intop_atomic _
   | Name_for_debugger _ | Probe_is_enabled _ | Opaque
   | Begin_region | End_region | Poll | Dls_get
-    -> super#class_of_operation op
+    -> Use_default
 
-end
-
-let cfg_with_layout cfg_with_layout =
-  (new cfg_cse)#cfg_with_layout cfg_with_layout
+let is_cheap_operation _op
+    : Cfg_cse_target_intf.is_cheap_operation_result =
+  Use_default

--- a/backend/arm64/CSE.ml
+++ b/backend/arm64/CSE.ml
@@ -12,67 +12,66 @@
 (*   special exception on linking described in the file LICENSE.          *)
 (*                                                                        *)
 (**************************************************************************)
+
 [@@@ocaml.warning "+a-40-41-42"]
+
 (* CSE for ARM64 *)
 
 open! Int_replace_polymorphic_compare
 
-let of_simd_class (cl : Simd.operation_class) : Cfg_cse.op_class =
+let of_simd_class (cl : Simd.operation_class) : Cfg_cse_target_intf.op_class =
   match cl with
   | Pure -> Op_pure
 
-class cfg_cse = object
+let class_of_operation (op : Operation.t)
+    : Cfg_cse_target_intf.class_of_operation_result =
+  match op with
+  | Specific spec ->
+    let op_class : Cfg_cse_target_intf.op_class =
+      match spec with
+      | Ifar_poll
+      | Ifar_alloc _
+      | Ishiftarith _
+      | Imuladd
+      | Imulsub
+      | Inegmulf
+      | Imuladdf
+      | Inegmuladdf
+      | Imulsubf
+      | Inegmulsubf
+      | Isqrtf
+      | Ibswap _
+      | Imove32
+      | Isignext _ -> Op_pure
+      | Isimd op -> of_simd_class (Simd.class_of_operation op)
+    in
+    Class op_class
+  | Move | Spill | Reload
+  | Floatop _
+  | Csel _
+  | Reinterpret_cast _ | Static_cast _
+  | Const_int _ | Const_float32 _ | Const_float _
+  | Const_symbol _ | Const_vec128 _
+  | Stackoffset _ | Load _ | Store _ | Alloc _
+  | Intop _ | Intop_imm _ | Intop_atomic _
+  | Name_for_debugger _ | Probe_is_enabled _ | Opaque
+  | Begin_region | End_region | Poll | Dls_get
+    -> Use_default
 
-  inherit Cfg_cse.cse_generic as super
-
-  method! class_of_operation op =
-    match op with
-    | Specific spec ->
-      (match spec with
-       | Ifar_poll
-       | Ifar_alloc _
-       | Ishiftarith _
-       | Imuladd
-       | Imulsub
-       | Inegmulf
-       | Imuladdf
-       | Inegmuladdf
-       | Imulsubf
-       | Inegmulsubf
-       | Isqrtf
-       | Ibswap _
-       | Imove32
-       | Isignext _ -> Op_pure
-       | Isimd op -> of_simd_class (Simd.class_of_operation op))
-    | Move | Spill | Reload
-    | Floatop _
-    | Csel _
-    | Reinterpret_cast _ | Static_cast _
-    | Const_int _ | Const_float32 _ | Const_float _
-    | Const_symbol _ | Const_vec128 _
-    | Stackoffset _ | Load _ | Store _ | Alloc _
-    | Intop _ | Intop_imm _ | Intop_atomic _
-    | Name_for_debugger _ | Probe_is_enabled _ | Opaque
-    | Begin_region | End_region | Poll | Dls_get
-      -> super#class_of_operation op
-
-  method! is_cheap_operation op =
-    match op with
-    | Const_int n -> Nativeint.compare n 65535n <= 0 && Nativeint.compare n 0n >= 0
-    | Specific _
-    | Move | Spill | Reload
-    | Floatop _
-    | Csel _
-    | Reinterpret_cast _ | Static_cast _
-    | Const_float32 _ | Const_float _
-    | Const_symbol _ | Const_vec128 _
-    | Stackoffset _ | Load _ | Store _ | Alloc _
-    | Intop _ | Intop_imm _ | Intop_atomic _
-    | Name_for_debugger _ | Probe_is_enabled _ | Opaque
-    | Begin_region | End_region | Poll | Dls_get
-      -> false
-
-end
-
-let cfg_with_layout cfg_with_layout =
-  (new cfg_cse)#cfg_with_layout cfg_with_layout
+let is_cheap_operation (op : Operation.t)
+    : Cfg_cse_target_intf.is_cheap_operation_result =
+  match op with
+  | Const_int n ->
+    Cheap (Nativeint.compare n 65535n <= 0 && Nativeint.compare n 0n >= 0)
+  | Specific _
+  | Move | Spill | Reload
+  | Floatop _
+  | Csel _
+  | Reinterpret_cast _ | Static_cast _
+  | Const_float32 _ | Const_float _
+  | Const_symbol _ | Const_vec128 _
+  | Stackoffset _ | Load _ | Store _ | Alloc _
+  | Intop _ | Intop_imm _ | Intop_atomic _
+  | Name_for_debugger _ | Probe_is_enabled _ | Opaque
+  | Begin_region | End_region | Poll | Dls_get
+    -> Cheap false

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -450,7 +450,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
    fun state cfg ->
     let visited = ref Label.Set.empty in
     let to_visit : (numbering * Cfg.basic_block) Queue.t = Queue.create () in
-    (* As in [CSEgen], for control structures, we set the numbering to empty at
+    (* For control structures, we set the numbering to empty at
        every join point, but propagate the current numbering across fork points.
        This is why blocks with zero or several predecessors and exception
        handlers start with an empty numbering: zero predecessors means we have

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -450,12 +450,11 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
    fun state cfg ->
     let visited = ref Label.Set.empty in
     let to_visit : (numbering * Cfg.basic_block) Queue.t = Queue.create () in
-    (* For control structures, we set the numbering to empty at
-       every join point, but propagate the current numbering across fork points.
-       This is why blocks with zero or several predecessors and exception
-       handlers start with an empty numbering: zero predecessors means we have
-       an entry point (or dead code), and several predecessors means we have an
-       entry point. *)
+    (* For control structures, we set the numbering to empty at every join
+       point, but propagate the current numbering across fork points. This is
+       why blocks with zero or several predecessors and exception handlers start
+       with an empty numbering: zero predecessors means we have an entry point
+       (or dead code), and several predecessors means we have an entry point. *)
     Cfg.iter_blocks cfg ~f:(fun _label block ->
         let to_add =
           block.is_trap_handler

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -1,3 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Gallium, INRIA Rocquencourt           *)
+(*                                 et al.                                 *)
+(*                                                                        *)
+(*   Copyright 2014 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2024--2025 Jane Street Group LLC.                          *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
 [@@@ocaml.warning "+a-30-40-41-42"]
 
 open! Int_replace_polymorphic_compare
@@ -9,11 +26,7 @@ type valnum = int
 
 (* Classification of operations *)
 
-type op_class =
-  | Op_pure (* pure arithmetic, produce one or several result *)
-  | Op_load of Simple_operation.mutable_flag (* memory load *)
-  | Op_store of bool (* memory store, false = init, true = assign *)
-  | Op_other (* anything else that does not allocate nor store in memory *)
+type op_class = Cfg_cse_target_intf.op_class
 
 module type Operation = sig
   type t
@@ -87,7 +100,7 @@ module Make (Op : Operation) : S with type op = Op.t = struct
         other_equations = Rhs_map.empty
       }
 
-    let add op_class op v m =
+    let add (op_class : op_class) op v m =
       match op_class with
       | Op_load Mutable ->
         { m with
@@ -96,7 +109,7 @@ module Make (Op : Operation) : S with type op = Op.t = struct
       | Op_pure | Op_load Immutable | Op_store _ | Op_other ->
         { m with other_equations = Rhs_map.add op v m.other_equations }
 
-    let find op_class op m =
+    let find (op_class : op_class) op m =
       match op_class with
       | Op_load Mutable -> Rhs_map.find op m.mutable_load_equations
       | Op_pure | Op_load Immutable | Op_store _ | Op_other ->
@@ -290,222 +303,215 @@ let insert_move :
     Array.iter2 tmps dsts ~f:insert_single_move;
     Array.iter2 srcs tmps ~f:insert_single_move
 
-class cse_generic =
-  object (self)
-    method class_of_operation : Operation.t -> op_class =
-      function
-      | Move | Spill | Reload -> assert false (* treated specially *)
-      | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-      | Const_vec128 _ ->
-        Op_pure
-      | Opaque -> assert false (* treated specially *)
-      | Stackoffset _ -> Op_other
-      | Load { mutability; is_atomic; memory_chunk = _; addressing_mode = _ } ->
-        (* #12173: disable CSE for atomic loads. *)
-        if is_atomic
-        then Op_other
-        else
-          Op_load
-            (match mutability with
-            | Mutable -> Mutable
-            | Immutable -> Immutable)
-      | Store (_, _, asg) -> Op_store asg
-      | Alloc _ | Poll -> assert false (* treated specially *)
-      | Intop _ -> Op_pure
-      | Intop_imm (_, _) -> Op_pure
-      | Intop_atomic _ -> Op_store true
-      | Floatop _ | Csel _ | Static_cast _ | Reinterpret_cast _ -> Op_pure
-      | Specific _ -> Op_other
-      | Name_for_debugger _ -> Op_other
-      | Probe_is_enabled _ -> Op_other
-      | Begin_region | End_region -> Op_other
-      | Dls_get -> Op_load Mutable
+module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
+  let class_of_operation0 : Operation.t -> op_class = function
+    | Move | Spill | Reload -> assert false (* treated specially *)
+    | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+    | Const_vec128 _ ->
+      Op_pure
+    | Opaque -> assert false (* treated specially *)
+    | Stackoffset _ -> Op_other
+    | Load { mutability; is_atomic; memory_chunk = _; addressing_mode = _ } ->
+      (* #12173: disable CSE for atomic loads. *)
+      if is_atomic
+      then Op_other
+      else
+        Op_load
+          (match mutability with Mutable -> Mutable | Immutable -> Immutable)
+    | Store (_, _, asg) -> Op_store asg
+    | Alloc _ | Poll -> assert false (* treated specially *)
+    | Intop _ -> Op_pure
+    | Intop_imm (_, _) -> Op_pure
+    | Intop_atomic _ -> Op_store true
+    | Floatop _ | Csel _ | Static_cast _ | Reinterpret_cast _ -> Op_pure
+    | Specific _ -> Op_other
+    | Name_for_debugger _ -> Op_other
+    | Probe_is_enabled _ -> Op_other
+    | Begin_region | End_region -> Op_other
+    | Dls_get -> Op_load Mutable
 
-    method is_cheap_operation : Operation.t -> bool =
-      function Const_int _ -> true | _ -> false
+  let class_of_operation op =
+    match Target.class_of_operation op with
+    | Class op_class -> op_class
+    | Use_default -> class_of_operation0 op
+
+  let is_cheap_operation : Operation.t -> bool = function
+    | Const_int _ -> true
+    | _ -> false
     [@@warning "-4"]
 
-    method private kill_loads (n : numbering) : numbering =
-      remove_mutable_load_numbering n
+  let kill_loads (n : numbering) : numbering = remove_mutable_load_numbering n
 
-    method private cse_instruction
-        : State.t ->
-          numbering ->
-          Cfg.basic Cfg.instruction DLL.cell ->
-          numbering =
-      fun state n cell ->
-        let i = DLL.value cell in
-        match i.desc with
-        | Reloadretaddr | Pushtrap _ | Poptrap | Prologue | Stack_check _ -> n
-        | Op (Move | Spill | Reload) ->
-          (* For moves, we associate the same value number to the result reg as
-             to the argument reg. *)
-          let n1 = set_move n i.arg.(0) i.res.(0) in
-          n1
-        | Op Opaque ->
-          (* Assume arbitrary side effects from Iopaque *)
-          empty_numbering
-        | Op (Alloc _) | Op Poll ->
-          (* For allocations, we must avoid extending the live range of a
-             pseudoregister across the allocation if this pseudoreg is a derived
-             heap pointer (a pointer into the heap that does not point to the
-             beginning of a Caml block). PR#6484 is an example of this
-             situation. Such pseudoregs have type [Addr]. Pseudoregs with types
-             other than [Addr] can be kept. Moreover, allocations and polls can
-             trigger the asynchronous execution of arbitrary Caml code
-             (finalizer, signal handler, context switch), which can contain
-             non-initializing stores. Hence, all equations over mutable loads
-             must be removed. *)
-          let n1 = kill_addr_regs (self#kill_loads n) in
-          let n2 = set_unknown_regs n1 i.res in
-          n2
-        | Op op -> (
-          match self#class_of_operation op with
-          | (Op_pure | Op_load _) as op_class -> (
-            let n1, varg = valnum_regs n i.arg in
-            let n2 = set_unknown_regs n1 (Proc.destroyed_at_basic i.desc) in
-            match find_equation op_class n1 (op, varg) with
-            | Some vres -> (
-              (* This operation was computed earlier. *)
-              (* Are there registers that hold the results computed earlier? *)
-              match find_regs_containing n1 vres with
-              | Some res when not (self#is_cheap_operation op) ->
-                (* We can replace the operation with a move, provided the
-                   registers are stable (non-volatile). If the operation is very
-                   cheap to compute, e.g. an integer constant, don't bother.*)
-                let n3 = set_known_regs n1 i.res vres in
-                (* This is n1 above and not n2 because the move does not destroy
-                   any regs *)
-                insert_move state res i.res cell;
-                DLL.delete_curr cell;
-                n3
-              | _ ->
-                (* We already computed the operation but lost its results.
-                   Associate the result registers to the result valnums of the
-                   previous operation. *)
-                let n3 = set_known_regs n2 i.res vres in
-                n3)
-            | None ->
-              (* This operation produces a result we haven't seen earlier. *)
-              let n3 = set_fresh_regs n2 i.res (op, varg) op_class in
-              n3)
-          | Op_store false | Op_other ->
-            (* An initializing store or an "other" operation do not invalidate
-               any equations, but we do not know anything about the results. *)
-            let n1 = set_unknown_regs n (Proc.destroyed_at_basic i.desc) in
-            let n2 = set_unknown_regs n1 i.res in
-            n2
-          | Op_store true ->
-            (* A non-initializing store can invalidate anything we know about
-               prior mutable loads. *)
-            let n1 = set_unknown_regs n (Proc.destroyed_at_basic i.desc) in
-            let n2 = set_unknown_regs n1 i.res in
-            let n3 = self#kill_loads n2 in
+  let cse_instruction :
+      State.t -> numbering -> Cfg.basic Cfg.instruction DLL.cell -> numbering =
+   fun state n cell ->
+    let i = DLL.value cell in
+    match i.desc with
+    | Reloadretaddr | Pushtrap _ | Poptrap | Prologue | Stack_check _ -> n
+    | Op (Move | Spill | Reload) ->
+      (* For moves, we associate the same value number to the result reg as to
+         the argument reg. *)
+      let n1 = set_move n i.arg.(0) i.res.(0) in
+      n1
+    | Op Opaque ->
+      (* Assume arbitrary side effects from Iopaque *)
+      empty_numbering
+    | Op (Alloc _) | Op Poll ->
+      (* For allocations, we must avoid extending the live range of a
+         pseudoregister across the allocation if this pseudoreg is a derived
+         heap pointer (a pointer into the heap that does not point to the
+         beginning of a Caml block). PR#6484 is an example of this situation.
+         Such pseudoregs have type [Addr]. Pseudoregs with types other than
+         [Addr] can be kept. Moreover, allocations and polls can trigger the
+         asynchronous execution of arbitrary Caml code (finalizer, signal
+         handler, context switch), which can contain non-initializing stores.
+         Hence, all equations over mutable loads must be removed. *)
+      let n1 = kill_addr_regs (kill_loads n) in
+      let n2 = set_unknown_regs n1 i.res in
+      n2
+    | Op op -> (
+      match class_of_operation op with
+      | (Op_pure | Op_load _) as op_class -> (
+        let n1, varg = valnum_regs n i.arg in
+        let n2 = set_unknown_regs n1 (Proc.destroyed_at_basic i.desc) in
+        match find_equation op_class n1 (op, varg) with
+        | Some vres -> (
+          (* This operation was computed earlier. *)
+          (* Are there registers that hold the results computed earlier? *)
+          match find_regs_containing n1 vres with
+          | Some res when not (is_cheap_operation op) ->
+            (* We can replace the operation with a move, provided the registers
+               are stable (non-volatile). If the operation is very cheap to
+               compute, e.g. an integer constant, don't bother.*)
+            let n3 = set_known_regs n1 i.res vres in
+            (* This is n1 above and not n2 because the move does not destroy any
+               regs *)
+            insert_move state res i.res cell;
+            DLL.delete_curr cell;
+            n3
+          | _ ->
+            (* We already computed the operation but lost its results. Associate
+               the result registers to the result valnums of the previous
+               operation. *)
+            let n3 = set_known_regs n2 i.res vres in
             n3)
-    [@@warning "-4"]
+        | None ->
+          (* This operation produces a result we haven't seen earlier. *)
+          let n3 = set_fresh_regs n2 i.res (op, varg) op_class in
+          n3)
+      | Op_store false | Op_other ->
+        (* An initializing store or an "other" operation do not invalidate any
+           equations, but we do not know anything about the results. *)
+        let n1 = set_unknown_regs n (Proc.destroyed_at_basic i.desc) in
+        let n2 = set_unknown_regs n1 i.res in
+        n2
+      | Op_store true ->
+        (* A non-initializing store can invalidate anything we know about prior
+           mutable loads. *)
+        let n1 = set_unknown_regs n (Proc.destroyed_at_basic i.desc) in
+        let n2 = set_unknown_regs n1 i.res in
+        let n3 = kill_loads n2 in
+        n3)
+   [@@warning "-4"]
 
-    method private cse_body
-        : State.t -> numbering -> Cfg.basic Cfg.instruction DLL.t -> numbering =
-      fun state numbering body ->
-        let numbering = ref numbering in
-        DLL.iter_cell body
-          ~f:(fun (cell : Cfg.basic Cfg.instruction DLL.cell) ->
-            numbering := self#cse_instruction state !numbering cell);
-        !numbering
+  let cse_body :
+      State.t -> numbering -> Cfg.basic Cfg.instruction DLL.t -> numbering =
+   fun state numbering body ->
+    let numbering = ref numbering in
+    DLL.iter_cell body ~f:(fun (cell : Cfg.basic Cfg.instruction DLL.cell) ->
+        numbering := cse_instruction state !numbering cell);
+    !numbering
 
-    method private cse_terminator
-        : numbering -> Cfg.terminator Cfg.instruction -> numbering =
-      fun numbering terminator ->
-        match terminator.desc with
-        | Never -> assert false
-        | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-        | Switch _ ->
-          set_unknown_regs numbering
-            (Proc.destroyed_at_terminator terminator.desc)
-        | Return | Raise _ | Tailcall_self _ | Tailcall_func _
-        | Call_no_return _ | Call _ | Prim _ ->
-          (* For function calls and probes, we should at least forget: -
-             equations involving memory loads, since the callee can perform
-             arbitrary memory stores; - equations involving arithmetic
-             operations that can produce [Addr]-typed derived pointers into the
-             heap (see below for Ialloc); - mappings from hardware registers to
-             value numbers, since the callee does not preserve these registers.
-             That doesn't leave much usable information: checkbounds could be
-             kept, but won't be usable for CSE as one of their arguments is
-             always a memory load. For simplicity, we just forget everything. *)
-          empty_numbering
-        | Specific_can_raise _ ->
-          (* CR-soon xclerc for xclerc: is it too conservative? *)
-          empty_numbering
+  let cse_terminator : numbering -> Cfg.terminator Cfg.instruction -> numbering
+      =
+   fun numbering terminator ->
+    match terminator.desc with
+    | Never -> assert false
+    | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+    | Switch _ ->
+      set_unknown_regs numbering (Proc.destroyed_at_terminator terminator.desc)
+    | Return | Raise _ | Tailcall_self _ | Tailcall_func _ | Call_no_return _
+    | Call _ | Prim _ ->
+      (* For function calls and probes, we should at least forget: - equations
+         involving memory loads, since the callee can perform arbitrary memory
+         stores; - equations involving arithmetic operations that can produce
+         [Addr]-typed derived pointers into the heap (see below for Ialloc); -
+         mappings from hardware registers to value numbers, since the callee
+         does not preserve these registers. That doesn't leave much usable
+         information: checkbounds could be kept, but won't be usable for CSE as
+         one of their arguments is always a memory load. For simplicity, we just
+         forget everything. *)
+      empty_numbering
+    | Specific_can_raise _ ->
+      (* CR-soon xclerc for xclerc: is it too conservative? *)
+      empty_numbering
 
-    method private cse_blocks : State.t -> Cfg.t -> unit =
-      fun state cfg ->
-        let visited = ref Label.Set.empty in
-        let to_visit : (numbering * Cfg.basic_block) Queue.t =
-          Queue.create ()
+  let cse_blocks : State.t -> Cfg.t -> unit =
+   fun state cfg ->
+    let visited = ref Label.Set.empty in
+    let to_visit : (numbering * Cfg.basic_block) Queue.t = Queue.create () in
+    (* As in [CSEgen], for control structures, we set the numbering to empty at
+       every join point, but propagate the current numbering across fork points.
+       This is why blocks with zero or several predecessors and exception
+       handlers start with an empty numbering: zero predecessors means we have
+       an entry point (or dead code), and several predecessors means we have an
+       entry point. *)
+    Cfg.iter_blocks cfg ~f:(fun _label block ->
+        let to_add =
+          block.is_trap_handler
+          ||
+          match Label.Set.cardinal block.predecessors with
+          | 0 -> true
+          | 1 -> false
+          | _ -> true
         in
-        (* As in CSEgen], for control structures, we set the numbering to empty
-           at every join point, but propagate the current numbering across fork
-           points. This is why blocks with zero or several predecessors and
-           exception handlers start with an empty numbering: zero predecessors
-           means we have an entry point (or dead code), and several predecessors
-           means we have an entry point. *)
-        Cfg.iter_blocks cfg ~f:(fun _label block ->
-            let to_add =
-              block.is_trap_handler
-              ||
-              match Label.Set.cardinal block.predecessors with
-              | 0 -> true
-              | 1 -> false
-              | _ -> true
-            in
-            if to_add then Queue.add (empty_numbering, block) to_visit);
-        while not (Queue.is_empty to_visit) do
-          let numbering, block = Queue.take to_visit in
-          if not (Label.Set.mem block.start !visited)
-          then (
-            if debug
-            then Format.eprintf "[cse] visiting %a\n%!" Label.format block.start;
-            visited := Label.Set.add block.start !visited;
-            let numbering = self#cse_body state numbering block.body in
-            let numbering = self#cse_terminator numbering block.terminator in
-            let successor_labels =
-              Cfg.successor_labels ~normal:true ~exn:false block
-            in
-            Label.Set.iter
-              (fun successor_label ->
-                let successor_block = Cfg.get_block_exn cfg successor_label in
-                let to_add =
-                  (* This condition is defensive / redundant, but avoids
-                     thinking too hard about weird corner cases like for
-                     instance an unreachable loop. (That particular case would
-                     actually be fine since the blocks from said loop would
-                     never be visited, meaning there is no risk they would
-                     prevent the loop from terminating.) *)
-                  (not (Label.Set.mem successor_label !visited))
-                  && Label.Set.cardinal successor_block.predecessors = 1
-                in
-                if debug
-                then
-                  Format.eprintf "[cse] successor %a to_add=%B %d\n%!"
-                    Label.format successor_label to_add
-                    (Label.Set.cardinal successor_block.predecessors);
-                if to_add then Queue.add (numbering, successor_block) to_visit)
-              successor_labels)
-        done;
-        (* The following assertion may fail if there is an unreachable loop,
-           since (as noted in the comment above), the blocks of such a loop
-           would not be visited. *)
+        if to_add then Queue.add (empty_numbering, block) to_visit);
+    while not (Queue.is_empty to_visit) do
+      let numbering, block = Queue.take to_visit in
+      if not (Label.Set.mem block.start !visited)
+      then (
         if debug
-        then assert (Label.Set.cardinal !visited = Label.Tbl.length cfg.blocks)
+        then Format.eprintf "[cse] visiting %a\n%!" Label.format block.start;
+        visited := Label.Set.add block.start !visited;
+        let numbering = cse_body state numbering block.body in
+        let numbering = cse_terminator numbering block.terminator in
+        let successor_labels =
+          Cfg.successor_labels ~normal:true ~exn:false block
+        in
+        Label.Set.iter
+          (fun successor_label ->
+            let successor_block = Cfg.get_block_exn cfg successor_label in
+            let to_add =
+              (* This condition is defensive / redundant, but avoids thinking
+                 too hard about weird corner cases like for instance an
+                 unreachable loop. (That particular case would actually be fine
+                 since the blocks from said loop would never be visited, meaning
+                 there is no risk they would prevent the loop from
+                 terminating.) *)
+              (not (Label.Set.mem successor_label !visited))
+              && Label.Set.cardinal successor_block.predecessors = 1
+            in
+            if debug
+            then
+              Format.eprintf "[cse] successor %a to_add=%B %d\n%!" Label.format
+                successor_label to_add
+                (Label.Set.cardinal successor_block.predecessors);
+            if to_add then Queue.add (numbering, successor_block) to_visit)
+          successor_labels)
+    done;
+    (* The following assertion may fail if there is an unreachable loop, since
+       (as noted in the comment above), the blocks of such a loop would not be
+       visited. *)
+    if debug
+    then assert (Label.Set.cardinal !visited = Label.Tbl.length cfg.blocks)
 
-    method cfg_with_layout : Cfg_with_layout.t -> Cfg_with_layout.t =
-      fun cfg_with_layout ->
-        let cfg = Cfg_with_layout.cfg cfg_with_layout in
-        (if not (List.mem ~set:cfg.fun_codegen_options Cfg.No_CSE)
-        then
-          let cfg_infos = Regalloc_utils.collect_cfg_infos cfg_with_layout in
-          let state = State.make ~last_used:cfg_infos.max_instruction_id in
-          self#cse_blocks state cfg);
-        cfg_with_layout
-  end
+  let cfg_with_layout : Cfg_with_layout.t -> Cfg_with_layout.t =
+   fun cfg_with_layout ->
+    let cfg = Cfg_with_layout.cfg cfg_with_layout in
+    (if not (List.mem ~set:cfg.fun_codegen_options Cfg.No_CSE)
+    then
+      let cfg_infos = Regalloc_utils.collect_cfg_infos cfg_with_layout in
+      let state = State.make ~last_used:cfg_infos.max_instruction_id in
+      cse_blocks state cfg);
+    cfg_with_layout
+end

--- a/backend/cfg/cfg_cse.mli
+++ b/backend/cfg/cfg_cse.mli
@@ -17,8 +17,7 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-(* Common subexpression elimination by value numbering over extended basic
-   blocks. *)
+(* Common subexpression elimination by value numbering over basic blocks. *)
 
 module Cse_generic (_ : Cfg_cse_target_intf.S) : sig
   val cfg_with_layout : Cfg_with_layout.t -> Cfg_with_layout.t

--- a/backend/cfg/cfg_cse_target_intf.ml
+++ b/backend/cfg/cfg_cse_target_intf.ml
@@ -15,11 +15,30 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-30-40-41-42"]
+(** Interface to be satisfied by target-specific code, for common subexpression
+    elimination. *)
 
-(* Common subexpression elimination by value numbering over extended basic
-   blocks. *)
+(** Classification of operations *)
 
-module Cse_generic (_ : Cfg_cse_target_intf.S) : sig
-  val cfg_with_layout : Cfg_with_layout.t -> Cfg_with_layout.t
+type op_class =
+  | Op_pure (* *pure arithmetic, produce one or several result *)
+  | Op_load of Simple_operation.mutable_flag  (** memory load *)
+  | Op_store of bool  (** memory store, false = init, true = assign *)
+  | Op_other  (** anything else that does not allocate nor store in memory *)
+
+type class_of_operation_result =
+  | Class of op_class
+  | Use_default
+
+type is_cheap_operation_result =
+  | Cheap of bool
+  | Use_default
+
+module type S = sig
+  (** The following methods can be overridden to handle processor-specific
+       operations. *)
+  val class_of_operation : Operation.t -> class_of_operation_result
+
+  (** Operations that are so cheap that it isn't worth factoring them. *)
+  val is_cheap_operation : Operation.t -> is_cheap_operation_result
 end

--- a/backend/cfg/cfg_cse_target_intf.ml
+++ b/backend/cfg/cfg_cse_target_intf.ml
@@ -21,7 +21,7 @@
 (** Classification of operations *)
 
 type op_class =
-  | Op_pure (* *pure arithmetic, produce one or several result *)
+  | Op_pure (** pure arithmetic, produce one or several result *)
   | Op_load of Simple_operation.mutable_flag  (** memory load *)
   | Op_store of bool  (** memory store, false = init, true = assign *)
   | Op_other  (** anything else that does not allocate nor store in memory *)

--- a/backend/cfg/cfg_cse_target_intf.ml
+++ b/backend/cfg/cfg_cse_target_intf.ml
@@ -21,7 +21,7 @@
 (** Classification of operations *)
 
 type op_class =
-  | Op_pure (** pure arithmetic, produce one or several result *)
+  | Op_pure  (** pure arithmetic, produce one or several result *)
   | Op_load of Simple_operation.mutable_flag  (** memory load *)
   | Op_store of bool  (** memory store, false = init, true = assign *)
   | Op_other  (** anything else that does not allocate nor store in memory *)

--- a/dune
+++ b/dune
@@ -502,6 +502,7 @@
   cfg_loop_infos
   cfg_to_linear_desc
   cfg_cse
+  cfg_cse_target_intf
   cfg_stack_checks
   cfg_polling
   eliminate_dead_code


### PR DESCRIPTION
Same approach as taken for instruction selection (#3782 ).