### PR TITLE
runtime events: disable flaky test

### DIFF
--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -9,9 +9,9 @@
    include unix;
    set OCAMLRUNPARAM = "e=6";
    hasunix;
+   arch_amd64;
    { bytecode; }
    {
-    arch_amd64;
     native;
    }
  }


### PR DESCRIPTION
The test for dropped runtime events has been failing intermittently on arm64 linux builds with runtime 5. It's already disabled on "native". This PR also disables it on bytecode, after a failure was [observed](https://github.com/ocaml-flambda/flambda-backend/actions/runs/14356072948/job/40245697583?pr=3813) on a different PR. There is a separate tracker to look into this issue.

