### PR TITLE
Specific instructions cannot raise

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -159,6 +159,7 @@ type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
 type float_width = Cmm.float_width
 
+(* Specific operations, include [Simd], must not raise. *)
 type specific_operation =
     Ilea of addressing_mode            (* "lea" gives scaled adds *)
   | Istore_int of nativeint * addressing_mode * bool
@@ -331,16 +332,6 @@ let operation_is_pure = function
   | Icldemote _ | Iprefetch _ -> false
   | Isimd op -> Simd.is_pure op
   | Isimd_mem (op, _addr) -> Simd.Mem.is_pure op
-
-(* Specific operations that can raise *)
-(* Keep in sync with [Vectorize_specific] *)
-let operation_can_raise = function
-  | Ilea _ | Ibswap _ | Isextend32 | Izextend32
-  | Ifloatarithmem _
-  | Irdtsc | Irdpmc | Ipause | Isimd _ | Isimd_mem _
-  | Ilfence | Isfence | Imfence
-  | Istore_int (_, _, _) | Ioffset_loc (_, _)
-  | Icldemote _ | Iprefetch _ -> false
 
 (* Keep in sync with [Vectorize_specific] *)
 let operation_allocates = function

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -159,7 +159,7 @@ type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
 type float_width = Cmm.float_width
 
-(* Specific operations, include [Simd], must not raise. *)
+(* Specific operations, including [Simd], must not raise. *)
 type specific_operation =
     Ilea of addressing_mode            (* "lea" gives scaled adds *)
   | Istore_int of nativeint * addressing_mode * bool

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -136,8 +136,6 @@ val win64 : bool
 
 val operation_is_pure : specific_operation -> bool
 
-val operation_can_raise : specific_operation -> bool
-
 val operation_allocates : specific_operation -> bool
 
 val float_cond_and_need_swap

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -125,9 +125,7 @@ let is_immediate_natint n =
   Nativeint.compare n 0x7FFF_FFFFn <= 0
   && Nativeint.compare n (-0x8000_0000n) >= 0
 
-let specific x : Cfg.basic_or_terminator =
-  assert (not (Arch.operation_can_raise x));
-  Basic (Op (Specific x))
+let specific x : Cfg.basic_or_terminator = Basic (Op (Specific x))
 
 let pseudoregs_for_operation op arg res =
   match (op : Operation.t) with

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -617,12 +617,6 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
     assert (stack_ofs >= 0);
     if alloc || stack_ofs > 0 then all_phys_regs else destroyed_at_c_call
   | Call {op = Indirect | Direct _; _} -> all_phys_regs
-  | Specific_can_raise { op = (Ilea _ | Ibswap _ | Isextend32 | Izextend32
-                       | Ifloatarithmem _ | Irdtsc | Irdpmc | Ipause
-                       | Isimd _ | Isimd_mem _ | Ilfence | Isfence | Imfence
-                       | Istore_int (_, _, _) | Ioffset_loc (_, _)
-                       | Icldemote _ | Iprefetch _); _ } ->
-    Misc.fatal_error "no instructions specific for this architecture can raise"
 
 (* CR-soon xclerc for xclerc: consider having more destruction points.
    We current return `true` when `destroyed_at_terminator` returns
@@ -647,12 +641,6 @@ let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_int
       if alloc then true else false
   | Call {op = Indirect | Direct _; _} ->
     true
-  | Specific_can_raise { op = (Ilea _ | Ibswap _ | Isextend32 | Izextend32
-                       | Ifloatarithmem _ | Irdtsc | Irdpmc | Ipause
-                       | Isimd _ | Isimd_mem _ | Ilfence | Isfence | Imfence
-                       | Istore_int (_, _, _) | Ioffset_loc (_, _)
-                       | Icldemote _ | Iprefetch _); _ } ->
-    Misc.fatal_error "no instructions specific for this architecture can raise"
 
 (* Layout of the stack frame *)
 

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -291,5 +291,3 @@ let terminator (map : spilled_map) (term : Cfg.terminator Cfg.instruction) =
     May_still_have_spilled_registers
   | Prim {op = Probe _; _} ->
     may_use_stack_operands_everywhere map term
-  | Specific_can_raise _ ->
-    fatal "no instructions specific for this architecture can raise"

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -320,23 +320,6 @@ let operation_is_pure : specific_operation -> bool = function
 
 (* Specific operations that can raise *)
 
-let operation_can_raise = function
-  | Ifar_alloc _
-  | Ifar_poll -> true
-  | Imuladd
-  | Imulsub
-  | Inegmulf
-  | Imuladdf
-  | Inegmuladdf
-  | Imulsubf
-  | Inegmulsubf
-  | Isqrtf
-  | Imove32
-  | Ishiftarith (_, _)
-  | Isignext _
-  | Ibswap _
-  | Isimd _ -> false
-
 let operation_allocates = function
   | Ifar_alloc _ -> true
   | Ifar_poll

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -52,6 +52,7 @@ type cmm_label = Label.t
 
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
+(* Specific operations, include [Simd], must not raise. *)
 type specific_operation =
   | Ifar_poll
   | Ifar_alloc of { bytes : int; dbginfo : Cmm.alloc_dbginfo }

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -52,7 +52,7 @@ type cmm_label = Label.t
 
 type bswap_bitwidth = Sixteen | Thirtytwo | Sixtyfour
 
-(* Specific operations, include [Simd], must not raise. *)
+(* Specific operations, including [Simd], must not raise. *)
 type specific_operation =
   | Ifar_poll
   | Ifar_alloc of { bytes : int; dbginfo : Cmm.alloc_dbginfo }

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -115,8 +115,6 @@ val operation_allocates : specific_operation -> bool
 
 (* Specific operations that can raise *)
 
-val operation_can_raise : specific_operation -> bool
-
 val isomorphic_specific_operation : specific_operation -> specific_operation -> bool
 
 (* See `amd64/arch.mli`. *)

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -64,10 +64,7 @@ let select_bitwidth : Cmm.bswap_bitwidth -> Arch.bswap_bitwidth = function
   | Thirtytwo -> Thirtytwo
   | Sixtyfour -> Sixtyfour
 
-let specific x ~label_after : Cfg.basic_or_terminator =
-  if Arch.operation_can_raise x
-  then Terminator (Specific_can_raise { op = x; label_after })
-  else Basic (Op (Specific x))
+let specific x : Cfg.basic_or_terminator = Basic (Op (Specific x))
 
 let is_immediate (op : Simple_operation.integer_operation) n :
     Cfg_selectgen_target_intf.is_immediate_result =
@@ -114,9 +111,8 @@ let select_addressing chunk (expr : Cmm.expression) :
   | arg -> Iindexed 0, arg
 
 let select_operation ~generic_select_condition:_ (op : Cmm.operation)
-    (args : Cmm.expression list) _dbg ~label_after :
+    (args : Cmm.expression list) _dbg ~label_after:_ :
     Cfg_selectgen_target_intf.select_operation_result =
-  let[@inline] specific op = specific op ~label_after in
   let[@inline] rewrite_multiply_add_or_sub shift_op mul_op ~arg1 ~args2 dbg :
       Cfg_selectgen_target_intf.select_operation_result =
     Select_operation_then_rewrite

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -400,8 +400,7 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
     all_phys_regs
   | Always _ | Parity_test _ | Truth_test _ | Float_test _
   | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
-  | Tailcall_func _ | Prim {op = Probe _; _}
-  | Specific_can_raise _ ->
+  | Tailcall_func _ | Prim {op = Probe _; _} ->
     [||]
   | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; _ }
   | Prim {op  = External { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; _ }; _} ->
@@ -419,8 +418,7 @@ let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_int
     true
   | Always _ | Parity_test _ | Truth_test _ | Float_test _
   | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
-  | Tailcall_func _ | Prim {op = Probe _; _}
-  | Specific_can_raise _ ->
+  | Tailcall_func _ | Prim {op = Probe _; _} ->
     false
   | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs = _; _}
   | Prim {op  = External { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs = _; _}; _} ->

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -338,8 +338,8 @@ module Transfer = struct
           (* CR xclerc for xclerc: TODO *)
           None, unreachable
         | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-        | Switch _ | Call _ | Prim _ | Specific_can_raise _ | Return | Raise _
-        | Tailcall_func _ | Call_no_return _ ->
+        | Switch _ | Call _ | Prim _ | Return | Raise _ | Tailcall_func _
+        | Call_no_return _ ->
           common ~avail_before ~destroyed_at:Proc.destroyed_at_terminator
             ~is_interesting_constructor:
               Cfg.(
@@ -348,7 +348,7 @@ module Transfer = struct
                 | Call _ | Prim { op = Probe _; label_after = _ } -> true
                 | Always _ | Parity_test _ | Truth_test _ | Float_test _
                 | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
-                | Tailcall_func _ | Call_no_return _ | Specific_can_raise _
+                | Tailcall_func _ | Call_no_return _
                 | Prim { op = External _; label_after = _ } ->
                   false)
             ~is_end_region:(fun _ -> false)

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -442,9 +442,6 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
          one of their arguments is always a memory load. For simplicity, we just
          forget everything. *)
       empty_numbering
-    | Specific_can_raise _ ->
-      (* CR-soon xclerc for xclerc: is it too conservative? *)
-      empty_numbering
 
   let cse_blocks : State.t -> Cfg.t -> unit =
    fun state cfg ->

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -153,7 +153,6 @@ module S = struct
        avoid the hack in [can_raise_terminator] *)
     | Call of func_call_operation with_label_after
     | Prim of prim_call_operation with_label_after
-    | Specific_can_raise of Arch.specific_operation with_label_after
 
   type basic_or_terminator =
     | Basic of basic

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -130,9 +130,9 @@ let check_tailrec t _label block =
       then
         report t "Two self-tailcall terminators with different labels: %a %a"
           Label.print l Label.print destination)
-  | Call _ | Prim _ | Specific_can_raise _ | Tailcall_func _ | Never | Always _
-  | Parity_test _ | Truth_test _ | Float_test _ | Int_test _ | Switch _ | Return
-  | Raise _ | Call_no_return _ ->
+  | Call _ | Prim _ | Tailcall_func _ | Never | Always _ | Parity_test _
+  | Truth_test _ | Float_test _ | Int_test _ | Switch _ | Return | Raise _
+  | Call_no_return _ ->
     ()
 
 let check_can_raise t label (block : Cfg.basic_block) =

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -88,7 +88,7 @@ module Transfer :
         ~exn Domain.bot instr
     | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
     | Switch _ | Return | Raise _ | Tailcall_func _ | Call_no_return _ | Call _
-    | Prim _ | Specific_can_raise _ ->
+    | Prim _ ->
       instruction
         ~can_raise:(Cfg.can_raise_terminator instr.desc)
         ~exn domain instr

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -131,7 +131,7 @@ let is_safe_terminator : Cfg.terminator Cfg.instruction -> bool =
     false
   | Raise _ -> false
   | Tailcall_self _ | Tailcall_func _ | Return -> true
-  | Call_no_return _ | Call _ | Prim _ | Specific_can_raise _ -> false
+  | Call_no_return _ | Call _ | Prim _ -> false
 
 let is_safe_block : Cfg.basic_block -> bool =
  fun block ->
@@ -212,7 +212,7 @@ module Polls_before_prtc_transfer = struct
       then Ok Might_not_poll
       else Ok Always_polls
     | Return -> Ok Always_polls
-    | Call_no_return _ | Call _ | Prim _ | Specific_can_raise _ ->
+    | Call_no_return _ | Call _ | Prim _ ->
       if Cfg.can_raise_terminator term.desc
       then Ok (Polls_before_prtc_domain.join dom exn)
       else Ok dom
@@ -365,7 +365,7 @@ let add_calls_terminator :
   match term.desc with
   | Never -> assert false
   | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-  | Switch _ | Return | Raise _ | Specific_can_raise _ ->
+  | Switch _ | Return | Raise _ ->
     points
   | Tailcall_self _ | Tailcall_func _ -> (Function_call, term.dbg) :: points
   | Call _ -> (Function_call, term.dbg) :: points

--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -41,11 +41,6 @@ let is_nontail_call : Cfg.terminator -> bool =
   | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
   | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _ | Prim _ ->
     false
-  | Specific_can_raise _ ->
-    (* Specific operations cannot raise, and hence cannot call OCaml functions;
-       for the purpose of this check it is thus fine to return `false` even
-       though a specific operation may call some C code. *)
-    false
 
 (* Returns the stack check info, and the max of seen instruction ids. *)
 let block_preproc_stack_check_result :

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -197,8 +197,6 @@ let linearize_terminator cfg_with_layout (func : string) start
           Lprobe { name; handler_code_sym; enabled_at_init }
       in
       branch_or_fallthrough [L.Lcall_op op] label_after, None
-    | Specific_can_raise { op; label_after } ->
-      branch_or_fallthrough [L.Lop (Specific op)] label_after, None
     | Switch labels -> single (L.Lswitch labels)
     | Never -> Misc.fatal_error "Cannot linearize terminator: Never"
     | Always label -> branch_or_fallthrough [] label, None
@@ -340,7 +338,7 @@ let need_starting_label (cfg_with_layout : CL.t) (block : Cfg.basic_block)
       | Switch _ -> true
       | Never -> Misc.fatal_error "Cannot linearize terminator: Never"
       | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-      | Call _ | Prim _ | Specific_can_raise _ ->
+      | Call _ | Prim _ ->
         (* If the label came from the original [Linear] code, preserve it for
            checking that the conversion from [Linear] to [Cfg] and back is the
            identity; and for various assertions in reorder. *)

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -121,8 +121,7 @@ let evaluate_terminator ~(reg : Reg.t) ~(const : nativeint)
     else None
   | Never -> assert false
   | Always _ | Float_test _ | Return | Raise _ | Tailcall_self _
-  | Tailcall_func _ | Call_no_return _ | Call _ | Prim _ | Specific_can_raise _
-    ->
+  | Tailcall_func _ | Call_no_return _ | Call _ | Prim _ ->
     None
 
 let is_last_instruction_const_int (body : C.basic C.instruction Dll.t) :
@@ -195,7 +194,7 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
       simplify_switch block labels;
       false)
   | Raise _ | Return | Tailcall_self _ | Tailcall_func _ | Call_no_return _
-  | Call _ | Prim _ | Specific_can_raise _ ->
+  | Call _ | Prim _ ->
     false
 
 let run cfg =

--- a/backend/cfg_selectgen_target_intf.ml
+++ b/backend/cfg_selectgen_target_intf.ml
@@ -84,6 +84,9 @@ module type S = sig
   val select_addressing :
     Cmm.memory_chunk -> Cmm.expression -> Arch.addressing_mode * Cmm.expression
 
+  (* CR-soon gyorsh: remove unused [label_after], maybe simplify
+     [select_operation_result] to return [Cfg.basic] instead of
+     [Cfg.basic_or_terminator]. *)
   val select_operation :
     generic_select_condition:
       (Cmm.expression -> Simple_operation.test * Cmm.expression) ->

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -103,9 +103,7 @@ let is_pure = function
   | Opaque -> false
   | Begin_region -> false
   | End_region -> false
-  | Specific s ->
-    assert (not (Arch.operation_can_raise s));
-    Arch.operation_is_pure s
+  | Specific s -> Arch.operation_is_pure s
   | Name_for_debugger _ -> false
   | Dls_get -> true
   | Poll -> false

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -15,36 +15,12 @@ let precondition : Cfg_with_layout.t -> unit =
       | Move -> ()
       | Spill -> fatal "instruction %a is a spill" InstructionId.format id
       | Reload -> fatal "instruction %a is a reload" InstructionId.format id
-      | Const_int _ -> ()
-      | Const_float32 _ -> ()
-      | Const_float _ -> ()
-      | Const_symbol _ -> ()
-      | Const_vec128 _ -> ()
-      | Stackoffset _ -> ()
-      | Load _ -> ()
-      | Store _ -> ()
-      | Intop _ -> ()
-      | Intop_imm _ -> ()
-      | Intop_atomic _ -> ()
-      | Floatop _ -> ()
-      | Csel _ -> ()
-      | Reinterpret_cast _ -> ()
-      | Static_cast _ -> ()
-      | Probe_is_enabled _ -> ()
-      | Opaque -> ()
-      | Begin_region -> ()
-      | End_region -> ()
-      | Specific op ->
-        if Arch.operation_can_raise op
-        then
-          fatal
-            "architecture specific instruction %a that can raise but isn't a \
-             terminator"
-            InstructionId.format id
-      | Name_for_debugger _ -> ()
-      | Dls_get -> ()
-      | Poll -> ()
-      | Alloc _ -> ())
+      | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+      | Const_vec128 _ | Stackoffset _ | Load _ | Store _ | Intop _
+      | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
+      | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region | End_region
+      | Specific _ | Name_for_debugger _ | Dls_get | Poll | Alloc _ ->
+        ())
     | Reloadretaddr | Pushtrap _ | Poptrap | Prologue | Stack_check _ -> ()
   in
   let register_must_not_be_on_stack (id : InstructionId.t) (reg : Reg.t) : unit

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -378,7 +378,7 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
             add_phi_moves_to_instr_list state ~before:predecessor_block
               ~phi:block substs to_unify predecessor_block.body
           | Switch _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-          | Call _ | Prim _ | Specific_can_raise _ ->
+          | Call _ | Prim _ ->
             let instrs = DLL.make_empty () in
             add_phi_moves_to_instr_list state ~before:predecessor_block
               ~phi:block substs to_unify instrs;

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -390,7 +390,7 @@ let remove_prologue_if_not_required : Cfg_with_layout.t -> unit =
         assert removed
       | Never | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
       | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _
-      | Call_no_return _ | Call _ | Prim _ | Specific_can_raise _ ->
+      | Call_no_return _ | Call _ | Prim _ ->
         assert false
 
 let update_live_fields : Cfg_with_layout.t -> liveness -> unit =
@@ -471,8 +471,7 @@ let update_spill_cost : Cfg_with_infos.t -> flat:bool -> unit -> unit =
       | Prim { op = Probe _; _ } -> ()
       | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
       | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
-      | Tailcall_func _ | Call_no_return _ | Call _ | Prim _
-      | Specific_can_raise _ ->
+      | Tailcall_func _ | Call_no_return _ | Call _ | Prim _ ->
         update_instr cost block.terminator)
 
 let check_length str arr expected =

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -593,11 +593,6 @@ end = struct
     (* CR-someday azewierzejew: Avoid using polymorphic comparison. *)
       when Stdlib.compare prim1 prim2 = 0 ->
       compare_label l1 l2
-    | ( Specific_can_raise { op = op1; label_after = l1 },
-        Specific_can_raise { op = op2; label_after = l2 } )
-    (* CR-someday azewierzejew: Avoid using polymorphic comparison. *)
-      when Stdlib.compare op1 op2 = 0 ->
-      compare_label l1 l2
     | _ ->
       Regalloc_utils.fatal
         "The desc of terminator with id %a changed, before: %a, after: %a."

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -501,8 +501,7 @@ module Stack_offset_and_exn = struct
         InstructionId.format term.id
     | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
     | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
-    | Tailcall_func _ | Call_no_return _ | Call _ | Prim _
-    | Specific_can_raise _ ->
+    | Tailcall_func _ | Call_no_return _ | Call _ | Prim _ ->
       stack_offset, traps
 
   let rec process_basic :

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2209,15 +2209,15 @@ end = struct
     let desc = "Arch.specific_operation" in
     report t next ~msg:"transform_specific next" ~desc dbg;
     report t exn ~msg:"transform_specific exn" ~desc dbg;
-    let can_raise = Arch.operation_can_raise s in
     let effect =
       let w = create_witnesses t Arch_specific dbg in
-      match Metadata.assume_value dbg ~can_raise w with
+      match Metadata.assume_value dbg ~can_raise:false w with
       | Some v -> v
       | None ->
         (* Conservatively assume that operation can return normally. *)
         let nor = if Arch.operation_allocates s then V.top w else V.safe in
-        let exn = if Arch.operation_can_raise s then nor else V.bot in
+        (* Specific operations cannot raise *)
+        let exn = V.bot in
         (* Assume that the operation does not diverge. *)
         let div = V.bot in
         { Value.nor; exn; div }
@@ -2581,8 +2581,6 @@ end = struct
           let w = create_witnesses t (Direct_call { callee = func }) dbg in
           transform_call t ~next ~exn func w ~desc:("direct call to " ^ func)
             dbg
-        | Specific_can_raise { op = s; _ } ->
-          transform_specific t s ~next ~exn dbg
 
       let terminator next ~exn (i : Cfg.terminator Cfg.instruction) t =
         Ok (terminator next ~exn i t)
@@ -2662,7 +2660,7 @@ let update_caml_flambda_invalid_cfg cfg_with_layout =
         | Prim { op = Probe _; _ }
         | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
         | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
-        | Tailcall_func _ | Call_no_return _ | Call _ | Specific_can_raise _ ->
+        | Tailcall_func _ | Call_no_return _ | Call _ ->
           ());
     if !modified
     then


### PR DESCRIPTION
Remove terminator `Cfg.Specific_can_raise` and `Arch.can_raise_operation`.

Currently arm64 and amd64 don't have specific instructions that can raise. Removing this terminator from CFG simplifies some passes.