### PR TITLE
Fix Weak.set on arm64 (and other relaxed architectures)

### DIFF
--- a/testsuite/tests/weak-ephe-final/weak_array_par.ml
+++ b/testsuite/tests/weak-ephe-final/weak_array_par.ml
@@ -11,7 +11,7 @@ let () = Random.self_init ()
 
 let num_domains = 4
 let iters = 1_000_000
-let len = 10_000
+let len = 10
 let table = Weak.create len
 
 let go () =
@@ -20,9 +20,11 @@ let go () =
     let h = String.hash s mod len in
     begin match Weak.get table h with
     | None -> ()
-    | Some s' -> assert (String.hash s' mod len = h)
+    | Some (s1, s2) ->
+      assert (String.equal s1 s2);
+      assert (String.hash s1 mod len = h)
     end;
-    Weak.set table h (Some s)
+    Weak.set table h (Some (s,s))
   done
 
 let () =


### PR DESCRIPTION
Safe use of mutation requires fences on weakly-ordered architectures such as arm64 (but not x86). These fences are part of `caml_modify`, but were missing from the functions that update ephemerons such as `Weak.set`. This caused sporadic segfaults in the `weak_array_par` test.

This patch contains two commits, which:

  1. Make the bug trigger more reliably, by tweaking the test.
  2. Fix the bug, by adding the same fences that `caml_modify` uses.

After commit (1), the test reliably fails on arm64, and then reliably passes after commit (2).