### PR TITLE
Small cleanup changes in emit.ml

### DIFF
--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1311,7 +1311,6 @@ let emit_instr i =
             cfi_remember_state ();
             cfi_def_cfa_register ~reg:29;
             let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
-            (* CR sspies: This code seems to be never triggered. It contained a wrong assembly instruction. *)
             DSL.ins I.LDR [| DSL.emit_reg reg_tmp1; DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr |];
               DSL.ins I.MOV [| DSL.sp; DSL.emit_reg reg_tmp1 |]
           end;
@@ -1626,11 +1625,11 @@ let emit_instr i =
     | Lpushtrap { lbl_handler; } ->
         DSL.ins I.ADR [| DSL.emit_reg reg_tmp1; DSL.emit_label lbl_handler |];
         stack_offset := !stack_offset + 16;
-        emit_printf "	stp	%a, %a, [sp, -16]!\n" femit_reg reg_trap_ptr femit_reg reg_tmp1;
+        emit_printf "	stp	%a, %a, [sp, #-16]!\n" femit_reg reg_trap_ptr femit_reg reg_tmp1;
         cfi_adjust_cfa_offset 16;
         DSL.ins I.MOV [| DSL.emit_reg reg_trap_ptr; DSL.sp |]
     | Lpoptrap ->
-        emit_printf "	ldr	%a, [sp], 16\n" femit_reg reg_trap_ptr;
+        emit_printf "	ldr	%a, [sp], #16\n" femit_reg reg_trap_ptr;
         cfi_adjust_cfa_offset (-16);
         stack_offset := !stack_offset - 16
     | Lraise k ->
@@ -1646,7 +1645,7 @@ let emit_instr i =
           emit_printf "%a\n" frecord_frame (Reg.Set.empty, Dbg_raise i.dbg)
         | Lambda.Raise_notrace ->
           DSL.ins I.MOV [| DSL.sp; DSL.emit_reg reg_trap_ptr |];
-          emit_printf "	ldp	%a, %a, [sp], 16\n" femit_reg reg_trap_ptr femit_reg reg_tmp1;
+          emit_printf "	ldp	%a, %a, [sp], #16\n" femit_reg reg_trap_ptr femit_reg reg_tmp1;
           DSL.ins I.BR [| DSL.emit_reg reg_tmp1 |];
       end
     | Lstackcheck { max_frame_size_bytes; } ->

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -991,7 +991,7 @@ let assembly_code_for_allocation i ~local ~n ~far ~dbginfo =
       emit_subimm reg_alloc_ptr reg_alloc_ptr n;
       DSL.ins I.CMP [| DSL.emit_reg reg_alloc_ptr; DSL.emit_reg reg_tmp1 |];
       if not far then begin
-        DSL.ins (I.B_cond LO) [| DSL.emit_label lbl_call_gc |]
+        DSL.ins (I.B_cond CC) [| DSL.emit_label lbl_call_gc |]
       end else begin
         let lbl = Cmm.new_label () in
         DSL.ins (I.B_cond CS) [| DSL.emit_label lbl |];
@@ -1658,7 +1658,7 @@ let emit_instr i =
       DSL.ins I.LDR [| DSL.emit_reg reg_tmp1; DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr |];
       emit_addimm reg_tmp1 reg_tmp1 f;
       DSL.ins I.CMP [| DSL.sp; DSL.emit_reg reg_tmp1 |];
-      DSL.ins I.BCC [| DSL.emit_label overflow |];
+      DSL.ins (I.B_cond CC) [| DSL.emit_label overflow |];
       emit_printf "%a:" femit_label ret;
       stack_realloc := Some {
         sc_label = overflow;

--- a/backend/arm64_ast.ml
+++ b/backend/arm64_ast.ml
@@ -145,8 +145,8 @@ module Instruction_name = struct
     type t =
       | EQ
       | NE
-      | CS
-      | CC
+      | CS (* alias HS *)
+      | CC (* alias LO *)
       | MI
       | PL
       | VS
@@ -158,7 +158,7 @@ module Instruction_name = struct
       | GT
       | LE
       | AL
-      | LO
+      | NV
 
     let to_string t =
       match t with
@@ -177,7 +177,7 @@ module Instruction_name = struct
       | GT -> "gt"
       | LE -> "le"
       | AL -> "al"
-      | LO -> "lo"
+      | NV -> "nv"
   end
 
   module Rounding_mode = struct
@@ -283,7 +283,6 @@ module Instruction_name = struct
     | TBZ
     | ADR
     | STP
-    | BCC
     (* neon *)
     | MOV
     | MOVI
@@ -379,7 +378,6 @@ module Instruction_name = struct
     | TBZ -> "tbz"
     | ADR -> "adr"
     | STP -> "stp"
-    | BCC -> "bcc"
     (* neon *)
     | MOV -> "mov"
     | MOVI -> "movi"

--- a/backend/arm64_ast.ml
+++ b/backend/arm64_ast.ml
@@ -157,8 +157,8 @@ module Instruction_name = struct
       | LT
       | GT
       | LE
-      (* | AL *)
-      (* | NV *)
+    (* | AL *)
+    (* | NV *)
 
     let to_string t =
       match t with

--- a/backend/arm64_ast.ml
+++ b/backend/arm64_ast.ml
@@ -157,8 +157,8 @@ module Instruction_name = struct
       | LT
       | GT
       | LE
-      | AL
-      | NV
+      (* | AL *)
+      (* | NV *)
 
     let to_string t =
       match t with
@@ -176,8 +176,6 @@ module Instruction_name = struct
       | LT -> "lt"
       | GT -> "gt"
       | LE -> "le"
-      | AL -> "al"
-      | NV -> "nv"
   end
 
   module Rounding_mode = struct

--- a/backend/arm64_ast.mli
+++ b/backend/arm64_ast.mli
@@ -81,10 +81,11 @@ module Instruction_name : sig
       | LT
       | GT
       | LE
-      (* The following are not supported, because NV means AL, but has a different encoding. *)
-      (* Use unconditional branching instead. *)
-      (* | AL *)
-      (* | NV *)
+    (* The following are not supported, because NV means AL, but has a different
+       encoding. *)
+    (* Use unconditional branching instead. *)
+    (* | AL *)
+    (* | NV *)
   end
 
   module Rounding_mode : sig

--- a/backend/arm64_ast.mli
+++ b/backend/arm64_ast.mli
@@ -81,8 +81,10 @@ module Instruction_name : sig
       | LT
       | GT
       | LE
-      | AL
-      | NV
+      (* The following are not supported, because NV means AL, but has a different encoding. *)
+      (* Use unconditional branching instead. *)
+      (* | AL *)
+      (* | NV *)
   end
 
   module Rounding_mode : sig

--- a/backend/arm64_ast.mli
+++ b/backend/arm64_ast.mli
@@ -69,8 +69,8 @@ module Instruction_name : sig
     type t =
       | EQ
       | NE
-      | CS
-      | CC
+      | CS (* alias HS *)
+      | CC (* alias LO *)
       | MI
       | PL
       | VS
@@ -82,8 +82,7 @@ module Instruction_name : sig
       | GT
       | LE
       | AL
-      (* CR sspies: Remove [LO], since it is an alias of [CC] *)
-      | LO
+      | NV
   end
 
   module Rounding_mode : sig
@@ -175,8 +174,6 @@ module Instruction_name : sig
     | TBZ
     | ADR
     | STP
-    (* CR sspies: Remove [BCC], since it is an alias of [B_cond LO] *)
-    | BCC
     (* neon *)
     | MOV
     | MOVI


### PR DESCRIPTION
This PR makes the following small changes to the ARM assembly emission:

- It removes an alias instruction, because `bcc` is the same as `b.cc`.
- It removes the comparison alias `lo`, because it is the same as `cc`.
- It adds hashes for immediates in several instructions that were missing them before.
- It removes the condition `al`, and clarifies why we do not implement `al` and `nv` (both mean always and should be replaced by a regular branch). 
