### PR TITLE
Fix incorrect comment

### DIFF
--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -608,8 +608,7 @@ module (Memprof @@ nonportable) :
         (** The size of the block, in words, excluding the header. *)
 
         source : allocation_source;
-        (** The cause of the allocation; [Marshal] cannot be produced
-          since OCaml 5. *)
+        (** The cause of the allocation. *)
 
         callstack : Printexc.raw_backtrace
         (** The callstack for the allocation. *)


### PR DESCRIPTION
Back during development of statmemprof, we didn't distinguish unmarshalling allocations from others. Then I fixed that, but this comment didn't get fixed.