### PR TITLE
Infer with-kinds for GADTs, using `Tof_kind` for existentials

### DIFF
--- a/jane/doc/proposals/kind-inference.md
+++ b/jane/doc/proposals/kind-inference.md
@@ -480,7 +480,7 @@ m_portability = portable
     Γ ⊢ κᵢ ≤ χᵢ
   κ₀' = κ₀{τsⱼ/[['aᵢ]]}
   ∀ Ξ:
-    mode m_Ξ ≤ Ξ(κ₀')
+    mode mⱼ_Ξ ≤ Ξ(κ₀')
     ∀ σ ∈ types_for(Ξ, field_typesⱼ), with σ ≤ Ξ(κ₀')
   value ≤ lay(κ₀')
 if [@@unboxed]:

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1255,27 +1255,13 @@ type 'a contended : immutable_data with 'a @@ contended
 type 'a contended_with_int : immutable_data with 'a @@ contended
 |}]
 
-(* Parsing implemented, but kind-checking not yet implemented *)
 type 'a abstract
 type existential_abstract : immutable_data with (type : value mod portable) abstract =
   | Mk : ('a : value mod portable) abstract -> existential_abstract
 [%%expect{|
 type 'a abstract
-Lines 2-3, characters 0-67:
-2 | type existential_abstract : immutable_data with (type : value mod portable) abstract =
-3 |   | Mk : ('a : value mod portable) abstract -> existential_abstract
-Error: The kind of type "existential_abstract" is value mod non_float
-         because it's a boxed variant type.
-       But the kind of type "existential_abstract" must be a subkind of
-         immutable_data with (type : value mod portable) abstract
-         because of the annotation on the declaration of the type existential_abstract.
-|}]
-
-type test_printing = (type : value) * (type : value) * (x:(type : value) -> int) -> (type : value)
-[%%expect{|
-type test_printing =
-    (type : value) * (type : value) * (x:(type : value) -> int) -> (type :
-    value)
+type existential_abstract =
+    Mk : ('a : value mod portable). 'a abstract -> existential_abstract
 |}]
 
 (* not yet supported *)

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -61,12 +61,8 @@ type t = Foo : ('a : immutable_data). 'a -> t
 |}]
 
 let foo (t : t @ contended) = use_uncontended t
-(* CR layouts v2.8: fix this *)
 [%%expect {|
-Line 1, characters 46-47:
-1 | let foo (t : t @ contended) = use_uncontended t
-                                                  ^
-Error: This value is "contended" but expected to be "uncontended".
+val foo : t @ contended -> unit = <fun>
 |}]
 
 let foo (t : t @ local) = use_global t [@nontail]
@@ -85,21 +81,16 @@ type 'a t = Foo : 'a -> 'a t
 |}]
 
 let foo (t : int t @ once) = use_many t
-(* CR layouts v2.8: fix this *)
 [%%expect {|
-Line 1, characters 38-39:
-1 | let foo (t : int t @ once) = use_many t
-                                          ^
-Error: This value is "once" but expected to be "many".
+val foo : int t @ once -> unit = <fun>
 |}]
 
-let foo (t : t @ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 13-14:
-1 | let foo (t : t @ aliased) = use_unique t
-                 ^
-Error: The type constructor "t" expects 1 argument(s),
-       but is here applied to 0 argument(s)
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
+Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (***********************************************************************)
@@ -158,4 +149,500 @@ Uncaught exception: Misc.Fatal_error
 |}]
 
 (*****************************************)
-(* CR layouts v2.8: write more gadt tests *)
+
+type ('a, 'b) t : immutable_data with 'a = { inner : 'a }
+[%%expect{|
+type ('a, 'b) t = { inner : 'a; }
+|}]
+
+(* We can have existential variables, as long as they don't end up in our with-bounds *)
+type 'a u : immutable_data with 'a =
+| P1 : ('a1, 'b) t -> 'a1 u
+| P2 : ('a2, 'b) t -> 'a2 u
+[%%expect{|
+type 'a u = P1 : ('a1, 'b) t -> 'a1 u | P2 : ('a2, 'b) t -> 'a2 u
+|}]
+
+(* Any existentials in the with-bounds turn into [(type : kind)] then get normalized away.
+   (this test intentionally causes a subkind error to make sure that the existentials
+   don't show up in the with-bounds)
+*)
+type 'x u : immediate =
+| P1 : ('b, 'a1) t -> 'a1 u
+[%%expect{|
+Lines 1-2, characters 0-27:
+1 | type 'x u : immediate =
+2 | | P1 : ('b, 'a1) t -> 'a1 u
+Error: The kind of type "u" is value
+         because it's a boxed variant type.
+       But the kind of type "u" must be a subkind of immediate
+         because of the annotation on the declaration of the type u.
+|}]
+
+type 'a u : immutable_data =
+| P1 : ('b, 'a) t -> 'a u
+[%%expect{|
+Lines 1-2, characters 0-25:
+1 | type 'a u : immutable_data =
+2 | | P1 : ('b, 'a) t -> 'a u
+Error: The kind of type "u" is value
+         because it's a boxed variant type.
+       But the kind of type "u" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type u.
+|}]
+
+(* CR layouts v2.8: It'd also be OK to infer or accept [immutable_data with 'y] here. *)
+type ('x, 'y) t : immutable_data with 'x with 'y =
+  | T : 'a -> ('a, 'a) t
+  | U : 'c -> ('b,  'c) t
+[%%expect{|
+type ('x, 'y) t = T : 'a -> ('a, 'a) t | U : 'c -> ('b, 'c) t
+|}]
+
+type 'a t : immediate =
+  | A : 'b -> 'b option t
+[%%expect{|
+Lines 1-2, characters 0-25:
+1 | type 'a t : immediate =
+2 |   | A : 'b -> 'b option t
+Error: The kind of type "t" is value
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of immediate
+         because of the annotation on the declaration of the type t.
+|}]
+
+type 'a t : immutable_data =
+  | A : ('b : immutable_data). 'b -> 'b option t
+[%%expect{|
+type 'a t = A : ('b : immutable_data). 'b -> 'b option t
+|}]
+
+type 'a t : immediate =
+  | A : ('b : immutable_data). 'b -> 'b option t
+[%%expect{|
+Lines 1-2, characters 0-48:
+1 | type 'a t : immediate =
+2 |   | A : ('b : immutable_data). 'b -> 'b option t
+Error: The kind of type "t" is immutable_data
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of immediate
+         because of the annotation on the declaration of the type t.
+|}]
+
+type 'a cell : mutable_data with 'a =
+  | Nil : 'a cell
+  | Cons of { value : 'a; mutable next: 'a cell }
+[%%expect{|
+type 'a cell =
+    Nil : 'a cell
+  | Cons of { value : 'a; mutable next : 'a cell; }
+|}]
+
+type 'a cell : mutable_data with 'a =
+  | Nil
+  | Cons : { value : 'b; mutable next: 'b cell } -> 'b cell
+[%%expect{|
+type 'a cell =
+    Nil
+  | Cons : { value : 'b; mutable next : 'b cell; } -> 'b cell
+|}]
+
+(* Existentials that are the type arguments to abstract types should end up as [type :
+   kind] in the with-bounds.
+
+   This test intentionally triggers a kind error to check this via the printed kind in the
+   error message. *)
+type 'a abstract : value mod portable
+type existential_abstract : immediate =
+  | P : ('a : value mod portable). 'a abstract -> existential_abstract
+[%%expect{|
+type 'a abstract : value mod portable
+Lines 2-3, characters 0-70:
+2 | type existential_abstract : immediate =
+3 |   | P : ('a : value mod portable). 'a abstract -> existential_abstract
+Error: The kind of type "existential_abstract" is immutable_data
+         with (type : value mod portable) abstract
+         because it's a boxed variant type.
+       But the kind of type "existential_abstract" must be a subkind of
+         immediate
+         because of the annotation on the declaration of the type existential_abstract.
+|}]
+
+type existential_abstract : immutable_data with (type : value mod portable) abstract =
+  | P : ('a : value mod portable). 'a abstract -> existential_abstract
+[%%expect{|
+type existential_abstract =
+    P : ('a : value mod portable). 'a abstract -> existential_abstract
+|}]
+
+type existential_abstract : value mod portable =
+  | P : ('a : value mod portable). 'a abstract -> existential_abstract
+[%%expect{|
+type existential_abstract =
+    P : ('a : value mod portable). 'a abstract -> existential_abstract
+|}]
+
+let foo (x : existential_abstract @ nonportable) =
+  use_portable x
+
+module M : sig
+  type t : immutable_data with (type : value mod portable) abstract
+end = struct
+  type t = P : ('a : value mod portable). 'a abstract -> t
+end
+[%%expect{|
+val foo : existential_abstract -> unit = <fun>
+module M :
+  sig type t : immutable_data with (type : value mod portable) abstract end
+|}]
+
+module M : sig
+  type t : immutable_data with (type : value) abstract
+end = struct
+  type t = P : ('a : immediate). 'a abstract -> t
+end
+(* CR layouts v2.8: This might be safe to accept, but it's tricky and unlikely to be
+   especially useful. Revisit later. It will require descending into arguments of non-best
+   Tconstrs, checking to see if corresponding arguments are in a sub-kind relationship --
+   but only if at least the argument on the right is best. Subtle. *)
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = P : ('a : immediate). 'a abstract -> t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = P : ('a : immediate). 'a abstract -> t end
+       is not included in
+         sig type t : immutable_data with (type : value) abstract end
+       Type declarations do not match:
+         type t = P : ('a : immediate). 'a abstract -> t
+       is not included in
+         type t : immutable_data with (type : value) abstract
+       The kind of the first is immutable_data
+         with (type : immediate) abstract
+         because of the definition of t at line 4, characters 2-49.
+       But the kind of the first must be a subkind of immutable_data
+         with (type : value) abstract
+         because of the definition of t at line 2, characters 2-54.
+|}]
+
+(* Some hard recursive types with existentials *)
+type existential_abstract : value mod portable with (type : value mod portable) abstract =
+  | P : ('a : value mod portable). 'a abstract t2 -> existential_abstract
+and 'a t2 = P : { contents : 'a; other : ('b : value mod portable) option } -> 'a t2
+and 'a abstract : value mod portable
+[%%expect{|
+type existential_abstract =
+    P : ('a : value mod portable). 'a abstract t2 -> existential_abstract
+and 'a t2 =
+    P : 'a ('b : value mod portable). { contents : 'a; other : 'b option;
+    } -> 'a t2
+and 'a abstract : value mod portable
+|}]
+
+(* Actually mode crossing for [type : kind] *)
+
+module type S = sig
+  type 'a b
+  type t = P : ('a : value mod portable) b -> t
+end
+[%%expect{|
+module type S =
+  sig type 'a b type t = P : ('a : value mod portable). 'a b -> t end
+|}]
+
+module F1(M : S) = struct
+  let foo (x : M.t @ nonportable) = use_portable x
+end
+[%%expect{|
+Line 2, characters 49-50:
+2 |   let foo (x : M.t @ nonportable) = use_portable x
+                                                     ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+module F2(M : S with type 'a b = int) = struct
+  type t : immutable_data = M.t
+  let foo1 (x : M.t @ nonportable) = use_portable x
+  let foo2 (x : M.t @ contended) = use_uncontended x
+end
+[%%expect{|
+module F2 :
+  functor
+    (M : sig
+           type 'a b = int
+           type t = P : ('a : value mod portable). 'a b -> t
+         end)
+    ->
+    sig
+      type t = M.t
+      val foo1 : M.t -> unit
+      val foo2 : M.t @ contended -> unit
+    end
+|}]
+
+module F3(M : S with type 'a b = 'a) = struct
+  type t : value mod portable = M.t
+  let foo (x : t @ nonportable) = use_portable x
+end
+[%%expect{|
+module F3 :
+  functor
+    (M : sig
+           type 'a b = 'a
+           type t = P : ('a : value mod portable). 'a b -> t
+         end)
+    -> sig type t = M.t val foo : t -> unit end
+|}]
+
+module F4(M : S with type 'a b = 'a) = struct
+  let foo (x : M.t @ contended) = use_uncontended x
+end
+[%%expect{|
+Line 2, characters 50-51:
+2 |   let foo (x : M.t @ contended) = use_uncontended x
+                                                      ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+(* _ in parameters *)
+
+(* CR layouts v2.8: Printing [_] here is not wrong (and in fact the overall inferred kind
+   is correct), but it's a little strange and will probably be confusing to users.
+   Probably the best thing to do is to number the distinct [_]s when printing and print
+   them as something like [_1], [_2], etc. *)
+
+type _ box = Box : 'a -> 'a box
+[%%expect{|
+type _ box = Box : 'a -> 'a box
+|}]
+
+let foo (x : int box @ contended) = use_uncontended x
+[%%expect{|
+val foo : int box @ contended -> unit = <fun>
+|}]
+
+let should_reject (x : int ref box @ contended) = use_uncontended x
+[%%expect{|
+Line 1, characters 66-67:
+1 | let should_reject (x : int ref box @ contended) = use_uncontended x
+                                                                      ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+
+type (_, _) box2 = Box2 : 'a -> ('a, 'a) box2
+[%%expect{|
+type (_, _) box2 = Box2 : 'a -> ('a, 'a) box2
+|}]
+
+let foo (x : (int, int) box2 @ contended) = use_uncontended x
+[%%expect{|
+val foo : (int, int) box2 @ contended -> unit = <fun>
+|}]
+
+let should_reject (x : (int ref, int ref) box2 @ contended) = use_uncontended x
+[%%expect{|
+Line 1, characters 78-79:
+1 | let should_reject (x : (int ref, int ref) box2 @ contended) = use_uncontended x
+                                                                                  ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+type show_me_the_kind : immediate = (int ref, int ref) box2
+[%%expect{|
+Line 1, characters 0-59:
+1 | type show_me_the_kind : immediate = (int ref, int ref) box2
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "(int ref, int ref) box2" is mutable_data
+         because of the definition of box2 at line 1, characters 0-45.
+       But the kind of type "(int ref, int ref) box2" must be a subkind of
+         immediate
+         because of the definition of show_me_the_kind at line 1, characters 0-59.
+|}]
+
+(* Demonstrate that this is only a printing issue *)
+type _ box : immediate = Box : 'a -> 'a box
+
+[%%expect{|
+Line 1, characters 0-43:
+1 | type _ box : immediate = Box : 'a -> 'a box
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "box" is immutable_data with _
+         because it's a boxed variant type.
+       But the kind of type "box" must be a subkind of immediate
+         because of the annotation on the declaration of the type box.
+|}]
+
+(* Only the first type parameter matters *)
+
+let crosses (x : (int, int ref) box2 @ contended) = use_uncontended x
+[%%expect{|
+val crosses : (int, int ref) box2 @ contended -> unit = <fun>
+|}]
+
+let doesn't_cross (x : (int ref, int) box2 @ contended) = use_uncontended x
+(* CR layouts v2.8: arguably this should be accepted if [crosses] is accepted (even though
+   x is uninhabited) *)
+[%%expect{|
+Line 1, characters 74-75:
+1 | let doesn't_cross (x : (int ref, int) box2 @ contended) = use_uncontended x
+                                                                              ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+(* Constraints and existentials *)
+
+type 'a t constraint 'a = 'b option
+type 'c t2 : immutable_data with (type : value) option t =
+  | K : 'd t -> 'd t2
+[%%expect{|
+type 'a t constraint 'a = 'b option
+type 'c t2 = K : 'a option t -> 'a option t2
+|}]
+
+type 'a t constraint 'a = 'b option
+type 'c t2 : immediate =
+  | K : 'd t -> 'd t2
+[%%expect{|
+type 'a t constraint 'a = 'b option
+Lines 2-3, characters 0-21:
+2 | type 'c t2 : immediate =
+3 |   | K : 'd t -> 'd t2
+Error: The kind of type "t2" is immutable_data with (type : value) option t
+         because it's a boxed variant type.
+       But the kind of type "t2" must be a subkind of immediate
+         because of the annotation on the declaration of the type t2.
+|}]
+
+(* Existential row variables *)
+
+type exist_row1 = Mk : ([< `A | `B of int ref] as 'a) -> exist_row1
+[%%expect{|
+type exist_row1 = Mk : [< `A | `B of int ref ] -> exist_row1
+|}]
+
+type show_me_the_kind : immediate = exist_row1
+[%%expect{|
+Line 1, characters 0-46:
+1 | type show_me_the_kind : immediate = exist_row1
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "exist_row1" is immutable_data
+         with [< `A | `B of int ref ]
+         because of the definition of exist_row1 at line 1, characters 0-67.
+       But the kind of type "exist_row1" must be a subkind of immediate
+         because of the definition of show_me_the_kind at line 1, characters 0-46.
+|}]
+
+let foo (x : exist_row1 @ nonportable) = use_portable x
+(* CR layouts v2.8: This should be accepted *)
+[%%expect{|
+Line 1, characters 54-55:
+1 | let foo (x : exist_row1 @ nonportable) = use_portable x
+                                                          ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+let foo (x : exist_row1 @ contended) = use_uncontended x
+[%%expect{|
+Line 1, characters 55-56:
+1 | let foo (x : exist_row1 @ contended) = use_uncontended x
+                                                           ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+type exist_row2 = Mk : ([> `A | `B of int ref] as 'a) -> exist_row2
+[%%expect{|
+type exist_row2 = Mk : [> `A | `B of int ref ] -> exist_row2
+|}]
+
+type show_me_the_kind : immediate = exist_row2
+[%%expect{|
+Line 1, characters 0-46:
+1 | type show_me_the_kind : immediate = exist_row2
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "exist_row2" is immutable_data
+         with [> `A | `B of int ref ]
+         because of the definition of exist_row2 at line 1, characters 0-67.
+       But the kind of type "exist_row2" must be a subkind of immediate
+         because of the definition of show_me_the_kind at line 1, characters 0-46.
+|}]
+
+let foo (x : exist_row2 @ nonportable) = use_portable x
+[%%expect{|
+Line 1, characters 54-55:
+1 | let foo (x : exist_row2 @ nonportable) = use_portable x
+                                                          ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+let foo (x : exist_row2 @ contended) = use_uncontended x
+[%%expect{|
+Line 1, characters 55-56:
+1 | let foo (x : exist_row2 @ contended) = use_uncontended x
+                                                           ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+type 'a exist_row3 = Mk : ([> `A | `B of int ref] as 'a) -> 'a option exist_row3
+[%%expect{|
+type 'a exist_row3 =
+    Mk : 'a -> ([> `A | `B of int ref ] as 'a) option exist_row3
+|}]
+
+type 'a show_me_the_kind : immediate = 'a option exist_row3
+[%%expect{|
+Line 1, characters 0-59:
+1 | type 'a show_me_the_kind : immediate = 'a option exist_row3
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "'a option exist_row3" is immutable_data
+         with [> `A | `B of int ref ]
+         because of the definition of exist_row3 at line 1, characters 0-80.
+       But the kind of type "'a option exist_row3" must be a subkind of
+         immediate
+         because of the definition of show_me_the_kind at line 1, characters 0-59.
+|}]
+
+let foo (x : [`A | `B of int ref] option exist_row3 @ contended) = use_uncontended x
+[%%expect{|
+Line 1, characters 83-84:
+1 | let foo (x : [`A | `B of int ref] option exist_row3 @ contended) = use_uncontended x
+                                                                                       ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+(* This would be lovely to accept, but it seems beyond the
+   expressiveness of our design. Specifically, we'd need to have some way
+   of connecting mode-crossing behavior to the choice of [option] in the
+   argument to [exist_row3]. *)
+let foo (x : [`A | `B of int ref] option exist_row3 @ nonportable) = use_portable x
+[%%expect{|
+Line 1, characters 82-83:
+1 | let foo (x : [`A | `B of int ref] option exist_row3 @ nonportable) = use_portable x
+                                                                                      ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+(* In the future, maybe local equations will let us figure out that something mode crosses
+   more than we would know otherwise. *)
+type 'a idx = | I : int idx | Br : bool ref idx
+type exist = Exist : ('a : value mod portable). 'a * 'a idx -> exist
+let foo (exist : exist @ contended) eq =
+  match exist with
+  | Exist (x, idx) -> begin
+    match idx with
+      | I ->
+        use_uncontended exist;
+        x
+    | Br -> 0
+  end
+(* CR layouts v2.8: Maybe this should be accepted? *)
+[%%expect{|
+type 'a idx = I : int idx | Br : bool ref idx
+type exist = Exist : ('a : value mod portable). 'a * 'a idx -> exist
+Line 8, characters 24-29:
+8 |         use_uncontended exist;
+                            ^^^^^
+Error: This value is "contended" but expected to be "uncontended".
+|}]

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -173,7 +173,7 @@ type 'x u : immediate =
 Lines 1-2, characters 0-27:
 1 | type 'x u : immediate =
 2 | | P1 : ('b, 'a1) t -> 'a1 u
-Error: The kind of type "u" is value
+Error: The kind of type "u" is value mod non_float
          because it's a boxed variant type.
        But the kind of type "u" must be a subkind of immediate
          because of the annotation on the declaration of the type u.
@@ -185,7 +185,7 @@ type 'a u : immutable_data =
 Lines 1-2, characters 0-25:
 1 | type 'a u : immutable_data =
 2 | | P1 : ('b, 'a) t -> 'a u
-Error: The kind of type "u" is value
+Error: The kind of type "u" is value mod non_float
          because it's a boxed variant type.
        But the kind of type "u" must be a subkind of immutable_data
          because of the annotation on the declaration of the type u.
@@ -205,7 +205,7 @@ type 'a t : immediate =
 Lines 1-2, characters 0-25:
 1 | type 'a t : immediate =
 2 |   | A : 'b -> 'b option t
-Error: The kind of type "t" is value
+Error: The kind of type "t" is value mod non_float
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immediate
          because of the annotation on the declaration of the type t.

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -335,21 +335,17 @@ Error: Signature mismatch:
          because of the definition of t at line 3, characters 2-34.
 |}]
 
-(* CR layouts v2.8: gadts shouldn't be "best" because we intend to give them more refined
-   jkinds in the future. So this program will error in the future. *)
 type gadt = Foo : int -> gadt
 module M : sig
   type t : value mod portable with gadt
 end = struct
-  type t
+  type t : value mod portable
 end
 [%%expect {|
 type gadt = Foo : int -> gadt
-module M : sig type t end
+module M : sig type t : value mod portable end
 |}]
 
-(* CR layouts v2.8: gadts shouldn't be "best". But maybe they should track quality along
-   individual axes, and so this should be accepted anyways? *)
 type gadt = Foo : int -> gadt
 module M : sig
   type t : value mod global with gadt
@@ -358,7 +354,23 @@ end = struct
 end
 [%%expect {|
 type gadt = Foo : int -> gadt
-module M : sig type t end
+Lines 4-6, characters 6-3:
+4 | ......struct
+5 |   type t
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t end
+       is not included in
+         sig type t : value mod unyielding end
+       Type declarations do not match:
+         type t
+       is not included in
+         type t : value mod unyielding
+       The kind of the first is value
+         because of the definition of t at line 5, characters 2-8.
+       But the kind of the first must be a subkind of value mod unyielding
+         because of the definition of t at line 3, characters 2-37.
 |}]
 
 type gadt = Foo : int -> gadt [@@unboxed]

--- a/tools/debug_printers.ml
+++ b/tools/debug_printers.ml
@@ -1,5 +1,7 @@
 let type_expr = Printtyp.raw_type_expr
+let type_set = Btype.TypeSet.debug_print
 let row_field = Printtyp.raw_field
+let row_desc = Printtyp.raw_row_desc
 let ident = Ident.print_with_scope
 let path = Path.print
 let ctype_global_state = Ctype.print_global_state

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -20,6 +20,11 @@ open Types
 
 open Local_store
 
+(**** Forward declarations ****)
+
+let print_raw =
+  ref (fun _ -> assert false : Format.formatter -> type_expr -> unit)
+
 (**** Sets, maps and hashtables of types ****)
 
 let wrap_repr f ty = f (Transient_expr.repr ty)
@@ -34,6 +39,13 @@ module TypeSet = struct
   let exists p = TransientTypeSet.exists (wrap_type_expr p)
   let elements set =
     List.map Transient_expr.type_expr (TransientTypeSet.elements set)
+  let debug_print ppf t =
+    Format.(
+      fprintf ppf "{ %a }"
+        (pp_print_seq
+           ~pp_sep:(fun ppf () -> fprintf ppf ";@,")
+           !print_raw)
+        (to_seq t |> Seq.map Transient_expr.type_expr))
 end
 module TransientTypeMap = Map.Make(TransientTypeOps)
 module TypeMap = struct
@@ -95,10 +107,6 @@ module TypePairs = struct
         f (type_expr t1, type_expr t2))
 end
 
-(**** Forward declarations ****)
-
-let print_raw =
-  ref (fun _ -> assert false : Format.formatter -> type_expr -> unit)
 
 (**** Type level management ****)
 
@@ -274,6 +282,7 @@ let fold_row f init row =
 
 let iter_row f row =
   fold_row (fun () v -> f v) () row
+
 
 let fold_type_expr f init ty =
   match get_desc ty with

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -27,6 +27,7 @@ module TypeSet : sig
   val singleton: type_expr -> t
   val exists: (type_expr -> bool) -> t -> bool
   val elements: t -> type_expr list
+  val debug_print : Format.formatter -> t -> unit
 end
 module TransientTypeMap : Map.S with type key = transient_expr
 module TypeMap : sig

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -648,6 +648,16 @@ let free_non_row_variables_of_list tyl =
   List.iter unmark_type tyl;
   tl
 
+let free_variable_set_of_list env tys =
+  let add_one ty jkind _kind acc =
+    match jkind with
+    | None -> (* not a Tvar *) acc
+    | Some _jkind -> TypeSet.add ty acc
+  in
+  let ts = free_vars ~zero:TypeSet.empty ~add_one ~env tys in
+  List.iter unmark_type tys;
+  ts
+
 let exists_free_variable f ty =
   let exception Exists in
   let add_one ty jkind _kind _acc =
@@ -1297,7 +1307,7 @@ let rec copy ?partial ?keep_names copy_scope ty =
                   Tsubst (ty, None) -> ty
                   (* TODO: is this case possible?
                      possibly an interaction with (copy more) below? *)
-                | Tconstr _ | Tnil ->
+                | Tconstr _ | Tnil | Tof_kind _ ->
                     copy more
                 | Tvar _ | Tunivar _ ->
                     if keep then more else newty mored

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2344,7 +2344,7 @@ let rec estimate_type_jkind ~expand_component env ty =
        down a test case that cares. *)
     Jkind.round_up ~jkind_of_type |>
     Jkind.disallow_right
-  | Tof_kind jkind -> Jkind.disallow_right jkind
+  | Tof_kind jkind -> Jkind.mark_best jkind
   | Tpackage _ -> Jkind.for_non_float ~why:First_class_module
 
 and close_open_jkind ~expand_component ~is_open env jkind =

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -535,6 +535,8 @@ val free_variables: ?env:Env.t -> type_expr -> type_expr list
            returns both normal variables and row variables*)
 val free_non_row_variables_of_list: type_expr list -> type_expr list
         (* gets only non-row variables *)
+val free_variable_set_of_list: Env.t -> type_expr list -> Btype.TypeSet.t
+        (* post-condition: all elements in the set are Tvars *)
 
 val exists_free_variable : (type_expr -> jkind_lr -> bool) -> type_expr -> bool
         (* Check if there exists a free variable that satisfies the

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -29,12 +29,12 @@ let free_vars ?(param=false) ty =
       | Tvar _ ->
           ret := TypeSet.add ty !ret
       | Tvariant row ->
-          iter_row loop row;
-          if not (static_row row) then begin
-            match get_desc (row_more row) with
-            | Tvar _ when param -> ret := TypeSet.add ty !ret
-            | _ -> loop (row_more row)
-          end
+        iter_row loop row;
+        if not (static_row row) then begin
+          match get_desc (row_more row) with
+          | Tvar _ when param -> ret := TypeSet.add ty !ret
+          | _ -> loop (row_more row)
+        end
       (* XXX: What about Tobject ? *)
       | _ ->
           iter_type_expr loop ty

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -497,8 +497,20 @@ val for_boxed_record : Types.label_declaration list -> Types.jkind_l
 (** Choose an appropriate jkind for an unboxed record type. *)
 val for_unboxed_record : Types.label_declaration list -> Types.jkind_l
 
-(** Choose an appropriate jkind for a boxed variant type. *)
-val for_boxed_variant : Types.constructor_declaration list -> Types.jkind_l
+(** Choose an appropriate jkind for a boxed variant type.
+
+    [decl_params] is the parameters in the head of the type declaration. [type_apply]
+    should be [Ctype.apply] partially applied to an [env]. *)
+val for_boxed_variant :
+  decl_params:Types.type_expr list ->
+  type_apply:
+    (Types.type_expr list ->
+    Types.type_expr ->
+    Types.type_expr list ->
+    Types.type_expr) ->
+  free_vars:(Types.type_expr list -> Btype.TypeSet.t) ->
+  Types.constructor_declaration list ->
+  Types.jkind_l
 
 (** Choose an appropriate jkind for a boxed tuple type. *)
 val for_boxed_tuple : (string option * Types.type_expr) list -> Types.jkind_l

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -662,6 +662,22 @@ and raw_lid_type_list tl =
   raw_list (fun ppf (lid, typ) ->
              fprintf ppf "(@,%a,@,%a)" longident lid raw_type typ)
     tl
+and raw_row_desc ppf row =
+  let Row {fields; more; name; fixed; closed} = row_repr row in
+  fprintf ppf
+    "@[<hov1>{@[%s@,%a;@]@ @[%s@,%a;@]@ %s%B;@ %s%a;@ @[<1>%s%t@]}@]"
+    "row_fields="
+    (raw_list (fun ppf (l, f) ->
+       fprintf ppf "@[%s,@ %a@]" l raw_field f))
+    fields
+    "row_more=" raw_type more
+    "row_closed=" closed
+    "row_fixed=" raw_row_fixed fixed
+    "row_name="
+    (fun ppf ->
+       match name with None -> fprintf ppf "None"
+                     | Some(p,tl) ->
+                       fprintf ppf "Some(@,%a,@,%a)" path p raw_type_list tl)
 and raw_type_desc ppf = function
     Tvar { name; jkind } ->
       fprintf ppf "Tvar (@,%a,@,%a)"
@@ -704,21 +720,7 @@ and raw_type_desc ppf = function
         raw_type t
         raw_type_list tl
   | Tvariant row ->
-      let Row {fields; more; name; fixed; closed} = row_repr row in
-      fprintf ppf
-        "@[<hov1>{@[%s@,%a;@]@ @[%s@,%a;@]@ %s%B;@ %s%a;@ @[<1>%s%t@]}@]"
-        "row_fields="
-        (raw_list (fun ppf (l, f) ->
-          fprintf ppf "@[%s,@ %a@]" l raw_field f))
-        fields
-        "row_more=" raw_type more
-        "row_closed=" closed
-        "row_fixed=" raw_row_fixed fixed
-        "row_name="
-        (fun ppf ->
-          match name with None -> fprintf ppf "None"
-          | Some(p,tl) ->
-              fprintf ppf "Some(@,%a,@,%a)" path p raw_type_list tl)
+    raw_row_desc ppf row
   | Tpackage (p, fl) ->
       fprintf ppf "@[<hov1>Tpackage(@,%a,@,%a)@]" path p
         raw_lid_type_list fl

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -41,6 +41,7 @@ val strings_of_paths: namespace -> Path.t list -> string list
     (** Print a list of paths, using the same naming context to
         avoid name collisions *)
 
+val raw_row_desc : formatter -> row_desc -> unit
 val raw_type_expr: formatter -> type_expr -> unit
 val raw_field : formatter -> row_field -> unit
 val string_of_label: Types.arg_label -> string

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -474,7 +474,7 @@ let rec typexp copy_scope s ty =
               let more' =
                 match mored with
                   Tsubst (ty, None) -> ty
-                | Tconstr _ | Tnil -> typexp copy_scope s more
+                | Tconstr _ | Tnil | Tof_kind _ -> typexp copy_scope s more
                 | Tunivar _ | Tvar _ ->
                     if should_duplicate_vars then newpersty mored
                     else if dup && is_Tvar more then newgenty mored

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1955,7 +1955,13 @@ let rec update_decl_jkind env dpath decl =
           (idx+1,cstr::cstrs)
         ) (0,[]) cstrs
       in
-      let jkind = Jkind.for_boxed_variant cstrs in
+      let jkind =
+        Jkind.for_boxed_variant
+          ~decl_params:decl.type_params
+          ~type_apply:(Ctype.apply env)
+          ~free_vars:(Ctype.free_variable_set_of_list env)
+          cstrs
+      in
       List.rev cstrs, rep, jkind
     | (([] | (_ :: _)), Variant_unboxed | _, Variant_extensible) ->
       assert false

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -1285,7 +1285,7 @@ module Transient_expr = struct
     match ty.desc with
     | Tvar { name; _ } ->
       set_desc ty (Tvar { name; jkind = jkind' })
-    | _ -> assert false
+    | _ -> Misc.fatal_error "set_var_jkind called on non-var"
   let coerce ty = ty
   let repr = repr
   let type_expr ty = ty

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -245,8 +245,7 @@ and type_desc =
 
       These types are uninhabited, and any appearing in translation will cause an error.
       They are only used to represent the kinds of existentially-quantified types
-      mentioned in with-bounds. *)
-      (* CR reisenberg: add link to test once one exists *)
+      mentioned in with-bounds. See test typing-jkind-bounds/gadt.ml *)
 
 (** This is used in the Typedtree. It is distinct from
     {{!Asttypes.arg_label}[arg_label]} because Position argument labels are


### PR DESCRIPTION
Infer full with-kinds for GADTs, using the new `Tof_kind` type to stand-in for existential type variables.

There's a big `Note` in `jkind.ml` explaining the approach here; see that for an overview.

Review all in one go, commit history is mostly not useful.