### PR TITLE
Tidying up in Cfg_selectgen

### DIFF
--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1135,8 +1135,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
             Sub_cfg.add_instruction sub_cfg instr_desc [||] [||] Debuginfo.none)
           traps;
         Sub_cfg.update_exit_terminator sub_cfg (Always handler.label);
-        SU.set_traps nfail handler.Select_utils.traps_ref env.SU.trap_stack
-          traps;
+        SU.set_traps nfail handler.SU.traps_ref env.SU.trap_stack traps;
         Never_returns
       | Return_lbl -> (
         match simple_list with

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -22,15 +22,10 @@ open! Int_replace_polymorphic_compare
 
 [@@@ocaml.warning "+a-4-9-40-41-42"]
 
-open Cmm
-
-(* CR mshinwell: remove ! *)
-open! Select_utils
-
-(* CR mshinwell: remove [open Or_never_returns] when the objects have gone *)
-open! Or_never_returns
 module DLL = Flambda_backend_utils.Doubly_linked_list
 module Int = Numbers.Int
+module Or_never_returns = Select_utils.Or_never_returns
+module SU = Select_utils
 module V = Backend_var
 module VP = Backend_var.With_provenance
 
@@ -91,8 +86,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
      order first with their results going into temporaries, then the block is
      allocated, then the remaining arguments are evaluated before being combined
      with the temporaries. *)
-  let rec effects_of0 exp =
-    let module EC = Select_utils.Effect_and_coeffect in
+  let rec effects_of0 (exp : Cmm.expression) =
+    let module EC = SU.Effect_and_coeffect in
     match exp with
     | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
     | Cconst_symbol _ | Cconst_vec128 _ | Cvar _ ->
@@ -107,19 +102,19 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       let from_op =
         match op with
         | Cextcall { effects = e; coeffects = ce } ->
-          EC.create (select_effects e) (select_coeffects ce)
+          EC.create (SU.select_effects e) (SU.select_coeffects ce)
         | Capply _ | Cprobe _ | Copaque | Cpoll -> EC.arbitrary
         | Calloc (Heap, _) -> EC.none
-        | Calloc (Local, _) -> EC.coeffect_only Coeffect.Arbitrary
-        | Cstore _ -> EC.effect_only Effect.Arbitrary
+        | Calloc (Local, _) -> EC.coeffect_only Arbitrary
+        | Cstore _ -> EC.effect_only Arbitrary
         | Cbeginregion | Cendregion -> EC.arbitrary
         | Cprefetch _ -> EC.arbitrary
         | Catomic _ -> EC.arbitrary
-        | Craise _ -> EC.effect_only Effect.Raise
-        | Cload { mutability = Asttypes.Immutable } -> EC.none
-        | Cload { mutability = Asttypes.Mutable } | Cdls_get ->
-          EC.coeffect_only Coeffect.Read_mutable
-        | Cprobe_is_enabled _ -> EC.coeffect_only Coeffect.Arbitrary
+        | Craise _ -> EC.effect_only Raise
+        | Cload { mutability = Immutable } -> EC.none
+        | Cload { mutability = Mutable } | Cdls_get ->
+          EC.coeffect_only Read_mutable
+        | Cprobe_is_enabled _ -> EC.coeffect_only Arbitrary
         | Ctuple_field _ | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
         | Cand | Cor | Cxor | Cbswap _ | Ccsel _ | Cclz _ | Cctz _ | Cpopcnt
         | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf _
@@ -133,7 +128,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
   and effects_of (expr : Cmm.expression) =
     match Target.effects_of expr with
     | Effects_of_all_expressions exprs ->
-      Select_utils.Effect_and_coeffect.join_list_map exprs effects_of
+      SU.Effect_and_coeffect.join_list_map exprs effects_of
     | Use_default -> effects_of0 expr
 
   (* Says whether an integer constant is a suitable immediate argument for the
@@ -161,15 +156,15 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       when is_immediate_test (Isigned cmp) n ->
       Iinttest_imm (Isigned cmp, n), arg1
     | Cop (Ccmpi cmp, [Cconst_int (n, _); arg2], _)
-      when is_immediate_test (Isigned (swap_integer_comparison cmp)) n ->
-      Iinttest_imm (Isigned (swap_integer_comparison cmp), n), arg2
+      when is_immediate_test (Isigned (Cmm.swap_integer_comparison cmp)) n ->
+      Iinttest_imm (Isigned (Cmm.swap_integer_comparison cmp), n), arg2
     | Cop (Ccmpi cmp, args, _) -> Iinttest (Isigned cmp), Ctuple args
     | Cop (Ccmpa cmp, [arg1; Cconst_int (n, _)], _)
       when is_immediate_test (Iunsigned cmp) n ->
       Iinttest_imm (Iunsigned cmp, n), arg1
     | Cop (Ccmpa cmp, [Cconst_int (n, _); arg2], _)
-      when is_immediate_test (Iunsigned (swap_integer_comparison cmp)) n ->
-      Iinttest_imm (Iunsigned (swap_integer_comparison cmp), n), arg2
+      when is_immediate_test (Iunsigned (Cmm.swap_integer_comparison cmp)) n ->
+      Iinttest_imm (Iunsigned (Cmm.swap_integer_comparison cmp), n), arg2
     | Cop (Ccmpa cmp, args, _) -> Iinttest (Iunsigned cmp), Ctuple args
     | Cop (Ccmpf (width, cmp), args, _) -> Ifloattest (width, cmp), Ctuple args
     | Cop (Cand, [arg1; Cconst_int (1, _)], _) -> Ioddtest, arg1
@@ -178,21 +173,21 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
   let is_store (op : Operation.t) =
     match op with Store (_, _, _) -> true | _ -> false
 
-  let bind_let (env : Select_utils.environment) sub_cfg v r1 =
+  let bind_let (env : SU.environment) sub_cfg v r1 =
     let env =
       let rv = Reg.createv_like r1 in
-      name_regs v rv;
-      insert_moves env sub_cfg r1 rv;
-      env_add v rv env
+      SU.name_regs v rv;
+      SU.insert_moves env sub_cfg r1 rv;
+      SU.env_add v rv env
     in
     let provenance = VP.provenance v in
     (if Option.is_some provenance
     then
       let naming_op =
-        make_name_for_debugger ~ident:(VP.var v) ~which_parameter:None
+        SU.make_name_for_debugger ~ident:(VP.var v) ~which_parameter:None
           ~provenance ~is_assignment:false ~regs:r1
       in
-      insert_debug env sub_cfg naming_op Debuginfo.none [||] [||]);
+      SU.insert_debug env sub_cfg naming_op Debuginfo.none [||] [||]);
     env
 
   (* Add an Iop opcode. Can be augmented by the processor description to insert
@@ -203,7 +198,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     match Target.insert_op_debug env sub_cfg op dbg rs rd with
     | Regs rd -> rd
     | Use_default ->
-      Select_utils.insert_debug env sub_cfg (Op op) dbg rs rd;
+      SU.insert_debug env sub_cfg (Op op) dbg rs rd;
       rd
 
   let insert_op env sub_cfg op rs rd =
@@ -216,8 +211,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
        special move instructions, for example a "32-bit move" instruction for
        int32 arguments. *)
     match Target.insert_move_extcall_arg ty_arg src dst with
-    | Rewritten (basic, src, dst) -> insert_debug env sub_cfg basic dbg src dst
-    | Use_default -> insert_moves env sub_cfg src dst
+    | Rewritten (basic, src, dst) ->
+      SU.insert_debug env sub_cfg basic dbg src dst
+    | Use_default -> SU.insert_moves env sub_cfg src dst
 
   (* Default instruction selection for integer operations *)
 
@@ -226,18 +222,18 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       Cfg.basic_or_terminator * Cmm.expression list =
     match args with
     | [arg; Cconst_int (n, _)] when is_immediate op n ->
-      basic_op (Intop_imm (op, n)), [arg]
+      SU.basic_op (Intop_imm (op, n)), [arg]
     | [Cconst_int (n, _); arg] when is_immediate op n ->
-      basic_op (Intop_imm (op, n)), [arg]
-    | _ -> basic_op (Intop op), args
+      SU.basic_op (Intop_imm (op, n)), [arg]
+    | _ -> SU.basic_op (Intop op), args
 
   let select_arith (op : Simple_operation.integer_operation)
       (args : Cmm.expression list) :
       Cfg.basic_or_terminator * Cmm.expression list =
     match args with
     | [arg; Cconst_int (n, _)] when is_immediate op n ->
-      basic_op (Intop_imm (op, n)), [arg]
-    | _ -> basic_op (Intop op), args
+      SU.basic_op (Intop_imm (op, n)), [arg]
+    | _ -> SU.basic_op (Intop op), args
 
   let select_arith_comp (cmp : Simple_operation.integer_comparison)
       (args : Cmm.expression list) :
@@ -245,13 +241,11 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     match args with
     | [arg; Cconst_int (n, _)] when is_immediate (Simple_operation.Icomp cmp) n
       ->
-      basic_op (Intop_imm (Icomp cmp, n)), [arg]
+      SU.basic_op (Intop_imm (Icomp cmp, n)), [arg]
     | [Cconst_int (n, _); arg]
-      when is_immediate
-             (Simple_operation.Icomp (Select_utils.swap_intcomp cmp))
-             n ->
-      basic_op (Intop_imm (Icomp (Select_utils.swap_intcomp cmp), n)), [arg]
-    | _ -> basic_op (Intop (Icomp cmp)), args
+      when is_immediate (Simple_operation.Icomp (SU.swap_intcomp cmp)) n ->
+      SU.basic_op (Intop_imm (Icomp (SU.swap_intcomp cmp), n)), [arg]
+    | _ -> SU.basic_op (Intop (Icomp cmp)), args
 
   (* Default instruction selection for operators *)
 
@@ -302,8 +296,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | Cload { memory_chunk; mutability; is_atomic } ->
       let arg = single_arg () in
       let addressing_mode, eloc = Target.select_addressing memory_chunk arg in
-      let mutability = select_mutable_flag mutability in
-      ( basic_op (Load { memory_chunk; addressing_mode; mutability; is_atomic }),
+      let mutability = SU.select_mutable_flag mutability in
+      ( SU.basic_op
+          (Load { memory_chunk; addressing_mode; mutability; is_atomic }),
         [eloc] )
     | Cstore (chunk, init) -> (
       let arg1, arg2 = two_args () in
@@ -326,75 +321,74 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                range:@ %s"
               (Printcmm.operation dbg op)
         in
-        basic_op op, [newarg2; eloc]
-      | _ -> basic_op (Store (chunk, addr, is_assign)), [arg2; eloc]
+        SU.basic_op op, [newarg2; eloc]
+      | _ -> SU.basic_op (Store (chunk, addr, is_assign)), [arg2; eloc]
       (* Inversion addr/datum in Istore *))
-    | Cdls_get -> basic_op Dls_get, args
+    | Cdls_get -> SU.basic_op Dls_get, args
     | Calloc (mode, alloc_block_kind) ->
-      let placeholder_for_alloc_block_kind =
+      let placeholder_for_alloc_block_kind : Cmm.alloc_dbginfo_item =
         { alloc_words = 0; alloc_block_kind; alloc_dbg = Debuginfo.none }
       in
-      ( basic_op
+      ( SU.basic_op
           (Alloc
              { bytes = 0; dbginfo = [placeholder_for_alloc_block_kind]; mode }),
         args )
-    | Cpoll -> basic_op Poll, args
-    | Caddi -> select_arith_comm Simple_operation.Iadd args
-    | Csubi -> select_arith Simple_operation.Isub args
-    | Cmuli -> select_arith_comm Simple_operation.Imul args
-    | Cmulhi { signed } ->
-      select_arith_comm (Simple_operation.Imulh { signed }) args
-    | Cdivi -> basic_op (Intop Idiv), args
-    | Cmodi -> basic_op (Intop Imod), args
-    | Cand -> select_arith_comm Simple_operation.Iand args
-    | Cor -> select_arith_comm Simple_operation.Ior args
-    | Cxor -> select_arith_comm Simple_operation.Ixor args
-    | Clsl -> select_arith Simple_operation.Ilsl args
-    | Clsr -> select_arith Simple_operation.Ilsr args
-    | Casr -> select_arith Simple_operation.Iasr args
+    | Cpoll -> SU.basic_op Poll, args
+    | Caddi -> select_arith_comm Iadd args
+    | Csubi -> select_arith Isub args
+    | Cmuli -> select_arith_comm Imul args
+    | Cmulhi { signed } -> select_arith_comm (Imulh { signed }) args
+    | Cdivi -> SU.basic_op (Intop Idiv), args
+    | Cmodi -> SU.basic_op (Intop Imod), args
+    | Cand -> select_arith_comm Iand args
+    | Cor -> select_arith_comm Ior args
+    | Cxor -> select_arith_comm Ixor args
+    | Clsl -> select_arith Ilsl args
+    | Clsr -> select_arith Ilsr args
+    | Casr -> select_arith Iasr args
     | Cclz { arg_is_non_zero } ->
-      basic_op (Intop (Iclz { arg_is_non_zero })), args
+      SU.basic_op (Intop (Iclz { arg_is_non_zero })), args
     | Cctz { arg_is_non_zero } ->
-      basic_op (Intop (Ictz { arg_is_non_zero })), args
-    | Cpopcnt -> basic_op (Intop Ipopcnt), args
-    | Ccmpi comp -> select_arith_comp (Simple_operation.Isigned comp) args
-    | Caddv -> select_arith_comm Simple_operation.Iadd args
-    | Cadda -> select_arith_comm Simple_operation.Iadd args
-    | Ccmpa comp -> select_arith_comp (Simple_operation.Iunsigned comp) args
-    | Ccmpf (w, comp) -> basic_op (Floatop (w, Icompf comp)), args
+      SU.basic_op (Intop (Ictz { arg_is_non_zero })), args
+    | Cpopcnt -> SU.basic_op (Intop Ipopcnt), args
+    | Ccmpi comp -> select_arith_comp (Isigned comp) args
+    | Caddv -> select_arith_comm Iadd args
+    | Cadda -> select_arith_comm Iadd args
+    | Ccmpa comp -> select_arith_comp (Iunsigned comp) args
+    | Ccmpf (w, comp) -> SU.basic_op (Floatop (w, Icompf comp)), args
     | Ccsel _ ->
       let cond, ifso, ifnot = three_args () in
       let cond, earg = select_condition cond in
-      basic_op (Csel cond), [earg; ifso; ifnot]
-    | Cnegf w -> basic_op (Floatop (w, Inegf)), args
-    | Cabsf w -> basic_op (Floatop (w, Iabsf)), args
-    | Caddf w -> basic_op (Floatop (w, Iaddf)), args
-    | Csubf w -> basic_op (Floatop (w, Isubf)), args
-    | Cmulf w -> basic_op (Floatop (w, Imulf)), args
-    | Cdivf w -> basic_op (Floatop (w, Idivf)), args
-    | Creinterpret_cast cast -> basic_op (Reinterpret_cast cast), args
-    | Cstatic_cast cast -> basic_op (Static_cast cast), args
+      SU.basic_op (Csel cond), [earg; ifso; ifnot]
+    | Cnegf w -> SU.basic_op (Floatop (w, Inegf)), args
+    | Cabsf w -> SU.basic_op (Floatop (w, Iabsf)), args
+    | Caddf w -> SU.basic_op (Floatop (w, Iaddf)), args
+    | Csubf w -> SU.basic_op (Floatop (w, Isubf)), args
+    | Cmulf w -> SU.basic_op (Floatop (w, Imulf)), args
+    | Cdivf w -> SU.basic_op (Floatop (w, Idivf)), args
+    | Creinterpret_cast cast -> SU.basic_op (Reinterpret_cast cast), args
+    | Cstatic_cast cast -> SU.basic_op (Static_cast cast), args
     | Catomic { op; size } -> (
       match op with
       | Exchange | Fetch_and_add | Add | Sub | Land | Lor | Lxor ->
         let src, dst = two_args () in
-        let dst_size =
+        let dst_size : Cmm.memory_chunk =
           match size with
           | Word | Sixtyfour -> Word_int
           | Thirtytwo -> Thirtytwo_signed
         in
         let addr, eloc = Target.select_addressing dst_size dst in
-        basic_op (Intop_atomic { op; size; addr }), [src; eloc]
+        SU.basic_op (Intop_atomic { op; size; addr }), [src; eloc]
       | Compare_set | Compare_exchange ->
         let compare_with, set_to, dst = three_args () in
-        let dst_size =
+        let dst_size : Cmm.memory_chunk =
           match size with
           | Word | Sixtyfour -> Word_int
           | Thirtytwo -> Thirtytwo_signed
         in
         let addr, eloc = Target.select_addressing dst_size dst in
-        basic_op (Intop_atomic { op; size; addr }), [compare_with; set_to; eloc]
-      )
+        ( SU.basic_op (Intop_atomic { op; size; addr }),
+          [compare_with; set_to; eloc] ))
     | Cprobe { name; handler_code_sym; enabled_at_init } ->
       ( Terminator
           (Prim
@@ -402,9 +396,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                label_after
              }),
         args )
-    | Cprobe_is_enabled { name } -> basic_op (Probe_is_enabled { name }), []
-    | Cbeginregion -> basic_op Begin_region, []
-    | Cendregion -> basic_op End_region, args
+    | Cprobe_is_enabled { name } -> SU.basic_op (Probe_is_enabled { name }), []
+    | Cbeginregion -> SU.basic_op Begin_region, []
+    | Cendregion -> SU.basic_op End_region, args
     | Cpackf32 | Copaque | Cbswap _ | Cprefetch _ | Craise _
     | Ctuple_field (_, _) ->
       Misc.fatal_error "Selection.select_oper"
@@ -426,7 +420,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | Use_default -> basic_or_terminator, args)
     | Use_default -> select_operation0 op args dbg ~label_after
 
-  let insert_return env sub_cfg r (traps : trap_action list) =
+  let insert_return env sub_cfg (r : _ Or_never_returns.t)
+      (traps : Cmm.trap_action list) =
     match r with
     | Never_returns -> ()
     | Ok r ->
@@ -440,8 +435,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           Sub_cfg.add_instruction sub_cfg instr_desc [||] [||] Debuginfo.none)
         traps;
       let loc = Proc.loc_results_return (Reg.typv r) in
-      insert_moves env sub_cfg r loc;
-      insert' env sub_cfg Cfg.Return loc [||]
+      SU.insert_moves env sub_cfg r loc;
+      SU.insert' env sub_cfg Cfg.Return loc [||]
 
   (* Buffering of instruction sequences *)
 
@@ -458,11 +453,11 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
      (and to be consistent with the bytecode compiler). *)
 
   let rec emit_parts env sub_cfg ~effects_after exp : _ Or_never_returns.t =
-    let module EC = Effect_and_coeffect in
+    let module EC = SU.Effect_and_coeffect in
     let may_defer_evaluation =
       let ec = effects_of exp in
       match EC.effect ec with
-      | Effect.Arbitrary | Effect.Raise ->
+      | Arbitrary | Raise ->
         (* Preserve the ordering of effectful expressions by evaluating them
            early (in the correct order) and assigning their results to
            temporaries. We can avoid this in just one case: if we know that
@@ -473,25 +468,25 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
            avoid e.g. moving mutable reads earlier than the raising of an
            exception.) *)
         EC.pure_and_copure effects_after
-      | Effect.None -> (
+      | None -> (
         match EC.coeffect ec with
-        | Coeffect.None ->
+        | None ->
           (* Pure expressions may be moved. *)
           true
-        | Coeffect.Read_mutable -> (
+        | Read_mutable -> (
           (* Read-mutable expressions may only be deferred if evaluation of
              every [exp'] (for [exp'] as in the comment above) has no effects
-             "worse" (in the sense of the ordering in [Effect.t]) than raising
-             an exception. *)
+             "worse" (in the sense of the ordering in [t]) than raising an
+             exception. *)
           match EC.effect effects_after with
-          | Effect.None | Effect.Raise -> true
-          | Effect.Arbitrary -> false)
-        | Coeffect.Arbitrary -> (
+          | None | Raise -> true
+          | Arbitrary -> false)
+        | Arbitrary -> (
           (* Arbitrary expressions may only be deferred if evaluation of every
              [exp'] (for [exp'] as in the comment above) has no effects. *)
           match EC.effect effects_after with
-          | Effect.None -> true
-          | Effect.(Arbitrary | Raise) -> false))
+          | None -> true
+          | Arbitrary | Raise -> false))
     in
     (* Even though some expressions may look like they can be deferred from the
        (co)effect analysis, it may be forbidden to move them. *)
@@ -502,17 +497,17 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | Never_returns -> Never_returns
       | Ok r ->
         if Array.length r = 0
-        then Ok (Ctuple [], env)
+        then Ok (Cmm.Ctuple [], env)
         else
           (* The normal case *)
           let id = V.create_local "bind" in
           (* Introduce a fresh temp to hold the result *)
           let tmp = Reg.createv_like r in
-          insert_moves env sub_cfg r tmp;
-          Ok (Cvar id, env_add (VP.create id) tmp env)
+          SU.insert_moves env sub_cfg r tmp;
+          Ok (Cmm.Cvar id, SU.env_add (VP.create id) tmp env)
 
-  and emit_parts_list env sub_cfg exp_list =
-    let module EC = Effect_and_coeffect in
+  and emit_parts_list env sub_cfg exp_list : _ Or_never_returns.t =
+    let module EC = SU.Effect_and_coeffect in
     let exp_list_right_to_left, _effect =
       (* Annotate each expression with the (co)effects that happen after it when
          the original expression list is evaluated from right to left. The
@@ -524,14 +519,15 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         ([], EC.none) exp_list
     in
     List.fold_left
-      (fun results_and_env (exp, effects_after) ->
+      (fun (results_and_env : _ Or_never_returns.t) (exp, effects_after) :
+           _ Or_never_returns.t ->
         match results_and_env with
         | Never_returns -> Never_returns
         | Ok (result, env) -> (
           match emit_parts env sub_cfg exp ~effects_after with
           | Never_returns -> Never_returns
           | Ok (exp_result, env) -> Ok (exp_result :: result, env)))
-      (Ok ([], env))
+      (Or_never_returns.Ok ([], env))
       exp_list_right_to_left
 
   and emit_tuple_not_flattened env sub_cfg exp_list =
@@ -554,13 +550,13 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     let args = emit_tuple_not_flattened env sub_cfg args in
     let ty_args =
       match ty_args with
-      | [] -> List.map (fun _ -> XInt) args
+      | [] -> List.map (fun _ -> Cmm.XInt) args
       | _ :: _ -> ty_args
     in
     let locs, stack_ofs = Proc.loc_external_arguments ty_args in
     let ty_args = Array.of_list ty_args in
     if stack_ofs <> 0
-    then insert env sub_cfg (make_stack_offset stack_ofs) [||] [||];
+    then SU.insert env sub_cfg (SU.make_stack_offset stack_ofs) [||] [||];
     List.iteri
       (fun i arg ->
         insert_move_extcall_arg env sub_cfg ty_args.(i) arg locs.(i) dbg)
@@ -598,7 +594,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         | None ->
           for i = 0 to Array.length regs - 1 do
             let r = regs.(i) in
-            let chunk =
+            let chunk : Cmm.memory_chunk =
               match r.Reg.typ with
               | Float -> Double
               | Float32 -> Single { reg = Float32 }
@@ -621,34 +617,32 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
               | Within_range -> !addressing_mode
               | Out_of_range ->
                 (* Use a temporary to store the address [!base + offset]. *)
-                let tmp = regs_for Cmm.typ_int in
+                let tmp = SU.regs_for Cmm.typ_int in
                 (* CR-someday xclerc: Now that this code in the "generic" part,
                    it is maybe a bit unexpected to assume there is no better
                    sequence to emit x += k. That being said, it is a corner
                    case. *)
                 insert_debug env sub_cfg
-                  (Cfg.Op (make_const_int (Nativeint.of_int !byte_offset)))
+                  (Op (SU.make_const_int (Nativeint.of_int !byte_offset)))
                   dbg [||] tmp;
-                insert_debug env sub_cfg (Cfg.Op (Operation.Intop Iadd)) dbg
+                insert_debug env sub_cfg (Op (Operation.Intop Iadd)) dbg
                   (Array.append !base tmp) tmp;
                 (* Use the temporary as the new base address. *)
                 base := tmp;
                 Arch.identity_addressing
             in
             insert_debug env sub_cfg
-              (Cfg.Op (Store (chunk, new_addressing_mode, false)))
+              (Op (Store (chunk, new_addressing_mode, false)))
               dbg
               (Array.append [| r |] regs_addr)
               [||];
-            let size = Select_utils.size_component r.Reg.typ in
+            let size = SU.size_component r.Reg.typ in
             addressing_mode := Arch.offset_addressing new_addressing_mode size;
             byte_offset := !byte_offset + size
           done
         | Some op ->
-          insert_debug env sub_cfg (Cfg.Op op) dbg
-            (Array.append regs regs_addr)
-            [||];
-          let size = size_expr env original_arg in
+          insert_debug env sub_cfg (Op op) dbg (Array.append regs regs_addr) [||];
+          let size = SU.size_expr env original_arg in
           addressing_mode := Arch.offset_addressing !addressing_mode size;
           byte_offset := !byte_offset + size)
       | Never_returns ->
@@ -667,29 +661,30 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
      - [Never_returns] if the expression does not finish normally (e.g. raises)
 
      - [Ok rs] if the expression yields a result in registers [rs] *)
-  and emit_expr env sub_cfg exp ~bound_name : Reg.t array Or_never_returns.t =
+  and emit_expr env sub_cfg (exp : Cmm.expression) ~bound_name :
+      Reg.t array Or_never_returns.t =
     match exp with
     | Cconst_int (n, _dbg) ->
-      let r = regs_for typ_int in
-      Ok (insert_op env sub_cfg (make_const_int (Nativeint.of_int n)) [||] r)
+      let r = SU.regs_for Cmm.typ_int in
+      Ok (insert_op env sub_cfg (SU.make_const_int (Nativeint.of_int n)) [||] r)
     | Cconst_natint (n, _dbg) ->
-      let r = regs_for typ_int in
-      Ok (insert_op env sub_cfg (make_const_int n) [||] r)
+      let r = SU.regs_for Cmm.typ_int in
+      Ok (insert_op env sub_cfg (SU.make_const_int n) [||] r)
     | Cconst_float32 (n, _dbg) ->
-      let r = regs_for typ_float32 in
+      let r = SU.regs_for Cmm.typ_float32 in
       Ok
         (insert_op env sub_cfg
-           (make_const_float32 (Int32.bits_of_float n))
+           (SU.make_const_float32 (Int32.bits_of_float n))
            [||] r)
     | Cconst_float (n, _dbg) ->
-      let r = regs_for typ_float in
+      let r = SU.regs_for Cmm.typ_float in
       Ok
         (insert_op env sub_cfg
-           (make_const_float (Int64.bits_of_float n))
+           (SU.make_const_float (Int64.bits_of_float n))
            [||] r)
     | Cconst_vec128 (bits, _dbg) ->
-      let r = regs_for typ_vec128 in
-      Ok (insert_op env sub_cfg (make_const_vec128 bits) [||] r)
+      let r = SU.regs_for Cmm.typ_vec128 in
+      Ok (insert_op env sub_cfg (SU.make_const_vec128 bits) [||] r)
     | Cconst_symbol (n, _dbg) ->
       (* Cconst_symbol _ evaluates to a statically-allocated address, so its
          value fits in a typ_int register and is never changed by the GC.
@@ -698,10 +693,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
          may point to heap values. However, any such blocks will be registered
          in the compilation unit's global roots structure, so adding this
          register to the frame table would be redundant *)
-      let r = regs_for typ_int in
-      Ok (insert_op env sub_cfg (make_const_symbol n) [||] r)
+      let r = SU.regs_for Cmm.typ_int in
+      Ok (insert_op env sub_cfg (SU.make_const_symbol n) [||] r)
     | Cvar v -> (
-      try Ok (env_find v env)
+      try Ok (SU.env_find v env)
       with Not_found ->
         Misc.fatal_error ("Selection.emit_expr: unbound var " ^ V.unique_name v)
       )
@@ -723,7 +718,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | Never_returns -> Never_returns
       | Ok (simple_args, env) ->
         let rs = emit_tuple env sub_cfg simple_args in
-        Ok (insert_op_debug env sub_cfg (make_opaque ()) dbg rs rs))
+        Ok (insert_op_debug env sub_cfg (SU.make_opaque ()) dbg rs rs))
     | Cop (Ctuple_field (field, fields_layout), [arg], _dbg) -> (
       match emit_expr env sub_cfg arg ~bound_name:None with
       | Never_returns -> Never_returns
@@ -757,7 +752,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         value_kind
 
   (* Emit an expression in tail position of a function. *)
-  and emit_tail env sub_cfg exp =
+  and emit_tail env sub_cfg (exp : Cmm.expression) =
     match exp with
     | Clet (v, e1, e2) -> (
       match emit_expr env sub_cfg e1 ~bound_name:None with
@@ -782,9 +777,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       emit_tail_trywith env sub_cfg e1 exn_cont v ~extra_args e2 dbg value_kind
     | Cop _ | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
     | Cconst_symbol _ | Cconst_vec128 _ | Cvar _ | Ctuple _ | Cexit _ ->
-      emit_return env sub_cfg exp (pop_all_traps env)
+      emit_return env sub_cfg exp (SU.pop_all_traps env)
 
-  and emit_expr_raise env sub_cfg k (args : expression list) dbg =
+  and emit_expr_raise (env : SU.environment) sub_cfg k
+      (args : Cmm.expression list) dbg : _ Or_never_returns.t =
     let r1 = emit_tuple env sub_cfg args in
     let extra_args_regs =
       match env.trap_stack with
@@ -793,19 +789,19 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
            args. *)
         [||]
       | Specific_trap (cont, _trap_stack) ->
-        Select_utils.env_find_regs_for_exception_extra_args cont env
+        SU.env_find_regs_for_exception_extra_args cont env
     in
     (* Populate the distinguished extra args registers, for the current
        exception handler, with the extra args for this particular raise. *)
     let rd = Array.append [| Proc.loc_exn_bucket |] extra_args_regs in
     Array.iter2
-      (fun r1 rd -> insert env sub_cfg (Cfg.Op Move) [| r1 |] [| rd |])
+      (fun r1 rd -> SU.insert env sub_cfg (Op Move) [| r1 |] [| rd |])
       r1 rd;
-    insert_debug' env sub_cfg (Cfg.Raise k) dbg rd [||];
-    set_traps_for_raise env;
+    SU.insert_debug' env sub_cfg (Cfg.Raise k) dbg rd [||];
+    SU.set_traps_for_raise env;
     Never_returns
 
-  and emit_expr_op env sub_cfg bound_name op args dbg =
+  and emit_expr_op env sub_cfg bound_name op args dbg : _ Or_never_returns.t =
     match emit_parts_list env sub_cfg args with
     | Never_returns -> Never_returns
     | Ok (simple_args, env) -> (
@@ -827,21 +823,21 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                   regs
                 }
             in
-            insert_debug env sub_cfg (Cfg.Op naming_op) Debuginfo.none [||] [||]
+            insert_debug env sub_cfg (Op naming_op) Debuginfo.none [||] [||]
       in
-      let ty = Select_utils.oper_result_type op in
+      let ty = SU.oper_result_type op in
       let label_after = Cmm.new_label () in
       let new_op, new_args = select_operation op simple_args dbg ~label_after in
       match new_op with
       | Terminator (Call { op = Indirect; label_after } as term) ->
         let r1 = emit_tuple env sub_cfg new_args in
         let rarg = Array.sub r1 1 (Array.length r1 - 1) in
-        let rd = regs_for ty in
+        let rd = SU.regs_for ty in
         let loc_arg, stack_ofs_args = Proc.loc_arguments (Reg.typv rarg) in
         let loc_res, stack_ofs_res = Proc.loc_results_call (Reg.typv rd) in
         let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
-        insert_move_args env sub_cfg rarg loc_arg stack_ofs;
-        insert_debug' env sub_cfg term dbg
+        SU.insert_move_args env sub_cfg rarg loc_arg stack_ofs;
+        SU.insert_debug' env sub_cfg term dbg
           (Array.append [| r1.(0) |] loc_arg)
           loc_res;
         Sub_cfg.add_never_block sub_cfg ~label:label_after;
@@ -849,45 +845,45 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
            need to be named right now, otherwise the result of the function call
            may be unavailable in the debugger immediately after the call. *)
         add_naming_op_for_bound_name sub_cfg loc_res;
-        insert_move_results env sub_cfg loc_res rd stack_ofs;
-        Select_utils.set_traps_for_raise env;
+        SU.insert_move_results env sub_cfg loc_res rd stack_ofs;
+        SU.set_traps_for_raise env;
         Ok rd
       | Terminator (Call { op = Direct _; label_after } as term) ->
         let r1 = emit_tuple env sub_cfg new_args in
-        let rd = regs_for ty in
+        let rd = SU.regs_for ty in
         let loc_arg, stack_ofs_args = Proc.loc_arguments (Reg.typv r1) in
         let loc_res, stack_ofs_res = Proc.loc_results_call (Reg.typv rd) in
         let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
-        insert_move_args env sub_cfg r1 loc_arg stack_ofs;
-        insert_debug' env sub_cfg term dbg loc_arg loc_res;
+        SU.insert_move_args env sub_cfg r1 loc_arg stack_ofs;
+        SU.insert_debug' env sub_cfg term dbg loc_arg loc_res;
         add_naming_op_for_bound_name sub_cfg loc_res;
         Sub_cfg.add_never_block sub_cfg ~label:label_after;
-        insert_move_results env sub_cfg loc_res rd stack_ofs;
-        Select_utils.set_traps_for_raise env;
+        SU.insert_move_results env sub_cfg loc_res rd stack_ofs;
+        SU.set_traps_for_raise env;
         Ok rd
       | Terminator
           (Prim { op = External ({ ty_args; ty_res; _ } as r); label_after }) ->
         let loc_arg, stack_ofs =
           emit_extcall_args env sub_cfg ty_args new_args dbg
         in
-        let rd = regs_for ty_res in
+        let rd = SU.regs_for ty_res in
         let term =
           Cfg.Prim { op = External { r with stack_ofs }; label_after }
         in
         let loc_res =
-          insert_op_debug' env sub_cfg term dbg loc_arg
+          SU.insert_op_debug' env sub_cfg term dbg loc_arg
             (Proc.loc_external_results (Reg.typv rd))
         in
         Sub_cfg.add_never_block sub_cfg ~label:label_after;
         add_naming_op_for_bound_name sub_cfg loc_res;
-        insert_move_results env sub_cfg loc_res rd stack_ofs;
-        Select_utils.set_traps_for_raise env;
+        SU.insert_move_results env sub_cfg loc_res rd stack_ofs;
+        SU.set_traps_for_raise env;
         Ok rd
       | Terminator (Prim { op = Probe _; label_after } as term) ->
         let r1 = emit_tuple env sub_cfg new_args in
-        let rd = regs_for ty in
-        let rd = insert_op_debug' env sub_cfg term dbg r1 rd in
-        Select_utils.set_traps_for_raise env;
+        let rd = SU.regs_for ty in
+        let rd = SU.insert_op_debug' env sub_cfg term dbg r1 rd in
+        SU.set_traps_for_raise env;
         Sub_cfg.add_never_block sub_cfg ~label:label_after;
         Ok rd
       | Terminator (Call_no_return ({ func_symbol; ty_args; _ } as r)) ->
@@ -895,13 +891,13 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           emit_extcall_args env sub_cfg ty_args new_args dbg
         in
         let keep_for_checking =
-          !Select_utils.current_function_is_check_enabled
+          !SU.current_function_is_check_enabled
           && String.equal func_symbol Cmm.caml_flambda2_invalid
         in
         let returns, ty =
-          if keep_for_checking then true, typ_int else false, ty
+          if keep_for_checking then true, Cmm.typ_int else false, ty
         in
-        let rd = regs_for ty in
+        let rd = SU.regs_for ty in
         let label = Cmm.new_label () in
         let r = { r with stack_ofs } in
         let term : Cfg.terminator =
@@ -910,18 +906,18 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           else Call_no_return r
         in
         let (_ : Reg.t array) =
-          insert_op_debug' env sub_cfg term dbg loc_arg
+          SU.insert_op_debug' env sub_cfg term dbg loc_arg
             (Proc.loc_external_results (Reg.typv rd))
         in
-        Select_utils.set_traps_for_raise env;
+        SU.set_traps_for_raise env;
         if returns
         then (
           Sub_cfg.add_never_block sub_cfg ~label;
           Ok rd)
         else Never_returns
       | Basic (Op (Alloc { bytes = _; mode; dbginfo = [placeholder] })) ->
-        let rd = regs_for typ_val in
-        let bytes = Select_utils.size_expr env (Ctuple new_args) in
+        let rd = SU.regs_for Cmm.typ_val in
+        let bytes = SU.size_expr env (Ctuple new_args) in
         let alloc_words = (bytes + Arch.size_addr - 1) / Arch.size_addr in
         let op =
           Operation.Alloc
@@ -930,10 +926,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
               mode
             }
         in
-        insert_debug env sub_cfg (Cfg.Op op) dbg [||] rd;
+        insert_debug env sub_cfg (Op op) dbg [||] rd;
         add_naming_op_for_bound_name sub_cfg rd;
         emit_stores env sub_cfg dbg new_args rd;
-        Select_utils.set_traps_for_raise env;
+        SU.set_traps_for_raise env;
         Ok rd
       | Basic (Op (Alloc { bytes = _; mode = _; dbginfo })) ->
         Misc.fatal_errorf
@@ -941,7 +937,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           (List.length dbginfo)
       | Basic (Op op) ->
         let r1 = emit_tuple env sub_cfg new_args in
-        let rd = regs_for ty in
+        let rd = SU.regs_for ty in
         add_naming_op_for_bound_name sub_cfg rd;
         Ok (insert_op_debug env sub_cfg op dbg r1 rd)
       | Basic basic ->
@@ -953,7 +949,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
 
   and emit_expr_ifthenelse env sub_cfg bound_name econd _ifso_dbg eif
       (_ifnot_dbg : Debuginfo.t) eelse (_dbg : Debuginfo.t)
-      (_value_kind : Cmm.kind_for_unboxing) =
+      (_value_kind : Cmm.kind_for_unboxing) : _ Or_never_returns.t =
     (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
     let cond, earg = select_condition econd in
     match emit_expr env sub_cfg earg ~bound_name:None with
@@ -962,9 +958,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       assert (Sub_cfg.exit_has_never_terminator sub_cfg);
       let rif, sub_if = emit_new_sub_cfg env eif ~bound_name in
       let relse, sub_else = emit_new_sub_cfg env eelse ~bound_name in
-      let r = join env rif sub_if relse sub_else ~bound_name in
+      let r = SU.join env rif sub_if relse sub_else ~bound_name in
       let term_desc =
-        terminator_of_test cond
+        SU.terminator_of_test cond
           ~label_true:(Sub_cfg.start_label sub_if)
           ~label_false:(Sub_cfg.start_label sub_else)
       in
@@ -973,7 +969,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       r
 
   and emit_expr_switch env sub_cfg bound_name esel index ecases
-      (_dbg : Debuginfo.t) (_value_kind : Cmm.kind_for_unboxing) =
+      (_dbg : Debuginfo.t) (_value_kind : Cmm.kind_for_unboxing) :
+      _ Or_never_returns.t =
     (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
     match emit_expr env sub_cfg esel ~bound_name:None with
     | Never_returns -> Never_returns
@@ -984,7 +981,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           (fun (case, _dbg) -> emit_new_sub_cfg env case ~bound_name)
           ecases
       in
-      let r = join_array env sub_cases ~bound_name in
+      let r = SU.join_array env sub_cases ~bound_name in
       let subs = Array.map (fun (_, sub_cfg) -> sub_cfg) sub_cases in
       let term_desc : Cfg.terminator =
         Switch (Array.map (fun idx -> Sub_cfg.start_label subs.(idx)) index)
@@ -1001,8 +998,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           let rs =
             List.map
               (fun (id, typ) ->
-                let r = regs_for typ in
-                Select_utils.name_regs id r;
+                let r = SU.regs_for typ in
+                SU.name_regs id r;
                 r)
               ids
           in
@@ -1015,9 +1012,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       List.fold_left
         (fun (env, map) (nfail, ids, rs, e2, dbg, is_cold) ->
           let label = Cmm.new_label () in
-          let env, r =
-            Select_utils.env_add_static_exception nfail rs env label
-          in
+          let env, r = SU.env_add_static_exception nfail rs env label in
           env, Int.Map.add nfail (r, (ids, rs, e2, dbg, is_cold, label)) map)
         (env, Int.Map.empty) handlers
     in
@@ -1026,15 +1021,15 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         (trap_info, (ids, rs, e2, _dbg, is_cold, label)) =
       assert (List.length ids = List.length rs);
       let trap_stack =
-        match (!trap_info : Select_utils.trap_stack_info) with
+        match (!trap_info : SU.trap_stack_info) with
         | Unreachable -> assert false
         | Reachable t -> t
       in
       let ids_and_rs = List.combine ids rs in
       let new_env =
         List.fold_left
-          (fun env ((id, _typ), r) -> Select_utils.env_add id r env)
-          (Select_utils.env_set_trap_stack env trap_stack)
+          (fun env ((id, _typ), r) -> SU.env_add id r env)
+          (SU.env_set_trap_stack env trap_stack)
           ids_and_rs
       in
       let r, sub =
@@ -1054,7 +1049,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                         regs = r
                       }
                   in
-                  insert_debug new_env sub_cfg (Cfg.Op naming_op) Debuginfo.none
+                  insert_debug new_env sub_cfg (Op naming_op) Debuginfo.none
                     [||] [||])
               ids_and_rs)
       in
@@ -1064,9 +1059,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       let not_built, to_build =
         Int.Map.partition
           (fun _n (r, _) ->
-            match !r with
-            | Select_utils.Unreachable -> true
-            | Select_utils.Reachable _ -> false)
+            match !r with SU.Unreachable -> true | SU.Reachable _ -> false)
           not_built
       in
       if Int.Map.is_empty to_build
@@ -1085,7 +1078,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       (* Note: we're dropping unreachable handlers here *)
     in
     let a = Array.of_list ((r_body, sub_body) :: List.map snd l) in
-    let r = join_array env a ~bound_name in
+    let r = SU.join_array env a ~bound_name in
     assert (Sub_cfg.exit_has_never_terminator sub_cfg);
     let sub_handlers =
       List.map
@@ -1099,7 +1092,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     Sub_cfg.join ~from:(sub_body :: sub_handlers) ~to_:sub_cfg;
     r
 
-  and emit_expr_exit env sub_cfg lbl args traps =
+  and emit_expr_exit env sub_cfg (lbl : Cmm.exit_label) args traps :
+      _ Or_never_returns.t =
     match emit_parts_list env sub_cfg args with
     | Never_returns -> Never_returns
     | Ok (simple_list, ext_env) -> (
@@ -1107,7 +1101,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | Lbl nfail ->
         let src = emit_tuple ext_env sub_cfg simple_list in
         let handler =
-          try Select_utils.env_find_static_exception nfail env
+          try SU.env_find_static_exception nfail env
           with Not_found ->
             Misc.fatal_error
               ("Selection.emit_expr: unbound label "
@@ -1124,8 +1118,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
             | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
             | Val | Int | Float | Vec128 | Float32 -> ())
           src;
-        insert_moves env sub_cfg src tmp_regs;
-        insert_moves env sub_cfg tmp_regs (Array.concat handler.regs);
+        SU.insert_moves env sub_cfg src tmp_regs;
+        SU.insert_moves env sub_cfg tmp_regs (Array.concat handler.regs);
         assert (Sub_cfg.exit_has_never_terminator sub_cfg);
         List.iter
           (fun trap ->
@@ -1133,7 +1127,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
               match trap with
               | Cmm.Push handler_id ->
                 let lbl_handler =
-                  (Select_utils.env_find_static_exception handler_id env).label
+                  (SU.env_find_static_exception handler_id env).label
                 in
                 Cfg.Pushtrap { lbl_handler }
               | Cmm.Pop _ -> Cfg.Poptrap
@@ -1141,8 +1135,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
             Sub_cfg.add_instruction sub_cfg instr_desc [||] [||] Debuginfo.none)
           traps;
         Sub_cfg.update_exit_terminator sub_cfg (Always handler.label);
-        Select_utils.set_traps nfail handler.Select_utils.traps_ref
-          env.Select_utils.trap_stack traps;
+        SU.set_traps nfail handler.Select_utils.traps_ref env.SU.trap_stack
+          traps;
         Never_returns
       | Return_lbl -> (
         match simple_list with
@@ -1166,15 +1160,15 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
        on its exception continuation has to compiled using a wrapper; see
        [To_cmm_expr.translate_apply]. *)
     let extra_arg_regs_split =
-      List.map (fun (_param, machtype) -> regs_for machtype) extra_args
+      List.map (fun (_param, machtype) -> SU.regs_for machtype) extra_args
     in
     let extra_arg_regs = Array.concat extra_arg_regs_split in
-    let env_body = Select_utils.env_enter_trywith env exn_cont exn_label in
+    let env_body = SU.env_enter_trywith env exn_cont exn_label in
     let env_body =
-      env_add_regs_for_exception_extra_args exn_cont extra_arg_regs env_body
+      SU.env_add_regs_for_exception_extra_args exn_cont extra_arg_regs env_body
     in
     let r1, sub1 = emit_new_sub_cfg env_body e1 ~bound_name in
-    let exn_bucket_in_handler = regs_for typ_val in
+    let exn_bucket_in_handler = SU.regs_for Cmm.typ_val in
     let rv_list = exn_bucket_in_handler :: extra_arg_regs_split in
     let with_handler env_handler e2 =
       let r2, sub2 =
@@ -1194,46 +1188,45 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                         regs
                       }
                   in
-                  insert_debug env sub_cfg (Cfg.Op naming_op) Debuginfo.none
-                    [||] [||])
+                  insert_debug env sub_cfg (Op naming_op) Debuginfo.none [||]
+                    [||])
               (v :: List.map fst extra_args)
               rv_list)
       in
-      let r = join env r1 sub1 r2 sub2 ~bound_name in
+      let r = SU.join env r1 sub1 r2 sub2 ~bound_name in
       Sub_cfg.mark_as_trap_handler sub2 ~exn_label;
-      Sub_cfg.add_instruction_at_start sub2 (Cfg.Op Move)
-        [| Proc.loc_exn_bucket |] exn_bucket_in_handler Debuginfo.none;
+      Sub_cfg.add_instruction_at_start sub2 (Op Move) [| Proc.loc_exn_bucket |]
+        exn_bucket_in_handler Debuginfo.none;
       Sub_cfg.update_exit_terminator sub_cfg (Always (Sub_cfg.start_label sub1));
       Sub_cfg.join ~from:[sub1; sub2] ~to_:sub_cfg;
       r
     in
     let env =
       List.fold_left2
-        (fun env var regs -> Select_utils.env_add var regs env)
+        (fun env var regs -> SU.env_add var regs env)
         env
         (v :: List.map fst extra_args)
         rv_list
     in
-    match Select_utils.env_find_static_exception exn_cont env_body with
+    match SU.env_find_static_exception exn_cont env_body with
     | { traps_ref = { contents = Reachable ts }; _ } ->
-      with_handler (Select_utils.env_set_trap_stack env ts) e2
+      with_handler (SU.env_set_trap_stack env ts) e2
     | { traps_ref = { contents = Unreachable }; _ } ->
-      let dummy_constant = Cconst_int (1, Debuginfo.none) in
-      let segfault =
-        Cmm.(
-          Cop
-            ( Cload
-                { memory_chunk = Word_int;
-                  mutability = Mutable;
-                  is_atomic = false
-                },
-              [Cconst_int (0, Debuginfo.none)],
-              Debuginfo.none ))
+      let dummy_constant : Cmm.expression = Cconst_int (1, Debuginfo.none) in
+      let segfault : Cmm.expression =
+        Cop
+          ( Cload
+              { memory_chunk = Word_int;
+                mutability = Mutable;
+                is_atomic = false
+              },
+            [Cconst_int (0, Debuginfo.none)],
+            Debuginfo.none )
       in
-      let dummy_raise =
+      let dummy_raise : Cmm.expression =
         Cop (Craise Raise_notrace, [dummy_constant], Debuginfo.none)
       in
-      let unreachable =
+      let unreachable : Cmm.expression =
         (* The use of a raise operation means that this handler is known not to
            return, making it compatible with any layout for the body or
            surrounding code. We also set the trap stack to [Uncaught] to ensure
@@ -1241,7 +1234,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
            function. *)
         Csequence (segfault, dummy_raise)
       in
-      let env = Select_utils.env_set_trap_stack env Uncaught in
+      let env = SU.env_set_trap_stack env Uncaught in
       with_handler env unreachable
       (* Misc.fatal_errorf "Selection.emit_expr: \ * Unreachable exception
          handler %d" lbl *)
@@ -1269,55 +1262,55 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       match new_op with
       | Terminator (Call { op = Indirect; label_after } as term) ->
         let r1 = emit_tuple env sub_cfg new_args in
-        let rd = regs_for ty in
+        let rd = SU.regs_for ty in
         let rarg = Array.sub r1 1 (Array.length r1 - 1) in
         let loc_arg, stack_ofs_args = Proc.loc_arguments (Reg.typv rarg) in
         let loc_res, stack_ofs_res = Proc.loc_results_call (Reg.typv rd) in
         let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
-        if stack_ofs = 0 && Select_utils.trap_stack_is_empty env
+        if stack_ofs = 0 && SU.trap_stack_is_empty env
         then (
           let call = Cfg.Tailcall_func Indirect in
-          insert_moves env sub_cfg rarg loc_arg;
-          insert_debug' env sub_cfg call dbg
+          SU.insert_moves env sub_cfg rarg loc_arg;
+          SU.insert_debug' env sub_cfg call dbg
             (Array.append [| r1.(0) |] loc_arg)
             [||])
         else (
-          insert_move_args env sub_cfg rarg loc_arg stack_ofs;
-          insert_debug' env sub_cfg term dbg
+          SU.insert_move_args env sub_cfg rarg loc_arg stack_ofs;
+          SU.insert_debug' env sub_cfg term dbg
             (Array.append [| r1.(0) |] loc_arg)
             loc_res;
           Sub_cfg.add_never_block sub_cfg ~label:label_after;
-          Select_utils.set_traps_for_raise env;
-          insert env sub_cfg (Cfg.Op (Stackoffset (-stack_ofs))) [||] [||];
-          insert_return env sub_cfg (Ok loc_res) (pop_all_traps env))
+          SU.set_traps_for_raise env;
+          SU.insert env sub_cfg (Op (Stackoffset (-stack_ofs))) [||] [||];
+          insert_return env sub_cfg (Ok loc_res) (SU.pop_all_traps env))
       | Terminator (Call { op = Direct func; label_after } as term) ->
         let r1 = emit_tuple env sub_cfg new_args in
-        let rd = regs_for ty in
+        let rd = SU.regs_for ty in
         let loc_arg, stack_ofs_args = Proc.loc_arguments (Reg.typv r1) in
         let loc_res, stack_ofs_res = Proc.loc_results_call (Reg.typv rd) in
         let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
-        if String.equal func.sym_name !Select_utils.current_function_name
-           && Select_utils.trap_stack_is_empty env
+        if String.equal func.sym_name !SU.current_function_name
+           && SU.trap_stack_is_empty env
         then (
-          let call = Cfg.Tailcall_self { destination = env.tailrec_label } in
+          let call = Cfg.Tailcall_self { destination = env.SU.tailrec_label } in
           let loc_arg' =
             assert (stack_ofs >= 0);
             if stack_ofs = 0 then loc_arg else Proc.loc_parameters (Reg.typv r1)
           in
-          insert_moves env sub_cfg r1 loc_arg';
-          insert_debug' env sub_cfg call dbg loc_arg' [||])
-        else if stack_ofs = 0 && Select_utils.trap_stack_is_empty env
+          SU.insert_moves env sub_cfg r1 loc_arg';
+          SU.insert_debug' env sub_cfg call dbg loc_arg' [||])
+        else if stack_ofs = 0 && SU.trap_stack_is_empty env
         then (
           let call = Cfg.Tailcall_func (Direct func) in
-          insert_moves env sub_cfg r1 loc_arg;
-          insert_debug' env sub_cfg call dbg loc_arg [||])
+          SU.insert_moves env sub_cfg r1 loc_arg;
+          SU.insert_debug' env sub_cfg call dbg loc_arg [||])
         else (
-          insert_move_args env sub_cfg r1 loc_arg stack_ofs;
-          insert_debug' env sub_cfg term dbg loc_arg loc_res;
+          SU.insert_move_args env sub_cfg r1 loc_arg stack_ofs;
+          SU.insert_debug' env sub_cfg term dbg loc_arg loc_res;
           Sub_cfg.add_never_block sub_cfg ~label:label_after;
-          Select_utils.set_traps_for_raise env;
-          insert env sub_cfg (Cfg.Op (Stackoffset (-stack_ofs))) [||] [||];
-          insert_return env sub_cfg (Ok loc_res) (pop_all_traps env))
+          SU.set_traps_for_raise env;
+          SU.insert env sub_cfg (Op (Stackoffset (-stack_ofs))) [||] [||];
+          insert_return env sub_cfg (Ok loc_res) (SU.pop_all_traps env))
       | _ -> Misc.fatal_error "Cfg_selectgen.emit_tail")
 
   and emit_tail_ifthenelse env sub_cfg econd (_ifso_dbg : Debuginfo.t) eif
@@ -1332,7 +1325,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       let sub_if = emit_tail_new_sub_cfg env eif in
       let sub_else = emit_tail_new_sub_cfg env eelse in
       let term_desc =
-        terminator_of_test cond
+        SU.terminator_of_test cond
           ~label_true:(Sub_cfg.start_label sub_if)
           ~label_false:(Sub_cfg.start_label sub_else)
       in
@@ -1364,8 +1357,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           let rs =
             List.map
               (fun (id, typ) ->
-                let r = regs_for typ in
-                Select_utils.name_regs id r;
+                let r = SU.regs_for typ in
+                SU.name_regs id r;
                 r)
               ids
           in
@@ -1376,9 +1369,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       List.fold_left
         (fun (env, map) (nfail, ids, rs, e2, dbg, is_cold) ->
           let label = Cmm.new_label () in
-          let env, r =
-            Select_utils.env_add_static_exception nfail rs env label
-          in
+          let env, r = SU.env_add_static_exception nfail rs env label in
           env, Int.Map.add nfail (r, (ids, rs, e2, dbg, is_cold, label)) map)
         (env, Int.Map.empty) handlers
     in
@@ -1388,15 +1379,15 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         (trap_info, (ids, rs, e2, _dbg, is_cold, label)) =
       assert (List.length ids = List.length rs);
       let trap_stack =
-        match (!trap_info : Select_utils.trap_stack_info) with
+        match (!trap_info : SU.trap_stack_info) with
         | Unreachable -> assert false
         | Reachable t -> t
       in
       let ids_and_rs = List.combine ids rs in
       let new_env =
         List.fold_left
-          (fun env ((id, _typ), r) -> Select_utils.env_add id r env)
-          (Select_utils.env_set_trap_stack env trap_stack)
+          (fun env ((id, _typ), r) -> SU.env_add id r env)
+          (SU.env_set_trap_stack env trap_stack)
           ids_and_rs
       in
       let seq : Sub_cfg.t =
@@ -1416,7 +1407,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                         regs = r
                       }
                   in
-                  insert_debug new_env sub_cfg (Cfg.Op naming_op) Debuginfo.none
+                  insert_debug new_env sub_cfg (Op naming_op) Debuginfo.none
                     [||] [||])
               ids_and_rs)
       in
@@ -1427,9 +1418,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       let not_built, to_build =
         Int.Map.partition
           (fun _n (r, _) ->
-            match !r with
-            | Select_utils.Unreachable -> true
-            | Select_utils.Reachable _ -> false)
+            match !r with SU.Unreachable -> true | SU.Reachable _ -> false)
           not_built
       in
       if Int.Map.is_empty to_build
@@ -1461,15 +1450,15 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     let exn_label = Cmm.new_label () in
     (* See comment in emit_expr_trywith about extra args *)
     let extra_arg_regs_split =
-      List.map (fun (_param, machtype) -> regs_for machtype) extra_args
+      List.map (fun (_param, machtype) -> SU.regs_for machtype) extra_args
     in
     let extra_arg_regs = Array.concat extra_arg_regs_split in
-    let env_body = Select_utils.env_enter_trywith env exn_cont exn_label in
+    let env_body = SU.env_enter_trywith env exn_cont exn_label in
     let env_body =
-      env_add_regs_for_exception_extra_args exn_cont extra_arg_regs env_body
+      SU.env_add_regs_for_exception_extra_args exn_cont extra_arg_regs env_body
     in
     let s1 : Sub_cfg.t = emit_tail_new_sub_cfg env_body e1 in
-    let exn_bucket_in_handler = regs_for typ_val in
+    let exn_bucket_in_handler = SU.regs_for Cmm.typ_val in
     let rv_list = exn_bucket_in_handler :: extra_arg_regs_split in
     let with_handler env_handler e2 =
       let s2 : Sub_cfg.t =
@@ -1489,27 +1478,27 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                         regs
                       }
                   in
-                  insert_debug env sub_cfg (Cfg.Op naming_op) Debuginfo.none
-                    [||] [||])
+                  insert_debug env sub_cfg (Op naming_op) Debuginfo.none [||]
+                    [||])
               (v :: List.map fst extra_args)
               rv_list)
       in
       Sub_cfg.mark_as_trap_handler s2 ~exn_label;
-      Sub_cfg.add_instruction_at_start s2 (Cfg.Op Move)
-        [| Proc.loc_exn_bucket |] exn_bucket_in_handler Debuginfo.none;
+      Sub_cfg.add_instruction_at_start s2 (Op Move) [| Proc.loc_exn_bucket |]
+        exn_bucket_in_handler Debuginfo.none;
       Sub_cfg.update_exit_terminator sub_cfg (Always (Sub_cfg.start_label s1));
       Sub_cfg.join_tail ~from:[s1; s2] ~to_:sub_cfg
     in
     let env =
       List.fold_left2
-        (fun env var regs -> Select_utils.env_add var regs env)
+        (fun env var regs -> SU.env_add var regs env)
         env
         (v :: List.map fst extra_args)
         rv_list
     in
-    match Select_utils.env_find_static_exception exn_cont env_body with
+    match SU.env_find_static_exception exn_cont env_body with
     | { traps_ref = { contents = Reachable ts }; _ } ->
-      with_handler (Select_utils.env_set_trap_stack env ts) e2
+      with_handler (SU.env_set_trap_stack env ts) e2
     | { traps_ref = { contents = Unreachable }; _ } ->
       (* Note: The following [unreachable] expression has machtype [|Int|], but
          this might not be the correct machtype for this function's return
@@ -1543,16 +1532,16 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
   (* Sequentialization of a function definition *)
 
   let emit_fundecl ~future_funcnames f =
-    Select_utils.current_function_name := f.Cmm.fun_name.sym_name;
-    Select_utils.current_function_is_check_enabled
+    SU.current_function_name := f.Cmm.fun_name.sym_name;
+    SU.current_function_is_check_enabled
       := Zero_alloc_checker.is_check_enabled f.Cmm.fun_codegen_options
            f.Cmm.fun_name.sym_name f.Cmm.fun_dbg;
     let num_regs_per_arg = Array.make (List.length f.Cmm.fun_args) 0 in
     let rargs =
       List.mapi
         (fun arg_index (var, ty) ->
-          let r = regs_for ty in
-          Select_utils.name_regs var r;
+          let r = SU.regs_for ty in
+          SU.name_regs var r;
           num_regs_per_arg.(arg_index) <- Array.length r;
           r)
         f.Cmm.fun_args
@@ -1560,10 +1549,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     let rarg = Array.concat rargs in
     let loc_arg = Proc.loc_parameters (Reg.typv rarg) in
     let tailrec_label = Cmm.new_label () in
-    let env = Select_utils.env_create ~tailrec_label in
+    let env = SU.env_create ~tailrec_label in
     let env =
       List.fold_right2
-        (fun (id, _ty) r env -> Select_utils.env_add id r env)
+        (fun (id, _ty) r env -> SU.env_add id r env)
         f.Cmm.fun_args rargs env
     in
     let body = Sub_cfg.make_empty () in
@@ -1589,10 +1578,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                 regs = hard_regs_for_arg
               }
           in
-          insert_debug env body (Cfg.Op naming_op) Debuginfo.none
-            hard_regs_for_arg [||])
+          insert_debug env body (Op naming_op) Debuginfo.none hard_regs_for_arg
+            [||])
       f.Cmm.fun_args;
-    insert_moves env body loc_arg rarg;
+    SU.insert_moves env body loc_arg rarg;
     let prologue_poll_instr_id =
       insert_op_debug_returning_id env body Operation.Poll Debuginfo.none [||]
         [||]
@@ -1660,7 +1649,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     (* note: `Cfgize.Stack_offset_and_exn.update_cfg` may add edges to the
        graph, and should hence be executed before
        `Cfg.register_predecessors_for_all_blocks`. *)
-    Stack_offset_and_exn.update_cfg cfg;
+    SU.Stack_offset_and_exn.update_cfg cfg;
     Cfg.register_predecessors_for_all_blocks cfg;
     let fun_contains_calls =
       Sub_cfg.exists_basic_blocks body ~f:Cfg.basic_block_contains_calls


### PR DESCRIPTION
This removes various now-unnecessary constructor module name qualifications.  It removes the remaining `open` directives too, which helps with legibility, since it isn't always clear which module a particular function comes from.