### PR TITLE
Remove all objects from ocamltest

### DIFF
--- a/ocamltest/ocaml_compilers.mli
+++ b/ocamltest/ocaml_compilers.mli
@@ -15,7 +15,18 @@
 
 (* Descriptions of the OCaml compilers *)
 
-class compiler :
+module type Compiler = sig
+  include Ocaml_tools.Tool
+
+  val host : Ocaml_backends.t
+  val target : Ocaml_backends.t
+  val program_variable : Variables.t
+  val program_output_variable : Variables.t option
+end
+
+type compiler = (module Compiler)
+
+val compiler :
   name : string ->
   flags : string ->
   directory : string ->
@@ -24,12 +35,7 @@ class compiler :
   output_variable : Variables.t ->
   host : Ocaml_backends.t ->
   target : Ocaml_backends.t ->
-object inherit Ocaml_tools.tool
-  method host : Ocaml_backends.t
-  method target : Ocaml_backends.t
-  method program_variable : Variables.t
-  method program_output_variable : Variables.t option
-end
+  compiler
 
 val ocamlc_byte : compiler
 

--- a/ocamltest/ocaml_tools.ml
+++ b/ocamltest/ocaml_tools.ml
@@ -17,7 +17,24 @@
 
 open Ocamltest_stdlib
 
-class tool
+module type Tool = sig
+  val name : string
+  val family : string
+  val flags : string
+  val directory : string
+  val exit_status_variable : Variables.t
+  val reference_variable : Variables.t
+  val output_variable : Variables.t
+  val reference_filename_suffix : Environments.t -> string
+  val reference_file : Environments.t -> string -> string
+end
+
+type tool = (module Tool)
+
+let reference_file_from_suffix prefix suffix ~directory =
+  (Filename.make_filename prefix directory) ^ suffix
+
+let tool
   ~(name : string)
   ~(family : string)
   ~(flags : string)
@@ -25,16 +42,16 @@ class tool
   ~(exit_status_variable : Variables.t)
   ~(reference_variable : Variables.t)
   ~(output_variable : Variables.t)
-= object (self)
-  method name = name
-  method family = family
-  method flags = flags
-  method directory = directory
-  method exit_status_variable = exit_status_variable
-  method reference_variable = reference_variable
-  method output_variable = output_variable
+= (module struct
+  let name = name
+  let family = family
+  let flags = flags
+  let directory = directory
+  let exit_status_variable = exit_status_variable
+  let reference_variable = reference_variable
+  let output_variable = output_variable
 
-  method reference_filename_suffix env =
+  let reference_filename_suffix env =
     let tool_reference_suffix =
       Environments.safe_lookup Ocaml_variables.compiler_reference_suffix env
     in
@@ -42,17 +59,17 @@ class tool
     then tool_reference_suffix ^ ".reference"
     else ".reference"
 
-  method reference_file env prefix =
-    let suffix = self#reference_filename_suffix env in
-    (Filename.make_filename prefix directory) ^ suffix
-end
+  let reference_file env prefix =
+    let suffix = reference_filename_suffix env in
+    reference_file_from_suffix prefix suffix ~directory
+end : Tool)
 
-let expected_exit_status env tool =
-  Actions_helpers.exit_status_of_variable env tool#exit_status_variable
+let expected_exit_status env (module Tool : Tool) =
+  Actions_helpers.exit_status_of_variable env Tool.exit_status_variable
 
 
 let ocamldoc =
-  object inherit
+  (module struct include (val
   tool
     ~name:Ocaml_files.ocamldoc
     ~family:"doc"
@@ -61,11 +78,16 @@ let ocamldoc =
     ~exit_status_variable:Ocaml_variables.ocamldoc_exit_status
     ~reference_variable:Ocaml_variables.ocamldoc_reference
     ~output_variable:Ocaml_variables.ocamldoc_output
+  )
 
-    method ! reference_filename_suffix env =
+    let reference_filename_suffix env =
       let backend =
         Environments.safe_lookup Ocaml_variables.ocamldoc_backend env in
       if backend = "" then
         ".reference"
       else "." ^ backend ^ ".reference"
-  end
+
+    let reference_file env prefix =
+      let suffix = reference_filename_suffix env in
+      reference_file_from_suffix prefix suffix ~directory
+  end : Tool)

--- a/ocamltest/ocaml_tools.mli
+++ b/ocamltest/ocaml_tools.mli
@@ -15,7 +15,21 @@
 
 (* Descriptions of the OCaml tools *)
 
-class tool :
+module type Tool = sig
+  val name : string
+  val family : string
+  val flags : string
+  val directory : string
+  val exit_status_variable : Variables.t
+  val reference_variable : Variables.t
+  val output_variable : Variables.t
+  val reference_filename_suffix : Environments.t -> string
+  val reference_file : Environments.t -> string -> string
+end
+
+type tool = (module Tool)
+
+val tool :
   name : string ->
   family : string ->
   flags : string ->
@@ -23,17 +37,7 @@ class tool :
   exit_status_variable : Variables.t ->
   reference_variable : Variables.t ->
   output_variable : Variables.t ->
-object
-  method name : string
-  method family : string
-  method flags : string
-  method directory : string
-  method exit_status_variable : Variables.t
-  method reference_variable : Variables.t
-  method output_variable : Variables.t
-  method reference_filename_suffix : Environments.t -> string
-  method reference_file : Environments.t -> string -> string
-end
+  tool
 
 val expected_exit_status : Environments.t -> tool -> int
 

--- a/ocamltest/ocaml_toplevels.mli
+++ b/ocamltest/ocaml_toplevels.mli
@@ -15,7 +15,16 @@
 
 (* Descriptions of the OCaml toplevels *)
 
-class toplevel :
+module type Toplevel = sig
+  include Ocaml_tools.Tool
+
+  val backend : Ocaml_backends.t
+  val compiler : Ocaml_compilers.compiler
+end
+
+type toplevel = (module Toplevel)
+
+val toplevel :
   name : string ->
   flags : string ->
   directory : string ->
@@ -24,10 +33,7 @@ class toplevel :
   output_variable : Variables.t ->
   backend : Ocaml_backends.t ->
   compiler : Ocaml_compilers.compiler ->
-object inherit Ocaml_tools.tool
-  method backend : Ocaml_backends.t
-  method compiler : Ocaml_compilers.compiler
-end
+  toplevel
 
 val ocaml : toplevel
 


### PR DESCRIPTION
A simple refactor. Replaces all objects with first-class modules. Inheritance is mimicked using `include`. There is exactly once instance where that doesn't work, since a method gets overridden and one one of the remaining methods calls it, but all that's necessary is to “override” both “methods” (and they're not even in different files so it's easy).

The formatting is pretty wonky as I was hoping to keep a small diff in case changes are made upstream. (Obviously this can only help so much, especially given the repeated uses of `method`.)