### PR TITLE
Import original Asm_directives module

### DIFF
--- a/backend/asm_targets/asm_directives_new.ml
+++ b/backend/asm_targets/asm_directives_new.ml
@@ -1,0 +1,1049 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*          Fabrice Le Fessant, projet Gallium, INRIA Rocquencourt        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+(* CR-someday mshinwell: Eliminate uses of [bprintf] from the assembly
+   generation code, then enable this warning. *)
+[@@@ocaml.warning "-3"]
+
+module Int8 = Numbers.Int8
+module Int16 = Numbers.Int16
+
+module Uint64 = Numbers.Uint64
+
+module TS = Target_system
+
+let dwarf_supported () =
+  match TS.object_file_format_and_abi () with
+  | ELF _ | Mach_O -> true
+  | A_out | PE | Unknown -> false
+
+let big_endian_ref = ref None
+let current_section_ref = ref None
+
+let not_initialized () =
+  Misc.fatal_error "[Asm_directives.initialize] has not been called"
+
+let current_section () =
+  match !current_section_ref with
+  | None -> not_initialized ()
+  | Some section -> section
+
+let current_section_is_text () =
+  match !current_section_ref with
+  | None -> not_initialized ()
+  | Some section -> Asm_section.section_is_text section
+
+let big_endian () =
+  match !big_endian_ref with
+  | None -> not_initialized ()
+  | Some big_endian -> big_endian
+
+let bprintf = Printf.bprintf
+
+module Directive = struct
+  module Constant = struct
+    type t =
+      | Signed_int of Int64.t
+      | Unsigned_int of Uint64.t
+      | This
+      | Named_thing of string
+      | Add of t * t
+      | Sub of t * t
+
+    let rec print buf t =
+      match t with
+      | Named_thing _ | Signed_int _ | Unsigned_int _
+      | This as c -> print_subterm buf c
+      | Add (c1, c2) ->
+        bprintf buf "%a + %a" print_subterm c1 print_subterm c2
+      | Sub (c1, c2) ->
+        bprintf buf "%a - %a" print_subterm c1 print_subterm c2
+
+    and print_subterm buf t =
+      match t with
+      | This ->
+        begin match TS.assembler () with
+        | MacOS | GAS_like -> Buffer.add_string buf "."
+        | MASM -> Buffer.add_string buf "THIS BYTE"
+        end
+      | Named_thing name -> Buffer.add_string buf name
+      | Signed_int n ->
+        begin match TS.assembler () with
+        (* We use %Ld and not %Lx on Unix-like platforms to ensure that
+           ".sleb128" directives do not end up with hex arguments (since this
+           denotes a variable-length encoding it would not be clear where the
+           sign bit is). *)
+        | MacOS | GAS_like -> bprintf buf "%Ld" n
+        | MASM ->
+          if n >= -0x8000_0000L && n <= 0x7fff_ffffL then
+            Buffer.add_string buf (Int64.to_string n)
+          else
+            bprintf buf "0%LxH" n
+        end
+      | Unsigned_int n ->
+        (* We can use the printer for [Signed_int] since we always print
+           as an unsigned hex representation. *)
+        print_subterm buf (Signed_int (Uint64.to_int64 n))
+      | Add (c1, c2) ->
+        bprintf buf "(%a + %a)" print_subterm c1 print_subterm c2
+      | Sub (c1, c2) ->
+        bprintf buf "(%a - %a)" print_subterm c1 print_subterm c2
+
+    let rec evaluate t =
+      let (>>=) = Misc.Stdlib.Option.(>>=) in
+      match t with
+      | Signed_int i -> Some i
+      | Unsigned_int _ ->
+        (* For the moment we don't evaluate arithmetic on unsigned ints. *)
+        None
+      | This -> None
+      | Named_thing _ -> None
+      | Add (t1, t2) ->
+        evaluate t1
+        >>= fun i1 ->
+        evaluate t2
+        >>= fun i2 ->
+        Some (Int64.add i1 i2)
+      | Sub (t1, t2) ->
+        evaluate t1
+        >>= fun i1 ->
+        evaluate t2
+        >>= fun i2 ->
+        Some (Int64.sub i1 i2)
+  end
+
+  module Constant_with_width = struct
+    type width_in_bytes =
+      | Eight
+      | Sixteen
+      | Thirty_two
+      | Sixty_four
+
+    let int_of_width_in_bytes = function
+      | Eight -> 8
+      | Sixteen -> 16
+      | Thirty_two -> 32
+      | Sixty_four -> 64
+
+    type t = {
+      constant : Constant.t;
+      width_in_bytes : width_in_bytes;
+    }
+
+    let create constant width_in_bytes =
+      begin match Constant.evaluate constant with
+      | None -> ()
+      | Some n ->
+        let in_range =
+          match width_in_bytes with
+          | Eight -> n >= -0x80L && n <= 0x7fL
+          | Sixteen -> n >= -0x8000L && n <= 0x7fffL
+          | Thirty_two -> n >= -0x8000_0000L && n <= 0x7fff_ffffL
+          | Sixty_four -> true
+        in
+        if not in_range then begin
+          Misc.fatal_errorf "Signed integer constant %Ld does not fit in \
+              %d bits"
+            n (int_of_width_in_bytes width_in_bytes)
+        end
+      end;
+      { constant;
+        width_in_bytes;
+      }
+
+    let constant t = t.constant
+    let width_in_bytes t = t.width_in_bytes
+  end
+
+  type thing_after_label =
+    | Code
+    | Machine_width_data
+
+  type comment = string
+
+  type t =
+    | Align of { bytes : int; }
+    | Bytes of { str : string; comment : string option; }
+    | Cfi_adjust_cfa_offset of int
+    | Cfi_def_cfa_offset of int
+    | Cfi_endproc
+    | Cfi_offset of { reg : int; offset : int; }
+    | Cfi_startproc
+    | Comment of comment
+    | Const of { constant : Constant_with_width.t; comment : string option; }
+    | Direct_assignment of string * Constant.t
+    | File of { file_num : int option; filename : string; }
+    | Global of string
+    | Indirect_symbol of string
+    | Loc of { file_num : int; line : int; col : int; }
+    | New_label of string * thing_after_label
+    | New_line
+    | Private_extern of string
+    | Section of {
+        names : string list;
+        flags : string option;
+        args : string list;
+      }
+    | Size of string * Constant.t
+    | Sleb128 of { constant : Constant.t; comment : string option; }
+    | Space of { bytes : int; }
+    | Type of string * string
+    | Uleb128 of { constant : Constant.t; comment : string option; }
+
+  let bprintf = Printf.bprintf
+
+  let emit_comments () = !Clflags.keep_asm_file
+
+  let string_of_string_literal s =
+    let buf = Buffer.create (String.length s + 2) in
+    let last_was_escape = ref false in
+    for i = 0 to String.length s - 1 do
+      let c = s.[i] in
+      if c >= '0' && c <= '9' then
+        if !last_was_escape
+        then Printf.bprintf buf "\\%o" (Char.code c)
+        else Buffer.add_char buf c
+      else if c >= ' ' && c <= '~' && c <> '"' (* '"' *) && c <> '\\' then begin
+        Buffer.add_char buf c;
+        last_was_escape := false
+      end else begin
+        Printf.bprintf buf "\\%o" (Char.code c);
+        last_was_escape := true
+      end
+    done;
+    Buffer.contents buf
+
+  let buf_bytes_directive buf ~directive s =
+    let pos = ref 0 in
+    for i = 0 to String.length s - 1 do
+      if !pos = 0
+      then begin
+        if i > 0 then Buffer.add_char buf '\n';
+        Buffer.add_char buf '\t';
+        Buffer.add_string buf directive;
+        Buffer.add_char buf '\t';
+      end
+      else Buffer.add_char buf ',';
+      Printf.bprintf buf "%d" (Char.code s.[i]);
+      incr pos;
+      if !pos >= 16 then begin pos := 0 end
+    done
+
+  let print_gas buf t =
+    let gas_comment_opt comment_opt =
+      if not (emit_comments ()) then ""
+      else
+        match comment_opt with
+        | None -> ""
+        | Some comment -> Printf.sprintf "\t/* %s */" comment
+    in
+    match t with
+    | Align { bytes = n; } ->
+      (* Some assemblers interpret the integer n as a 2^n alignment and
+         others as a number of bytes. *)
+      let n =
+        match TS.assembler (), TS.architecture () with
+        | MacOS, _
+        | GAS_like, (ARM | AArch64 | POWER) -> Misc.log2 n
+        | _, _ -> n
+      in
+      bprintf buf "\t.align\t%d" n
+    | Const { constant; comment; } ->
+      let directive =
+        match Constant_with_width.width_in_bytes constant with
+        | Eight -> "byte"
+        | Sixteen ->
+          begin match TS.system () with
+          | Solaris -> "value"
+          | _ ->
+            (* Apple's documentation says that ".word" is i386-specific, so
+               we use ".short" instead.
+               Additionally, it appears on ARM that ".word" may be 32 bits wide,
+               not 16 bits. *)
+            "short"
+          end
+        | Thirty_two -> "long"
+        | Sixty_four -> "quad"
+      in
+      let comment = gas_comment_opt comment in
+      bprintf buf "\t.%s\t%a%s"
+        directive
+        Constant.print (Constant_with_width.constant constant)
+        comment
+    | Bytes { str; comment; } ->
+      begin match TS.system (), TS.architecture () with
+      | Solaris, _
+      | _, POWER -> buf_bytes_directive buf ~directive:".byte" str
+      | _ -> bprintf buf "\t.ascii\t\"%s\"" (string_of_string_literal str)
+      end;
+      bprintf buf "%s" (gas_comment_opt comment)
+    | Comment s -> bprintf buf "\t\t\t/* %s */" s
+    | Global s -> bprintf buf "\t.globl\t%s" s
+    | New_label (s, _typ) -> bprintf buf "%s:" s
+    | New_line -> ()
+    | Section { names = [".data"]; _ } -> bprintf buf "\t.data"
+    | Section { names = [".text"]; _ } -> bprintf buf "\t.text"
+    | Section { names; flags; args; } ->
+      bprintf buf "\t.section %s" (String.concat "," names);
+      begin match flags with
+      | None -> ()
+      | Some flags -> bprintf buf ",%S" flags
+      end;
+      begin match args with
+      | [] -> ()
+      | _ -> bprintf buf ",%s" (String.concat "," args)
+      end
+    | Space { bytes; } ->
+      begin match TS.system () with
+      | Solaris -> bprintf buf "\t.zero\t%d" bytes
+      | _ -> bprintf buf "\t.space\t%d" bytes
+      end
+    | Cfi_adjust_cfa_offset n -> bprintf buf "\t.cfi_adjust_cfa_offset %d" n
+    | Cfi_def_cfa_offset n -> bprintf buf "\t.cfi_def_cfa_offset %d" n
+    | Cfi_endproc -> bprintf buf "\t.cfi_endproc"
+    | Cfi_offset { reg; offset; } ->
+      bprintf buf "\t.cfi_offset %d, %d" reg offset
+    | Cfi_startproc -> bprintf buf "\t.cfi_startproc"
+    | File { file_num = None; filename; } ->
+      bprintf buf "\t.file\t\"%s\"" filename
+    | File { file_num = Some file_num; filename; } ->
+      bprintf buf "\t.file\t%d\t\"%s\""
+        file_num (string_of_string_literal filename)
+    | Indirect_symbol s -> bprintf buf "\t.indirect_symbol %s" s
+    | Loc { file_num; line; col; } ->
+      (* PR#7726: Location.none uses column -1, breaks LLVM assembler *)
+      if col >= 0 then bprintf buf "\t.loc\t%d\t%d\t%d" file_num line col
+      else bprintf buf "\t.loc\t%d\t%d" file_num line
+    | Private_extern s -> bprintf buf "\t.private_extern %s" s
+    | Size (s, c) -> bprintf buf "\t.size %s,%a" s Constant.print c
+    | Sleb128 { constant; comment; } ->
+      let comment = gas_comment_opt comment in
+      bprintf buf "\t.sleb128 %a%s" Constant.print constant comment
+    | Type (s, typ) ->
+      (* We use the "STT" forms when they are supported as they are
+         unambiguous across platforms
+         (cf. https://sourceware.org/binutils/docs/as/Type.html ). *)
+      bprintf buf "\t.type %s %s" s typ
+    | Uleb128 { constant; comment; } ->
+      let comment = gas_comment_opt comment in
+      bprintf buf "\t.uleb128 %a%s" Constant.print constant comment
+    | Direct_assignment (var, const) ->
+      begin match TS.assembler () with
+      | MacOS -> bprintf buf "%s = %a" var Constant.print const
+      | _ ->
+        Misc.fatal_error "Cannot emit [Direct_assignment] except on macOS-like \
+          assemblers"
+      end
+
+  let print_masm buf t =
+    let unsupported name =
+      Misc.fatal_errorf "Unsupported asm directive [%s] for MASM" name
+    in
+    let masm_comment_opt comment_opt =
+      if not (emit_comments ()) then ""
+      else
+        match comment_opt with
+        | None -> ""
+        | Some comment -> Printf.sprintf "\t; %s" comment
+    in
+    match t with
+    | Align { bytes; } -> bprintf buf "\tALIGN\t%d" bytes
+    | Bytes { str; comment; } ->
+      buf_bytes_directive buf ~directive:"BYTE" str;
+      bprintf buf "%s" (masm_comment_opt comment)
+    | Comment s -> bprintf buf " ; %s " s
+    | Const { constant; comment; } ->
+      let directive =
+        match Constant_with_width.width_in_bytes constant with
+        | Eight -> "BYTE"
+        | Sixteen -> "WORD"
+        | Thirty_two -> "DWORD"
+        | Sixty_four -> "QWORD"
+      in
+      let comment = masm_comment_opt comment in
+      bprintf buf "\t%s\t%a%s"
+        directive
+        Constant.print (Constant_with_width.constant constant)
+        comment
+    | Global s -> bprintf buf "\tPUBLIC\t%s" s
+    | Section { names = [".data"]; _ } -> bprintf buf "\t.DATA"
+    | Section { names = [".text"]; _ } -> bprintf buf "\t.CODE"
+    | Section _ -> Misc.fatal_error "Unknown section name for MASM emitter"
+    | Space { bytes; } -> bprintf buf "\tBYTE\t%d DUP (?)" bytes
+    | New_label (label, Code) -> bprintf buf "%s:" label
+    | New_label (label, Machine_width_data) ->
+      begin match TS.machine_width () with
+      | Thirty_two -> bprintf buf "%s LABEL DWORD" label
+      | Sixty_four -> bprintf buf "%s LABEL QWORD" label
+      end
+    | New_line -> ()
+    | Cfi_adjust_cfa_offset _ -> unsupported "Cfi_adjust_cfa_offset"
+    | Cfi_def_cfa_offset _ -> unsupported "Cfi_def_cfa_offset"
+    | Cfi_endproc -> unsupported "Cfi_endproc"
+    | Cfi_offset _ -> unsupported "Cfi_offset"
+    | Cfi_startproc -> unsupported "Cfi_startproc"
+    | File _ -> unsupported "File"
+    | Indirect_symbol _ -> unsupported "Indirect_symbol"
+    | Loc _ -> unsupported "Loc"
+    | Private_extern _ -> unsupported "Private_extern"
+    | Size _ -> unsupported "Size"
+    | Sleb128 _ -> unsupported "Sleb128"
+    | Type _ -> unsupported "Type"
+    | Uleb128 _ -> unsupported "Uleb128"
+    | Direct_assignment _ -> unsupported "Direct_assignment"
+
+  let print b t =
+    match TS.assembler () with
+    | MASM -> print_masm b t
+    | MacOS | GAS_like -> print_gas b t
+end
+
+(* A higher-level version of [Constant.t] which contains some more
+   abstractions (e.g. use of [Cmm.label], and in the future distinguished
+   types to represent symbols and symbol references before they are mangled
+   to plain [string]s for [Constant.t]). *)
+type expr =
+  | Signed_int of Int64.t
+  | Unsigned_int of Uint64.t
+  | This
+  | Label of Asm_label.t
+  | Symbol of Asm_symbol.t
+  | Add of expr * expr
+  | Sub of expr * expr
+
+let rec lower_expr (cst : expr) : Directive.Constant.t =
+  match cst with
+  | Signed_int n -> Signed_int n
+  | Unsigned_int n -> Unsigned_int n
+  | This -> This
+  | Label lbl -> Named_thing (Asm_label.encode lbl)
+  | Symbol sym -> Named_thing (Asm_symbol.encode sym)
+  | Add (cst1, cst2) ->
+    Add (lower_expr cst1, lower_expr cst2)
+  | Sub (cst1, cst2) ->
+    Sub (lower_expr cst1, lower_expr cst2)
+
+let emit_ref = ref None
+
+let emit (d : Directive.t) =
+  match !emit_ref with
+  | Some emit -> emit d
+  | None -> Misc.fatal_error "initialize not called"
+
+let emit_non_masm (d : Directive.t) =
+  match TS.assembler () with
+  | MASM ->  ()
+  | MacOS | GAS_like -> emit d
+
+let section ~names ~flags ~args = emit (Section { names; flags; args; })
+
+let align ~bytes = emit (Align { bytes; })
+
+let should_generate_cfi () =
+  (* We generate CFI info even if we're not generating any other debugging
+     information.  This is in fact necessary on macOS, where it may be
+     expected that OCaml stack frames are unwindable (see
+     testsuite/tests/unwind/README for more information). *)
+  Config.asm_cfi_supported
+
+let cfi_adjust_cfa_offset ~bytes =
+  if should_generate_cfi () && bytes <> 0 then begin
+    emit (Cfi_adjust_cfa_offset bytes)
+  end
+
+let cfi_def_cfa_offset ~bytes =
+  if should_generate_cfi () then begin
+    emit (Cfi_def_cfa_offset bytes)
+  end
+
+let cfi_endproc () =
+  if should_generate_cfi () then begin
+    emit Cfi_endproc
+  end
+
+let cfi_offset ~reg ~offset =
+  if should_generate_cfi () && offset <> 0 then begin
+    emit (Cfi_offset { reg; offset; })
+  end
+
+let cfi_startproc () =
+  if should_generate_cfi () then begin
+    emit Cfi_startproc
+  end
+
+let comment text =
+  if !Clflags.keep_asm_file then begin
+    emit (Comment text)
+  end
+
+let loc ~file_num ~line ~col = emit_non_masm (Loc { file_num; line; col; })
+let space ~bytes = emit (Space { bytes; })
+let string ?comment str = emit (Bytes { str; comment; })
+
+let global symbol = emit (Global (Asm_symbol.encode symbol))
+let indirect_symbol symbol = emit (Indirect_symbol (Asm_symbol.encode symbol))
+let private_extern symbol = emit (Private_extern (Asm_symbol.encode symbol))
+let size symbol cst =
+  emit (Size (Asm_symbol.encode symbol, (lower_expr cst)))
+let type_ symbol ~type_ = emit (Type (Asm_symbol.encode symbol, type_))
+
+let sleb128 ?comment i =
+  emit (Sleb128 { constant = Directive.Constant.Signed_int i; comment; })
+
+let uleb128 ?comment i =
+  emit (Uleb128 { constant = Directive.Constant.Unsigned_int i; comment; })
+
+let direct_assignment var cst =
+  emit (Direct_assignment (var, lower_expr cst))
+
+let const ?comment constant
+      (width : Directive.Constant_with_width.width_in_bytes) =
+  let constant = lower_expr constant in
+  let constant = Directive.Constant_with_width.create constant width in
+  emit (Const { constant; comment; })
+
+let const_machine_width ?comment constant =
+  match TS.machine_width () with
+  | Thirty_two -> const ?comment constant Thirty_two
+  | Sixty_four -> const ?comment constant Sixty_four
+
+let float32 f =
+  let comment =
+    if !Clflags.keep_asm_file then Some (Printf.sprintf "%.12f" f)
+    else None
+  in
+  let f_int32 = Int64.of_int32 (Int32.bits_of_float f) in
+  const ?comment (Signed_int f_int32) Sixty_four
+
+let float64_core f f_int64 =
+  match TS.machine_width () with
+  | Sixty_four ->
+    let comment =
+      if !Clflags.keep_asm_file then Some (Printf.sprintf "%.12g" f)
+      else None
+    in
+    const ?comment (Signed_int f_int64) Sixty_four
+  | Thirty_two ->
+    let comment_lo =
+      if !Clflags.keep_asm_file then
+        Some (Printf.sprintf "low part of %.12g" f)
+      else
+        None
+    in
+    let comment_hi =
+      if !Clflags.keep_asm_file then
+        Some (Printf.sprintf "high part of %.12g" f)
+      else
+        None
+    in
+    let lo = Signed_int (Int64.logand f_int64 0xffff_ffffL) in
+    let hi = Signed_int (Int64.shift_right_logical f_int64 32) in
+    if big_endian () then begin
+      const ?comment:comment_hi hi Thirty_two;
+      const ?comment:comment_lo lo Thirty_two
+    end else begin
+      const ?comment:comment_lo lo Thirty_two;
+      const ?comment:comment_hi hi Thirty_two
+    end
+
+let float64 f = float64_core f (Int64.bits_of_float f)
+let float64_from_bits f = float64_core (Int64.float_of_bits f) f
+
+let size ?size_of symbol =
+  match TS.system () with
+  | GNU | Linux | FreeBSD | NetBSD | OpenBSD | Generic_BSD ->
+    let size_of =
+      match size_of with
+      | None -> symbol
+      | Some size_of -> size_of
+    in
+    size size_of (Sub (This, Symbol symbol))
+  | _ -> ()
+
+let label ?comment label =
+  const_machine_width ?comment (Label label)
+
+let define_label label =
+  let lbl_section = Asm_label.section label in
+  let this_section =
+    match !current_section_ref with
+    | None -> not_initialized ()
+    | Some this_section -> this_section
+  in
+  if not (Asm_section.equal lbl_section this_section) then begin
+    Misc.fatal_errorf "Cannot define label %a intended for section %a \
+        in section %a"
+      Asm_label.print label
+      Asm_section.print lbl_section
+      Asm_section.print this_section
+  end;
+  let typ : Directive.thing_after_label =
+    if current_section_is_text () then Code
+    else Machine_width_data
+  in
+  emit (New_label (Asm_label.encode label, typ))
+
+let new_line () =
+  if !Clflags.keep_asm_file then begin
+    emit New_line
+  end
+
+let sections_seen = ref []
+
+let switch_to_section section =
+  let first_occurrence =
+    if List.mem section !sections_seen then false
+    else begin
+      sections_seen := section::!sections_seen;
+      true
+    end
+  in
+  match !current_section_ref with
+  | Some section' when Asm_section.equal section section' ->
+    assert (not first_occurrence);
+    ()
+  | _ ->
+    current_section_ref := Some section;
+    let ({ names; flags; args; } : Asm_section.flags_for_section) =
+      Asm_section.flags section ~first_occurrence
+    in
+    if not first_occurrence then begin
+      new_line ()
+    end;
+    emit (Section { names; flags; args; });
+    if first_occurrence then begin
+      define_label (Asm_label.for_section section)
+    end
+
+let switch_to_section_raw ~names ~flags ~args =
+  emit (Section { names; flags; args; })
+
+let text () = switch_to_section Asm_section.Text
+let data () = switch_to_section Asm_section.Data
+
+module Cached_string = struct
+  type t = {
+    section : Asm_section.t;
+    str : string;
+    comment : string option;
+  }
+
+  include Identifiable.Make (struct
+    type nonrec t = t
+
+    let compare { section = section1; str = str1; comment = comment1; }
+          { section = section2; str = str2; comment = comment2; } =
+      let c = Asm_section.compare section1 section2 in
+      if c <> 0 then c
+      else
+        let c = String.compare str1 str2 in
+        if c <> 0 then c
+        else
+          match comment1, comment2 with
+          | None, None -> 0
+          | None, Some _ -> -1
+          | Some _, None -> 1
+          | Some comment1, Some comment2 -> String.compare comment1 comment2
+
+    let equal t1 t2 =
+      compare t1 t2 = 0
+
+    let hash t = Hashtbl.hash t
+
+    let print _ _ = Misc.fatal_error "Not yet implemented"
+    let output _ _ = Misc.fatal_error "Not yet implemented"
+  end)
+end
+
+let cached_strings = ref Cached_string.Map.empty
+let temp_var_counter = ref 0
+
+let reset () =
+  cached_strings := Cached_string.Map.empty;
+  sections_seen := [];
+  temp_var_counter := 0
+
+let file ?file_num ~file_name () =
+  (* gas can silently emit corrupted line tables if a .file directive
+     contains a number but an empty filename. *)
+  let file_name =
+    match file_num with
+    | None -> file_name
+    | Some _file_num ->
+      if String.length file_name <= 0 then "none"
+      else file_name
+  in
+  emit_non_masm (File { file_num = file_num; filename = file_name; })
+
+let initialize ~big_endian ~(emit : Directive.t -> unit) =
+  big_endian_ref := Some big_endian;
+  emit_ref := Some emit;
+  reset ();
+  begin match TS.assembler () with
+  | MASM | MacOS -> ()
+  | GAS_like ->
+    (* CR mshinwell: Is this really the case?  Surely some of the DIEs
+       would have gone wrong if this were the case.  Maybe it only applies
+       across sections. *)
+    (* Forward label references are illegal in gas.  Just put them in for
+       all assemblers, they won't harm. *)
+    List.iter (fun (section : Asm_section.t) ->
+        match section with
+        | Text
+        | Data
+        | Read_only_data
+        | Eight_byte_literals
+        | Sixteen_byte_literals
+        | Jump_tables -> switch_to_section section
+        | DWARF _ ->
+          (* All of the other settings that require these DWARF sections
+             imply [Debug_dwarf_functions]; see clflags.ml. *)
+          if Clflags.debug_thing Debug_dwarf_functions
+            && dwarf_supported ()
+          then begin
+            switch_to_section section
+          end)
+      (Asm_section.all_sections_in_order ())
+  end;
+  (* Stop dsymutil complaining about empty __debug_line sections (produces
+     bogus error "line table parameters mismatch") by making sure such sections
+     are never empty. *)
+  file ~file_num:1 ~file_name:"none" ();  (* also PR#7037 *)
+  loc ~file_num:1 ~line:1 ~col:1;
+  switch_to_section Asm_section.Text
+
+let file ~file_num ~file_name = file ~file_num ~file_name ()
+
+let check_symbol_for_definition_in_current_section symbol =
+  let symbol_section = Asm_symbol.section symbol in
+  let this_section =
+    match !current_section_ref with
+    | None -> not_initialized ()
+    | Some this_section -> this_section
+  in
+  if not (Asm_section.equal symbol_section this_section) then begin
+    Misc.fatal_errorf "Cannot define symbol %a intended for section %a \
+        in section %a"
+      Asm_symbol.print symbol
+      Asm_section.print symbol_section
+      Asm_section.print this_section
+  end
+
+let define_data_symbol symbol =
+  check_symbol_for_definition_in_current_section symbol;
+  emit (New_label (Asm_symbol.encode symbol, Machine_width_data));
+  begin match TS.assembler (), TS.windows () with
+  | GAS_like, false -> type_ symbol ~type_:"STT_OBJECT"
+  | GAS_like, true | MacOS, _ | MASM, _ -> ()
+  end
+
+(* CR mshinwell: Rename to [define_text_symbol]? *)
+let define_function_symbol symbol =
+  check_symbol_for_definition_in_current_section symbol;
+  (* CR mshinwell: This shouldn't be called "New_label" *)
+  emit (New_label (Asm_symbol.encode symbol, Code));
+  begin match TS.assembler (), TS.windows () with
+  | GAS_like, false -> type_ symbol ~type_:"STT_FUNC"
+  | GAS_like, true | MacOS, _ | MASM, _ -> ()
+  end
+
+let symbol ?comment sym = const_machine_width ?comment (Symbol sym)
+
+let symbol_plus_offset symbol ~offset_in_bytes =
+  let offset_in_bytes = Targetint.to_int64 offset_in_bytes in
+  const_machine_width (
+    Add (Symbol symbol, Signed_int offset_in_bytes))
+
+let int8 ?comment i =
+  const ?comment (Signed_int (Int64.of_int (Int8.to_int i))) Eight
+
+let int16 ?comment i =
+  const ?comment (Signed_int (Int64.of_int (Int16.to_int i))) Sixteen
+
+let int32 ?comment i =
+  const ?comment (Signed_int (Int64.of_int32 i)) Thirty_two
+
+let int64 ?comment i =
+  const ?comment (Signed_int i) Sixty_four
+
+let uint8 ?comment i =
+  const ?comment (Unsigned_int (Uint64.of_uint8 i)) Eight
+
+let uint16 ?comment i =
+  const ?comment (Unsigned_int (Uint64.of_uint16 i)) Sixteen
+
+let uint32 ?comment i =
+  const ?comment (Unsigned_int (Uint64.of_uint32 i)) Thirty_two
+
+let uint64 ?comment i =
+  const ?comment (Unsigned_int i) Sixty_four
+
+let targetint ?comment n =
+  match Targetint.repr n with
+  | Int32 n -> int32 ?comment n
+  | Int64 n -> int64 ?comment n
+
+let cache_string ?comment section str =
+  let cached : Cached_string.t = { section; str; comment; } in
+  match Cached_string.Map.find cached !cached_strings with
+  | label -> label
+  | exception Not_found ->
+    let label = Asm_label.create section in
+    cached_strings := Cached_string.Map.add cached label !cached_strings;
+    label
+
+let emit_cached_strings () =
+  Cached_string.Map.iter (fun { section; str; comment; } label_name ->
+      switch_to_section section;
+      define_label label_name;
+      string ?comment str;
+      int8 Int8.zero)
+    !cached_strings;
+  cached_strings := Cached_string.Map.empty
+
+let mark_stack_non_executable () =
+  let current_section = current_section () in
+  match TS.system () with
+  | Linux ->
+    section ~names:[".note.GNU-stack"] ~flags:(Some "") ~args:["%progbits"];
+    switch_to_section current_section
+  | _ -> ()
+
+let new_temp_var () =
+  let id = !temp_var_counter in
+  incr temp_var_counter;
+  Printf.sprintf "Ltemp%d" id
+
+let force_assembly_time_constant section expr =
+  match TS.assembler () with
+  | GAS_like | MASM -> expr
+  | MacOS ->
+    (* This ensures the correct result is obtained on macOS.  (Apparently
+       just writing expressions such as "L100 - L101" inline can cause
+       unexpected results when one of the labels is on a section boundary,
+       for example.) *)
+    let temp = new_temp_var () in
+    direct_assignment temp expr;
+    let compilation_unit = Compilation_unit.get_current_exn () in
+    let sym =
+      Asm_symbol.of_external_name_no_prefix section compilation_unit temp
+    in
+    Symbol sym  (* not really a symbol, but OK. *)
+
+let check_symbol_in_current_unit sym =
+  let sym_unit = Asm_symbol.compilation_unit sym in
+  let this_unit = Compilation_unit.get_current_exn () in
+  if not (Compilation_unit.equal sym_unit this_unit) then begin
+    Misc.fatal_errorf "Symbol %a (in compilation unit %a) not in current \
+        compilation unit %a"
+      Asm_symbol.print sym
+      Compilation_unit.print sym_unit
+      Compilation_unit.print this_unit
+  end
+
+let check_symbols_in_same_section sym1 sym2 =
+  let sym1_section = Asm_symbol.section sym1 in
+  let sym2_section = Asm_symbol.section sym2 in
+  if not (Asm_section.equal sym1_section sym2_section) then begin
+    Misc.fatal_errorf "Symbols %a (in section %a) and %a (in section %a) \
+        are not in the same section"
+      Asm_symbol.print sym1
+      Asm_section.print sym1_section
+      Asm_symbol.print sym2
+      Asm_section.print sym2_section
+  end
+
+let check_labels_in_same_section lbl1 lbl2 =
+  let lbl1_section = Asm_label.section lbl1 in
+  let lbl2_section = Asm_label.section lbl2 in
+  if not (Asm_section.equal lbl1_section lbl2_section) then begin
+    Misc.fatal_errorf "Labels %a (in section %a) and %a (in section %a) \
+        are not in the same section"
+      Asm_label.print lbl1
+      Asm_section.print lbl1_section
+      Asm_label.print lbl2
+      Asm_section.print lbl2_section
+  end
+
+let check_symbol_and_label_in_same_section sym lbl =
+  let sym_section = Asm_symbol.section sym in
+  let lbl_section = Asm_label.section lbl in
+  if not (Asm_section.equal sym_section lbl_section) then begin
+    Misc.fatal_errorf "Symbol %a (in section %a) and label %a (in section %a) \
+        are not in the same section"
+      Asm_symbol.print sym
+      Asm_section.print sym_section
+      Asm_label.print lbl
+      Asm_section.print lbl_section
+  end
+
+let between_symbols_in_current_unit ~upper ~lower =
+  check_symbol_in_current_unit upper;
+  check_symbol_in_current_unit lower;
+  check_symbols_in_same_section upper lower;
+  let expr = Sub (Symbol upper, Symbol lower) in
+  let section = Asm_symbol.section upper in
+  const_machine_width (force_assembly_time_constant section expr)
+
+let between_labels_16_bit ?comment ~upper ~lower () =
+  check_labels_in_same_section upper lower;
+  let expr = Sub (Label upper, Label lower) in
+  let section = Asm_label.section upper in
+  const ?comment (force_assembly_time_constant section expr) Sixteen
+
+let between_labels_32_bit ?comment ~upper ~lower () =
+  check_labels_in_same_section upper lower;
+  let expr = Sub (Label upper, Label lower) in
+  let section = Asm_label.section upper in
+  const ?comment (force_assembly_time_constant section expr) Thirty_two
+
+let between_labels_64_bit ?comment ~upper ~lower () =
+  check_labels_in_same_section upper lower;
+  let expr = Sub (Label upper, Label lower) in
+  let section = Asm_label.section upper in
+  const ?comment (force_assembly_time_constant section expr) Sixty_four
+
+let between_symbol_in_current_unit_and_label_offset ?comment
+      ~upper ~lower ~offset_upper =
+  check_symbol_in_current_unit lower;
+  check_symbol_and_label_in_same_section lower upper;
+  let section = Asm_symbol.section lower in
+  if Targetint.compare offset_upper Targetint.zero = 0 then
+    let expr = Sub (Label upper, Symbol lower) in
+    const_machine_width ?comment (force_assembly_time_constant section expr)
+  else
+    let offset_upper = Targetint.to_int64 offset_upper in
+    let expr =
+      Sub (Add (Label upper, Signed_int offset_upper), Symbol lower)
+    in
+    const_machine_width ?comment (force_assembly_time_constant section expr)
+
+let between_this_and_label_offset_32bit ~upper ~offset_upper =
+  let upper_section = Asm_label.section upper in
+  begin match !current_section_ref with
+  | None -> not_initialized ()
+  | Some this_section ->
+    if not (Asm_section.equal upper_section this_section) then begin
+      Misc.fatal_errorf "Label %a in section %a is not in the \
+          current section %a"
+        Asm_label.print upper
+        Asm_section.print upper_section
+        Asm_section.print this_section
+    end
+  end;
+  let offset_upper = Targetint.to_int64 offset_upper in
+  let expr =
+    Sub (Add (Label upper, Signed_int offset_upper), This)
+  in
+  const (force_assembly_time_constant upper_section expr) Thirty_two
+
+let offset_into_dwarf_section_label ?comment section upper
+      ~(width : TS.machine_width) =
+  let upper_section = Asm_label.section upper in
+  let expected_section : Asm_section.t = DWARF section in
+  if not (Asm_section.equal upper_section expected_section) then begin
+    Misc.fatal_errorf "Label %a (in section %a) is not in section %a"
+      Asm_label.print upper
+      Asm_section.print upper_section
+      Asm_section.print expected_section
+  end;
+  let expr : expr =
+    match TS.assembler () with
+    | MacOS ->
+      let lower = Asm_label.for_dwarf_section section in
+      (* macOS does not use relocations in DWARF sections in places, such as
+         here, where they might be expected.  Instead dsymutil and other tools
+         parse DWARF sections properly and adjust offsets manually. *)
+      force_assembly_time_constant expected_section
+        (Sub (Label upper, Label lower))
+    | GAS_like | MASM ->
+      Label upper
+  in
+  let width : Directive.Constant_with_width.width_in_bytes =
+    match width with
+    | Thirty_two -> Thirty_two
+    | Sixty_four -> Sixty_four
+  in
+  let comment =
+    if not !Clflags.keep_asm_file then None
+    else
+      match comment with
+      | None ->
+        Some (Format.asprintf "offset into %s"
+          (Asm_section.to_string expected_section))
+      | Some comment ->
+        Some (Format.asprintf "%s (offset into %s)"
+          comment (Asm_section.to_string expected_section))
+  in
+  const ?comment expr width
+
+let offset_into_dwarf_section_symbol ?comment section upper
+      ~(width : TS.machine_width) =
+  let upper_section = Asm_symbol.section upper in
+  if not (Asm_section.equal upper_section (DWARF section)) then begin
+    Misc.fatal_errorf "Symbol %a (in section %a) not in section %a"
+      Asm_symbol.print upper
+      Asm_section.print upper_section
+      Asm_section.print (Asm_section.DWARF section)
+  end;
+  (* The macOS assembler doesn't seem to allow "distance to undefined symbol
+     from start of given section".  As such we do not allow this function to
+     be used for undefined symbols on macOS at the moment.
+     Relevant link:
+     <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82005>.
+  *)
+  let expr : expr =
+    match TS.assembler () with
+    | MacOS ->
+      let in_current_unit =
+        Compilation_unit.equal (Compilation_unit.get_current_exn ())
+          (Asm_symbol.compilation_unit upper)
+      in
+      if in_current_unit then
+        let lower = Asm_label.for_dwarf_section section in
+        (* Same note as in [offset_into_dwarf_section_label] applies here. *)
+        force_assembly_time_constant (DWARF section)
+          (Sub (Symbol upper, Label lower))
+      else
+        Misc.fatal_errorf "Don't know how to encode offset from start of \
+            section %a to undefined symbol %a on macOS (current compilation \
+            unit %a, symbol in compilation unit %a)"
+          Asm_section.print upper_section
+          Asm_symbol.print upper
+          Compilation_unit.print (Compilation_unit.get_current_exn ())
+          Compilation_unit.print (Asm_symbol.compilation_unit upper)
+    | GAS_like | MASM ->
+      Symbol upper
+  in
+  let width : Directive.Constant_with_width.width_in_bytes =
+    match width with
+    | Thirty_two -> Thirty_two
+    | Sixty_four -> Sixty_four
+  in
+  let comment =
+    if not !Clflags.keep_asm_file then None
+    else
+      match comment with
+      | None ->
+        Some (Format.asprintf "offset into %s"
+          (Asm_section.to_string (DWARF section)))
+      | Some comment ->
+        Some (Format.asprintf "%s (offset into %s)"
+          comment (Asm_section.to_string (DWARF section)))
+  in
+  const ?comment expr width

--- a/backend/asm_targets/asm_directives_new.ml
+++ b/backend/asm_targets/asm_directives_new.ml
@@ -16,15 +16,14 @@
 (**************************************************************************)
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
+
 (* CR-someday mshinwell: Eliminate uses of [bprintf] from the assembly
    generation code, then enable this warning. *)
 [@@@ocaml.warning "-3"]
 
 module Int8 = Numbers.Int8
 module Int16 = Numbers.Int16
-
 module Uint64 = Numbers.Uint64
-
 module TS = Target_system
 
 let dwarf_supported () =
@@ -33,6 +32,7 @@ let dwarf_supported () =
   | A_out | PE | Unknown -> false
 
 let big_endian_ref = ref None
+
 let current_section_ref = ref None
 
 let not_initialized () =
@@ -67,37 +67,32 @@ module Directive = struct
 
     let rec print buf t =
       match t with
-      | Named_thing _ | Signed_int _ | Unsigned_int _
-      | This as c -> print_subterm buf c
-      | Add (c1, c2) ->
-        bprintf buf "%a + %a" print_subterm c1 print_subterm c2
-      | Sub (c1, c2) ->
-        bprintf buf "%a - %a" print_subterm c1 print_subterm c2
+      | (Named_thing _ | Signed_int _ | Unsigned_int _ | This) as c ->
+        print_subterm buf c
+      | Add (c1, c2) -> bprintf buf "%a + %a" print_subterm c1 print_subterm c2
+      | Sub (c1, c2) -> bprintf buf "%a - %a" print_subterm c1 print_subterm c2
 
     and print_subterm buf t =
       match t with
-      | This ->
-        begin match TS.assembler () with
+      | This -> (
+        match TS.assembler () with
         | MacOS | GAS_like -> Buffer.add_string buf "."
-        | MASM -> Buffer.add_string buf "THIS BYTE"
-        end
+        | MASM -> Buffer.add_string buf "THIS BYTE")
       | Named_thing name -> Buffer.add_string buf name
-      | Signed_int n ->
-        begin match TS.assembler () with
+      | Signed_int n -> (
+        match TS.assembler () with
         (* We use %Ld and not %Lx on Unix-like platforms to ensure that
            ".sleb128" directives do not end up with hex arguments (since this
            denotes a variable-length encoding it would not be clear where the
            sign bit is). *)
         | MacOS | GAS_like -> bprintf buf "%Ld" n
         | MASM ->
-          if n >= -0x8000_0000L && n <= 0x7fff_ffffL then
-            Buffer.add_string buf (Int64.to_string n)
-          else
-            bprintf buf "0%LxH" n
-        end
+          if n >= -0x8000_0000L && n <= 0x7fff_ffffL
+          then Buffer.add_string buf (Int64.to_string n)
+          else bprintf buf "0%LxH" n)
       | Unsigned_int n ->
-        (* We can use the printer for [Signed_int] since we always print
-           as an unsigned hex representation. *)
+        (* We can use the printer for [Signed_int] since we always print as an
+           unsigned hex representation. *)
         print_subterm buf (Signed_int (Uint64.to_int64 n))
       | Add (c1, c2) ->
         bprintf buf "(%a + %a)" print_subterm c1 print_subterm c2
@@ -105,7 +100,7 @@ module Directive = struct
         bprintf buf "(%a - %a)" print_subterm c1 print_subterm c2
 
     let rec evaluate t =
-      let (>>=) = Misc.Stdlib.Option.(>>=) in
+      let ( >>= ) = Misc.Stdlib.Option.( >>= ) in
       match t with
       | Signed_int i -> Some i
       | Unsigned_int _ ->
@@ -114,17 +109,11 @@ module Directive = struct
       | This -> None
       | Named_thing _ -> None
       | Add (t1, t2) ->
-        evaluate t1
-        >>= fun i1 ->
-        evaluate t2
-        >>= fun i2 ->
-        Some (Int64.add i1 i2)
+        evaluate t1 >>= fun i1 ->
+        evaluate t2 >>= fun i2 -> Some (Int64.add i1 i2)
       | Sub (t1, t2) ->
-        evaluate t1
-        >>= fun i1 ->
-        evaluate t2
-        >>= fun i2 ->
-        Some (Int64.sub i1 i2)
+        evaluate t1 >>= fun i1 ->
+        evaluate t2 >>= fun i2 -> Some (Int64.sub i1 i2)
   end
 
   module Constant_with_width = struct
@@ -140,13 +129,13 @@ module Directive = struct
       | Thirty_two -> 32
       | Sixty_four -> 64
 
-    type t = {
-      constant : Constant.t;
-      width_in_bytes : width_in_bytes;
-    }
+    type t =
+      { constant : Constant.t;
+        width_in_bytes : width_in_bytes
+      }
 
     let create constant width_in_bytes =
-      begin match Constant.evaluate constant with
+      (match Constant.evaluate constant with
       | None -> ()
       | Some n ->
         let in_range =
@@ -156,17 +145,15 @@ module Directive = struct
           | Thirty_two -> n >= -0x8000_0000L && n <= 0x7fff_ffffL
           | Sixty_four -> true
         in
-        if not in_range then begin
-          Misc.fatal_errorf "Signed integer constant %Ld does not fit in \
-              %d bits"
-            n (int_of_width_in_bytes width_in_bytes)
-        end
-      end;
-      { constant;
-        width_in_bytes;
-      }
+        if not in_range
+        then
+          Misc.fatal_errorf
+            "Signed integer constant %Ld does not fit in %d bits" n
+            (int_of_width_in_bytes width_in_bytes));
+      { constant; width_in_bytes }
 
     let constant t = t.constant
+
     let width_in_bytes t = t.width_in_bytes
   end
 
@@ -177,33 +164,55 @@ module Directive = struct
   type comment = string
 
   type t =
-    | Align of { bytes : int; }
-    | Bytes of { str : string; comment : string option; }
+    | Align of { bytes : int }
+    | Bytes of
+        { str : string;
+          comment : string option
+        }
     | Cfi_adjust_cfa_offset of int
     | Cfi_def_cfa_offset of int
     | Cfi_endproc
-    | Cfi_offset of { reg : int; offset : int; }
+    | Cfi_offset of
+        { reg : int;
+          offset : int
+        }
     | Cfi_startproc
     | Comment of comment
-    | Const of { constant : Constant_with_width.t; comment : string option; }
+    | Const of
+        { constant : Constant_with_width.t;
+          comment : string option
+        }
     | Direct_assignment of string * Constant.t
-    | File of { file_num : int option; filename : string; }
+    | File of
+        { file_num : int option;
+          filename : string
+        }
     | Global of string
     | Indirect_symbol of string
-    | Loc of { file_num : int; line : int; col : int; }
+    | Loc of
+        { file_num : int;
+          line : int;
+          col : int
+        }
     | New_label of string * thing_after_label
     | New_line
     | Private_extern of string
-    | Section of {
-        names : string list;
-        flags : string option;
-        args : string list;
-      }
+    | Section of
+        { names : string list;
+          flags : string option;
+          args : string list
+        }
     | Size of string * Constant.t
-    | Sleb128 of { constant : Constant.t; comment : string option; }
-    | Space of { bytes : int; }
+    | Sleb128 of
+        { constant : Constant.t;
+          comment : string option
+        }
+    | Space of { bytes : int }
     | Type of string * string
-    | Uleb128 of { constant : Constant.t; comment : string option; }
+    | Uleb128 of
+        { constant : Constant.t;
+          comment : string option
+        }
 
   let bprintf = Printf.bprintf
 
@@ -214,17 +223,18 @@ module Directive = struct
     let last_was_escape = ref false in
     for i = 0 to String.length s - 1 do
       let c = s.[i] in
-      if c >= '0' && c <= '9' then
+      if c >= '0' && c <= '9'
+      then
         if !last_was_escape
         then Printf.bprintf buf "\\%o" (Char.code c)
         else Buffer.add_char buf c
-      else if c >= ' ' && c <= '~' && c <> '"' (* '"' *) && c <> '\\' then begin
+      else if c >= ' ' && c <= '~' && c <> '"' (* '"' *) && c <> '\\'
+      then (
         Buffer.add_char buf c;
-        last_was_escape := false
-      end else begin
+        last_was_escape := false)
+      else (
         Printf.bprintf buf "\\%o" (Char.code c);
-        last_was_escape := true
-      end
+        last_was_escape := true)
     done;
     Buffer.contents buf
 
@@ -232,65 +242,59 @@ module Directive = struct
     let pos = ref 0 in
     for i = 0 to String.length s - 1 do
       if !pos = 0
-      then begin
+      then (
         if i > 0 then Buffer.add_char buf '\n';
         Buffer.add_char buf '\t';
         Buffer.add_string buf directive;
-        Buffer.add_char buf '\t';
-      end
+        Buffer.add_char buf '\t')
       else Buffer.add_char buf ',';
       Printf.bprintf buf "%d" (Char.code s.[i]);
       incr pos;
-      if !pos >= 16 then begin pos := 0 end
+      if !pos >= 16 then pos := 0
     done
 
   let print_gas buf t =
     let gas_comment_opt comment_opt =
-      if not (emit_comments ()) then ""
+      if not (emit_comments ())
+      then ""
       else
         match comment_opt with
         | None -> ""
         | Some comment -> Printf.sprintf "\t/* %s */" comment
     in
     match t with
-    | Align { bytes = n; } ->
-      (* Some assemblers interpret the integer n as a 2^n alignment and
-         others as a number of bytes. *)
+    | Align { bytes = n } ->
+      (* Some assemblers interpret the integer n as a 2^n alignment and others
+         as a number of bytes. *)
       let n =
         match TS.assembler (), TS.architecture () with
-        | MacOS, _
-        | GAS_like, (ARM | AArch64 | POWER) -> Misc.log2 n
+        | MacOS, _ | GAS_like, (ARM | AArch64 | POWER) -> Misc.log2 n
         | _, _ -> n
       in
       bprintf buf "\t.align\t%d" n
-    | Const { constant; comment; } ->
+    | Const { constant; comment } ->
       let directive =
         match Constant_with_width.width_in_bytes constant with
         | Eight -> "byte"
-        | Sixteen ->
-          begin match TS.system () with
+        | Sixteen -> (
+          match TS.system () with
           | Solaris -> "value"
           | _ ->
-            (* Apple's documentation says that ".word" is i386-specific, so
-               we use ".short" instead.
-               Additionally, it appears on ARM that ".word" may be 32 bits wide,
-               not 16 bits. *)
-            "short"
-          end
+            (* Apple's documentation says that ".word" is i386-specific, so we
+               use ".short" instead. Additionally, it appears on ARM that
+               ".word" may be 32 bits wide, not 16 bits. *)
+            "short")
         | Thirty_two -> "long"
         | Sixty_four -> "quad"
       in
       let comment = gas_comment_opt comment in
-      bprintf buf "\t.%s\t%a%s"
-        directive
-        Constant.print (Constant_with_width.constant constant)
+      bprintf buf "\t.%s\t%a%s" directive Constant.print
+        (Constant_with_width.constant constant)
         comment
-    | Bytes { str; comment; } ->
-      begin match TS.system (), TS.architecture () with
-      | Solaris, _
-      | _, POWER -> buf_bytes_directive buf ~directive:".byte" str
-      | _ -> bprintf buf "\t.ascii\t\"%s\"" (string_of_string_literal str)
-      end;
+    | Bytes { str; comment } ->
+      (match TS.system (), TS.architecture () with
+      | Solaris, _ | _, POWER -> buf_bytes_directive buf ~directive:".byte" str
+      | _ -> bprintf buf "\t.ascii\t\"%s\"" (string_of_string_literal str));
       bprintf buf "%s" (gas_comment_opt comment)
     | Comment s -> bprintf buf "\t\t\t/* %s */" s
     | Global s -> bprintf buf "\t.globl\t%s" s
@@ -298,76 +302,72 @@ module Directive = struct
     | New_line -> ()
     | Section { names = [".data"]; _ } -> bprintf buf "\t.data"
     | Section { names = [".text"]; _ } -> bprintf buf "\t.text"
-    | Section { names; flags; args; } ->
+    | Section { names; flags; args } -> (
       bprintf buf "\t.section %s" (String.concat "," names);
-      begin match flags with
-      | None -> ()
-      | Some flags -> bprintf buf ",%S" flags
-      end;
-      begin match args with
+      (match flags with None -> () | Some flags -> bprintf buf ",%S" flags);
+      match args with
       | [] -> ()
-      | _ -> bprintf buf ",%s" (String.concat "," args)
-      end
-    | Space { bytes; } ->
-      begin match TS.system () with
+      | _ -> bprintf buf ",%s" (String.concat "," args))
+    | Space { bytes } -> (
+      match TS.system () with
       | Solaris -> bprintf buf "\t.zero\t%d" bytes
-      | _ -> bprintf buf "\t.space\t%d" bytes
-      end
+      | _ -> bprintf buf "\t.space\t%d" bytes)
     | Cfi_adjust_cfa_offset n -> bprintf buf "\t.cfi_adjust_cfa_offset %d" n
     | Cfi_def_cfa_offset n -> bprintf buf "\t.cfi_def_cfa_offset %d" n
     | Cfi_endproc -> bprintf buf "\t.cfi_endproc"
-    | Cfi_offset { reg; offset; } ->
+    | Cfi_offset { reg; offset } ->
       bprintf buf "\t.cfi_offset %d, %d" reg offset
     | Cfi_startproc -> bprintf buf "\t.cfi_startproc"
-    | File { file_num = None; filename; } ->
+    | File { file_num = None; filename } ->
       bprintf buf "\t.file\t\"%s\"" filename
-    | File { file_num = Some file_num; filename; } ->
-      bprintf buf "\t.file\t%d\t\"%s\""
-        file_num (string_of_string_literal filename)
+    | File { file_num = Some file_num; filename } ->
+      bprintf buf "\t.file\t%d\t\"%s\"" file_num
+        (string_of_string_literal filename)
     | Indirect_symbol s -> bprintf buf "\t.indirect_symbol %s" s
-    | Loc { file_num; line; col; } ->
+    | Loc { file_num; line; col } ->
       (* PR#7726: Location.none uses column -1, breaks LLVM assembler *)
-      if col >= 0 then bprintf buf "\t.loc\t%d\t%d\t%d" file_num line col
+      if col >= 0
+      then bprintf buf "\t.loc\t%d\t%d\t%d" file_num line col
       else bprintf buf "\t.loc\t%d\t%d" file_num line
     | Private_extern s -> bprintf buf "\t.private_extern %s" s
     | Size (s, c) -> bprintf buf "\t.size %s,%a" s Constant.print c
-    | Sleb128 { constant; comment; } ->
+    | Sleb128 { constant; comment } ->
       let comment = gas_comment_opt comment in
       bprintf buf "\t.sleb128 %a%s" Constant.print constant comment
     | Type (s, typ) ->
-      (* We use the "STT" forms when they are supported as they are
-         unambiguous across platforms
-         (cf. https://sourceware.org/binutils/docs/as/Type.html ). *)
+      (* We use the "STT" forms when they are supported as they are unambiguous
+         across platforms (cf. https://sourceware.org/binutils/docs/as/Type.html
+         ). *)
       bprintf buf "\t.type %s %s" s typ
-    | Uleb128 { constant; comment; } ->
+    | Uleb128 { constant; comment } ->
       let comment = gas_comment_opt comment in
       bprintf buf "\t.uleb128 %a%s" Constant.print constant comment
-    | Direct_assignment (var, const) ->
-      begin match TS.assembler () with
+    | Direct_assignment (var, const) -> (
+      match TS.assembler () with
       | MacOS -> bprintf buf "%s = %a" var Constant.print const
       | _ ->
-        Misc.fatal_error "Cannot emit [Direct_assignment] except on macOS-like \
-          assemblers"
-      end
+        Misc.fatal_error
+          "Cannot emit [Direct_assignment] except on macOS-like assemblers")
 
   let print_masm buf t =
     let unsupported name =
       Misc.fatal_errorf "Unsupported asm directive [%s] for MASM" name
     in
     let masm_comment_opt comment_opt =
-      if not (emit_comments ()) then ""
+      if not (emit_comments ())
+      then ""
       else
         match comment_opt with
         | None -> ""
         | Some comment -> Printf.sprintf "\t; %s" comment
     in
     match t with
-    | Align { bytes; } -> bprintf buf "\tALIGN\t%d" bytes
-    | Bytes { str; comment; } ->
+    | Align { bytes } -> bprintf buf "\tALIGN\t%d" bytes
+    | Bytes { str; comment } ->
       buf_bytes_directive buf ~directive:"BYTE" str;
       bprintf buf "%s" (masm_comment_opt comment)
     | Comment s -> bprintf buf " ; %s " s
-    | Const { constant; comment; } ->
+    | Const { constant; comment } ->
       let directive =
         match Constant_with_width.width_in_bytes constant with
         | Eight -> "BYTE"
@@ -376,21 +376,19 @@ module Directive = struct
         | Sixty_four -> "QWORD"
       in
       let comment = masm_comment_opt comment in
-      bprintf buf "\t%s\t%a%s"
-        directive
-        Constant.print (Constant_with_width.constant constant)
+      bprintf buf "\t%s\t%a%s" directive Constant.print
+        (Constant_with_width.constant constant)
         comment
     | Global s -> bprintf buf "\tPUBLIC\t%s" s
     | Section { names = [".data"]; _ } -> bprintf buf "\t.DATA"
     | Section { names = [".text"]; _ } -> bprintf buf "\t.CODE"
     | Section _ -> Misc.fatal_error "Unknown section name for MASM emitter"
-    | Space { bytes; } -> bprintf buf "\tBYTE\t%d DUP (?)" bytes
+    | Space { bytes } -> bprintf buf "\tBYTE\t%d DUP (?)" bytes
     | New_label (label, Code) -> bprintf buf "%s:" label
-    | New_label (label, Machine_width_data) ->
-      begin match TS.machine_width () with
+    | New_label (label, Machine_width_data) -> (
+      match TS.machine_width () with
       | Thirty_two -> bprintf buf "%s LABEL DWORD" label
-      | Sixty_four -> bprintf buf "%s LABEL QWORD" label
-      end
+      | Sixty_four -> bprintf buf "%s LABEL QWORD" label)
     | New_line -> ()
     | Cfi_adjust_cfa_offset _ -> unsupported "Cfi_adjust_cfa_offset"
     | Cfi_def_cfa_offset _ -> unsupported "Cfi_def_cfa_offset"
@@ -413,10 +411,10 @@ module Directive = struct
     | MacOS | GAS_like -> print_gas b t
 end
 
-(* A higher-level version of [Constant.t] which contains some more
-   abstractions (e.g. use of [Cmm.label], and in the future distinguished
-   types to represent symbols and symbol references before they are mangled
-   to plain [string]s for [Constant.t]). *)
+(* A higher-level version of [Constant.t] which contains some more abstractions
+   (e.g. use of [Cmm.label], and in the future distinguished types to represent
+   symbols and symbol references before they are mangled to plain [string]s for
+   [Constant.t]). *)
 type expr =
   | Signed_int of Int64.t
   | Unsigned_int of Uint64.t
@@ -433,10 +431,8 @@ let rec lower_expr (cst : expr) : Directive.Constant.t =
   | This -> This
   | Label lbl -> Named_thing (Asm_label.encode lbl)
   | Symbol sym -> Named_thing (Asm_symbol.encode sym)
-  | Add (cst1, cst2) ->
-    Add (lower_expr cst1, lower_expr cst2)
-  | Sub (cst1, cst2) ->
-    Sub (lower_expr cst1, lower_expr cst2)
+  | Add (cst1, cst2) -> Add (lower_expr cst1, lower_expr cst2)
+  | Sub (cst1, cst2) -> Sub (lower_expr cst1, lower_expr cst2)
 
 let emit_ref = ref None
 
@@ -446,76 +442,65 @@ let emit (d : Directive.t) =
   | None -> Misc.fatal_error "initialize not called"
 
 let emit_non_masm (d : Directive.t) =
-  match TS.assembler () with
-  | MASM ->  ()
-  | MacOS | GAS_like -> emit d
+  match TS.assembler () with MASM -> () | MacOS | GAS_like -> emit d
 
-let section ~names ~flags ~args = emit (Section { names; flags; args; })
+let section ~names ~flags ~args = emit (Section { names; flags; args })
 
-let align ~bytes = emit (Align { bytes; })
+let align ~bytes = emit (Align { bytes })
 
 let should_generate_cfi () =
   (* We generate CFI info even if we're not generating any other debugging
-     information.  This is in fact necessary on macOS, where it may be
-     expected that OCaml stack frames are unwindable (see
-     testsuite/tests/unwind/README for more information). *)
+     information. This is in fact necessary on macOS, where it may be expected
+     that OCaml stack frames are unwindable (see testsuite/tests/unwind/README
+     for more information). *)
   Config.asm_cfi_supported
 
 let cfi_adjust_cfa_offset ~bytes =
-  if should_generate_cfi () && bytes <> 0 then begin
-    emit (Cfi_adjust_cfa_offset bytes)
-  end
+  if should_generate_cfi () && bytes <> 0
+  then emit (Cfi_adjust_cfa_offset bytes)
 
 let cfi_def_cfa_offset ~bytes =
-  if should_generate_cfi () then begin
-    emit (Cfi_def_cfa_offset bytes)
-  end
+  if should_generate_cfi () then emit (Cfi_def_cfa_offset bytes)
 
-let cfi_endproc () =
-  if should_generate_cfi () then begin
-    emit Cfi_endproc
-  end
+let cfi_endproc () = if should_generate_cfi () then emit Cfi_endproc
 
 let cfi_offset ~reg ~offset =
-  if should_generate_cfi () && offset <> 0 then begin
-    emit (Cfi_offset { reg; offset; })
-  end
+  if should_generate_cfi () && offset <> 0
+  then emit (Cfi_offset { reg; offset })
 
-let cfi_startproc () =
-  if should_generate_cfi () then begin
-    emit Cfi_startproc
-  end
+let cfi_startproc () = if should_generate_cfi () then emit Cfi_startproc
 
-let comment text =
-  if !Clflags.keep_asm_file then begin
-    emit (Comment text)
-  end
+let comment text = if !Clflags.keep_asm_file then emit (Comment text)
 
-let loc ~file_num ~line ~col = emit_non_masm (Loc { file_num; line; col; })
-let space ~bytes = emit (Space { bytes; })
-let string ?comment str = emit (Bytes { str; comment; })
+let loc ~file_num ~line ~col = emit_non_masm (Loc { file_num; line; col })
+
+let space ~bytes = emit (Space { bytes })
+
+let string ?comment str = emit (Bytes { str; comment })
 
 let global symbol = emit (Global (Asm_symbol.encode symbol))
+
 let indirect_symbol symbol = emit (Indirect_symbol (Asm_symbol.encode symbol))
+
 let private_extern symbol = emit (Private_extern (Asm_symbol.encode symbol))
-let size symbol cst =
-  emit (Size (Asm_symbol.encode symbol, (lower_expr cst)))
+
+let size symbol cst = emit (Size (Asm_symbol.encode symbol, lower_expr cst))
+
 let type_ symbol ~type_ = emit (Type (Asm_symbol.encode symbol, type_))
 
 let sleb128 ?comment i =
-  emit (Sleb128 { constant = Directive.Constant.Signed_int i; comment; })
+  emit (Sleb128 { constant = Directive.Constant.Signed_int i; comment })
 
 let uleb128 ?comment i =
-  emit (Uleb128 { constant = Directive.Constant.Unsigned_int i; comment; })
+  emit (Uleb128 { constant = Directive.Constant.Unsigned_int i; comment })
 
-let direct_assignment var cst =
-  emit (Direct_assignment (var, lower_expr cst))
+let direct_assignment var cst = emit (Direct_assignment (var, lower_expr cst))
 
 let const ?comment constant
-      (width : Directive.Constant_with_width.width_in_bytes) =
+    (width : Directive.Constant_with_width.width_in_bytes) =
   let constant = lower_expr constant in
   let constant = Directive.Constant_with_width.create constant width in
-  emit (Const { constant; comment; })
+  emit (Const { constant; comment })
 
 let const_machine_width ?comment constant =
   match TS.machine_width () with
@@ -524,8 +509,7 @@ let const_machine_width ?comment constant =
 
 let float32 f =
   let comment =
-    if !Clflags.keep_asm_file then Some (Printf.sprintf "%.12f" f)
-    else None
+    if !Clflags.keep_asm_file then Some (Printf.sprintf "%.12f" f) else None
   in
   let f_int32 = Int64.of_int32 (Int32.bits_of_float f) in
   const ?comment (Signed_int f_int32) Sixty_four
@@ -534,49 +518,44 @@ let float64_core f f_int64 =
   match TS.machine_width () with
   | Sixty_four ->
     let comment =
-      if !Clflags.keep_asm_file then Some (Printf.sprintf "%.12g" f)
-      else None
+      if !Clflags.keep_asm_file then Some (Printf.sprintf "%.12g" f) else None
     in
     const ?comment (Signed_int f_int64) Sixty_four
   | Thirty_two ->
     let comment_lo =
-      if !Clflags.keep_asm_file then
-        Some (Printf.sprintf "low part of %.12g" f)
-      else
-        None
+      if !Clflags.keep_asm_file
+      then Some (Printf.sprintf "low part of %.12g" f)
+      else None
     in
     let comment_hi =
-      if !Clflags.keep_asm_file then
-        Some (Printf.sprintf "high part of %.12g" f)
-      else
-        None
+      if !Clflags.keep_asm_file
+      then Some (Printf.sprintf "high part of %.12g" f)
+      else None
     in
     let lo = Signed_int (Int64.logand f_int64 0xffff_ffffL) in
     let hi = Signed_int (Int64.shift_right_logical f_int64 32) in
-    if big_endian () then begin
+    if big_endian ()
+    then (
       const ?comment:comment_hi hi Thirty_two;
-      const ?comment:comment_lo lo Thirty_two
-    end else begin
+      const ?comment:comment_lo lo Thirty_two)
+    else (
       const ?comment:comment_lo lo Thirty_two;
-      const ?comment:comment_hi hi Thirty_two
-    end
+      const ?comment:comment_hi hi Thirty_two)
 
 let float64 f = float64_core f (Int64.bits_of_float f)
+
 let float64_from_bits f = float64_core (Int64.float_of_bits f) f
 
 let size ?size_of symbol =
   match TS.system () with
   | GNU | Linux | FreeBSD | NetBSD | OpenBSD | Generic_BSD ->
     let size_of =
-      match size_of with
-      | None -> symbol
-      | Some size_of -> size_of
+      match size_of with None -> symbol | Some size_of -> size_of
     in
     size size_of (Sub (This, Symbol symbol))
   | _ -> ()
 
-let label ?comment label =
-  const_machine_width ?comment (Label label)
+let label ?comment label = const_machine_width ?comment (Label label)
 
 let define_label label =
   let lbl_section = Asm_label.section label in
@@ -585,33 +564,28 @@ let define_label label =
     | None -> not_initialized ()
     | Some this_section -> this_section
   in
-  if not (Asm_section.equal lbl_section this_section) then begin
-    Misc.fatal_errorf "Cannot define label %a intended for section %a \
-        in section %a"
-      Asm_label.print label
-      Asm_section.print lbl_section
-      Asm_section.print this_section
-  end;
+  if not (Asm_section.equal lbl_section this_section)
+  then
+    Misc.fatal_errorf
+      "Cannot define label %a intended for section %a in section %a"
+      Asm_label.print label Asm_section.print lbl_section Asm_section.print
+      this_section;
   let typ : Directive.thing_after_label =
-    if current_section_is_text () then Code
-    else Machine_width_data
+    if current_section_is_text () then Code else Machine_width_data
   in
   emit (New_label (Asm_label.encode label, typ))
 
-let new_line () =
-  if !Clflags.keep_asm_file then begin
-    emit New_line
-  end
+let new_line () = if !Clflags.keep_asm_file then emit New_line
 
 let sections_seen = ref []
 
 let switch_to_section section =
   let first_occurrence =
-    if List.mem section !sections_seen then false
-    else begin
-      sections_seen := section::!sections_seen;
-      true
-    end
+    if List.mem section !sections_seen
+    then false
+    else (
+      sections_seen := section :: !sections_seen;
+      true)
   in
   match !current_section_ref with
   | Some section' when Asm_section.equal section section' ->
@@ -619,40 +593,39 @@ let switch_to_section section =
     ()
   | _ ->
     current_section_ref := Some section;
-    let ({ names; flags; args; } : Asm_section.flags_for_section) =
+    let ({ names; flags; args } : Asm_section.flags_for_section) =
       Asm_section.flags section ~first_occurrence
     in
-    if not first_occurrence then begin
-      new_line ()
-    end;
-    emit (Section { names; flags; args; });
-    if first_occurrence then begin
-      define_label (Asm_label.for_section section)
-    end
+    if not first_occurrence then new_line ();
+    emit (Section { names; flags; args });
+    if first_occurrence then define_label (Asm_label.for_section section)
 
 let switch_to_section_raw ~names ~flags ~args =
-  emit (Section { names; flags; args; })
+  emit (Section { names; flags; args })
 
 let text () = switch_to_section Asm_section.Text
+
 let data () = switch_to_section Asm_section.Data
 
 module Cached_string = struct
-  type t = {
-    section : Asm_section.t;
-    str : string;
-    comment : string option;
-  }
+  type t =
+    { section : Asm_section.t;
+      str : string;
+      comment : string option
+    }
 
   include Identifiable.Make (struct
     type nonrec t = t
 
-    let compare { section = section1; str = str1; comment = comment1; }
-          { section = section2; str = str2; comment = comment2; } =
+    let compare { section = section1; str = str1; comment = comment1 }
+        { section = section2; str = str2; comment = comment2 } =
       let c = Asm_section.compare section1 section2 in
-      if c <> 0 then c
+      if c <> 0
+      then c
       else
         let c = String.compare str1 str2 in
-        if c <> 0 then c
+        if c <> 0
+        then c
         else
           match comment1, comment2 with
           | None, None -> 0
@@ -660,17 +633,18 @@ module Cached_string = struct
           | Some _, None -> 1
           | Some comment1, Some comment2 -> String.compare comment1 comment2
 
-    let equal t1 t2 =
-      compare t1 t2 = 0
+    let equal t1 t2 = compare t1 t2 = 0
 
     let hash t = Hashtbl.hash t
 
     let print _ _ = Misc.fatal_error "Not yet implemented"
+
     let output _ _ = Misc.fatal_error "Not yet implemented"
   end)
 end
 
 let cached_strings = ref Cached_string.Map.empty
+
 let temp_var_counter = ref 0
 
 let reset () =
@@ -679,51 +653,45 @@ let reset () =
   temp_var_counter := 0
 
 let file ?file_num ~file_name () =
-  (* gas can silently emit corrupted line tables if a .file directive
-     contains a number but an empty filename. *)
+  (* gas can silently emit corrupted line tables if a .file directive contains a
+     number but an empty filename. *)
   let file_name =
     match file_num with
     | None -> file_name
     | Some _file_num ->
-      if String.length file_name <= 0 then "none"
-      else file_name
+      if String.length file_name <= 0 then "none" else file_name
   in
-  emit_non_masm (File { file_num = file_num; filename = file_name; })
+  emit_non_masm (File { file_num; filename = file_name })
 
 let initialize ~big_endian ~(emit : Directive.t -> unit) =
   big_endian_ref := Some big_endian;
   emit_ref := Some emit;
   reset ();
-  begin match TS.assembler () with
+  (match TS.assembler () with
   | MASM | MacOS -> ()
   | GAS_like ->
-    (* CR mshinwell: Is this really the case?  Surely some of the DIEs
-       would have gone wrong if this were the case.  Maybe it only applies
-       across sections. *)
-    (* Forward label references are illegal in gas.  Just put them in for
-       all assemblers, they won't harm. *)
-    List.iter (fun (section : Asm_section.t) ->
+    (* CR mshinwell: Is this really the case? Surely some of the DIEs would have
+       gone wrong if this were the case. Maybe it only applies across
+       sections. *)
+    (* Forward label references are illegal in gas. Just put them in for all
+       assemblers, they won't harm. *)
+    List.iter
+      (fun (section : Asm_section.t) ->
         match section with
-        | Text
-        | Data
-        | Read_only_data
-        | Eight_byte_literals
-        | Sixteen_byte_literals
-        | Jump_tables -> switch_to_section section
+        | Text | Data | Read_only_data | Eight_byte_literals
+        | Sixteen_byte_literals | Jump_tables ->
+          switch_to_section section
         | DWARF _ ->
-          (* All of the other settings that require these DWARF sections
-             imply [Debug_dwarf_functions]; see clflags.ml. *)
-          if Clflags.debug_thing Debug_dwarf_functions
-            && dwarf_supported ()
-          then begin
-            switch_to_section section
-          end)
-      (Asm_section.all_sections_in_order ())
-  end;
-  (* Stop dsymutil complaining about empty __debug_line sections (produces
-     bogus error "line table parameters mismatch") by making sure such sections
-     are never empty. *)
-  file ~file_num:1 ~file_name:"none" ();  (* also PR#7037 *)
+          (* All of the other settings that require these DWARF sections imply
+             [Debug_dwarf_functions]; see clflags.ml. *)
+          if Clflags.debug_thing Debug_dwarf_functions && dwarf_supported ()
+          then switch_to_section section)
+      (Asm_section.all_sections_in_order ()));
+  (* Stop dsymutil complaining about empty __debug_line sections (produces bogus
+     error "line table parameters mismatch") by making sure such sections are
+     never empty. *)
+  file ~file_num:1 ~file_name:"none" ();
+  (* also PR#7037 *)
   loc ~file_num:1 ~line:1 ~col:1;
   switch_to_section Asm_section.Text
 
@@ -736,38 +704,34 @@ let check_symbol_for_definition_in_current_section symbol =
     | None -> not_initialized ()
     | Some this_section -> this_section
   in
-  if not (Asm_section.equal symbol_section this_section) then begin
-    Misc.fatal_errorf "Cannot define symbol %a intended for section %a \
-        in section %a"
-      Asm_symbol.print symbol
-      Asm_section.print symbol_section
-      Asm_section.print this_section
-  end
+  if not (Asm_section.equal symbol_section this_section)
+  then
+    Misc.fatal_errorf
+      "Cannot define symbol %a intended for section %a in section %a"
+      Asm_symbol.print symbol Asm_section.print symbol_section Asm_section.print
+      this_section
 
 let define_data_symbol symbol =
   check_symbol_for_definition_in_current_section symbol;
   emit (New_label (Asm_symbol.encode symbol, Machine_width_data));
-  begin match TS.assembler (), TS.windows () with
+  match TS.assembler (), TS.windows () with
   | GAS_like, false -> type_ symbol ~type_:"STT_OBJECT"
   | GAS_like, true | MacOS, _ | MASM, _ -> ()
-  end
 
 (* CR mshinwell: Rename to [define_text_symbol]? *)
 let define_function_symbol symbol =
   check_symbol_for_definition_in_current_section symbol;
   (* CR mshinwell: This shouldn't be called "New_label" *)
   emit (New_label (Asm_symbol.encode symbol, Code));
-  begin match TS.assembler (), TS.windows () with
+  match TS.assembler (), TS.windows () with
   | GAS_like, false -> type_ symbol ~type_:"STT_FUNC"
   | GAS_like, true | MacOS, _ | MASM, _ -> ()
-  end
 
 let symbol ?comment sym = const_machine_width ?comment (Symbol sym)
 
 let symbol_plus_offset symbol ~offset_in_bytes =
   let offset_in_bytes = Targetint.to_int64 offset_in_bytes in
-  const_machine_width (
-    Add (Symbol symbol, Signed_int offset_in_bytes))
+  const_machine_width (Add (Symbol symbol, Signed_int offset_in_bytes))
 
 let int8 ?comment i =
   const ?comment (Signed_int (Int64.of_int (Int8.to_int i))) Eight
@@ -775,14 +739,11 @@ let int8 ?comment i =
 let int16 ?comment i =
   const ?comment (Signed_int (Int64.of_int (Int16.to_int i))) Sixteen
 
-let int32 ?comment i =
-  const ?comment (Signed_int (Int64.of_int32 i)) Thirty_two
+let int32 ?comment i = const ?comment (Signed_int (Int64.of_int32 i)) Thirty_two
 
-let int64 ?comment i =
-  const ?comment (Signed_int i) Sixty_four
+let int64 ?comment i = const ?comment (Signed_int i) Sixty_four
 
-let uint8 ?comment i =
-  const ?comment (Unsigned_int (Uint64.of_uint8 i)) Eight
+let uint8 ?comment i = const ?comment (Unsigned_int (Uint64.of_uint8 i)) Eight
 
 let uint16 ?comment i =
   const ?comment (Unsigned_int (Uint64.of_uint16 i)) Sixteen
@@ -790,8 +751,7 @@ let uint16 ?comment i =
 let uint32 ?comment i =
   const ?comment (Unsigned_int (Uint64.of_uint32 i)) Thirty_two
 
-let uint64 ?comment i =
-  const ?comment (Unsigned_int i) Sixty_four
+let uint64 ?comment i = const ?comment (Unsigned_int i) Sixty_four
 
 let targetint ?comment n =
   match Targetint.repr n with
@@ -799,7 +759,7 @@ let targetint ?comment n =
   | Int64 n -> int64 ?comment n
 
 let cache_string ?comment section str =
-  let cached : Cached_string.t = { section; str; comment; } in
+  let cached : Cached_string.t = { section; str; comment } in
   match Cached_string.Map.find cached !cached_strings with
   | label -> label
   | exception Not_found ->
@@ -808,7 +768,8 @@ let cache_string ?comment section str =
     label
 
 let emit_cached_strings () =
-  Cached_string.Map.iter (fun { section; str; comment; } label_name ->
+  Cached_string.Map.iter
+    (fun { section; str; comment } label_name ->
       switch_to_section section;
       define_label label_name;
       string ?comment str;
@@ -833,64 +794,59 @@ let force_assembly_time_constant section expr =
   match TS.assembler () with
   | GAS_like | MASM -> expr
   | MacOS ->
-    (* This ensures the correct result is obtained on macOS.  (Apparently
-       just writing expressions such as "L100 - L101" inline can cause
-       unexpected results when one of the labels is on a section boundary,
-       for example.) *)
+    (* This ensures the correct result is obtained on macOS. (Apparently just
+       writing expressions such as "L100 - L101" inline can cause unexpected
+       results when one of the labels is on a section boundary, for example.) *)
     let temp = new_temp_var () in
     direct_assignment temp expr;
     let compilation_unit = Compilation_unit.get_current_exn () in
     let sym =
       Asm_symbol.of_external_name_no_prefix section compilation_unit temp
     in
-    Symbol sym  (* not really a symbol, but OK. *)
+    Symbol sym (* not really a symbol, but OK. *)
 
 let check_symbol_in_current_unit sym =
   let sym_unit = Asm_symbol.compilation_unit sym in
   let this_unit = Compilation_unit.get_current_exn () in
-  if not (Compilation_unit.equal sym_unit this_unit) then begin
-    Misc.fatal_errorf "Symbol %a (in compilation unit %a) not in current \
-        compilation unit %a"
-      Asm_symbol.print sym
-      Compilation_unit.print sym_unit
+  if not (Compilation_unit.equal sym_unit this_unit)
+  then
+    Misc.fatal_errorf
+      "Symbol %a (in compilation unit %a) not in current compilation unit %a"
+      Asm_symbol.print sym Compilation_unit.print sym_unit
       Compilation_unit.print this_unit
-  end
 
 let check_symbols_in_same_section sym1 sym2 =
   let sym1_section = Asm_symbol.section sym1 in
   let sym2_section = Asm_symbol.section sym2 in
-  if not (Asm_section.equal sym1_section sym2_section) then begin
-    Misc.fatal_errorf "Symbols %a (in section %a) and %a (in section %a) \
-        are not in the same section"
-      Asm_symbol.print sym1
-      Asm_section.print sym1_section
-      Asm_symbol.print sym2
+  if not (Asm_section.equal sym1_section sym2_section)
+  then
+    Misc.fatal_errorf
+      "Symbols %a (in section %a) and %a (in section %a) are not in the same \
+       section"
+      Asm_symbol.print sym1 Asm_section.print sym1_section Asm_symbol.print sym2
       Asm_section.print sym2_section
-  end
 
 let check_labels_in_same_section lbl1 lbl2 =
   let lbl1_section = Asm_label.section lbl1 in
   let lbl2_section = Asm_label.section lbl2 in
-  if not (Asm_section.equal lbl1_section lbl2_section) then begin
-    Misc.fatal_errorf "Labels %a (in section %a) and %a (in section %a) \
-        are not in the same section"
-      Asm_label.print lbl1
-      Asm_section.print lbl1_section
-      Asm_label.print lbl2
+  if not (Asm_section.equal lbl1_section lbl2_section)
+  then
+    Misc.fatal_errorf
+      "Labels %a (in section %a) and %a (in section %a) are not in the same \
+       section"
+      Asm_label.print lbl1 Asm_section.print lbl1_section Asm_label.print lbl2
       Asm_section.print lbl2_section
-  end
 
 let check_symbol_and_label_in_same_section sym lbl =
   let sym_section = Asm_symbol.section sym in
   let lbl_section = Asm_label.section lbl in
-  if not (Asm_section.equal sym_section lbl_section) then begin
-    Misc.fatal_errorf "Symbol %a (in section %a) and label %a (in section %a) \
-        are not in the same section"
-      Asm_symbol.print sym
-      Asm_section.print sym_section
-      Asm_label.print lbl
+  if not (Asm_section.equal sym_section lbl_section)
+  then
+    Misc.fatal_errorf
+      "Symbol %a (in section %a) and label %a (in section %a) are not in the \
+       same section"
+      Asm_symbol.print sym Asm_section.print sym_section Asm_label.print lbl
       Asm_section.print lbl_section
-  end
 
 let between_symbols_in_current_unit ~upper ~lower =
   check_symbol_in_current_unit upper;
@@ -918,132 +874,127 @@ let between_labels_64_bit ?comment ~upper ~lower () =
   let section = Asm_label.section upper in
   const ?comment (force_assembly_time_constant section expr) Sixty_four
 
-let between_symbol_in_current_unit_and_label_offset ?comment
-      ~upper ~lower ~offset_upper =
+let between_symbol_in_current_unit_and_label_offset ?comment ~upper ~lower
+    ~offset_upper =
   check_symbol_in_current_unit lower;
   check_symbol_and_label_in_same_section lower upper;
   let section = Asm_symbol.section lower in
-  if Targetint.compare offset_upper Targetint.zero = 0 then
+  if Targetint.compare offset_upper Targetint.zero = 0
+  then
     let expr = Sub (Label upper, Symbol lower) in
     const_machine_width ?comment (force_assembly_time_constant section expr)
   else
     let offset_upper = Targetint.to_int64 offset_upper in
-    let expr =
-      Sub (Add (Label upper, Signed_int offset_upper), Symbol lower)
-    in
+    let expr = Sub (Add (Label upper, Signed_int offset_upper), Symbol lower) in
     const_machine_width ?comment (force_assembly_time_constant section expr)
 
 let between_this_and_label_offset_32bit ~upper ~offset_upper =
   let upper_section = Asm_label.section upper in
-  begin match !current_section_ref with
+  (match !current_section_ref with
   | None -> not_initialized ()
   | Some this_section ->
-    if not (Asm_section.equal upper_section this_section) then begin
-      Misc.fatal_errorf "Label %a in section %a is not in the \
-          current section %a"
-        Asm_label.print upper
-        Asm_section.print upper_section
-        Asm_section.print this_section
-    end
-  end;
+    if not (Asm_section.equal upper_section this_section)
+    then
+      Misc.fatal_errorf
+        "Label %a in section %a is not in the current section %a"
+        Asm_label.print upper Asm_section.print upper_section Asm_section.print
+        this_section);
   let offset_upper = Targetint.to_int64 offset_upper in
-  let expr =
-    Sub (Add (Label upper, Signed_int offset_upper), This)
-  in
+  let expr = Sub (Add (Label upper, Signed_int offset_upper), This) in
   const (force_assembly_time_constant upper_section expr) Thirty_two
 
 let offset_into_dwarf_section_label ?comment section upper
-      ~(width : TS.machine_width) =
+    ~(width : TS.machine_width) =
   let upper_section = Asm_label.section upper in
   let expected_section : Asm_section.t = DWARF section in
-  if not (Asm_section.equal upper_section expected_section) then begin
+  if not (Asm_section.equal upper_section expected_section)
+  then
     Misc.fatal_errorf "Label %a (in section %a) is not in section %a"
-      Asm_label.print upper
-      Asm_section.print upper_section
-      Asm_section.print expected_section
-  end;
+      Asm_label.print upper Asm_section.print upper_section Asm_section.print
+      expected_section;
   let expr : expr =
     match TS.assembler () with
     | MacOS ->
       let lower = Asm_label.for_dwarf_section section in
       (* macOS does not use relocations in DWARF sections in places, such as
-         here, where they might be expected.  Instead dsymutil and other tools
+         here, where they might be expected. Instead dsymutil and other tools
          parse DWARF sections properly and adjust offsets manually. *)
       force_assembly_time_constant expected_section
         (Sub (Label upper, Label lower))
-    | GAS_like | MASM ->
-      Label upper
+    | GAS_like | MASM -> Label upper
   in
   let width : Directive.Constant_with_width.width_in_bytes =
-    match width with
-    | Thirty_two -> Thirty_two
-    | Sixty_four -> Sixty_four
+    match width with Thirty_two -> Thirty_two | Sixty_four -> Sixty_four
   in
   let comment =
-    if not !Clflags.keep_asm_file then None
+    if not !Clflags.keep_asm_file
+    then None
     else
       match comment with
       | None ->
-        Some (Format.asprintf "offset into %s"
-          (Asm_section.to_string expected_section))
+        Some
+          (Format.asprintf "offset into %s"
+             (Asm_section.to_string expected_section))
       | Some comment ->
-        Some (Format.asprintf "%s (offset into %s)"
-          comment (Asm_section.to_string expected_section))
+        Some
+          (Format.asprintf "%s (offset into %s)" comment
+             (Asm_section.to_string expected_section))
   in
   const ?comment expr width
 
 let offset_into_dwarf_section_symbol ?comment section upper
-      ~(width : TS.machine_width) =
+    ~(width : TS.machine_width) =
   let upper_section = Asm_symbol.section upper in
-  if not (Asm_section.equal upper_section (DWARF section)) then begin
+  if not (Asm_section.equal upper_section (DWARF section))
+  then
     Misc.fatal_errorf "Symbol %a (in section %a) not in section %a"
-      Asm_symbol.print upper
-      Asm_section.print upper_section
-      Asm_section.print (Asm_section.DWARF section)
-  end;
+      Asm_symbol.print upper Asm_section.print upper_section Asm_section.print
+      (Asm_section.DWARF section);
   (* The macOS assembler doesn't seem to allow "distance to undefined symbol
-     from start of given section".  As such we do not allow this function to
-     be used for undefined symbols on macOS at the moment.
-     Relevant link:
-     <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82005>.
-  *)
+     from start of given section". As such we do not allow this function to be
+     used for undefined symbols on macOS at the moment. Relevant link:
+     <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82005>. *)
   let expr : expr =
     match TS.assembler () with
     | MacOS ->
       let in_current_unit =
-        Compilation_unit.equal (Compilation_unit.get_current_exn ())
+        Compilation_unit.equal
+          (Compilation_unit.get_current_exn ())
           (Asm_symbol.compilation_unit upper)
       in
-      if in_current_unit then
+      if in_current_unit
+      then
         let lower = Asm_label.for_dwarf_section section in
         (* Same note as in [offset_into_dwarf_section_label] applies here. *)
         force_assembly_time_constant (DWARF section)
           (Sub (Symbol upper, Label lower))
       else
-        Misc.fatal_errorf "Don't know how to encode offset from start of \
-            section %a to undefined symbol %a on macOS (current compilation \
-            unit %a, symbol in compilation unit %a)"
-          Asm_section.print upper_section
-          Asm_symbol.print upper
-          Compilation_unit.print (Compilation_unit.get_current_exn ())
-          Compilation_unit.print (Asm_symbol.compilation_unit upper)
-    | GAS_like | MASM ->
-      Symbol upper
+        Misc.fatal_errorf
+          "Don't know how to encode offset from start of section %a to \
+           undefined symbol %a on macOS (current compilation unit %a, symbol \
+           in compilation unit %a)"
+          Asm_section.print upper_section Asm_symbol.print upper
+          Compilation_unit.print
+          (Compilation_unit.get_current_exn ())
+          Compilation_unit.print
+          (Asm_symbol.compilation_unit upper)
+    | GAS_like | MASM -> Symbol upper
   in
   let width : Directive.Constant_with_width.width_in_bytes =
-    match width with
-    | Thirty_two -> Thirty_two
-    | Sixty_four -> Sixty_four
+    match width with Thirty_two -> Thirty_two | Sixty_four -> Sixty_four
   in
   let comment =
-    if not !Clflags.keep_asm_file then None
+    if not !Clflags.keep_asm_file
+    then None
     else
       match comment with
       | None ->
-        Some (Format.asprintf "offset into %s"
-          (Asm_section.to_string (DWARF section)))
+        Some
+          (Format.asprintf "offset into %s"
+             (Asm_section.to_string (DWARF section)))
       | Some comment ->
-        Some (Format.asprintf "%s (offset into %s)"
-          comment (Asm_section.to_string (DWARF section)))
+        Some
+          (Format.asprintf "%s (offset into %s)" comment
+             (Asm_section.to_string (DWARF section)))
   in
   const ?comment expr width

--- a/backend/asm_targets/asm_directives_new.ml
+++ b/backend/asm_targets/asm_directives_new.ml
@@ -809,6 +809,7 @@ let between_symbols_in_current_unit ~upper ~lower =
   let upper = const_symbol upper in
   let lower = const_symbol lower in
   let expr = const_sub upper lower in
+  (* CR sspies: is this check even needed? *)
   if TS.is_macos ()
   then const_machine_width (force_assembly_time_constant expr)
   else const_machine_width expr

--- a/backend/asm_targets/asm_directives_new.ml
+++ b/backend/asm_targets/asm_directives_new.ml
@@ -7,7 +7,7 @@
 (*                                                                        *)
 (*   Copyright 2014 Institut National de Recherche en Informatique et     *)
 (*     en Automatique.                                                    *)
-(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*   Copyright 2016--2025 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)

--- a/backend/asm_targets/asm_directives_new.ml
+++ b/backend/asm_targets/asm_directives_new.ml
@@ -600,8 +600,8 @@ let switch_to_section section =
     ()
   | _ ->
     current_section_ref := Some section;
-    let ({ names; flags; args } : Asm_section.flags_for_section) =
-      Asm_section.flags section ~first_occurrence
+    let ({ names; flags; args } : Asm_section.section_details) =
+      Asm_section.details section ~first_occurrence
     in
     if not first_occurrence then new_line ();
     emit (Section { names; flags; args });

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -221,12 +221,16 @@ val between_labels_32_bit :
 val between_labels_64_bit :
   ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> unit
 
-
-
 (** Like [between_symbols], but for two labels with additional offsets, emitting a 64-bit-wide
     reference.  The labels must be in the same section. *)
 val between_labels_64_bit_with_offsets :
-  ?comment:string -> upper:Asm_label.t -> upper_offset:Targetint.t -> lower:Asm_label.t -> lower_offset:Targetint.t -> unit -> unit
+  ?comment:string ->
+  upper:Asm_label.t ->
+  upper_offset:Targetint.t ->
+  lower:Asm_label.t ->
+  lower_offset:Targetint.t ->
+  unit ->
+  unit
 
 (** Emit a machine-width reference giving the displacement between the
     [lower] symbol and the sum of the address of the [upper] label plus
@@ -240,7 +244,6 @@ val between_symbol_in_current_unit_and_label_offset :
   offset_upper:Targetint.t ->
   unit ->
   unit
-
 
 (** Emit an offset into a DWARF section given a label identifying the place
     within such section. *)

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -1,0 +1,377 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*          Fabrice Le Fessant, projet Gallium, INRIA Rocquencourt        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2014 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Abstraction layer for the emission of assembly directives that conceals
+    many intricate details differing between target systems. *)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+(* CR-someday mshinwell: Use this module throughout the backends as per
+   the original GPR. *)
+
+(** Emit subsequent directives to the given section.  If this function
+    has not been called before on the particular section, a label
+    declaration will be emitted after declaring the section.
+    Such labels may seem strange, but they are necessary so that
+    references (e.g. DW_FORM_ref_addr / DW_FORM_sec_offset when emitting
+    DWARF) to places that are currently at the start of these sections
+    get relocated correctly when those places become not at the start
+    (e.g. during linking). *)
+val switch_to_section : Asm_section.t -> unit
+
+(** Emit subsequent directives to the given section, where the section must
+    not be one of those in type [section] (see above).  The section is
+    specified by the three components of a typical assembler section-switching
+    command.  This function is only intended to be used for target-specific
+    sections. *)
+val switch_to_section_raw
+   : names:string list
+  -> flags:string option
+  -> args:string list
+  -> unit
+
+(** Abbreviation for [switch_to_section Text]. *)
+val text : unit -> unit
+
+(** Abbreviation for [switch_to_section Data]. *)
+val data : unit -> unit
+
+(** Emit an 8-bit signed integer.  There is no padding or sign extension.
+    If the [comment] is specified it will be put on the same line as the
+    integer. *)
+val int8 : ?comment:string -> Numbers.Int8.t -> unit
+
+(** Emit a 16-bit signed integer.  There is no padding or sign extension. *)
+val int16 : ?comment:string -> Numbers.Int16.t -> unit
+
+(** Emit a 32-bit signed integer.  There is no padding or sign extension. *)
+val int32 : ?comment:string -> Int32.t -> unit
+
+(** Emit a 64-bit signed integer. *)
+val int64 : ?comment:string -> Int64.t -> unit
+
+(** Emit an 8-bit unsigned integer.  There is no padding. *)
+val uint8 : ?comment:string -> Numbers.Uint8.t -> unit
+
+(** Emit an 16-bit unsigned integer.  There is no padding. *)
+val uint16 : ?comment:string -> Numbers.Uint16.t -> unit
+
+(** Emit an 32-bit unsigned integer.  There is no padding. *)
+val uint32 : ?comment:string -> Numbers.Uint32.t -> unit
+
+(** Emit an 64-bit unsigned integer.  There is no padding. *)
+val uint64 : ?comment:string -> Numbers.Uint64.t -> unit
+
+(** Emit a signed integer whose width is that of an address on the target
+    machine.  There is no padding or sign extension. *)
+(* CR-soon mshinwell: Target addresses should not be signed *)
+val targetint : ?comment:string -> Targetint.t -> unit
+
+(** Emit a 64-bit integer in unsigned LEB128 variable-length encoding
+    (cf. DWARF debugging information standard). *)
+val uleb128 : ?comment:string -> Numbers.Uint64.t -> unit
+
+(** Emit a 64-bit integer in signed LEB128 variable-length encoding. *)
+val sleb128 : ?comment:string -> Int64.t -> unit
+
+(** Emit a 32-bit-wide floating point number. *)
+val float32 : float -> unit
+
+(** Emit a 64-bit-wide floating point number. *)
+val float64 : float -> unit
+
+(** Emit a 64-bit-wide floating point number whose bits are contained
+    in an [Int64.t]. *)
+val float64_from_bits : Int64.t -> unit
+
+(** Emit a string (directly into the current section).  This function
+    does not write a terminating null. *)
+val string : ?comment:string -> string -> unit
+
+(** Cache a string for later emission.  The returned label may be used to
+    obtain the address of the string in the section.  This function does
+    not emit anything.  (See [emit_cached_strings], below.)
+    If a string is supplied to this function that is already in the cache
+    then the previously-assigned label is returned, not a new one. *)
+val cache_string : ?comment:string -> Asm_section.t -> string -> Asm_label.t
+
+(** Emit the sequence of:
+      label definition:
+        <string><null terminator>
+    pairs as per previous calls to [cache_string] with appropriate directives
+    to switch section interspersed.  This function clears the cache. *)
+val emit_cached_strings : unit -> unit
+
+(** Emit a comment. *)
+val comment : string -> unit
+
+(** Assign a file number to a filename. *)
+val file : file_num:int -> file_name:string -> unit
+
+(** Mark the source location of the current assembly position. *)
+val loc : file_num:int -> line:int -> col:int -> unit
+
+(** Emit a blank line. *)
+val new_line : unit -> unit
+
+(** Adjust the current frame address offset by the given number of bytes.
+    This and other CFI functions will not emit anything in the case where
+    CFI is not supported on the target. *)
+val cfi_adjust_cfa_offset : bytes:int -> unit
+
+(** Define the current frame address offset.
+    This and other CFI functions will not emit anything in the case where
+    CFI is not supported on the target. *)
+val cfi_def_cfa_offset : bytes:int -> unit
+
+(** Note that the previous value of [reg] is saved at [offset] from
+    the current frame address. *)
+val cfi_offset : reg:int -> offset:int -> unit
+
+(** Mark the beginning of a function, for CFI purposes. *)
+val cfi_startproc : unit -> unit
+
+(** Mark the end of a function, for CFI purposes. *)
+val cfi_endproc : unit -> unit
+
+(** Mark that the call stack is not to be executable at runtime.  Not
+    supported on all platforms. *)
+val mark_stack_non_executable : unit -> unit
+
+(** Leave as much space as is required to achieve the given alignment. *)
+val align : bytes:int -> unit
+
+(** Emit a directive giving the displacement between the given symbol and
+    the current position.  This should only be used to state sizes of
+    blocks (e.g. functions) emitted immediately prior into the assembly stream.
+    [size_of] may be specified when the symbol used for measurement differs
+    from that whose size is being stated (e.g. on POWER with ELF ABI v1). *)
+val size : ?size_of:Asm_symbol.t -> Asm_symbol.t -> unit
+
+(** Leave a gap in the object file. *)
+val space : bytes:int -> unit
+
+(** Define a data ("object") symbol at the current output position.  When
+    emitting for MASM this will cause loads and stores to/from the symbol to
+    be treated as if they are loading machine-width words (unless the
+    instruction has an explicit width suffix). *)
+val define_data_symbol : Asm_symbol.t -> unit
+
+(** Define a function symbol at the current output position.  An exception
+    will be raised if the current section is not a text section. *)
+val define_function_symbol : Asm_symbol.t -> unit
+
+(** Mark a symbol as global. *)
+val global : Asm_symbol.t -> unit
+
+(** Emit a machine-width reference to the given symbol. *)
+val symbol : ?comment:string -> Asm_symbol.t -> unit
+
+(** Mark a symbol as "private extern" (see assembler documentation for
+    details). *)
+val private_extern : Asm_symbol.t -> unit
+
+(** Marker inside the definition of a lazy symbol stub (see platform or
+    assembler documentation for details). *)
+val indirect_symbol : Asm_symbol.t -> unit
+
+(** Define a label at the current position in the current section.
+    The treatment for MASM when emitting into non-text sections is as for
+    [define_symbol], above. *)
+val define_label : Asm_label.t -> unit
+
+(** Emit a machine-width reference to the given label. *)
+val label : ?comment:string -> Asm_label.t -> unit
+
+(** Emit a machine-width reference to the address formed by adding the
+    given byte offset to the address of the given symbol.  The symbol may be
+    in a compilation unit and/or section different from the current one. *)
+val symbol_plus_offset
+   : Asm_symbol.t
+  -> offset_in_bytes:Targetint.t
+  -> unit
+
+(** Emit a machine-width reference giving the displacement between two given
+    symbols.  To obtain a positive result the symbol at the [lower] address
+    should be the second argument, as for normal subtraction.  The symbols
+    must be in the current compilation unit and in the same section. *)
+val between_symbols_in_current_unit
+   : upper:Asm_symbol.t
+  -> lower:Asm_symbol.t
+  -> unit
+
+(** Like [between_symbols], but for two labels, emitting a 16-bit-wide
+    reference.  The behaviour upon overflow is unspecified.  The labels must
+    be in the same section. *)
+val between_labels_16_bit
+   : ?comment:string
+  -> upper:Asm_label.t
+  -> lower:Asm_label.t
+  -> unit
+  -> unit
+
+(** Like [between_symbols], but for two labels, emitting a 32-bit-wide
+    reference.  The behaviour upon overflow is unspecified.  The labels must
+    be in the same section. *)
+val between_labels_32_bit
+   : ?comment:string
+  -> upper:Asm_label.t
+  -> lower:Asm_label.t
+  -> unit
+  -> unit
+
+(** Like [between_symbols], but for two labels, emitting a 64-bit-wide
+    reference.  The labels must be in the same section. *)
+val between_labels_64_bit
+   : ?comment:string
+  -> upper:Asm_label.t
+  -> lower:Asm_label.t
+  -> unit
+  -> unit
+
+(** Emit a machine-width reference giving the displacement between the
+    [lower] symbol and the sum of the address of the [upper] label plus
+    [offset_upper].  The [lower] symbol must be in the current compilation
+    unit.  The [upper] label must be in the same section as the [lower]
+    symbol. *)
+val between_symbol_in_current_unit_and_label_offset
+   : ?comment:string
+  -> upper:Asm_label.t
+  -> lower:Asm_symbol.t
+  -> offset_upper:Targetint.t
+  -> unit
+
+(** Emit a 32-bit-wide reference giving the displacement between obtained
+    by subtracting the current assembly location from the sum of the address
+    of the given label plus the given offset.  The label must be in the
+    same section as the assembler is currently emitting into. *)
+(* CR mshinwell: double-check use of this function *)
+val between_this_and_label_offset_32bit
+   : upper:Asm_label.t
+  -> offset_upper:Targetint.t
+  -> unit
+
+(** Emit an offset into a DWARF section given a label identifying the place
+    within such section. *)
+val offset_into_dwarf_section_label
+   : ?comment:string
+  -> Asm_section.dwarf_section
+  -> Asm_label.t
+  -> width:Target_system.machine_width
+  -> unit
+
+(** Emit an offset into a DWARF section given a symbol identifying the place
+    within such section.  The symbol may only be in a compilation unit different
+    from the current one if the supplied section is [Debug_info].  The symbol
+    must always be in the given section. *)
+val offset_into_dwarf_section_symbol
+   : ?comment:string
+  -> Asm_section.dwarf_section
+  -> Asm_symbol.t
+  -> width:Target_system.machine_width
+  -> unit
+
+module Directive : sig
+  module Constant : sig
+    type t = private
+      | Signed_int of Int64.t
+      | Unsigned_int of Numbers.Uint64.t
+      | This
+      | Named_thing of string
+      (** [Named_thing] covers symbols, labels and variables. (Name mangling
+          conventions have by now been applied to these entities.) *)
+      | Add of t * t
+      | Sub of t * t
+  end
+
+  module Constant_with_width : sig
+    (** A constant together with a width indicating the number of bytes in
+        the object file within which the constant is to fit.  Some validation
+        is performed on values of type [t] to try to ensure that this is the
+        case, but it cannot be exhaustive, as the values of [This] and
+        [Named_thing] constructions are not known. *)
+    type t
+
+    val constant : t -> Constant.t
+
+    type width_in_bytes = private
+      | Eight
+      | Sixteen
+      | Thirty_two
+      | Sixty_four
+
+    val width_in_bytes : t -> width_in_bytes
+  end
+
+  type thing_after_label = private
+    | Code
+    | Machine_width_data
+
+  type comment = private string
+
+  (** Internal representation of directives.  Only needed if writing a custom
+      assembler or printer instead of using [print], below.
+      Symbols that occur in values of type [t] are encoded as [string]s and
+      have had all necessary prefixing, mangling, escaping and suffixing
+      applied. *)
+  type t = private
+    | Align of { bytes : int; }
+    | Bytes of { str : string; comment : string option; }
+    | Cfi_adjust_cfa_offset of int
+    | Cfi_def_cfa_offset of int
+    | Cfi_endproc
+    | Cfi_offset of { reg : int; offset : int; }
+    | Cfi_startproc
+    | Comment of comment
+    | Const of { constant : Constant_with_width.t; comment : string option; }
+    | Direct_assignment of string * Constant.t
+    | File of { file_num : int option; filename : string; }
+    | Global of string
+    | Indirect_symbol of string
+    | Loc of { file_num : int; line : int; col : int; }
+    | New_label of string * thing_after_label
+    | New_line
+    | Private_extern of string
+    | Section of {
+        names : string list;
+        flags : string option;
+        args : string list;
+      }
+    | Size of string * Constant.t
+    | Sleb128 of { constant : Constant.t; comment : string option; }
+    | Space of { bytes : int; }
+    | Type of string * string
+    | Uleb128 of { constant : Constant.t; comment : string option; }
+
+  (** Translate the given directive to textual form.  This produces output
+      suitable for either gas or MASM as appropriate. *)
+  val print : Buffer.t -> t -> unit
+end
+
+(** To be called by the emitter at the very start of code generation.
+    [big_endian] should always be [Arch.big_endian].
+    Calling the functions in this module will cause directives to be passed
+    to the given [emit] function (a typical implementation of which will just
+    call [Directive.print] on its parameter).
+    This function switches to the text section. *)
+val initialize
+   : big_endian:bool
+  -> emit:(Directive.t -> unit)
+  -> unit
+
+(** Reinitialize the emitter before compiling a different source file. *)
+val reset : unit -> unit

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -20,8 +20,8 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
-(* CR-someday mshinwell: Use this module throughout the backends as per
-   the original GPR. *)
+(* CR-someday mshinwell: Use this module throughout the backends as per the
+   original GPR. *)
 
 (** Emit subsequent directives to the given section.  If this function
     has not been called before on the particular section, a label
@@ -38,11 +38,8 @@ val switch_to_section : Asm_section.t -> unit
     specified by the three components of a typical assembler section-switching
     command.  This function is only intended to be used for target-specific
     sections. *)
-val switch_to_section_raw
-   : names:string list
-  -> flags:string option
-  -> args:string list
-  -> unit
+val switch_to_section_raw :
+  names:string list -> flags:string option -> args:string list -> unit
 
 (** Abbreviation for [switch_to_section Text]. *)
 val text : unit -> unit
@@ -76,9 +73,10 @@ val uint32 : ?comment:string -> Numbers.Uint32.t -> unit
 (** Emit an 64-bit unsigned integer.  There is no padding. *)
 val uint64 : ?comment:string -> Numbers.Uint64.t -> unit
 
+(* CR-soon mshinwell: Target addresses should not be signed *)
+
 (** Emit a signed integer whose width is that of an address on the target
     machine.  There is no padding or sign extension. *)
-(* CR-soon mshinwell: Target addresses should not be signed *)
 val targetint : ?comment:string -> Targetint.t -> unit
 
 (** Emit a 64-bit integer in unsigned LEB128 variable-length encoding
@@ -200,90 +198,72 @@ val label : ?comment:string -> Asm_label.t -> unit
 (** Emit a machine-width reference to the address formed by adding the
     given byte offset to the address of the given symbol.  The symbol may be
     in a compilation unit and/or section different from the current one. *)
-val symbol_plus_offset
-   : Asm_symbol.t
-  -> offset_in_bytes:Targetint.t
-  -> unit
+val symbol_plus_offset : Asm_symbol.t -> offset_in_bytes:Targetint.t -> unit
 
 (** Emit a machine-width reference giving the displacement between two given
     symbols.  To obtain a positive result the symbol at the [lower] address
     should be the second argument, as for normal subtraction.  The symbols
     must be in the current compilation unit and in the same section. *)
-val between_symbols_in_current_unit
-   : upper:Asm_symbol.t
-  -> lower:Asm_symbol.t
-  -> unit
+val between_symbols_in_current_unit :
+  upper:Asm_symbol.t -> lower:Asm_symbol.t -> unit
 
 (** Like [between_symbols], but for two labels, emitting a 16-bit-wide
     reference.  The behaviour upon overflow is unspecified.  The labels must
     be in the same section. *)
-val between_labels_16_bit
-   : ?comment:string
-  -> upper:Asm_label.t
-  -> lower:Asm_label.t
-  -> unit
-  -> unit
+val between_labels_16_bit :
+  ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> unit
 
 (** Like [between_symbols], but for two labels, emitting a 32-bit-wide
     reference.  The behaviour upon overflow is unspecified.  The labels must
     be in the same section. *)
-val between_labels_32_bit
-   : ?comment:string
-  -> upper:Asm_label.t
-  -> lower:Asm_label.t
-  -> unit
-  -> unit
+val between_labels_32_bit :
+  ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> unit
 
 (** Like [between_symbols], but for two labels, emitting a 64-bit-wide
     reference.  The labels must be in the same section. *)
-val between_labels_64_bit
-   : ?comment:string
-  -> upper:Asm_label.t
-  -> lower:Asm_label.t
-  -> unit
-  -> unit
+val between_labels_64_bit :
+  ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> unit
 
 (** Emit a machine-width reference giving the displacement between the
     [lower] symbol and the sum of the address of the [upper] label plus
     [offset_upper].  The [lower] symbol must be in the current compilation
     unit.  The [upper] label must be in the same section as the [lower]
     symbol. *)
-val between_symbol_in_current_unit_and_label_offset
-   : ?comment:string
-  -> upper:Asm_label.t
-  -> lower:Asm_symbol.t
-  -> offset_upper:Targetint.t
-  -> unit
+val between_symbol_in_current_unit_and_label_offset :
+  ?comment:string ->
+  upper:Asm_label.t ->
+  lower:Asm_symbol.t ->
+  offset_upper:Targetint.t ->
+  unit
+
+(* CR mshinwell: double-check use of this function *)
 
 (** Emit a 32-bit-wide reference giving the displacement between obtained
     by subtracting the current assembly location from the sum of the address
     of the given label plus the given offset.  The label must be in the
     same section as the assembler is currently emitting into. *)
-(* CR mshinwell: double-check use of this function *)
-val between_this_and_label_offset_32bit
-   : upper:Asm_label.t
-  -> offset_upper:Targetint.t
-  -> unit
+val between_this_and_label_offset_32bit :
+  upper:Asm_label.t -> offset_upper:Targetint.t -> unit
 
 (** Emit an offset into a DWARF section given a label identifying the place
     within such section. *)
-val offset_into_dwarf_section_label
-   : ?comment:string
-  -> Asm_section.dwarf_section
-  -> Asm_label.t
-  -> width:Target_system.machine_width
-  -> unit
+val offset_into_dwarf_section_label :
+  ?comment:string ->
+  Asm_section.dwarf_section ->
+  Asm_label.t ->
+  width:Target_system.machine_width ->
+  unit
 
 (** Emit an offset into a DWARF section given a symbol identifying the place
     within such section.  The symbol may only be in a compilation unit different
     from the current one if the supplied section is [Debug_info].  The symbol
     must always be in the given section. *)
-val offset_into_dwarf_section_symbol
-   : ?comment:string
-  -> Asm_section.dwarf_section
-  -> Asm_symbol.t
-  -> width:Target_system.machine_width
-  -> unit
+val offset_into_dwarf_section_symbol :
+  ?comment:string ->
+  Asm_section.dwarf_section ->
+  Asm_symbol.t ->
+  width:Target_system.machine_width ->
+  unit
 
 module Directive : sig
   module Constant : sig
@@ -292,7 +272,7 @@ module Directive : sig
       | Unsigned_int of Numbers.Uint64.t
       | This
       | Named_thing of string
-      (** [Named_thing] covers symbols, labels and variables. (Name mangling
+          (** [Named_thing] covers symbols, labels and variables. (Name mangling
           conventions have by now been applied to these entities.) *)
       | Add of t * t
       | Sub of t * t
@@ -329,33 +309,55 @@ module Directive : sig
       have had all necessary prefixing, mangling, escaping and suffixing
       applied. *)
   type t = private
-    | Align of { bytes : int; }
-    | Bytes of { str : string; comment : string option; }
+    | Align of { bytes : int }
+    | Bytes of
+        { str : string;
+          comment : string option
+        }
     | Cfi_adjust_cfa_offset of int
     | Cfi_def_cfa_offset of int
     | Cfi_endproc
-    | Cfi_offset of { reg : int; offset : int; }
+    | Cfi_offset of
+        { reg : int;
+          offset : int
+        }
     | Cfi_startproc
     | Comment of comment
-    | Const of { constant : Constant_with_width.t; comment : string option; }
+    | Const of
+        { constant : Constant_with_width.t;
+          comment : string option
+        }
     | Direct_assignment of string * Constant.t
-    | File of { file_num : int option; filename : string; }
+    | File of
+        { file_num : int option;
+          filename : string
+        }
     | Global of string
     | Indirect_symbol of string
-    | Loc of { file_num : int; line : int; col : int; }
+    | Loc of
+        { file_num : int;
+          line : int;
+          col : int
+        }
     | New_label of string * thing_after_label
     | New_line
     | Private_extern of string
-    | Section of {
-        names : string list;
-        flags : string option;
-        args : string list;
-      }
+    | Section of
+        { names : string list;
+          flags : string option;
+          args : string list
+        }
     | Size of string * Constant.t
-    | Sleb128 of { constant : Constant.t; comment : string option; }
-    | Space of { bytes : int; }
+    | Sleb128 of
+        { constant : Constant.t;
+          comment : string option
+        }
+    | Space of { bytes : int }
     | Type of string * string
-    | Uleb128 of { constant : Constant.t; comment : string option; }
+    | Uleb128 of
+        { constant : Constant.t;
+          comment : string option
+        }
 
   (** Translate the given directive to textual form.  This produces output
       suitable for either gas or MASM as appropriate. *)
@@ -368,10 +370,7 @@ end
     to the given [emit] function (a typical implementation of which will just
     call [Directive.print] on its parameter).
     This function switches to the text section. *)
-val initialize
-   : big_endian:bool
-  -> emit:(Directive.t -> unit)
-  -> unit
+val initialize : big_endian:bool -> emit:(Directive.t -> unit) -> unit
 
 (** Reinitialize the emitter before compiling a different source file. *)
 val reset : unit -> unit

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -7,7 +7,7 @@
 (*                                                                        *)
 (*   Copyright 2014 Institut National de Recherche en Informatique et     *)
 (*     en Automatique.                                                    *)
-(*   Copyright 2016--2018 Jane Street Group LLC                           *)
+(*   Copyright 2016--2025 Jane Street Group LLC                           *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -19,9 +19,6 @@
     many intricate details differing between target systems. *)
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
-
-(* CR-someday mshinwell: Use this module throughout the backends as per the
-   original GPR. *)
 
 (** Emit subsequent directives to the given section.  If this function
     has not been called before on the particular section, a label

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -221,6 +221,13 @@ val between_labels_32_bit :
 val between_labels_64_bit :
   ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> unit
 
+
+
+(** Like [between_symbols], but for two labels with additional offsets, emitting a 64-bit-wide
+    reference.  The labels must be in the same section. *)
+val between_labels_64_bit_with_offsets :
+  ?comment:string -> upper:Asm_label.t -> upper_offset:Targetint.t -> lower:Asm_label.t -> lower_offset:Targetint.t -> unit -> unit
+
 (** Emit a machine-width reference giving the displacement between the
     [lower] symbol and the sum of the address of the [upper] label plus
     [offset_upper].  The [lower] symbol must be in the current compilation
@@ -234,14 +241,6 @@ val between_symbol_in_current_unit_and_label_offset :
   unit ->
   unit
 
-(* CR mshinwell: double-check use of this function *)
-
-(** Emit a 32-bit-wide reference giving the displacement between obtained
-    by subtracting the current assembly location from the sum of the address
-    of the given label plus the given offset.  The label must be in the
-    same section as the assembler is currently emitting into. *)
-val between_this_and_label_offset_32bit :
-  upper:Asm_label.t -> offset_upper:Targetint.t -> unit
 
 (** Emit an offset into a DWARF section given a label identifying the place
     within such section. *)
@@ -258,9 +257,9 @@ val offset_into_dwarf_section_label :
     must always be in the given section. *)
 val offset_into_dwarf_section_symbol :
   ?comment:string ->
+  width:Dwarf_flags.dwarf_format ->
   Asm_section.dwarf_section ->
   Asm_symbol.t ->
-  width:Target_system.machine_width ->
   unit
 
 module Directive : sig

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -234,6 +234,7 @@ val between_symbol_in_current_unit_and_label_offset :
   upper:Asm_label.t ->
   lower:Asm_symbol.t ->
   offset_upper:Targetint.t ->
+  unit ->
   unit
 
 (* CR mshinwell: double-check use of this function *)
@@ -249,9 +250,9 @@ val between_this_and_label_offset_32bit :
     within such section. *)
 val offset_into_dwarf_section_label :
   ?comment:string ->
+  width:Dwarf_flags.dwarf_format ->
   Asm_section.dwarf_section ->
   Asm_label.t ->
-  width:Target_system.machine_width ->
   unit
 
 (** Emit an offset into a DWARF section given a symbol identifying the place

--- a/backend/asm_targets/asm_label.ml
+++ b/backend/asm_targets/asm_label.ml
@@ -113,6 +113,18 @@ let debug_str_label = lazy (create (DWARF Debug_str))
 
 let debug_line_label = lazy (create (DWARF Debug_line))
 
+let text_label = lazy (create Text)
+
+let data_label = lazy (create Data)
+
+let read_only_data_label = lazy (create Read_only_data)
+
+let eight_byte_literals_label = lazy (create Eight_byte_literals)
+
+let sixteen_byte_literals_label = lazy (create Sixteen_byte_literals)
+
+let jump_tables_label = lazy (create Jump_tables)
+
 let for_dwarf_section (dwarf_section : Asm_section.dwarf_section) =
   match dwarf_section with
   | Debug_info -> Lazy.force debug_info_label
@@ -129,9 +141,9 @@ let for_dwarf_section (dwarf_section : Asm_section.dwarf_section) =
 let for_section (section : Asm_section.t) =
   match section with
   | DWARF dwarf_section -> for_dwarf_section dwarf_section
-  | Text -> Misc.fatal_error "Not yet implemented"
-  | Data -> Misc.fatal_error "Not yet implemented"
-  | Read_only_data -> Misc.fatal_error "Not yet implemented"
-  | Eight_byte_literals -> Misc.fatal_error "Not yet implemented"
-  | Sixteen_byte_literals -> Misc.fatal_error "Not yet implemented"
-  | Jump_tables -> Misc.fatal_error "Not yet implemented"
+  | Text -> Lazy.force text_label
+  | Data -> Lazy.force data_label
+  | Read_only_data -> Lazy.force read_only_data_label
+  | Eight_byte_literals -> Lazy.force eight_byte_literals_label
+  | Sixteen_byte_literals -> Lazy.force sixteen_byte_literals_label
+  | Jump_tables -> Lazy.force jump_tables_label

--- a/backend/asm_targets/asm_label.ml
+++ b/backend/asm_targets/asm_label.ml
@@ -130,3 +130,8 @@ let for_section (section : Asm_section.t) =
   match section with
   | DWARF dwarf_section -> for_dwarf_section dwarf_section
   | Text -> Misc.fatal_error "Not yet implemented"
+  | Data -> Misc.fatal_error "Not yet implemented"
+  | Read_only_data -> Misc.fatal_error "Not yet implemented"
+  | Eight_byte_literals -> Misc.fatal_error "Not yet implemented"
+  | Sixteen_byte_literals -> Misc.fatal_error "Not yet implemented"
+  | Jump_tables -> Misc.fatal_error "Not yet implemented"

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -76,13 +76,10 @@ let is_delayed = function
       ( Debug_info | Debug_abbrev | Debug_aranges | Debug_str | Debug_loclists
       | Debug_rnglists | Debug_addr | Debug_loc | Debug_ranges )
   (* CR sspies: Decide which of these are delayed. *)
-  | Data ->
-    Misc.fatal_error "Not yet implemented"
-  | Read_only_data -> Misc.fatal_error "Not yet implemented"
-  | Eight_byte_literals -> Misc.fatal_error "Not yet implemented"
-  | Sixteen_byte_literals -> Misc.fatal_error "Not yet implemented"
-  | Jump_tables -> Misc.fatal_error "Not yet implemented"
-  | Text -> false
+  (* FIXME: Except for [Text], these are just a guess. *)
+  | Data | Read_only_data | Eight_byte_literals | Sixteen_byte_literals
+  | Jump_tables | Text ->
+    false
 
 let details t ~first_occurrence =
   let names, flags, args =

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -71,9 +71,8 @@ let dwarf_sections_in_order () =
   sections @ dwarf_version_dependent_sections
 
 let is_delayed = function
-  (* Only .debug_line and .debug_frames are delayed.
-     All other sections should be emitted directly.
-     See PR #1719. *)
+  (* Only .debug_line and .debug_frames are delayed. All other sections should
+     be emitted directly. See PR #1719. *)
   | DWARF Debug_line -> true
   | DWARF
       ( Debug_info | Debug_abbrev | Debug_aranges | Debug_str | Debug_loclists

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -49,7 +49,6 @@ type t =
   | Jump_tables
   | Text
 
-
 let dwarf_sections_in_order () =
   let sections =
     [ DWARF Debug_info;
@@ -107,7 +106,6 @@ let section_is_text = function
   | Data | Read_only_data | Eight_byte_literals | Sixteen_byte_literals
   | Jump_tables | DWARF _ ->
     false
-
 
 type section_details =
   { names : string list;
@@ -193,7 +191,6 @@ let details t ~first_occurrence =
 let to_string t =
   let { names; flags = _; args = _ } = details t ~first_occurrence:true in
   String.concat " " names
-
 
 let all_sections_in_order () =
   let sections =

--- a/backend/asm_targets/asm_section.mli
+++ b/backend/asm_targets/asm_section.mli
@@ -78,4 +78,3 @@ val equal : t -> t -> bool
 val section_is_text : t -> bool
 
 val all_sections_in_order : unit -> t list
-

--- a/backend/asm_targets/asm_section.mli
+++ b/backend/asm_targets/asm_section.mli
@@ -79,13 +79,3 @@ val section_is_text : t -> bool
 
 val all_sections_in_order : unit -> t list
 
-type flags_for_section = private
-  { names : string list;
-    flags : string option;
-    args : string list
-  }
-
-(** The necessary information for a section directive.  [first_occurrence]
-    should be [true] iff the corresponding directive will be the first such
-    in the relevant assembly file for the given section. *)
-val flags : t -> first_occurrence:bool -> flags_for_section

--- a/backend/asm_targets/asm_section.mli
+++ b/backend/asm_targets/asm_section.mli
@@ -42,6 +42,11 @@ type dwarf_section =
 
 type t =
   | DWARF of dwarf_section
+  | Data
+  | Read_only_data
+  | Eight_byte_literals
+  | Sixteen_byte_literals
+  | Jump_tables
   | Text
 
 val to_string : t -> string
@@ -68,3 +73,19 @@ val print : Format.formatter -> t -> unit
 val compare : t -> t -> int
 
 val equal : t -> t -> bool
+
+(** Whether the section holds code. *)
+val section_is_text : t -> bool
+
+val all_sections_in_order : unit -> t list
+
+type flags_for_section = private
+  { names : string list;
+    flags : string option;
+    args : string list
+  }
+
+(** The necessary information for a section directive.  [first_occurrence]
+    should be [true] iff the corresponding directive will be the first such
+    in the relevant assembly file for the given section. *)
+val flags : t -> first_occurrence:bool -> flags_for_section

--- a/backend/asm_targets/asm_symbol.ml
+++ b/backend/asm_targets/asm_symbol.ml
@@ -56,14 +56,10 @@ module Thing = struct
 
   let hash = Hashtbl.hash
 
-  (* CR sspies: This changed from not having the prefix previously to now
-     outputting the prefix as well. *)
   let output chan { name; without_prefix } =
     let symbol_prefix = if without_prefix then symbol_prefix () else "" in
     Printf.fprintf chan "%s%s" symbol_prefix name
 
-  (* CR sspies: This changed from not having the prefix previously to now
-     printing the prefix as well. *)
   let print fmt { name; without_prefix } =
     let symbol_prefix = if without_prefix then symbol_prefix () else "" in
     Format.pp_print_string fmt (symbol_prefix ^ name)

--- a/backend/asm_targets/asm_symbol.ml
+++ b/backend/asm_targets/asm_symbol.ml
@@ -41,7 +41,6 @@ let should_be_escaped = function
   | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '.' -> false
   | _c -> true
 
-(* CR sspies: This hack with the prefix is not great. *)
 module Thing = struct
   type t =
     { name : string;
@@ -50,9 +49,10 @@ module Thing = struct
 
   let compare { name = name1; without_prefix = without_prefix1 }
       { name = name2; without_prefix = without_prefix2 } =
-    if String.compare name1 name2 = 0
+    let cmp = String.compare name1 name2 in
+    if cmp = 0
     then Bool.compare without_prefix1 without_prefix2
-    else String.compare name1 name2
+    else cmp
 
   let equal t1 t2 = compare t1 t2 = 0
 

--- a/backend/asm_targets/asm_symbol.ml
+++ b/backend/asm_targets/asm_symbol.ml
@@ -50,9 +50,7 @@ module Thing = struct
   let compare { name = name1; without_prefix = without_prefix1 }
       { name = name2; without_prefix = without_prefix2 } =
     let cmp = String.compare name1 name2 in
-    if cmp = 0
-    then Bool.compare without_prefix1 without_prefix2
-    else cmp
+    if cmp = 0 then Bool.compare without_prefix1 without_prefix2 else cmp
 
   let equal t1 t2 = compare t1 t2 = 0
 

--- a/backend/asm_targets/asm_symbol.ml
+++ b/backend/asm_targets/asm_symbol.ml
@@ -26,30 +26,59 @@
 
 open! Int_replace_polymorphic_compare
 
+let symbol_prefix () =
+  (* CR mshinwell: needs checking *)
+  match Target_system.architecture () with
+  | IA32 | X86_64 | AArch64 -> (
+    match Target_system.derived_system () with
+    | Linux | Win32 | Win64 | MinGW_32 | MinGW_64 | Cygwin | FreeBSD | NetBSD
+    | OpenBSD | Generic_BSD | Solaris | BeOS | GNU | Dragonfly | Unknown ->
+      "" (* checked ok. *)
+    | MacOS_like -> "_" (* checked ok. *))
+  | ARM | POWER | Z | Riscv -> ""
+
 let should_be_escaped = function
   | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '.' -> false
   | _c -> true
 
+(* CR sspies: This hack with the prefix is not great. *)
 module Thing = struct
-  type t = string
+  type t =
+    { name : string;
+      without_prefix : bool
+    }
 
-  let compare = String.compare
+  let compare { name = name1; without_prefix = without_prefix1 }
+      { name = name2; without_prefix = without_prefix2 } =
+    if String.compare name1 name2 = 0
+    then Bool.compare without_prefix1 without_prefix2
+    else String.compare name1 name2
 
-  let equal = String.equal
+  let equal t1 t2 = compare t1 t2 = 0
 
   let hash = Hashtbl.hash
 
-  let output chan t = Printf.fprintf chan "%s" t
+  (* CR sspies: This changed from not having the prefix previously to now
+     outputting the prefix as well. *)
+  let output chan { name; without_prefix } =
+    let symbol_prefix = if without_prefix then symbol_prefix () else "" in
+    Printf.fprintf chan "%s%s" symbol_prefix name
 
-  let print = Format.pp_print_string
+  (* CR sspies: This changed from not having the prefix previously to now
+     printing the prefix as well. *)
+  let print fmt { name; without_prefix } =
+    let symbol_prefix = if without_prefix then symbol_prefix () else "" in
+    Format.pp_print_string fmt (symbol_prefix ^ name)
 end
 
 include Thing
 include Identifiable.Make (Thing)
 
-let create name = name
+let create ?without_prefix name =
+  let without_prefix = Option.is_some without_prefix in
+  { name; without_prefix }
 
-let to_raw_string t = t
+let to_raw_string { name; without_prefix } = name
 
 let escape name =
   let escaped_nb = ref 0 in
@@ -70,23 +99,10 @@ let escape name =
       name;
     Buffer.contents b
 
-let symbol_prefix () =
-  (* CR mshinwell: needs checking *)
-  match Target_system.architecture () with
-  | IA32 | X86_64 | AArch64 -> (
-    match Target_system.derived_system () with
-    | Linux | Win32 | Win64 | MinGW_32 | MinGW_64 | Cygwin | FreeBSD | NetBSD
-    | OpenBSD | Generic_BSD | Solaris | BeOS | GNU | Dragonfly | Unknown ->
-      "" (* checked ok. *)
-    | MacOS_like -> "_" (* checked ok. *))
-  | ARM | POWER | Z | Riscv -> ""
-
 let to_escaped_string ?suffix ~symbol_prefix t =
   let suffix = match suffix with None -> "" | Some suffix -> suffix in
   symbol_prefix ^ escape t ^ suffix
 
-let encode ?without_prefix t =
-  let symbol_prefix =
-    match without_prefix with None -> symbol_prefix () | Some () -> ""
-  in
-  to_escaped_string ~symbol_prefix t
+let encode t =
+  let symbol_prefix = if t.without_prefix then "" else symbol_prefix () in
+  to_escaped_string ~symbol_prefix t.name

--- a/backend/asm_targets/asm_symbol.mli
+++ b/backend/asm_targets/asm_symbol.mli
@@ -29,10 +29,11 @@ val should_be_escaped : char -> bool
 
 include Identifiable.S
 
-val create : string -> t
-
 (* If [without_prefix] is not provided [encode] will prefix the symbol using the
-   (architecture-dependent) prefix for symbols, for example "_" on macOS. *)
-val encode : ?without_prefix:unit -> t -> string
+   (architecture-dependent) prefix for symbols, for example "_" on macOS. In
+   contrast, [to_raw_string] will always return the non-prefixed version. *)
+val create : ?without_prefix:unit -> string -> t
+
+val encode : t -> string
 
 val to_raw_string : t -> string

--- a/utils/target_system.ml
+++ b/utils/target_system.ml
@@ -120,3 +120,61 @@ let assembler () =
   | MinGW_32 | MinGW_64 | Cygwin | Linux | FreeBSD | NetBSD | OpenBSD
   | Generic_BSD | Solaris | GNU | Dragonfly | BeOS | Unknown ->
     GAS_like
+
+
+type machine_width =
+  | Thirty_two
+  | Sixty_four
+
+let machine_width () =
+  match Targetint.size with
+  | 32 -> Thirty_two
+  | 64 -> Sixty_four
+  | bits -> Misc.fatal_errorf "Unknown machine width: %d" bits
+
+
+
+type windows_system =
+  | Cygwin
+  | MinGW
+  | Native
+
+type system =
+  | Linux
+  | Windows of windows_system
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown
+
+let system () : system =
+  match derived_system () with
+  | Linux -> Linux
+  | MinGW_32 | MinGW_64 -> Windows MinGW
+  | Win32 | Win64 -> Windows Native
+  | Cygwin -> Windows Cygwin
+  | MacOS_like -> MacOS_like
+  | FreeBSD -> FreeBSD
+  | NetBSD -> NetBSD
+  | OpenBSD -> OpenBSD
+  | Generic_BSD -> Generic_BSD
+  | Solaris -> Solaris
+  | Dragonfly -> Dragonfly
+  | GNU -> GNU
+  | BeOS -> BeOS
+  | Unknown -> Unknown
+
+let windows () =
+  match system () with
+  | Windows _ -> true
+  | _ -> false
+let is_macos () =
+  match assembler () with
+  | MASM | GAS_like -> false
+  | MacOS -> true

--- a/utils/target_system.ml
+++ b/utils/target_system.ml
@@ -121,7 +121,6 @@ let assembler () =
   | Generic_BSD | Solaris | GNU | Dragonfly | BeOS | Unknown ->
     GAS_like
 
-
 type machine_width =
   | Thirty_two
   | Sixty_four
@@ -131,8 +130,6 @@ let machine_width () =
   | 32 -> Thirty_two
   | 64 -> Sixty_four
   | bits -> Misc.fatal_errorf "Unknown machine width: %d" bits
-
-
 
 type windows_system =
   | Cygwin
@@ -174,6 +171,7 @@ let windows () =
   match system () with
   | Windows _ -> true
   | _ -> false
+
 let is_macos () =
   match assembler () with
   | MASM | GAS_like -> false

--- a/utils/target_system.mli
+++ b/utils/target_system.mli
@@ -41,3 +41,38 @@ type assembler =
   | MASM
 
 val assembler : unit -> assembler
+
+
+type machine_width =
+  | Thirty_two
+  | Sixty_four
+
+
+(** The natural machine width of the target system. *)
+val machine_width : unit -> machine_width
+
+
+type windows_system = private
+  | Cygwin
+  | MinGW
+  | Native
+
+type system = private
+  | Linux
+  | Windows of windows_system
+  | MacOS_like
+  | FreeBSD
+  | NetBSD
+  | OpenBSD
+  | Generic_BSD
+  | Solaris
+  | Dragonfly
+  | GNU
+  | BeOS
+  | Unknown
+
+val system: unit -> system
+
+val windows : unit -> bool
+
+val is_macos : unit -> bool

--- a/utils/target_system.mli
+++ b/utils/target_system.mli
@@ -42,21 +42,19 @@ type assembler =
 
 val assembler : unit -> assembler
 
-
 type machine_width =
   | Thirty_two
   | Sixty_four
 
-
 (** The natural machine width of the target system. *)
 val machine_width : unit -> machine_width
-
 
 type windows_system = private
   | Cygwin
   | MinGW
   | Native
 
+(* CR sspies: Remove some of the systems below that are a bit dated. *)
 type system = private
   | Linux
   | Windows of windows_system


### PR DESCRIPTION
This PR adds a new module to emit assembly directives based on [an old branch](https://github.com/mshinwell/ocaml/tree/gdb-names-gpr) of @mshinwell. The file itself should have no impact on the existing compiler, but the changes in the existing files could affect other parts of the compiler (e.g., if the they iterate over the list of available sections in order).