### PR TITLE
Format emit.ml

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -1,3 +1,4 @@
+; CR-soon gyorsh: format all files under arm64/amd64
 amd64/cfg_selection.ml
 amd64/emit.ml
 amd64/selection.ml

--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -1,4 +1,5 @@
 amd64/cfg_selection.ml
+amd64/emit.ml
 amd64/selection.ml
 amd64/selection_utils.ml
 amd64/simd*.ml
@@ -6,6 +7,7 @@ amd64/stack_check.ml
 amd64/stack_class.ml
 amd64/vectorize_specific.ml
 arm64/cfg_selection.ml
+arm64/emit.ml
 arm64/selection.ml
 arm64/selection_utils.ml
 arm64/simd*.ml

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -16,11 +16,10 @@
 (* Emission of Intel x86_64 assembly code *)
 
 (* Correctness: carefully consider any use of [Config], [Clflags],
-   [Flambda_backend_flags] and shared variables.
-   For details, see [asmgen.mli]. *)
+   [Flambda_backend_flags] and shared variables. For details, see
+   [asmgen.mli]. *)
 
 open! Int_replace_polymorphic_compare
-
 open Cmm
 open Arch
 open Proc
@@ -28,7 +27,6 @@ open Reg
 open Operation
 open Linear
 open Emitaux
-
 open X86_ast
 open X86_ast_utils
 open X86_proc
@@ -36,11 +34,11 @@ open X86_dsl
 module String = Misc.Stdlib.String
 module Int = Numbers.Int
 
-(* [Branch_relaxation] is not used in this file, but is required by
-   emit.ml files for certain other targets; the reference here ensures
-   that when releases are being prepared the .depend files are correct
-   for all targets. *)
+(* [Branch_relaxation] is not used in this file, but is required by emit.ml
+   files for certain other targets; the reference here ensures that when
+   releases are being prepared the .depend files are correct for all targets. *)
 [@@@ocaml.warning "-66"]
+
 open! Branch_relaxation
 
 let _label s = D.label ~typ:QWORD s
@@ -48,28 +46,28 @@ let _label s = D.label ~typ:QWORD s
 (* Override proc.ml *)
 
 let int_reg_name =
-  [| RAX; RBX; RDI; RSI; RDX; RCX; R8; R9;
-     R12; R13; R10; R11; RBP; |]
+  [| RAX; RBX; RDI; RSI; RDX; RCX; R8; R9; R12; R13; R10; R11; RBP |]
 
 let float_reg_name = Array.init 16 (fun i -> XMM i)
 
 let register_name typ r =
   match (typ : machtype_component) with
-  | Int | Val | Addr -> Reg64 (int_reg_name.(r))
-  | Float | Float32 | Vec128 | Valx2 -> Regf (float_reg_name.(r - 100))
+  | Int | Val | Addr -> Reg64 int_reg_name.(r)
+  | Float | Float32 | Vec128 | Valx2 -> Regf float_reg_name.(r - 100)
 
 let phys_rax = phys_reg Int 0
+
 let phys_rdx = phys_reg Int 4
+
 let phys_rcx = phys_reg Int 5
+
 let phys_xmm0v () = phys_reg Vec128 100
 
 (* CFI directives *)
 
-let cfi_startproc () =
-  if Config.asm_cfi_supported then D.cfi_startproc ()
+let cfi_startproc () = if Config.asm_cfi_supported then D.cfi_startproc ()
 
-let cfi_endproc () =
-  if Config.asm_cfi_supported then D.cfi_endproc ()
+let cfi_endproc () = if Config.asm_cfi_supported then D.cfi_endproc ()
 
 let cfi_adjust_cfa_offset n =
   if Config.asm_cfi_supported then D.cfi_adjust_cfa_offset n
@@ -89,8 +87,7 @@ let emit_debug_info ?discriminator dbg =
 let emit_debug_info_linear i =
   match i.fdo with
   | None -> emit_debug_info i.dbg
-  | Some { discriminator; dbg } ->
-    emit_debug_info ~discriminator dbg
+  | Some { discriminator; dbg } -> emit_debug_info ~discriminator dbg
 
 let fp = Config.with_frame_pointers
 
@@ -110,9 +107,7 @@ let frame_required = ref false
 let contains_calls = ref false
 
 let frame_size () =
-  Proc.frame_size
-    ~stack_offset:!stack_offset
-    ~num_stack_slots
+  Proc.frame_size ~stack_offset:!stack_offset ~num_stack_slots
     ~contains_calls:!contains_calls
 
 let slot_offset loc stack_class =
@@ -126,12 +121,8 @@ let slot_offset loc stack_class =
     Misc.fatal_errorf "Not a stack slot"
 
 let emit_stack_offset n =
-  if n < 0
-  then I.add (int (-n)) rsp
-  else if n > 0
-  then I.sub (int n) rsp;
-  if n <> 0
-  then cfi_adjust_cfa_offset n;
+  if n < 0 then I.add (int (-n)) rsp else if n > 0 then I.sub (int n) rsp;
+  if n <> 0 then cfi_adjust_cfa_offset n;
   stack_offset := !stack_offset + n
 
 let push r =
@@ -150,13 +141,15 @@ let symbol_prefix = match system with S_macosx -> "_" | _ -> ""
 
 let emit_symbol s = string_of_symbol symbol_prefix s
 
-(* Record symbols used and defined - at the end generate extern for those
-   used but not defined *)
+(* Record symbols used and defined - at the end generate extern for those used
+   but not defined *)
 
 let symbols_defined = ref String.Set.empty
+
 let symbols_used = ref String.Set.empty
 
 let add_def_symbol s = symbols_defined := String.Set.add s !symbols_defined
+
 let add_used_symbol s = symbols_used := String.Set.add s !symbols_used
 
 let imp_table = Hashtbl.create 16
@@ -166,9 +159,9 @@ let reset_imp_table () = Hashtbl.clear imp_table
 let get_imp_symbol s =
   match Hashtbl.find imp_table s with
   | exception Not_found ->
-      let imps = "__caml_imp_" ^ s in
-      Hashtbl.add imp_table s imps;
-      imps
+    let imps = "__caml_imp_" ^ s in
+    Hashtbl.add imp_table s imps;
+    imps
   | imps -> imps
 
 let emit_imp_table () =
@@ -176,7 +169,7 @@ let emit_imp_table () =
     _label (emit_symbol imps);
     D.qword (ConstLabel (emit_symbol s))
   in
-  D.data();
+  D.data ();
   D.comment "relocation table start";
   D.align ~data:true 8;
   Hashtbl.iter f imp_table;
@@ -189,18 +182,16 @@ let mem__imp s =
 (* Output a label *)
 
 let label_name lbl =
-  match system with
-  | S_macosx | S_win64 -> "L" ^ lbl
-  | _ -> ".L" ^ lbl
+  match system with S_macosx | S_win64 -> "L" ^ lbl | _ -> ".L" ^ lbl
 
-let emit_label lbl =
-  label_name (Label.to_string lbl)
+let emit_label lbl = label_name (Label.to_string lbl)
 
 let rel_plt (s : Cmm.symbol) =
   match s.sym_global with
   | Local -> sym (label_name (emit_symbol s.sym_name))
   | Global ->
-    if windows && !Clflags.dlcode then mem__imp s.sym_name
+    if windows && !Clflags.dlcode
+    then mem__imp s.sym_name
     else
       let s = emit_symbol s.sym_name in
       sym (if use_plt then s ^ "@PLT" else s)
@@ -209,13 +200,11 @@ let emit_call s = I.call (rel_plt s)
 
 let emit_jump s = I.jmp (rel_plt s)
 
-let domain_field f =
-  mem64 QWORD (Domainstate.idx_of_field f * 8) R14
+let domain_field f = mem64 QWORD (Domainstate.idx_of_field f * 8) R14
 
 let label s = sym (emit_label s)
 
-let def_label ?typ s =
-  D.label ?typ (emit_label s)
+let def_label ?typ s = D.label ?typ (emit_label s)
 
 let emit_cmm_symbol (s : Cmm.symbol) =
   match s.sym_global with
@@ -224,70 +213,68 @@ let emit_cmm_symbol (s : Cmm.symbol) =
 
 let load_symbol_addr s arg =
   match s.sym_global with
-  | Local ->
-    I.lea (mem64_rip NONE (label_name (emit_symbol s.sym_name))) arg
+  | Local -> I.lea (mem64_rip NONE (label_name (emit_symbol s.sym_name))) arg
   | Global ->
-    if !Clflags.dlcode then
-      if windows then begin
+    if !Clflags.dlcode
+    then
+      if windows
+      then
         (* I.mov (mem__imp s) arg (\* mov __caml_imp_foo(%rip), ... *\) *)
         I.mov (sym (emit_symbol s.sym_name)) arg (* movabsq $foo, ... *)
-      end else I.mov (mem64_rip QWORD (emit_symbol s.sym_name ^ "@GOTPCREL")) arg
-    else if !Clflags.pic_code then
-      I.lea (mem64_rip NONE (emit_symbol s.sym_name)) arg
-    else
-      I.mov (sym (emit_symbol s.sym_name)) arg
+      else I.mov (mem64_rip QWORD (emit_symbol s.sym_name ^ "@GOTPCREL")) arg
+    else if !Clflags.pic_code
+    then I.lea (mem64_rip NONE (emit_symbol s.sym_name)) arg
+    else I.mov (sym (emit_symbol s.sym_name)) arg
 
 (* Output .text section directive, or named .text.caml.<name> if enabled and
    supported on the target system. *)
 
 let emit_named_text_section ?(suffix = "") func_name =
-  if !Clflags.function_sections ||
-     !Flambda_backend_flags.basic_block_sections then
-    begin match system with
+  if !Clflags.function_sections || !Flambda_backend_flags.basic_block_sections
+  then
+    match system with
     | S_macosx
-    (* Names of section segments in macosx are restricted to 16 characters,
-       but function names are often longer, especially anonymous functions. *)
-    | S_win64 | S_mingw64 | S_cygwin
-    (* Win systems provide named text sections, but configure on these
-       systems does not support function sections. *)
-      ->  assert false
-    | _ -> D.section
-             [ Printf.sprintf ".text.caml.%s%s" (emit_symbol func_name) suffix ]
-             (Some "ax")
-             ["@progbits"]
-    end
+    (* Names of section segments in macosx are restricted to 16 characters, but
+       function names are often longer, especially anonymous functions. *)
+    | S_win64 | S_mingw64
+    | S_cygwin
+      (* Win systems provide named text sections, but configure on these systems
+         does not support function sections. *) ->
+      assert false
+    | _ ->
+      D.section
+        [Printf.sprintf ".text.caml.%s%s" (emit_symbol func_name) suffix]
+        (Some "ax") ["@progbits"]
   else D.text ()
 
 (* Name of current function *)
 let function_name = ref ""
 
-(* Keep the name of the current block section to get back to it
-   after emitting data. *)
+(* Keep the name of the current block section to get back to it after emitting
+   data. *)
 let current_basic_block_section = ref ""
 
 let emit_function_or_basic_block_section_name () =
   let suffix =
-    if String.length !current_basic_block_section = 0 then
-      ""
-    else
-      "."^(!current_basic_block_section)
+    if String.length !current_basic_block_section = 0
+    then ""
+    else "." ^ !current_basic_block_section
   in
   emit_named_text_section !function_name ~suffix
 
 let emit_Llabel fallthrough lbl section_name =
-  if !Flambda_backend_flags.basic_block_sections then begin
+  (if !Flambda_backend_flags.basic_block_sections
+  then
     match section_name with
     | Some name ->
-      if not (String.equal name !current_basic_block_section) then begin
+      if not (String.equal name !current_basic_block_section)
+      then (
         current_basic_block_section := name;
         cfi_endproc ();
         emit_function_or_basic_block_section_name ();
-        cfi_startproc ();
-      end
-    | None ->
-      ()
-  end;
-  if not fallthrough && !fastcode_flag then D.align ~data:false 4;
+        cfi_startproc ())
+    | None -> ());
+  if (not fallthrough) && !fastcode_flag then D.align ~data:false 4;
   def_label lbl
 
 (* Output a pseudo-register *)
@@ -302,18 +289,16 @@ let x86_data_type_for_stack_slot : machtype_component -> data_type = function
 let reg = function
   | { loc = Reg.Reg r; typ = ty } -> register_name ty r
   | { loc = Stack (Domainstate n); typ = ty } ->
-      let ofs = n + Domainstate.(idx_of_field Domain_extra_params) * 8 in
-      mem64 (x86_data_type_for_stack_slot ty) ofs R14
+    let ofs = n + (Domainstate.(idx_of_field Domain_extra_params) * 8) in
+    mem64 (x86_data_type_for_stack_slot ty) ofs R14
   | { loc = Stack s; typ = ty } as r ->
-      let ofs = slot_offset s (Stack_class.of_machtype r.typ) in
-      mem64 (x86_data_type_for_stack_slot ty) ofs RSP
-  | { loc = Unknown } ->
-      assert false
+    let ofs = slot_offset s (Stack_class.of_machtype r.typ) in
+    mem64 (x86_data_type_for_stack_slot ty) ofs RSP
+  | { loc = Unknown } -> assert false
 
 let reg64 = function
   | { loc = Reg.Reg r } -> int_reg_name.(r)
   | _ -> assert false
-
 
 let res i n = reg i.res.(n)
 
@@ -321,8 +306,10 @@ let arg i n = reg i.arg.(n)
 
 (* Output a reference to the lower 8, 16 or 32 bits of a register *)
 
-let reg_low_8_name  = Array.map (fun r -> Reg8L r) int_reg_name
+let reg_low_8_name = Array.map (fun r -> Reg8L r) int_reg_name
+
 let reg_low_16_name = Array.map (fun r -> Reg16 r) int_reg_name
+
 let reg_low_32_name = Array.map (fun r -> Reg32 r) int_reg_name
 
 let emit_subreg tbl typ r =
@@ -332,33 +319,35 @@ let emit_subreg tbl typ r =
   | _ -> assert false
 
 let arg8 i n = emit_subreg reg_low_8_name BYTE i.arg.(n)
+
 let arg16 i n = emit_subreg reg_low_16_name WORD i.arg.(n)
+
 let arg32 i n = emit_subreg reg_low_32_name DWORD i.arg.(n)
+
 let arg64 i n = reg64 i.arg.(n)
 
 let res8 i n = emit_subreg reg_low_8_name BYTE i.res.(n)
+
 let res16 i n = emit_subreg reg_low_16_name WORD i.res.(n)
+
 let res32 i n = emit_subreg reg_low_32_name DWORD i.res.(n)
 
 (* Output an addressing mode *)
 
 let addressing addr typ i n =
   match addr with
-  | Ibased(sym_name, sym_global, ofs) ->
-      add_used_symbol sym_name;
-      let sym_global : Cmm.is_global =
-        match sym_global with Global -> Global | Local -> Local in
-      mem64_rip typ (emit_cmm_symbol { sym_name ; sym_global }) ~ofs
-  | Iindexed d ->
-      mem64 typ d (arg64 i n)
-  | Iindexed2 d ->
-      mem64 typ ~base:(arg64 i n) d (arg64 i (n+1))
-  | Iscaled(2, d) ->
-      mem64 typ ~base:(arg64 i n) d (arg64 i n)
-  | Iscaled(scale, d) ->
-      mem64 typ ~scale d (arg64 i n)
-  | Iindexed2scaled(scale, d) ->
-      mem64 typ ~scale ~base:(arg64 i n) d (arg64 i (n+1))
+  | Ibased (sym_name, sym_global, ofs) ->
+    add_used_symbol sym_name;
+    let sym_global : Cmm.is_global =
+      match sym_global with Global -> Global | Local -> Local
+    in
+    mem64_rip typ (emit_cmm_symbol { sym_name; sym_global }) ~ofs
+  | Iindexed d -> mem64 typ d (arg64 i n)
+  | Iindexed2 d -> mem64 typ ~base:(arg64 i n) d (arg64 i (n + 1))
+  | Iscaled (2, d) -> mem64 typ ~base:(arg64 i n) d (arg64 i n)
+  | Iscaled (scale, d) -> mem64 typ ~scale d (arg64 i n)
+  | Iindexed2scaled (scale, d) ->
+    mem64 typ ~scale ~base:(arg64 i n) d (arg64 i (n + 1))
 
 (* Record live pointers at call points -- see Emitaux *)
 
@@ -367,26 +356,25 @@ let record_frame_label live dbg =
   let live_offset = ref [] in
   Reg.Set.iter
     (function
-      | {typ = Val; loc = Reg r} as reg ->
-          assert (Proc.gc_regs_offset reg = r);
-          live_offset := ((r lsl 1) + 1) :: !live_offset
-      | {typ = Val; loc = Stack s} as reg ->
-          live_offset := slot_offset s (Stack_class.of_machtype reg.typ) :: !live_offset
-      | {typ = Valx2; loc = Reg r} as reg ->
-          let n = Proc.gc_regs_offset reg in
-          let encode n = ((n lsl 1) + 1) in
-          live_offset := encode n :: encode (n + 1) :: !live_offset
-      | {typ = Valx2; loc = Stack s} as reg ->
-          let n = slot_offset s (Stack_class.of_machtype reg.typ)  in
-          live_offset := n :: n + Arch.size_addr :: !live_offset
-      | {typ = Addr} as r ->
-          Misc.fatal_error ("bad GC root " ^ Reg.name r)
-      | { typ = (Val | Valx2); loc = Unknown ; } as r ->
+      | { typ = Val; loc = Reg r } as reg ->
+        assert (Proc.gc_regs_offset reg = r);
+        live_offset := ((r lsl 1) + 1) :: !live_offset
+      | { typ = Val; loc = Stack s } as reg ->
+        live_offset
+          := slot_offset s (Stack_class.of_machtype reg.typ) :: !live_offset
+      | { typ = Valx2; loc = Reg r } as reg ->
+        let n = Proc.gc_regs_offset reg in
+        let encode n = (n lsl 1) + 1 in
+        live_offset := encode n :: encode (n + 1) :: !live_offset
+      | { typ = Valx2; loc = Stack s } as reg ->
+        let n = slot_offset s (Stack_class.of_machtype reg.typ) in
+        live_offset := n :: (n + Arch.size_addr) :: !live_offset
+      | { typ = Addr } as r -> Misc.fatal_error ("bad GC root " ^ Reg.name r)
+      | { typ = Val | Valx2; loc = Unknown } as r ->
         Misc.fatal_error ("Unknown location " ^ Reg.name r)
-      | { typ = Int | Float | Float32 | Vec128; _ } -> ()
-    )
+      | { typ = Int | Float | Float32 | Vec128; _ } -> ())
     live;
-  record_frame_descr ~label:lbl ~frame_size:(frame_size())
+  record_frame_descr ~label:lbl ~frame_size:(frame_size ())
     ~live_offset:!live_offset dbg;
   lbl
 
@@ -397,16 +385,16 @@ let record_frame live dbg =
 (* Record calls to the GC -- we've moved them out of the way *)
 
 type gc_call =
-  { gc_lbl: label;                      (* Entry label *)
-    gc_return_lbl: label;               (* Where to branch after GC *)
-    gc_frame: label;                    (* Label of frame descriptor *)
-    gc_dbg : Debuginfo.t;               (* Location of the original instruction *)
+  { gc_lbl : label; (* Entry label *)
+    gc_return_lbl : label; (* Where to branch after GC *)
+    gc_frame : label; (* Label of frame descriptor *)
+    gc_dbg : Debuginfo.t (* Location of the original instruction *)
   }
 
 let call_gc_sites = ref ([] : gc_call list)
 
 let call_gc_local_sym : Cmm.symbol =
-  {sym_name = "caml_call_gc_"; sym_global=Local}
+  { sym_name = "caml_call_gc_"; sym_global = Local }
 
 let emit_call_gc gc =
   def_label gc.gc_lbl;
@@ -418,9 +406,9 @@ let emit_call_gc gc =
 (* Record calls to local stack reallocation *)
 
 type local_realloc_call =
-  { lr_lbl: label;
-    lr_return_lbl: label;
-    lr_dbg: Debuginfo.t;
+  { lr_lbl : label;
+    lr_return_lbl : label;
+    lr_dbg : Debuginfo.t
   }
 
 let local_realloc_sites = ref ([] : local_realloc_call list)
@@ -431,24 +419,27 @@ let emit_local_realloc lr =
   emit_call (Cmm.global_symbol "caml_call_local_realloc");
   I.jmp (label lr.lr_return_lbl)
 
-(* Record calls to caml_ml_array_bound_error and caml_ml_array_align_error.
-   In -g mode we maintain one call per bound check site.  Without -g, we can share
-   a single call. *)
+(* Record calls to caml_ml_array_bound_error and caml_ml_array_align_error. In
+   -g mode we maintain one call per bound check site. Without -g, we can share a
+   single call. *)
 
-type safety_check = Bound_check | Align_check
+type safety_check =
+  | Bound_check
+  | Align_check
 
-type safety_check_failure = {
-    sc_lbl: label;              (* Entry label *)
-    sc_frame: label;            (* Label of frame descriptor *)
-    sc_dbg: Debuginfo.t;        (* As for [gc_call]. *)
+type safety_check_failure =
+  { sc_lbl : label; (* Entry label *)
+    sc_frame : label; (* Label of frame descriptor *)
+    sc_dbg : Debuginfo.t (* As for [gc_call]. *)
   }
 
-type safety_check_sites = {
-    mutable sc_sites: safety_check_failure list;
-    mutable sc_call: label option;
+type safety_check_sites =
+  { mutable sc_sites : safety_check_failure list;
+    mutable sc_call : label option
   }
 
 let bound_checks = { sc_sites = []; sc_call = None }
+
 let align_checks = { sc_sites = []; sc_call = None }
 
 let emit_call_safety_error kind sc =
@@ -467,75 +458,76 @@ let clear_safety_checks () =
 
 let emit_call_safety_errors () =
   List.iter (emit_call_safety_error Bound_check) bound_checks.sc_sites;
-  begin match bound_checks.sc_call with
+  (match bound_checks.sc_call with
   | None -> ()
   | Some sc_call ->
     def_label sc_call;
-    emit_call (Cmm.global_symbol "caml_ml_array_bound_error")
-  end;
+    emit_call (Cmm.global_symbol "caml_ml_array_bound_error"));
   List.iter (emit_call_safety_error Align_check) align_checks.sc_sites;
-  begin match align_checks.sc_call with
+  match align_checks.sc_call with
   | None -> ()
   | Some sc_call ->
     def_label sc_call;
     emit_call (Cmm.global_symbol "caml_ml_array_align_error")
-  end
 
 (* Stack reallocation *)
-type stack_realloc = {
-  sc_label : Label.t; (* Label of the reallocation code. *)
-  sc_return : Label.t; (* Label to return to after reallocation. *)
-  sc_size_in_bytes : int; (* Size for reallocation. *)
-}
+type stack_realloc =
+  { sc_label : Label.t; (* Label of the reallocation code. *)
+    sc_return : Label.t; (* Label to return to after reallocation. *)
+    sc_size_in_bytes : int (* Size for reallocation. *)
+  }
 
 let stack_realloc = ref ([] : stack_realloc list)
 
-let clear_stack_realloc () =
-  stack_realloc := []
+let clear_stack_realloc () = stack_realloc := []
 
 let emit_stack_realloc () =
   List.iter
-    (fun { sc_label; sc_return; sc_size_in_bytes; } ->
-       def_label sc_label;
-       (* Pass the desired frame size on the stack, since all of the
-          argument-passing registers may be in use.
-          Also serves to align the stack properly before the call *)
-       I.push (int (Config.stack_threshold + sc_size_in_bytes / 8));
-       cfi_adjust_cfa_offset 8;
-       (* measured in words *)
-       emit_call (Cmm.global_symbol "caml_call_realloc_stack");
-       I.add (int 8) rsp;
-       cfi_adjust_cfa_offset (-8);
-       I.jmp (label sc_return))
+    (fun { sc_label; sc_return; sc_size_in_bytes } ->
+      def_label sc_label;
+      (* Pass the desired frame size on the stack, since all of the
+         argument-passing registers may be in use. Also serves to align the
+         stack properly before the call *)
+      I.push (int (Config.stack_threshold + (sc_size_in_bytes / 8)));
+      cfi_adjust_cfa_offset 8;
+      (* measured in words *)
+      emit_call (Cmm.global_symbol "caml_call_realloc_stack");
+      I.add (int 8) rsp;
+      cfi_adjust_cfa_offset (-8);
+      I.jmp (label sc_return))
     !stack_realloc
 
 let emit_stack_check ~size_in_bytes ~save_registers =
   let overflow = new_label () and ret = new_label () in
-  let threshold_offset = Domainstate.stack_ctx_words * 8 + Stack_check.stack_threshold_size in
+  let threshold_offset =
+    (Domainstate.stack_ctx_words * 8) + Stack_check.stack_threshold_size
+  in
   if save_registers then I.push r10;
   I.lea (mem64 NONE (-(size_in_bytes + threshold_offset)) RSP) r10;
   I.cmp (domain_field Domainstate.Domain_current_stack) r10;
   if save_registers then I.pop r10;
   I.jb (label overflow);
   def_label ret;
-  stack_realloc := {
-    sc_label = overflow;
-    sc_return = ret;
-    sc_size_in_bytes = size_in_bytes;
-  } :: !stack_realloc
+  stack_realloc
+    := { sc_label = overflow;
+         sc_return = ret;
+         sc_size_in_bytes = size_in_bytes
+       }
+       :: !stack_realloc
 
 (* Record jump tables *)
 type jump_table =
-  { table_lbl: string;
-    elems: Linear.label array }
+  { table_lbl : string;
+    elems : Linear.label array
+  }
 
 let jump_tables = ref ([] : jump_table list)
 
 let emit_jump_table t =
   _label t.table_lbl;
   for i = 0 to Array.length t.elems - 1 do
-    D.long (ConstSub (ConstLabel(emit_label t.elems.(i)),
-                      ConstLabel t.table_lbl))
+    D.long
+      (ConstSub (ConstLabel (emit_label t.elems.(i)), ConstLabel t.table_lbl))
   done
 
 let emit_jump_tables () =
@@ -543,53 +535,55 @@ let emit_jump_tables () =
   List.iter emit_jump_table !jump_tables;
   jump_tables := []
 
-let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
-    module Asm_targets.Asm_directives.Make(struct
+let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) =
+  (module Asm_targets.Asm_directives.Make (struct
+    let emit_line str = X86_dsl.D.comment str
 
-      let emit_line str = X86_dsl.D.comment str
+    let get_file_num file_name =
+      Emitaux.get_file_num ~file_emitter:X86_dsl.D.file file_name
 
-      let get_file_num file_name =
-        Emitaux.get_file_num ~file_emitter:X86_dsl.D.file file_name
+    let debugging_comments_in_asm_files = !Flambda_backend_flags.dasm_comments
 
-      let debugging_comments_in_asm_files =
-        !Flambda_backend_flags.dasm_comments
+    module D = struct
+      open X86_ast
+      include X86_dsl.D
 
-      module D = struct
-        open X86_ast
+      type data_type =
+        | NONE
+        | DWORD
+        | QWORD
+        | VEC128
 
-        include X86_dsl.D
+      type nonrec constant = constant
 
-        type data_type =
-          | NONE | DWORD | QWORD | VEC128
+      let const_int64 num = Const num
 
-        type nonrec constant = constant
-        let const_int64 num = Const num
-        let const_label str = ConstLabel str
-        let const_add c1 c2 = ConstAdd (c1, c2)
-        let const_sub c1 c2 = ConstSub (c1, c2)
+      let const_label str = ConstLabel str
 
-        let label ?data_type str =
-          let typ =
-            Option.map
-              (function
-                | NONE -> X86_ast.NONE
-                | DWORD -> X86_ast.DWORD
-                | QWORD -> X86_ast.QWORD
-                | VEC128 -> X86_ast.VEC128)
-              data_type
-          in
-          label ?typ str
-      end
-    end)
-  )
+      let const_add c1 c2 = ConstAdd (c1, c2)
 
+      let const_sub c1 c2 = ConstSub (c1, c2)
+
+      let label ?data_type str =
+        let typ =
+          Option.map
+            (function
+              | NONE -> X86_ast.NONE
+              | DWORD -> X86_ast.DWORD
+              | QWORD -> X86_ast.QWORD
+              | VEC128 -> X86_ast.VEC128)
+            data_type
+        in
+        label ?typ str
+    end
+  end))
 
 (* Names for instructions *)
 
 let instr_for_intop = function
   | Iadd -> I.add
   | Isub -> I.sub
-  | Imul -> (fun arg1 arg2 -> I.imul arg1 (Some arg2))
+  | Imul -> fun arg1 arg2 -> I.imul arg1 (Some arg2)
   | Iand -> I.and_
   | Ior -> I.or_
   | Ixor -> I.xor
@@ -622,24 +616,30 @@ let instr_for_floatarithmem width op =
   | Float32, Ifloatdiv -> I.divss
 
 let cond = function
-  | Isigned Ceq   -> E   | Isigned Cne   -> NE
-  | Isigned Cle   -> LE  | Isigned Cgt   -> G
-  | Isigned Clt   -> L   | Isigned Cge   -> GE
-  | Iunsigned Ceq -> E   | Iunsigned Cne -> NE
-  | Iunsigned Cle -> BE  | Iunsigned Cgt -> A
-  | Iunsigned Clt -> B   | Iunsigned Cge -> AE
+  | Isigned Ceq -> E
+  | Isigned Cne -> NE
+  | Isigned Cle -> LE
+  | Isigned Cgt -> G
+  | Isigned Clt -> L
+  | Isigned Cge -> GE
+  | Iunsigned Ceq -> E
+  | Iunsigned Cne -> NE
+  | Iunsigned Cle -> BE
+  | Iunsigned Cgt -> A
+  | Iunsigned Clt -> B
+  | Iunsigned Cge -> AE
 
 (* Output an = 0 or <> 0 test. *)
 
 let output_test_zero arg =
   match arg.loc with
   | Reg.Reg _ -> I.test (reg arg) (reg arg)
-  | _  -> I.cmp (int 0) (reg arg)
+  | _ -> I.cmp (int 0) (reg arg)
 
 (* Output a floating-point compare and branch *)
 
-let emit_float_test (width : Cmm.float_width)
-                    cmp i ~(taken:X86_ast.condition -> unit) =
+let emit_float_test (width : Cmm.float_width) cmp i
+    ~(taken : X86_ast.condition -> unit) =
   (*= Effect of comisd on flags and conditional branches:
                      ZF PF CF  cond. branches taken
         unordered     1  1  1  je, jb, jbe, jp
@@ -656,47 +656,54 @@ let emit_float_test (width : Cmm.float_width)
   in
   match cmp with
   | CFeq when equal_arg (arg i 1) (arg i 0) ->
-      ucomi (arg i 1) (arg i 0);
-      taken NP
+    ucomi (arg i 1) (arg i 0);
+    taken NP
   | CFeq ->
-      let next = new_label() in
-      ucomi (arg i 1) (arg i 0);
-      I.jp (label next);           (* skip if unordered *)
-      taken E;                     (* branch taken if x=y *)
-      def_label next
+    let next = new_label () in
+    ucomi (arg i 1) (arg i 0);
+    I.jp (label next);
+    (* skip if unordered *)
+    taken E;
+    (* branch taken if x=y *)
+    def_label next
   | CFneq when equal_arg (arg i 1) (arg i 0) ->
-      ucomi (arg i 1) (arg i 0);
-      taken P
+    ucomi (arg i 1) (arg i 0);
+    taken P
   | CFneq ->
-      ucomi (arg i 1) (arg i 0);
-      taken P;                     (* branch taken if unordered *)
-      taken NE                     (* branch taken if x<y or x>y *)
+    ucomi (arg i 1) (arg i 0);
+    taken P;
+    (* branch taken if unordered *)
+    taken NE (* branch taken if x<y or x>y *)
   | CFlt ->
-      comi (arg i 0) (arg i 1);
-      taken A                      (* branch taken if y>x i.e. x<y *)
+    comi (arg i 0) (arg i 1);
+    taken A (* branch taken if y>x i.e. x<y *)
   | CFnlt ->
-      comi (arg i 0) (arg i 1);
-      taken BE                     (* taken if unordered or y<=x i.e. !(x<y) *)
+    comi (arg i 0) (arg i 1);
+    taken BE (* taken if unordered or y<=x i.e. !(x<y) *)
   | CFle ->
-      comi (arg i 0) (arg i 1);    (* swap compare *)
-      taken AE                     (* branch taken if y>=x i.e. x<=y *)
+    comi (arg i 0) (arg i 1);
+    (* swap compare *)
+    taken AE (* branch taken if y>=x i.e. x<=y *)
   | CFnle ->
-      comi (arg i 0) (arg i 1);    (* swap compare *)
-      taken B                      (* taken if unordered or y<x i.e. !(x<=y) *)
+    comi (arg i 0) (arg i 1);
+    (* swap compare *)
+    taken B (* taken if unordered or y<x i.e. !(x<=y) *)
   | CFgt ->
-      comi (arg i 1) (arg i 0);
-      taken A                      (* branch taken if x>y *)
+    comi (arg i 1) (arg i 0);
+    taken A (* branch taken if x>y *)
   | CFngt ->
-      comi (arg i 1) (arg i 0);
-      taken BE                     (* taken if unordered or x<=y i.e. !(x>y) *)
+    comi (arg i 1) (arg i 0);
+    taken BE (* taken if unordered or x<=y i.e. !(x>y) *)
   | CFge ->
-      comi (arg i 1) (arg i 0);    (* swap compare *)
-      taken AE                     (* branch taken if x>=y *)
+    comi (arg i 1) (arg i 0);
+    (* swap compare *)
+    taken AE (* branch taken if x>=y *)
   | CFnge ->
-      comi (arg i 1) (arg i 0);    (* swap compare *)
-      taken B                      (* taken if unordered or x<y i.e. !(x>=y) *)
+    comi (arg i 1) (arg i 0);
+    (* swap compare *)
+    taken B (* taken if unordered or x<y i.e. !(x>=y) *)
 
-let emit_test i ~(taken:X86_ast.condition -> unit) = function
+let emit_test i ~(taken : X86_ast.condition -> unit) = function
   | Itruetest ->
     output_test_zero i.arg.(0);
     taken NE
@@ -706,15 +713,15 @@ let emit_test i ~(taken:X86_ast.condition -> unit) = function
   | Iinttest cmp ->
     I.cmp (arg i 1) (arg i 0);
     taken (cond cmp)
-  | Iinttest_imm((Isigned Ceq | Isigned Cne |
-                  Iunsigned Ceq | Iunsigned Cne) as cmp, 0) ->
+  | Iinttest_imm
+      (((Isigned Ceq | Isigned Cne | Iunsigned Ceq | Iunsigned Cne) as cmp), 0)
+    ->
     output_test_zero i.arg.(0);
     taken (cond cmp)
-  | Iinttest_imm(cmp, n) ->
+  | Iinttest_imm (cmp, n) ->
     I.cmp (int n) (arg i 0);
     taken (cond cmp)
-  | Ifloattest (width, cmp) ->
-    emit_float_test width cmp i ~taken
+  | Ifloattest (width, cmp) -> emit_float_test width cmp i ~taken
   | Ioddtest ->
     I.test (int 1) (arg8 i 0);
     taken NE
@@ -725,31 +732,27 @@ let emit_test i ~(taken:X86_ast.condition -> unit) = function
 (* Deallocate the stack frame before a return or tail call *)
 
 let output_epilogue f =
-  if !frame_required then begin
-    let n = frame_size() - 8 - (if fp then 8 else 0) in
+  if !frame_required
+  then (
+    let n = frame_size () - 8 - if fp then 8 else 0 in
     if n <> 0
-    then begin
+    then (
       I.add (int n) rsp;
-      cfi_adjust_cfa_offset (-n);
-    end;
+      cfi_adjust_cfa_offset (-n));
     if fp then I.pop rbp;
     f ();
     (* reset CFA back cause function body may continue *)
-    if n <> 0
-    then cfi_adjust_cfa_offset n
-  end
-  else
-    f ()
+    if n <> 0 then cfi_adjust_cfa_offset n)
+  else f ()
 
 (* Floating-point constants *)
 
 let float_constants = ref ([] : (int64 * label) list)
 
 let add_float_constant cst =
-  try
-    List.assoc cst !float_constants
+  try List.assoc cst !float_constants
   with Not_found ->
-    let lbl = new_label() in
+    let lbl = new_label () in
     float_constants := (cst, lbl) :: !float_constants;
     lbl
 
@@ -762,14 +765,13 @@ let emit_float_constant f lbl =
 let vec128_constants = ref ([] : (Cmm.vec128_bits * label) list)
 
 let add_vec128_constant bits =
-  try
-    List.assoc bits !vec128_constants
+  try List.assoc bits !vec128_constants
   with Not_found ->
-    let lbl = new_label() in
+    let lbl = new_label () in
     vec128_constants := (bits, lbl) :: !vec128_constants;
     lbl
 
-let emit_vec128_constant {high; low} lbl =
+let emit_vec128_constant { high; low } lbl =
   (* SIMD vectors respect little-endian byte order *)
   _label (emit_label lbl);
   D.qword (Const low);
@@ -777,26 +779,17 @@ let emit_vec128_constant {high; low} lbl =
 
 let global_maybe_protected sym =
   D.global sym;
-  if !Flambda_backend_flags.symbol_visibility_protected then
+  if !Flambda_backend_flags.symbol_visibility_protected
+  then
     match system with
-    | S_macosx
-    | S_win32
-    | S_win64
-    | S_mingw64
-    | S_cygwin
-    | S_mingw
-    | S_unknown -> ()
-    | S_gnu
-    | S_solaris
-    | S_linux_elf
-    | S_bsd_elf
-    | S_beos
-    | S_linux
-    | S_freebsd
-    | S_netbsd
-    | S_openbsd ->
-      (* Global symbols can be marked as being protected. Unlike in C we don't want
-        them to be preempted as we're doing a lot of cross module inlining. *)
+    | S_macosx | S_win32 | S_win64 | S_mingw64 | S_cygwin | S_mingw | S_unknown
+      ->
+      ()
+    | S_gnu | S_solaris | S_linux_elf | S_bsd_elf | S_beos | S_linux | S_freebsd
+    | S_netbsd | S_openbsd ->
+      (* Global symbols can be marked as being protected. Unlike in C we don't
+         want them to be preempted as we're doing a lot of cross module
+         inlining. *)
       D.protected sym
 
 let emit_global_label_for_symbol lbl =
@@ -811,26 +804,27 @@ let emit_global_label s =
 
 let move (src : Reg.t) (dst : Reg.t) =
   let distinct = not (Reg.same_loc src dst) in
-  begin match src.typ, src.loc, dst.typ, dst.loc with
+  match src.typ, src.loc, dst.typ, dst.loc with
   | Float, Reg _, Float, Reg _
   | Float32, Reg _, Float32, Reg _
-  | (Vec128 | Valx2), _, (Vec128 | Valx2), _ (* Vec128 stack slots are always aligned. *) ->
+  | ( (Vec128 | Valx2),
+      _,
+      (Vec128 | Valx2),
+      _ (* Vec128 stack slots are always aligned. *) ) ->
     if distinct then I.movapd (reg src) (reg dst)
-  | Float, _, Float, _ ->
-    if distinct then I.movsd (reg src) (reg dst)
-  | Float32, _, Float32, _ ->
-    if distinct then I.movss (reg src) (reg dst)
+  | Float, _, Float, _ -> if distinct then I.movsd (reg src) (reg dst)
+  | Float32, _, Float32, _ -> if distinct then I.movss (reg src) (reg dst)
   | (Int | Val | Addr), _, (Int | Val | Addr), _ ->
     if distinct then I.mov (reg src) (reg dst)
   | (Float | Float32 | Vec128 | Int | Val | Addr | Valx2), _, _, _ ->
     Misc.fatal_errorf
       "Illegal move between registers of differing types (%a to %a)\n"
       Printreg.reg src Printreg.reg dst
-  end
 
 let stack_to_stack_move (src : Reg.t) (dst : Reg.t) =
   assert (Cmm.equal_machtype_component src.typ dst.typ);
-  if not (Reg.equal_location src.loc dst.loc) then begin
+  if not (Reg.equal_location src.loc dst.loc)
+  then
     match src.typ with
     | Int | Val ->
       (* Not calling move because r15 is not in int_reg_name. *)
@@ -840,7 +834,6 @@ let stack_to_stack_move (src : Reg.t) (dst : Reg.t) =
       Misc.fatal_errorf
         "Unexpected register type for stack to stack move: from %s to %s\n"
         (Reg.name src) (Reg.name dst)
-  end
 
 let move_allowing_stack_to_stack src dst =
   match Reg.is_stack src, Reg.is_stack dst with
@@ -853,22 +846,20 @@ let tailrec_entry_point = ref None
 (* Emit tracing probes *)
 
 type probe =
-  {
-    stack_offset: int;
-    num_stack_slots: int Stack_class.Tbl.t;
+  { stack_offset : int;
+    num_stack_slots : int Stack_class.Tbl.t;
     (* Record frame info held in the corresponding mutable variables. *)
-    probe_label: label;
-    (* Probe site, recorded in .note.stapsdt section
-       for enabling and disabling the probes  *)
-    probe_insn: Linear.instruction;
-    (* Iprobe instruction, recorded at probe site and used for emitting
-       the notes and the wrapper code at the end of the compilation unit. *)
+    probe_label : label;
+    (* Probe site, recorded in .note.stapsdt section for enabling and disabling
+       the probes *)
+    probe_insn : Linear.instruction
+        (* Iprobe instruction, recorded at probe site and used for emitting the
+           notes and the wrapper code at the end of the compilation unit. *)
   }
 
 let probe_handler_wrapper_name probe_label =
   let w = Printf.sprintf "probe_wrapper_%s" (Label.to_string probe_label) in
-  Cmm_helpers.make_symbol w
-  |> emit_symbol
+  Cmm_helpers.make_symbol w |> emit_symbol
 
 let probes = ref []
 
@@ -884,46 +875,42 @@ let find_or_add_semaphore name enabled_at_init dbg =
   match String.Map.find_opt name !probe_semaphores with
   | Some (label, e) ->
     (match e, enabled_at_init with
-     | None, None -> ()
-     | None, Some _ ->
-       let d = (label, enabled_at_init) in
-       probe_semaphores :=
-         String.Map.remove name !probe_semaphores |>
-         String.Map.add name d
-     | Some _, None ->
-       (*  [find_or_add_semaphore] is called with None for Iprobe_is_enabled
-           during code emission only. [find_or_add_semaphore] us called with
-           Some to emit probe notes only after all code is emitted. *)
-       assert false
-     | Some b, Some b' ->
-       if not (Bool.equal b b') then
-         raise (Error (Inconsistent_probe_init (name,dbg))));
+    | None, None -> ()
+    | None, Some _ ->
+      let d = label, enabled_at_init in
+      probe_semaphores
+        := String.Map.remove name !probe_semaphores |> String.Map.add name d
+    | Some _, None ->
+      (* [find_or_add_semaphore] is called with None for Iprobe_is_enabled
+         during code emission only. [find_or_add_semaphore] us called with Some
+         to emit probe notes only after all code is emitted. *)
+      assert false
+    | Some b, Some b' ->
+      if not (Bool.equal b b')
+      then raise (Error (Inconsistent_probe_init (name, dbg))));
     label
   | None ->
-    let sym = "caml_probes_semaphore_"^name in
-    let d = (sym, enabled_at_init) in
+    let sym = "caml_probes_semaphore_" ^ name in
+    let d = sym, enabled_at_init in
     probe_semaphores := String.Map.add name d !probe_semaphores;
     sym
 
 let emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label =
   assert !frame_required;
   let wrap_label = probe_handler_wrapper_name probe_label in
-  (* We emit a cmp instruction that is effectively a nop:
-     it only sets flags that are not read anywhere.
-     To enable the probe, cmp is replaced with call
-     by changing the first byte of the encoding from 3d to e8.
-     The operand of the call is a displacement relative to
-     the next instruction. Hence, the immediate operand
-     of cmp is set up to have that value. *)
-  if enabled_at_init then begin
-      I.call (sym wrap_label)
-  end else
-  if !Clflags.pic_code then begin
-    (* Manually emit encoding of cmp and an explicit relocation on it
-       as needed for a call instruction, to ensure a correct
-       result, instead of relying on an assembler that might choose a different
-       encoding which produces an incorrect relocation and changes the meaning
-       of the program. *)
+  (* We emit a cmp instruction that is effectively a nop: it only sets flags
+     that are not read anywhere. To enable the probe, cmp is replaced with call
+     by changing the first byte of the encoding from 3d to e8. The operand of
+     the call is a displacement relative to the next instruction. Hence, the
+     immediate operand of cmp is set up to have that value. *)
+  if enabled_at_init
+  then I.call (sym wrap_label)
+  else if !Clflags.pic_code
+  then (
+    (* Manually emit encoding of cmp and an explicit relocation on it as needed
+       for a call instruction, to ensure a correct result, instead of relying on
+       an assembler that might choose a different encoding which produces an
+       incorrect relocation and changes the meaning of the program. *)
     (* Emit the required encoding of "cmp $0, %eax" directly using .byte *)
     D.byte (Const 0x3dL);
     D.byte (Const 0L);
@@ -931,40 +918,39 @@ let emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label =
     D.byte (Const 0L);
     D.byte (Const 0L);
     (* Emit the relocation for the call target *)
-    (* [rel_size] is the number of bytes taken by the operand of cmp/call
-       that needs to be relocated. It is used to form reloc's offset.
+    (* [rel_size] is the number of bytes taken by the operand of cmp/call that
+       needs to be relocated. It is used to form reloc's offset.
        [rel_offset_from_next] is the distance from the start of the relocated
-       bytes to the start to the next instruction after the call.
-       It used to form reloc's expr for call's operand (see above).
-       [rel_size] is equal to [rel_offset_from_next] because
-       the relocated operand is the last one and arch is little endian. *)
+       bytes to the start to the next instruction after the call. It used to
+       form reloc's expr for call's operand (see above). [rel_size] is equal to
+       [rel_offset_from_next] because the relocated operand is the last one and
+       arch is little endian. *)
     let rel_size = 4L in
     let rel_offset_from_next = 4L in
-    D.reloc ~offset:(ConstSub (ConstThis, Const rel_size))
+    D.reloc
+      ~offset:(ConstSub (ConstThis, Const rel_size))
       ~name:R_X86_64_PLT32
-      ~expr:(ConstSub (ConstLabel wrap_label,
-                       Const rel_offset_from_next));
-  end else begin
-    (* Emit absolute value, no relocation.
-       The immediate operand of cmp is the offset of the wrapper
-       from the current instruction's address "."
-       minus the length of the current instruction, which is 5,
-       and the wrapper is emitted at the end of the compilation unit. *)
-    I.cmp (sym (Printf.sprintf "%s - . - 5" wrap_label)) eax
-  end;
-  (* Live registers are saved by the probe wrapper,
-     so they are not recorded as gc roots at the probe site. *)
+      ~expr:(ConstSub (ConstLabel wrap_label, Const rel_offset_from_next)))
+  else
+    (* Emit absolute value, no relocation. The immediate operand of cmp is the
+       offset of the wrapper from the current instruction's address "." minus
+       the length of the current instruction, which is 5, and the wrapper is
+       emitted at the end of the compilation unit. *)
+    I.cmp (sym (Printf.sprintf "%s - . - 5" wrap_label)) eax;
+  (* Live registers are saved by the probe wrapper, so they are not recorded as
+     gc roots at the probe site. *)
   let stack_live = Reg.Set.filter Reg.is_stack i.live in
   record_frame stack_live (Dbg_other i.dbg)
 
 (* Emit trap handler notes *)
 
-type traps = { mutable push_traps : label list;
-               mutable pop_traps : label list;
-               mutable enter_traps : Label.Set.t;
-             }
+type traps =
+  { mutable push_traps : label list;
+    mutable pop_traps : label list;
+    mutable enter_traps : Label.Set.t
+  }
 
-let traps = { push_traps = []; pop_traps = []; enter_traps = Label.Set.empty; }
+let traps = { push_traps = []; pop_traps = []; enter_traps = Label.Set.empty }
 
 let reset_traps () =
   traps.push_traps <- [];
@@ -974,30 +960,44 @@ let reset_traps () =
 let emit_pop_trap_label () =
   let lbl = Cmm.new_label () in
   def_label lbl;
-  traps.pop_traps <- lbl::traps.pop_traps
+  traps.pop_traps <- lbl :: traps.pop_traps
 
 let emit_push_trap_label handler =
   let lbl = Cmm.new_label () in
   def_label lbl;
-  traps.push_traps <- lbl::traps.push_traps;
+  traps.push_traps <- lbl :: traps.push_traps;
   traps.enter_traps <- Label.Set.add handler traps.enter_traps
 
 (* Emit Code *)
 
 module Address_sanitizer : sig
-  type memory_access = Load | Store_initialize | Store_modify
+  type memory_access =
+    | Load
+    | Store_initialize
+    | Store_modify
 
   (** Implements [https://github.com/google/sanitizers/wiki/AddressSanitizerAlgorithm#mapping]. *)
-  val emit_sanitize : ?dependencies:arg array -> address:arg -> memory_chunk -> memory_access -> unit
+  val emit_sanitize :
+    ?dependencies:arg array ->
+    address:arg ->
+    memory_chunk ->
+    memory_access ->
+    unit
 end = struct
-  type memory_access = Load | Store_initialize | Store_modify
+  type memory_access =
+    | Load
+    | Store_initialize
+    | Store_modify
 
   module Memory_chunk_size : sig
     type t
 
     val of_memory_chunk : memory_chunk -> t
+
     val to_bytes : t -> int
+
     val to_bytes_log2 : t -> int
+
     val is_small : t -> bool
   end = struct
     type t =
@@ -1013,16 +1013,12 @@ end = struct
       | Thirtytwo_unsigned | Thirtytwo_signed | Single _ -> I32
       | Word_int | Word_val | Double -> I64
       | Onetwentyeight_unaligned | Onetwentyeight_aligned -> I128
-    ;;
 
     external to_bytes_log2 : t -> int = "%identity"
 
     let to_bytes t = 1 lsl to_bytes_log2 t
 
-    let is_small = function
-      | I8 | I16 | I32 -> true
-      | I64 | I128 -> false
-    ;;
+    let is_small = function I8 | I16 | I32 -> true | I64 | I128 -> false
   end
 
   let mov_address src dest =
@@ -1038,18 +1034,20 @@ end = struct
         } ->
       I.mov (Reg64 idx) dest
     | _ -> I.lea src dest
-  ;;
 
   let[@inline always] is_stack_16_byte_aligned () =
-    (* Yes, sadly this does result in materially better assembly than [(!stack_offset mod 16) = 0]
+    (* Yes, sadly this does result in materially better assembly than
+       [(!stack_offset mod 16) = 0]
        https://github.com/ocaml-flambda/flambda-backend/issues/2187 *)
     !stack_offset land 15 = 0
-  ;;
 
   let asan_report_function memory_chunk_size memory_access =
     let index =
       (Memory_chunk_size.to_bytes_log2 memory_chunk_size lsl 1)
-      + match memory_access with Load -> 0 | (Store_initialize | Store_modify) -> 1
+      +
+      match memory_access with
+      | Load -> 0
+      | Store_initialize | Store_modify -> 1
     in
     (* We take extra care to structure our code such that these are statically
        allocated as manifest constants in a flat array. *)
@@ -1068,7 +1066,6 @@ end = struct
       (* Larger loads and stores can be reported using
          [__asan_report_load_n_noabort], but we don't support this yet. *)
       assert false
-  ;;
 
   (* CR-soon ksvetlitski: find a way to accomplish this without breaking the
      abstraction barrier of [X86_ast]. *)
@@ -1080,12 +1077,14 @@ end = struct
     | Mem { idx = register'; base = Some register''; _ } ->
       equal_reg64 register register' || equal_reg64 register register''
     | _ -> false
-  ;;
 
-  (* The C code snippets in the comments throughout this function refer to the implementation given in
+  (* The C code snippets in the comments throughout this function refer to the
+     implementation given in
      [https://github.com/google/sanitizers/wiki/AddressSanitizerAlgorithm#mapping].
-     I'd recommend reading that first for reference before touching this function. *)
-  let emit_sanitize ?(dependencies = [||]) ~address (memory_chunk : memory_chunk) (memory_access : memory_access) =
+     I'd recommend reading that first for reference before touching this
+     function. *)
+  let emit_sanitize ?(dependencies = [||]) ~address
+      (memory_chunk : memory_chunk) (memory_access : memory_access) =
     let[@inline always] need_to_save_register register =
       uses_register register address
       || Array.exists (uses_register register) dependencies
@@ -1098,14 +1097,15 @@ end = struct
        that we do this now before we change the contents of any other registers,
        because we don't want to clobber any of [address]'s component registers.
 
-       You could do this at the end of the prologue if you wanted to; the point is
-       just that you have to do this before you modify the contents of any
-       registers (other than [rsp]).
-     *)
+       You could do this at the end of the prologue if you wanted to; the point
+       is just that you have to do this before you modify the contents of any
+       registers (other than [rsp]). *)
     mov_address address rdi;
     let need_to_save_r11 = need_to_save_register R11 in
     if need_to_save_r11 then push r11;
-    let need_to_save_r10 = Memory_chunk_size.is_small memory_chunk_size && need_to_save_register R10 in
+    let need_to_save_r10 =
+      Memory_chunk_size.is_small memory_chunk_size && need_to_save_register R10
+    in
     if need_to_save_r10 then push r10;
     (* -------- End prologue -------- *)
     let asan_check_succeded_label = new_label () in
@@ -1115,19 +1115,17 @@ end = struct
     I.shr (int 3) r11;
     let shadow_address = mem64 BYTE 0x7FFF8000 R11 in
     let () =
-      if not (Memory_chunk_size.is_small memory_chunk_size) then (
+      if not (Memory_chunk_size.is_small memory_chunk_size)
+      then (
         I.cmp (int 0) shadow_address;
         I.je (label asan_check_succeded_label)
-        (* There is no slow-path check for word-sized and larger accesses *)
-      ) else (
+        (* There is no slow-path check for word-sized and larger accesses *))
+      else (
         I.movzx shadow_address r11;
         I.test (Reg8L R11) (Reg8L R11);
         I.je (label asan_check_succeded_label);
-        (* Begin the [SlowPathCheck]. Place [last_accessed_byte] in [r10].
-           ```
-           last_accessed_byte = (address & 7) + kAccessSize - 1;
-           ```
-        *)
+        (* Begin the [SlowPathCheck]. Place [last_accessed_byte] in [r10]. ```
+           last_accessed_byte = (address & 7) + kAccessSize - 1; ``` *)
         I.mov rdi r10;
         I.and_ (int 7) r10;
         let () =
@@ -1140,22 +1138,21 @@ end = struct
         in
         (* [ return (last_accessed_byte >= shadow_value) ] *)
         I.cmp (Reg8L R11) (Reg8L R10);
-        I.jl (label asan_check_succeded_label)
-      )
+        I.jl (label asan_check_succeded_label))
     in
     (* [ ReportError(address, kAccessSize, kIsWrite); ] *)
     let () =
       let need_to_align_stack = not (is_stack_16_byte_aligned ()) in
-      if need_to_align_stack then (
-        (* [push rax] is a single-byte instruction, as opposed to something like [push 0]
-           which is a 2-byte instruction. *)
-        push rax
-      );
+      if need_to_align_stack
+      then
+        (* [push rax] is a single-byte instruction, as opposed to something like
+           [push 0] which is a 2-byte instruction. *)
+        push rax;
       (* The asan report wrappers use a special calling convention via the C
          attribute [__attribute__((preserve_all))] so that all registers except
-         for [r11] (which is clobbered) are callee-saved, in order to minimize the
-         amount of spilling we have to do here. [address] is already in [rdi], and
-         this function accepts just a single argument. *)
+         for [r11] (which is clobbered) are callee-saved, in order to minimize
+         the amount of spilling we have to do here. [address] is already in
+         [rdi], and this function accepts just a single argument. *)
       I.call (asan_report_function memory_chunk_size memory_access);
       if need_to_align_stack then pop rax
     in
@@ -1163,23 +1160,22 @@ end = struct
     if need_to_save_r10 then pop r10;
     if need_to_save_r11 then pop r11;
     if need_to_save_rdi then pop rdi
-  ;;
 
-  let[@inline always] emit_sanitize ?dependencies ~address memory_chunk memory_access =
-    (* Checking [Config.with_address_sanitizer] is redundant, but we do it because
-       it's a compile-time constant, so it enables the compiler to completely
-       optimize-out the AddressSanitizer code when the compiler was configured
-       without it. *)
+  let[@inline always] emit_sanitize ?dependencies ~address memory_chunk
+      memory_access =
+    (* Checking [Config.with_address_sanitizer] is redundant, but we do it
+       because it's a compile-time constant, so it enables the compiler to
+       completely optimize-out the AddressSanitizer code when the compiler was
+       configured without it. *)
     if Config.with_address_sanitizer && !Arch.is_asan_enabled
-    then (
+    then
       match memory_access with
-      (* We can elide the ASAN check for stores made to initialize record fields on the grounds
-         that the backing memory for freshly allocated records is provided directly by the runtime
-         and guaranteed to be safe to use. *)
+      (* We can elide the ASAN check for stores made to initialize record fields
+         on the grounds that the backing memory for freshly allocated records is
+         provided directly by the runtime and guaranteed to be safe to use. *)
       | Store_initialize -> ()
-      | Load | Store_modify -> emit_sanitize ?dependencies ~address memory_chunk memory_access
-    )
-  ;;
+      | Load | Store_modify ->
+        emit_sanitize ?dependencies ~address memory_chunk memory_access
 end
 
 let emit_atomic instr op (size : Cmm.atomic_bitwidth) addr =
@@ -1191,16 +1187,14 @@ let emit_atomic instr op (size : Cmm.atomic_bitwidth) addr =
     | Exchange -> 1
     | Compare_exchange -> 2
   in
-  let dst =
-    addressing addr DWORD instr first_memory_arg_index
-  in
+  let dst = addressing addr DWORD instr first_memory_arg_index in
   let src_index = first_memory_arg_index - 1 in
   let typ, src =
     match size with
     | Thirtytwo -> DWORD, arg32 instr src_index
-    | (Sixtyfour|Word) -> QWORD, arg instr src_index
+    | Sixtyfour | Word -> QWORD, arg instr src_index
   in
-  Address_sanitizer.emit_sanitize ~dependencies:[|src|] ~address:dst
+  Address_sanitizer.emit_sanitize ~dependencies:[| src |] ~address:dst
     Thirtytwo_unsigned Store_modify;
   match op with
   | Fetch_and_add ->
@@ -1233,12 +1227,10 @@ let emit_atomic instr op (size : Cmm.atomic_bitwidth) addr =
 let emit_reinterpret_cast (cast : Cmm.reinterpret_cast) i =
   let distinct = not (Reg.same_loc i.arg.(0) i.res.(0)) in
   match cast with
-  | Int_of_value | Value_of_int ->
-    if distinct then I.mov (arg i 0) (res i 0)
+  | Int_of_value | Value_of_int -> if distinct then I.mov (arg i 0) (res i 0)
   | Float_of_float32 | Float32_of_float ->
     if distinct then I.movss (arg i 0) (res i 0)
-  | V128_of_v128 ->
-    if distinct then I.movapd (arg i 0) (res i 0)
+  | V128_of_v128 -> if distinct then I.movapd (arg i 0) (res i 0)
   | Float_of_int64 | Int64_of_float -> I.movq (arg i 0) (res i 0)
   | Float32_of_int32 -> I.movd (arg32 i 0) (res i 0)
   | Int32_of_float32 -> I.movd (arg i 0) (res32 i 0)
@@ -1261,22 +1253,22 @@ let emit_static_cast (cast : Cmm.static_cast) i =
   | V128_of_scalar Float32x4 | Scalar_of_v128 Float32x4 ->
     if distinct then I.movss (arg i 0) (res i 0)
   | Scalar_of_v128 Int16x8 ->
-    (* [movw] and [movzx] cannot operate on vector registers.
-       We must zero extend as the result is an untagged positive int.
-       CR mslater: (SIMD) remove zx once we have unboxed int16 *)
+    (* [movw] and [movzx] cannot operate on vector registers. We must zero
+       extend as the result is an untagged positive int. CR mslater: (SIMD)
+       remove zx once we have unboxed int16 *)
     I.movd (arg i 0) (res32 i 0);
     I.movzx (res16 i 0) (res i 0)
   | Scalar_of_v128 Int8x16 ->
-    (* [movb] and [movzx] cannot operate on vector registers.
-       We must zero extend as the result is an untagged positive int.
-       CR mslater: (SIMD) remove zx once we have unboxed int8 *)
+    (* [movb] and [movzx] cannot operate on vector registers. We must zero
+       extend as the result is an untagged positive int. CR mslater: (SIMD)
+       remove zx once we have unboxed int8 *)
     I.movd (arg i 0) (res32 i 0);
     I.movzx (res8 i 0) (res i 0)
   | V128_of_scalar Int16x8 | V128_of_scalar Int8x16 ->
-    (* [movw] and [movb] cannot operate on vector registers.
-       Moving 32 bits is OK because the argument is an untagged
-       positive int and these operations leave the top bits of the vector unspecified.
-       CR mslater: (SIMD) don't load 32 bits once we have unboxed int16/int8 *)
+    (* [movw] and [movb] cannot operate on vector registers. Moving 32 bits is
+       OK because the argument is an untagged positive int and these operations
+       leave the top bits of the vector unspecified. CR mslater: (SIMD) don't
+       load 32 bits once we have unboxed int16/int8 *)
     I.movd (arg32 i 0) (res i 0)
 
 let check_simd_instr (register_behavior : Simd_proc.register_behavior) i =
@@ -1284,12 +1276,9 @@ let check_simd_instr (register_behavior : Simd_proc.register_behavior) i =
   | R_to_fst ->
     assert (Reg.same_loc i.arg.(0) i.res.(0));
     assert (Reg.is_reg i.arg.(0))
-  | R_to_RM ->
-    assert (Reg.is_reg i.arg.(0))
-  | RM_to_R ->
-    assert (Reg.is_reg i.res.(0))
-  | R_to_R ->
-    assert (Reg.is_reg i.arg.(0) && Reg.is_reg i.res.(0))
+  | R_to_RM -> assert (Reg.is_reg i.arg.(0))
+  | RM_to_R -> assert (Reg.is_reg i.res.(0))
+  | R_to_R -> assert (Reg.is_reg i.arg.(0) && Reg.is_reg i.res.(0))
   | R_RM_to_fst ->
     assert (Reg.same_loc i.arg.(0) i.res.(0));
     assert (Reg.is_reg i.arg.(0))
@@ -1305,21 +1294,20 @@ let check_simd_instr (register_behavior : Simd_proc.register_behavior) i =
     assert (Reg.is_reg i.arg.(0) && Reg.is_reg i.arg.(1))
   | R_RM_rax_rdx_to_rcx ->
     assert (Reg.is_reg i.arg.(0));
-    assert (Reg.same_loc (i.arg.(2)) phys_rax);
-    assert (Reg.same_loc (i.arg.(3)) phys_rdx);
+    assert (Reg.same_loc i.arg.(2) phys_rax);
+    assert (Reg.same_loc i.arg.(3) phys_rdx);
     assert (Reg.same_loc i.res.(0) phys_rcx)
   | R_RM_to_rcx ->
     assert (Reg.is_reg i.arg.(0));
-    assert (Reg.same_loc (i.res.(0)) phys_rcx)
+    assert (Reg.same_loc i.res.(0) phys_rcx)
   | R_RM_rax_rdx_to_xmm0 ->
     assert (Reg.is_reg i.arg.(0));
-    assert (Reg.same_loc (i.arg.(2)) phys_rax);
-    assert (Reg.same_loc (i.arg.(3)) phys_rdx);
-    assert (Reg.same_loc (i.res.(0)) (phys_xmm0v ()))
+    assert (Reg.same_loc i.arg.(2) phys_rax);
+    assert (Reg.same_loc i.arg.(3) phys_rdx);
+    assert (Reg.same_loc i.res.(0) (phys_xmm0v ()))
   | R_RM_to_xmm0 ->
     assert (Reg.is_reg i.arg.(0));
-    assert (Reg.same_loc i.res.(0) (phys_xmm0v ()))
-  );
+    assert (Reg.same_loc i.res.(0) (phys_xmm0v ())));
   ()
 
 let emit_simd_instr_with_memory_arg op i addr =
@@ -1342,8 +1330,8 @@ let emit_simd_instr op i =
   | BMI2 Deposit_64 -> I.pdep (arg i 1) (arg i 0) (res i 0)
   | SSE Round_current_f32_i64 -> I.cvtss2si (arg i 0) (res i 0)
   | SSE Sqrt_scalar_f32 ->
-    if not (equal_arg (arg i 0) (res i 0)) then
-      I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
+    if not (equal_arg (arg i 0) (res i 0)) then I.xorpd (res i 0) (res i 0);
+    (* avoid partial register stall *)
     I.sqrtss (arg i 0) (res i 0)
   | SSE Max_scalar_f32 -> I.maxss (arg i 1) (res i 0)
   | SSE Min_scalar_f32 -> I.minss (arg i 1) (res i 0)
@@ -1367,8 +1355,8 @@ let emit_simd_instr op i =
   | SSE2 Max_scalar_f64 -> I.maxsd (arg i 1) (res i 0)
   | SSE2 Min_scalar_f64 -> I.minsd (arg i 1) (res i 0)
   | SSE2 Sqrt_scalar_f64 ->
-    if not(equal_arg (arg i 0) (res i 0)) then
-      I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
+    if not (equal_arg (arg i 0) (res i 0)) then I.xorpd (res i 0) (res i 0);
+    (* avoid partial register stall *)
     I.sqrtsd (arg i 0) (res i 0)
   | SSE2 Sqrt_f64 -> I.sqrtpd (arg i 0) (res i 0)
   | SSE2 Add_i8 -> I.paddb (arg i 1) (res i 0)
@@ -1476,7 +1464,7 @@ let emit_simd_instr op i =
   | SSSE3 Mulsign_i8 -> I.psignb (arg i 1) (res i 0)
   | SSSE3 Mulsign_i16 -> I.psignw (arg i 1) (res i 0)
   | SSSE3 Mulsign_i32 -> I.psignd (arg i 1) (res i 0)
-  | SSSE3 Alignr_i8 n -> I.palignr (X86_dsl.int n) (arg i 1) (res i 0)
+  | SSSE3 (Alignr_i8 n) -> I.palignr (X86_dsl.int n) (arg i 1) (res i 0)
   | SSSE3 Shuffle_8 -> I.pshufb (arg i 1) (res i 0)
   | SSSE3 Mul_unsigned_hadd_saturating_i8_to_i16 ->
     I.pmaddubsw (arg i 1) (res i 0)
@@ -1506,8 +1494,8 @@ let emit_simd_instr op i =
     I.pextrb (X86_dsl.int n) (arg i 0) (res i 0);
     I.movzx (res8 i 0) (res i 0)
   | SSE41 (Extract_i16 n) ->
-    (* CR mslater: (SIMD) change once we have unboxed int16,
-       the result will not need to zero-extend. *)
+    (* CR mslater: (SIMD) change once we have unboxed int16, the result will not
+       need to zero-extend. *)
     I.pextrw (X86_dsl.int n) (arg i 0) (res i 0);
     I.movzx (res16 i 0) (res i 0)
   | SSE41 (Extract_i32 n) -> I.pextrd (X86_dsl.int n) (arg i 0) (res32 i 0)
@@ -1525,16 +1513,17 @@ let emit_simd_instr op i =
   | SSE41 Min_unsigned_i16 -> I.pminuw (arg i 1) (res i 0)
   | SSE41 Min_unsigned_i32 -> I.pminud (arg i 1) (res i 0)
   | SSE41 (Round_scalar_f64 n) ->
-    if not (equal_arg (arg i 0) (res i 0)) then
-      I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
+    if not (equal_arg (arg i 0) (res i 0)) then I.xorpd (res i 0) (res i 0);
+    (* avoid partial register stall *)
     I.roundsd n (arg i 0) (res i 0)
   | SSE41 (Round_scalar_f32 n) ->
-    if not (equal_arg (arg i 0) (res i 0)) then
-      I.xorpd (res i 0) (res i 0); (* avoid partial register stall *)
+    if not (equal_arg (arg i 0) (res i 0)) then I.xorpd (res i 0) (res i 0);
+    (* avoid partial register stall *)
     I.roundss n (arg i 0) (res i 0)
   | SSE41 (Round_f64 n) -> I.roundpd n (arg i 0) (res i 0)
   | SSE41 (Round_f32 n) -> I.roundps n (arg i 0) (res i 0)
-  | SSE41 (Multi_sad_unsigned_i8 n) -> I.mpsadbw (X86_dsl.int n) (arg i 1) (res i 0)
+  | SSE41 (Multi_sad_unsigned_i8 n) ->
+    I.mpsadbw (X86_dsl.int n) (arg i 1) (res i 0)
   | SSE41 Minpos_unsigned_i16 -> I.phminposuw (arg i 0) (res i 0)
   | SSE41 Mullo_i32 -> I.pmulld (arg i 1) (res i 0)
   | SSE42 Cmpgt_i64 -> I.pcmpgtq (arg i 1) (res i 0)
@@ -1544,25 +1533,45 @@ let emit_simd_instr op i =
   | SSE42 (Cmpestri n) -> I.pcmpestri (X86_dsl.int n) (arg i 1) (arg i 0)
   | SSE42 (Cmpistri n) -> I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0)
   | SSE42 (Cmpestra n) ->
-    I.pcmpestri (X86_dsl.int n) (arg i 1) (arg i 0); I.set A (res8 i 0); I.movzx (res8 i 0) (res i 0)
+    I.pcmpestri (X86_dsl.int n) (arg i 1) (arg i 0);
+    I.set A (res8 i 0);
+    I.movzx (res8 i 0) (res i 0)
   | SSE42 (Cmpestrc n) ->
-    I.pcmpestri (X86_dsl.int n) (arg i 1) (arg i 0); I.set B (res8 i 0); I.movzx (res8 i 0) (res i 0)
+    I.pcmpestri (X86_dsl.int n) (arg i 1) (arg i 0);
+    I.set B (res8 i 0);
+    I.movzx (res8 i 0) (res i 0)
   | SSE42 (Cmpestro n) ->
-    I.pcmpestri (X86_dsl.int n) (arg i 1) (arg i 0); I.set O (res8 i 0); I.movzx (res8 i 0) (res i 0)
+    I.pcmpestri (X86_dsl.int n) (arg i 1) (arg i 0);
+    I.set O (res8 i 0);
+    I.movzx (res8 i 0) (res i 0)
   | SSE42 (Cmpestrs n) ->
-    I.pcmpestri (X86_dsl.int n) (arg i 1) (arg i 0); I.set S (res8 i 0); I.movzx (res8 i 0) (res i 0)
+    I.pcmpestri (X86_dsl.int n) (arg i 1) (arg i 0);
+    I.set S (res8 i 0);
+    I.movzx (res8 i 0) (res i 0)
   | SSE42 (Cmpestrz n) ->
-    I.pcmpestri (X86_dsl.int n) (arg i 1) (arg i 0); I.set E (res8 i 0); I.movzx (res8 i 0) (res i 0)
+    I.pcmpestri (X86_dsl.int n) (arg i 1) (arg i 0);
+    I.set E (res8 i 0);
+    I.movzx (res8 i 0) (res i 0)
   | SSE42 (Cmpistra n) ->
-    I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0); I.set A (res8 i 0); I.movzx (res8 i 0) (res i 0)
+    I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0);
+    I.set A (res8 i 0);
+    I.movzx (res8 i 0) (res i 0)
   | SSE42 (Cmpistrc n) ->
-    I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0); I.set B (res8 i 0); I.movzx (res8 i 0) (res i 0)
+    I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0);
+    I.set B (res8 i 0);
+    I.movzx (res8 i 0) (res i 0)
   | SSE42 (Cmpistro n) ->
-    I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0); I.set O (res8 i 0); I.movzx (res8 i 0) (res i 0)
+    I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0);
+    I.set O (res8 i 0);
+    I.movzx (res8 i 0) (res i 0)
   | SSE42 (Cmpistrs n) ->
-    I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0); I.set S (res8 i 0); I.movzx (res8 i 0) (res i 0)
+    I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0);
+    I.set S (res8 i 0);
+    I.movzx (res8 i 0) (res i 0)
   | SSE42 (Cmpistrz n) ->
-    I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0); I.set E (res8 i 0); I.movzx (res8 i 0) (res i 0)
+    I.pcmpistri (X86_dsl.int n) (arg i 1) (arg i 0);
+    I.set E (res8 i 0);
+    I.movzx (res8 i 0) (res i 0)
 
 (* Emit an instruction *)
 let emit_instr ~first ~fallthrough i =
@@ -1570,449 +1579,430 @@ let emit_instr ~first ~fallthrough i =
   match i.desc with
   | Lend -> ()
   | Lprologue ->
-    assert (!prologue_required);
-    if fp then begin
+    assert !prologue_required;
+    if fp
+    then (
       I.push rbp;
       cfi_adjust_cfa_offset 8;
-      I.mov rsp rbp;
-    end;
-    if !frame_required then begin
-      let n = frame_size() - 8 - (if fp then 8 else 0) in
+      I.mov rsp rbp);
+    if !frame_required
+    then
+      let n = frame_size () - 8 - if fp then 8 else 0 in
       if n <> 0
-      then begin
+      then (
         I.sub (int n) rsp;
-        cfi_adjust_cfa_offset n;
-      end;
-    end
-  | Lop(Move | Spill | Reload) ->
-      move i.arg.(0) i.res.(0)
-  | Lop(Const_int n) ->
-      if Nativeint.equal n 0n then begin
-        match i.res.(0).loc with
-        | Reg _ ->
-          (* Clearing the bottom half also clears the top half (except for
-             64-bit-only registers where the behaviour is as if the operands
-             were 64 bit). *)
-          I.xor (res32 i 0) (res32 i 0)
-        | _ ->
-          I.mov (int 0) (res i 0)
-      end else if Nativeint.compare n 0n > 0 && Nativeint.compare n 0xFFFF_FFFFn <= 0 then begin
-        match i.res.(0).loc with
-        | Reg _ ->
-          (* Similarly, setting only the bottom half clears the top half. *)
-          I.mov (nat n) (res32 i 0)
-        | _ ->
-          I.mov (nat n) (res i 0)
-      end else
-        I.mov (nat n) (res i 0)
-  | Lop(Const_float32 f) ->
-      begin match f with
-      | 0x0000_0000l ->       (* +0.0 *)
-          I.xorpd (res i 0) (res i 0)
-      | _ ->
-          (* float32 constants still take up 8 bytes; we load the lower half. *)
-          let lbl = add_float_constant (Int64.of_int32 f) in
-          I.movss (mem64_rip REAL4 (emit_label lbl)) (res i 0)
-      end
-  | Lop(Const_float f) ->
-      begin match f with
-      | 0x0000_0000_0000_0000L ->       (* +0.0 *)
-          I.xorpd (res i 0) (res i 0)
-      | _ ->
-          let lbl = add_float_constant f in
-          I.movsd (mem64_rip REAL8 (emit_label lbl)) (res i 0)
-      end
-  | Lop(Const_vec128 {high; low}) ->
-      begin match (high, low) with
-      | 0x0000_0000_0000_0000L, 0x0000_0000_0000_0000L ->
-          I.xorpd (res i 0) (res i 0)
-      | _ ->
-          let lbl = add_vec128_constant {high; low} in
-          I.movapd (mem64_rip VEC128 (emit_label lbl)) (res i 0)
-      end
-  | Lop(Const_symbol s) ->
-      add_used_symbol s.sym_name;
-      load_symbol_addr s (res i 0)
-  | Lcall_op(Lcall_ind) ->
-      I.call (arg i 0);
-      record_frame i.live (Dbg_other i.dbg)
-  | Lcall_op(Lcall_imm { func; }) ->
-      add_used_symbol func.sym_name;
-      emit_call func;
-      record_frame i.live (Dbg_other i.dbg)
-  | Lcall_op(Ltailcall_ind) ->
-      output_epilogue (fun () -> I.jmp (arg i 0))
-  | Lcall_op(Ltailcall_imm { func; }) ->
-      begin
-        if String.equal func.sym_name !function_name then
-          match !tailrec_entry_point with
-          | None -> Misc.fatal_error "jump to missing tailrec entry point"
-          | Some tailrec_entry_point -> I.jmp (label tailrec_entry_point)
-        else begin
-          output_epilogue begin fun () ->
-            add_used_symbol func.sym_name;
-            emit_jump func
-          end
-        end
-      end
-  | Lcall_op(Lextcall { func; alloc; stack_ofs }) ->
-      add_used_symbol func;
-      if Config.runtime5 && stack_ofs > 0 then begin
-        I.mov rsp r13;
-        I.lea (mem64 QWORD stack_ofs RSP) r12;
-        load_symbol_addr (Cmm.global_symbol func) rax;
-        emit_call (Cmm.global_symbol "caml_c_call_stack_args");
-        record_frame i.live (Dbg_other i.dbg);
-      end else if alloc then begin
-        load_symbol_addr (Cmm.global_symbol func) rax;
-        emit_call (Cmm.global_symbol "caml_c_call");
-        record_frame i.live (Dbg_other i.dbg);
-        if not Config.runtime5 && not (is_win64 system) then begin
+        cfi_adjust_cfa_offset n)
+  | Lop (Move | Spill | Reload) -> move i.arg.(0) i.res.(0)
+  | Lop (Const_int n) ->
+    if Nativeint.equal n 0n
+    then
+      match i.res.(0).loc with
+      | Reg _ ->
+        (* Clearing the bottom half also clears the top half (except for
+           64-bit-only registers where the behaviour is as if the operands were
+           64 bit). *)
+        I.xor (res32 i 0) (res32 i 0)
+      | _ -> I.mov (int 0) (res i 0)
+    else if Nativeint.compare n 0n > 0 && Nativeint.compare n 0xFFFF_FFFFn <= 0
+    then
+      match i.res.(0).loc with
+      | Reg _ ->
+        (* Similarly, setting only the bottom half clears the top half. *)
+        I.mov (nat n) (res32 i 0)
+      | _ -> I.mov (nat n) (res i 0)
+    else I.mov (nat n) (res i 0)
+  | Lop (Const_float32 f) -> (
+    match f with
+    | 0x0000_0000l ->
+      (* +0.0 *)
+      I.xorpd (res i 0) (res i 0)
+    | _ ->
+      (* float32 constants still take up 8 bytes; we load the lower half. *)
+      let lbl = add_float_constant (Int64.of_int32 f) in
+      I.movss (mem64_rip REAL4 (emit_label lbl)) (res i 0))
+  | Lop (Const_float f) -> (
+    match f with
+    | 0x0000_0000_0000_0000L ->
+      (* +0.0 *)
+      I.xorpd (res i 0) (res i 0)
+    | _ ->
+      let lbl = add_float_constant f in
+      I.movsd (mem64_rip REAL8 (emit_label lbl)) (res i 0))
+  | Lop (Const_vec128 { high; low }) -> (
+    match high, low with
+    | 0x0000_0000_0000_0000L, 0x0000_0000_0000_0000L ->
+      I.xorpd (res i 0) (res i 0)
+    | _ ->
+      let lbl = add_vec128_constant { high; low } in
+      I.movapd (mem64_rip VEC128 (emit_label lbl)) (res i 0))
+  | Lop (Const_symbol s) ->
+    add_used_symbol s.sym_name;
+    load_symbol_addr s (res i 0)
+  | Lcall_op Lcall_ind ->
+    I.call (arg i 0);
+    record_frame i.live (Dbg_other i.dbg)
+  | Lcall_op (Lcall_imm { func }) ->
+    add_used_symbol func.sym_name;
+    emit_call func;
+    record_frame i.live (Dbg_other i.dbg)
+  | Lcall_op Ltailcall_ind -> output_epilogue (fun () -> I.jmp (arg i 0))
+  | Lcall_op (Ltailcall_imm { func }) ->
+    if String.equal func.sym_name !function_name
+    then
+      match !tailrec_entry_point with
+      | None -> Misc.fatal_error "jump to missing tailrec entry point"
+      | Some tailrec_entry_point -> I.jmp (label tailrec_entry_point)
+    else
+      output_epilogue (fun () ->
+          add_used_symbol func.sym_name;
+          emit_jump func)
+  | Lcall_op (Lextcall { func; alloc; stack_ofs }) ->
+    add_used_symbol func;
+    if Config.runtime5 && stack_ofs > 0
+    then (
+      I.mov rsp r13;
+      I.lea (mem64 QWORD stack_ofs RSP) r12;
+      load_symbol_addr (Cmm.global_symbol func) rax;
+      emit_call (Cmm.global_symbol "caml_c_call_stack_args");
+      record_frame i.live (Dbg_other i.dbg))
+    else if alloc
+    then (
+      load_symbol_addr (Cmm.global_symbol func) rax;
+      emit_call (Cmm.global_symbol "caml_c_call");
+      record_frame i.live (Dbg_other i.dbg);
+      if (not Config.runtime5) && not (is_win64 system)
+      then
+        (* In amd64.S, "caml_c_call" tail-calls the C function (in order to
+           produce nicer backtraces), so we need to restore r15 manually after
+           it returns (note that this increases code size).
 
-          (* In amd64.S, "caml_c_call" tail-calls the C function (in order to
-             produce nicer backtraces), so we need to restore r15 manually after
-             it returns (note that this increases code size).
-
-             In amd64nt.asm (used for Win64), "caml_c_call" invokes the C
-             function via a regular call, and restores r15 itself, thus avoiding
-             the code size increase. *)
-
-          I.mov (domain_field Domainstate.Domain_young_ptr) r15
-        end
-      end else begin
-        if Config.runtime5 then begin
-          I.mov rsp rbx;
-          cfi_remember_state ();
-          cfi_def_cfa_register "rbx";
-          (* NB: gdb has asserts on contiguous stacks that mean it
-            will not unwind through this unless we were to tag this
-            calling frame with cfi_signal_frame in it's definition. *)
-          I.mov (domain_field Domainstate.Domain_c_stack) rsp;
-        end;
-        emit_call (Cmm.global_symbol func);
-        if Config.runtime5 then begin
-          I.mov rbx rsp;
-          cfi_restore_state ();
-        end;
-           end
-  | Lop(Stackoffset n) ->
-      emit_stack_offset n
-  | Lop(Load { memory_chunk; addressing_mode; _ }) ->
-      let[@inline always] load ~dest data_type instruction =
-        let address = (addressing addressing_mode data_type i 0) in
-        Address_sanitizer.emit_sanitize ~address memory_chunk Load;
-        instruction address dest
-      in
-      begin match memory_chunk with
-      | Word_int | Word_val -> load ~dest:(res i 0) QWORD I.mov
-      | Byte_unsigned -> load ~dest:(res i 0) BYTE I.movzx
-      | Byte_signed -> load ~dest:(res i 0) BYTE I.movsx
-      | Sixteen_unsigned -> load ~dest:(res i 0) WORD I.movzx
-      | Sixteen_signed -> load ~dest:(res i 0) WORD I.movsx
-      | Thirtytwo_unsigned -> load ~dest:(res32 i 0) DWORD I.mov
-      | Thirtytwo_signed -> load ~dest:(res i 0) DWORD I.movsxd
-      | Onetwentyeight_unaligned -> load ~dest:(res i 0) VEC128 I.movupd
-      | Onetwentyeight_aligned -> load ~dest:(res i 0) VEC128 I.movapd
-      | Single { reg = Float64 } -> load ~dest:(res i 0) REAL4 I.cvtss2sd
-      | Single { reg = Float32 } -> load ~dest:(res i 0) REAL4 I.movss
-      | Double -> load ~dest:(res i 0) REAL8 I.movsd
-      end
-  | Lop(Store(chunk, addr, is_modify)) ->
-      let memory_access : Address_sanitizer.memory_access =
-        if is_modify then Store_modify else Store_initialize
-      in
-      let[@inline always] store data_type arg_func instruction =
-        let address = (addressing addr data_type i 1) in
-        let src = (arg_func i 0) in
-        Address_sanitizer.emit_sanitize ~dependencies:[|src|] ~address chunk memory_access;
-        instruction src address
-      in
-      begin match chunk with
-      | Word_int | Word_val -> store QWORD arg I.mov
-      | Byte_unsigned | Byte_signed -> store BYTE arg8 I.mov
-      | Sixteen_unsigned | Sixteen_signed -> store WORD arg16 I.mov
-      | Thirtytwo_signed | Thirtytwo_unsigned -> store DWORD arg32 I.mov
-      | Onetwentyeight_unaligned -> store VEC128 arg I.movupd
-      | Onetwentyeight_aligned -> store VEC128 arg I.movapd
-      | Single { reg = Float64 } ->
-          let src = (arg i 0) in
-          I.cvtsd2ss src xmm15;
-          let address = (addressing addr REAL4 i 1) in
-          Address_sanitizer.emit_sanitize ~dependencies:[|src; xmm15|] ~address chunk memory_access;
-          I.movss xmm15 address
-      | Single { reg = Float32 } -> store REAL4 arg I.movss
-      | Double -> store REAL8 arg I.movsd
-      end
-  | Lop(Specific(Istore_int(n, addr, is_modify))) ->
-      let address = (addressing addr QWORD i 0) in
-      let src = nat n in
-      let memory_access : Address_sanitizer.memory_access =
-        if is_modify then Store_modify else Store_initialize
-      in
-      Address_sanitizer.emit_sanitize ~dependencies:[|src|] ~address Word_int memory_access;
-      I.mov src address
-  | Lop(Alloc { bytes = n; dbginfo; mode = Heap }) ->
-      assert (n <= (Config.max_young_wosize + 1) * Arch.size_addr);
-      if !fastcode_flag then begin
-        I.sub (int n) r15;
-        I.cmp (domain_field Domainstate.Domain_young_limit) r15;
-        let lbl_call_gc = new_label() in
-        let lbl_frame =
-          record_frame_label i.live (Dbg_alloc dbginfo)
-        in
-        I.jb (label lbl_call_gc);
-        let lbl_after_alloc = new_label() in
-        def_label lbl_after_alloc;
-        I.lea (mem64 NONE 8 R15) (res i 0);
-        call_gc_sites :=
-          { gc_lbl = lbl_call_gc;
-            gc_return_lbl = lbl_after_alloc;
-            gc_dbg = i.dbg;
-            gc_frame = lbl_frame; } :: !call_gc_sites
-      end else begin
-        begin match n with
-        | 16 -> emit_call (Cmm.global_symbol "caml_alloc1")
-        | 24 -> emit_call (Cmm.global_symbol "caml_alloc2")
-        | 32 -> emit_call (Cmm.global_symbol "caml_alloc3")
-        | _  ->
-            I.sub (int n) r15;
-            emit_call (Cmm.global_symbol "caml_allocN")
-        end;
-        let label = record_frame_label i.live (Dbg_alloc dbginfo) in
-        def_label label;
-        I.lea (mem64 NONE 8 R15) (res i 0)
-      end
-  | Lop(Alloc { bytes = n; dbginfo=_; mode = Local }) ->
-      let r = res i 0 in
-      I.mov (domain_field Domainstate.Domain_local_sp) r;
-      I.sub (int n) r;
-      I.mov r (domain_field Domainstate.Domain_local_sp);
-      I.cmp (domain_field Domainstate.Domain_local_limit) r;
-      let lbl_call = new_label () in
-      I.j L (label lbl_call);
+           In amd64nt.asm (used for Win64), "caml_c_call" invokes the C function
+           via a regular call, and restores r15 itself, thus avoiding the code
+           size increase. *)
+        I.mov (domain_field Domainstate.Domain_young_ptr) r15)
+    else (
+      if Config.runtime5
+      then (
+        I.mov rsp rbx;
+        cfi_remember_state ();
+        cfi_def_cfa_register "rbx";
+        (* NB: gdb has asserts on contiguous stacks that mean it will not unwind
+           through this unless we were to tag this calling frame with
+           cfi_signal_frame in it's definition. *)
+        I.mov (domain_field Domainstate.Domain_c_stack) rsp);
+      emit_call (Cmm.global_symbol func);
+      if Config.runtime5
+      then (
+        I.mov rbx rsp;
+        cfi_restore_state ()))
+  | Lop (Stackoffset n) -> emit_stack_offset n
+  | Lop (Load { memory_chunk; addressing_mode; _ }) -> (
+    let[@inline always] load ~dest data_type instruction =
+      let address = addressing addressing_mode data_type i 0 in
+      Address_sanitizer.emit_sanitize ~address memory_chunk Load;
+      instruction address dest
+    in
+    match memory_chunk with
+    | Word_int | Word_val -> load ~dest:(res i 0) QWORD I.mov
+    | Byte_unsigned -> load ~dest:(res i 0) BYTE I.movzx
+    | Byte_signed -> load ~dest:(res i 0) BYTE I.movsx
+    | Sixteen_unsigned -> load ~dest:(res i 0) WORD I.movzx
+    | Sixteen_signed -> load ~dest:(res i 0) WORD I.movsx
+    | Thirtytwo_unsigned -> load ~dest:(res32 i 0) DWORD I.mov
+    | Thirtytwo_signed -> load ~dest:(res i 0) DWORD I.movsxd
+    | Onetwentyeight_unaligned -> load ~dest:(res i 0) VEC128 I.movupd
+    | Onetwentyeight_aligned -> load ~dest:(res i 0) VEC128 I.movapd
+    | Single { reg = Float64 } -> load ~dest:(res i 0) REAL4 I.cvtss2sd
+    | Single { reg = Float32 } -> load ~dest:(res i 0) REAL4 I.movss
+    | Double -> load ~dest:(res i 0) REAL8 I.movsd)
+  | Lop (Store (chunk, addr, is_modify)) -> (
+    let memory_access : Address_sanitizer.memory_access =
+      if is_modify then Store_modify else Store_initialize
+    in
+    let[@inline always] store data_type arg_func instruction =
+      let address = addressing addr data_type i 1 in
+      let src = arg_func i 0 in
+      Address_sanitizer.emit_sanitize ~dependencies:[| src |] ~address chunk
+        memory_access;
+      instruction src address
+    in
+    match chunk with
+    | Word_int | Word_val -> store QWORD arg I.mov
+    | Byte_unsigned | Byte_signed -> store BYTE arg8 I.mov
+    | Sixteen_unsigned | Sixteen_signed -> store WORD arg16 I.mov
+    | Thirtytwo_signed | Thirtytwo_unsigned -> store DWORD arg32 I.mov
+    | Onetwentyeight_unaligned -> store VEC128 arg I.movupd
+    | Onetwentyeight_aligned -> store VEC128 arg I.movapd
+    | Single { reg = Float64 } ->
+      let src = arg i 0 in
+      I.cvtsd2ss src xmm15;
+      let address = addressing addr REAL4 i 1 in
+      Address_sanitizer.emit_sanitize ~dependencies:[| src; xmm15 |] ~address
+        chunk memory_access;
+      I.movss xmm15 address
+    | Single { reg = Float32 } -> store REAL4 arg I.movss
+    | Double -> store REAL8 arg I.movsd)
+  | Lop (Specific (Istore_int (n, addr, is_modify))) ->
+    let address = addressing addr QWORD i 0 in
+    let src = nat n in
+    let memory_access : Address_sanitizer.memory_access =
+      if is_modify then Store_modify else Store_initialize
+    in
+    Address_sanitizer.emit_sanitize ~dependencies:[| src |] ~address Word_int
+      memory_access;
+    I.mov src address
+  | Lop (Alloc { bytes = n; dbginfo; mode = Heap }) ->
+    assert (n <= (Config.max_young_wosize + 1) * Arch.size_addr);
+    if !fastcode_flag
+    then (
+      I.sub (int n) r15;
+      I.cmp (domain_field Domainstate.Domain_young_limit) r15;
+      let lbl_call_gc = new_label () in
+      let lbl_frame = record_frame_label i.live (Dbg_alloc dbginfo) in
+      I.jb (label lbl_call_gc);
       let lbl_after_alloc = new_label () in
       def_label lbl_after_alloc;
-      I.add (domain_field Domainstate.Domain_local_top) r;
-      I.add (int 8) r;
-      local_realloc_sites :=
-        { lr_lbl = lbl_call;
-          lr_dbg = i.dbg;
-          lr_return_lbl = lbl_after_alloc } :: !local_realloc_sites
-  | Lop (Poll) ->
-      I.cmp (domain_field Domainstate.Domain_young_limit) r15;
-      let gc_call_label = new_label () in
-      let lbl_after_poll = new_label() in
-      let lbl_frame =
-        record_frame_label i.live (Dbg_alloc [])
-      in
-      I.jbe (label gc_call_label);
-      call_gc_sites :=
-        { gc_lbl = gc_call_label;
-          gc_return_lbl = lbl_after_poll;
-          gc_dbg = i.dbg;
-          gc_frame = lbl_frame; } :: !call_gc_sites;
-      def_label lbl_after_poll
-  | Lop(Intop(Icomp cmp)) ->
-      I.cmp (arg i 1) (arg i 0);
-      I.set (cond cmp) al;
-      I.movzx al (res i 0)
-  | Lop(Intop_imm(Icomp cmp, n)) ->
-      I.cmp (int n) (arg i 0);
-      I.set (cond cmp) al;
-      I.movzx al (res i 0)
-  | Lop(Intop_imm (Iand, n)) when n >= 0 && n <= 0xFFFF_FFFF && Reg.is_reg i.res.(0) ->
-      I.and_ (int n) (res32 i 0)
-  | Lop(Intop Ixor) when Reg.equal_location i.arg.(1).loc i.res.(0).loc && Reg.is_reg i.res.(0) ->
-      I.xor (res32 i 0) (res32 i 0)
-  | Lop(Intop(Idiv | Imod)) ->
-      I.cqo ();
-      I.idiv (arg i 1)
-  | Lop(Intop(Ilsl | Ilsr | Iasr as op)) ->
-      (* We have i.arg.(0) = i.res.(0) and i.arg.(1) = %rcx *)
-      instr_for_intop op cl (res i 0)
-  | Lop(Intop (Imulh { signed = true })) ->
-      I.imul (arg i 1) None
-  | Lop(Intop (Imulh { signed = false })) ->
-      I.mul (arg i 1)
-  | Lop(Intop ((Iadd|Isub|Imul|Iand|Ior|Ixor) as op)) ->
-      (* We have i.arg.(0) = i.res.(0) *)
-      instr_for_intop op (arg i 1) (res i 0)
-  | Lop(Intop_imm(Iadd, n)) when not (Reg.equal_location i.arg.(0).loc i.res.(0).loc) ->
-      I.lea (mem64 NONE n (arg64 i 0)) (res i 0)
-  | Lop(Intop_imm(Iadd, 1) | Intop_imm(Isub, -1)) ->
-      I.inc (res i 0)
-  | Lop(Intop_imm(Iadd, -1) | Intop_imm(Isub, 1)) ->
-      I.dec (res i 0)
-  | Lop(Intop_imm(op, n)) ->
-      (* We have i.arg.(0) = i.res.(0) *)
-      instr_for_intop op (int n) (res i 0)
-  | Lop(Intop_atomic{op; size; addr}) ->
-      emit_atomic i op size addr
-  | Lop(Floatop(Float64, Icompf cmp)) ->
-      let cond, need_swap = float_cond_and_need_swap cmp in
-      let a0, a1 = if need_swap then arg i 1, arg i 0 else arg i 0, arg i 1 in
-      I.cmpsd cond a1 a0;
-      I.movq a0 (res i 0);
-      I.neg (res i 0)
-  | Lop(Floatop(Float32, Icompf cmp)) ->
-      let cond, need_swap = float_cond_and_need_swap cmp in
-      let a0, a1 = if need_swap then arg i 1, arg i 0 else arg i 0, arg i 1 in
-      I.cmpss cond a1 a0;
-      I.movd a0 (res32 i 0);
-      (* CMPSS only sets the bottom 32 bits of the result, so we sign-extend to
-         copy the result to the top 32 bits. *)
-      I.movsxd (res32 i 0) (res i 0);
-      I.neg (res i 0)
-  | Lop(Floatop(Float64, Inegf)) ->
-      I.xorpd (mem64_rip VEC128 (emit_symbol "caml_negf_mask")) (res i 0)
-  | Lop(Floatop(Float64, Iabsf)) ->
-      I.andpd (mem64_rip VEC128 (emit_symbol "caml_absf_mask")) (res i 0)
-  | Lop(Floatop(Float32, Inegf)) ->
-      I.xorps (mem64_rip VEC128 (emit_symbol "caml_negf32_mask")) (res i 0)
-  | Lop(Floatop(Float32, Iabsf)) ->
-      I.andps (mem64_rip VEC128 (emit_symbol "caml_absf32_mask")) (res i 0)
-  | Lop(Floatop(width, (Iaddf | Isubf | Imulf | Idivf as floatop))) ->
-      instr_for_floatop width floatop (arg i 1) (res i 0)
-  | Lop(Opaque) ->
-      assert (Reg.equal_location i.arg.(0).loc i.res.(0).loc)
-  | Lop(Specific(Ilea addr)) ->
-      I.lea (addressing addr NONE i 0) (res i 0)
-  | Lop(Specific(Ioffset_loc(n, addr))) ->
-      I.add (int n) (addressing addr QWORD i 0)
-  | Lop(Specific(Ifloatarithmem(Float64, op, addr))) ->
-      let address = (addressing addr REAL8 i 1) in
-      let dest = (res i 0) in
-      Address_sanitizer.emit_sanitize ~dependencies:[|dest|] ~address Double Load;
-      instr_for_floatarithmem Float64 op address dest
-  | Lop(Specific(Ifloatarithmem(Float32, op, addr))) ->
-      let address = (addressing addr REAL4 i 1) in
-      let dest = (res i 0) in
-      Address_sanitizer.emit_sanitize ~dependencies:[|dest|] ~address (Single {reg = Float32}) Load;
-      instr_for_floatarithmem Float32 op address dest
-  | Lop(Specific(Ibswap { bitwidth = Sixteen })) ->
-      I.xchg ah al;
-      I.movzx (res16 i 0) (res i 0)
-  | Lop(Specific(Ibswap { bitwidth = Thirtytwo })) ->
-      I.bswap (res32 i 0);
-  | Lop(Specific(Ibswap { bitwidth = Sixtyfour })) ->
-      I.bswap (res i 0)
-  | Lop(Specific(Isextend32)) ->
-      I.movsxd (arg32 i 0) (res i 0)
-  | Lop(Specific(Izextend32)) ->
-      I.mov (arg32 i 0) (res32 i 0)
-  | Lop(Intop(Iclz { arg_is_non_zero; })) ->
-      (* CR-someday gyorsh: can we do it at selection?
-         mshinwell: We need to address this and the similar CRs below.
-         My feeling is that we should try to do this earlier, based on
-         previous experience with similar things, but maybe the change
-         should be left for later.
-         mshinwell: The current situation is fine for now. *)
-      if Arch.Extension.enabled LZCNT then begin
-        I.lzcnt (arg i 0) (res i 0)
-      end else if arg_is_non_zero then begin
-        (* No need to handle that bsr is undefined on 0 input. *)
-        I.bsr (arg i 0) (res i 0);
-        (* We need (63 - result_of_bsr), which can be done with xor. *)
-        I.xor (int 63) (res i 0)
-      end else begin
-        let lbl_z = new_label () in
-        let lbl_nz = new_label () in
-        I.bsr (arg i 0) (res i 0);
-        I.je (label lbl_z);
-        I.xor (int 63) (res i 0);
-        I.jmp (label lbl_nz);
-        def_label lbl_z;
-        I.mov (int 64) (res i 0);
-        def_label lbl_nz
-      end
-  | Lop(Intop(Ictz { arg_is_non_zero; })) ->
+      I.lea (mem64 NONE 8 R15) (res i 0);
+      call_gc_sites
+        := { gc_lbl = lbl_call_gc;
+             gc_return_lbl = lbl_after_alloc;
+             gc_dbg = i.dbg;
+             gc_frame = lbl_frame
+           }
+           :: !call_gc_sites)
+    else (
+      (match n with
+      | 16 -> emit_call (Cmm.global_symbol "caml_alloc1")
+      | 24 -> emit_call (Cmm.global_symbol "caml_alloc2")
+      | 32 -> emit_call (Cmm.global_symbol "caml_alloc3")
+      | _ ->
+        I.sub (int n) r15;
+        emit_call (Cmm.global_symbol "caml_allocN"));
+      let label = record_frame_label i.live (Dbg_alloc dbginfo) in
+      def_label label;
+      I.lea (mem64 NONE 8 R15) (res i 0))
+  | Lop (Alloc { bytes = n; dbginfo = _; mode = Local }) ->
+    let r = res i 0 in
+    I.mov (domain_field Domainstate.Domain_local_sp) r;
+    I.sub (int n) r;
+    I.mov r (domain_field Domainstate.Domain_local_sp);
+    I.cmp (domain_field Domainstate.Domain_local_limit) r;
+    let lbl_call = new_label () in
+    I.j L (label lbl_call);
+    let lbl_after_alloc = new_label () in
+    def_label lbl_after_alloc;
+    I.add (domain_field Domainstate.Domain_local_top) r;
+    I.add (int 8) r;
+    local_realloc_sites
+      := { lr_lbl = lbl_call; lr_dbg = i.dbg; lr_return_lbl = lbl_after_alloc }
+         :: !local_realloc_sites
+  | Lop Poll ->
+    I.cmp (domain_field Domainstate.Domain_young_limit) r15;
+    let gc_call_label = new_label () in
+    let lbl_after_poll = new_label () in
+    let lbl_frame = record_frame_label i.live (Dbg_alloc []) in
+    I.jbe (label gc_call_label);
+    call_gc_sites
+      := { gc_lbl = gc_call_label;
+           gc_return_lbl = lbl_after_poll;
+           gc_dbg = i.dbg;
+           gc_frame = lbl_frame
+         }
+         :: !call_gc_sites;
+    def_label lbl_after_poll
+  | Lop (Intop (Icomp cmp)) ->
+    I.cmp (arg i 1) (arg i 0);
+    I.set (cond cmp) al;
+    I.movzx al (res i 0)
+  | Lop (Intop_imm (Icomp cmp, n)) ->
+    I.cmp (int n) (arg i 0);
+    I.set (cond cmp) al;
+    I.movzx al (res i 0)
+  | Lop (Intop_imm (Iand, n))
+    when n >= 0 && n <= 0xFFFF_FFFF && Reg.is_reg i.res.(0) ->
+    I.and_ (int n) (res32 i 0)
+  | Lop (Intop Ixor)
+    when Reg.equal_location i.arg.(1).loc i.res.(0).loc && Reg.is_reg i.res.(0)
+    ->
+    I.xor (res32 i 0) (res32 i 0)
+  | Lop (Intop (Idiv | Imod)) ->
+    I.cqo ();
+    I.idiv (arg i 1)
+  | Lop (Intop ((Ilsl | Ilsr | Iasr) as op)) ->
+    (* We have i.arg.(0) = i.res.(0) and i.arg.(1) = %rcx *)
+    instr_for_intop op cl (res i 0)
+  | Lop (Intop (Imulh { signed = true })) -> I.imul (arg i 1) None
+  | Lop (Intop (Imulh { signed = false })) -> I.mul (arg i 1)
+  | Lop (Intop ((Iadd | Isub | Imul | Iand | Ior | Ixor) as op)) ->
+    (* We have i.arg.(0) = i.res.(0) *)
+    instr_for_intop op (arg i 1) (res i 0)
+  | Lop (Intop_imm (Iadd, n))
+    when not (Reg.equal_location i.arg.(0).loc i.res.(0).loc) ->
+    I.lea (mem64 NONE n (arg64 i 0)) (res i 0)
+  | Lop (Intop_imm (Iadd, 1) | Intop_imm (Isub, -1)) -> I.inc (res i 0)
+  | Lop (Intop_imm (Iadd, -1) | Intop_imm (Isub, 1)) -> I.dec (res i 0)
+  | Lop (Intop_imm (op, n)) ->
+    (* We have i.arg.(0) = i.res.(0) *)
+    instr_for_intop op (int n) (res i 0)
+  | Lop (Intop_atomic { op; size; addr }) -> emit_atomic i op size addr
+  | Lop (Floatop (Float64, Icompf cmp)) ->
+    let cond, need_swap = float_cond_and_need_swap cmp in
+    let a0, a1 = if need_swap then arg i 1, arg i 0 else arg i 0, arg i 1 in
+    I.cmpsd cond a1 a0;
+    I.movq a0 (res i 0);
+    I.neg (res i 0)
+  | Lop (Floatop (Float32, Icompf cmp)) ->
+    let cond, need_swap = float_cond_and_need_swap cmp in
+    let a0, a1 = if need_swap then arg i 1, arg i 0 else arg i 0, arg i 1 in
+    I.cmpss cond a1 a0;
+    I.movd a0 (res32 i 0);
+    (* CMPSS only sets the bottom 32 bits of the result, so we sign-extend to
+       copy the result to the top 32 bits. *)
+    I.movsxd (res32 i 0) (res i 0);
+    I.neg (res i 0)
+  | Lop (Floatop (Float64, Inegf)) ->
+    I.xorpd (mem64_rip VEC128 (emit_symbol "caml_negf_mask")) (res i 0)
+  | Lop (Floatop (Float64, Iabsf)) ->
+    I.andpd (mem64_rip VEC128 (emit_symbol "caml_absf_mask")) (res i 0)
+  | Lop (Floatop (Float32, Inegf)) ->
+    I.xorps (mem64_rip VEC128 (emit_symbol "caml_negf32_mask")) (res i 0)
+  | Lop (Floatop (Float32, Iabsf)) ->
+    I.andps (mem64_rip VEC128 (emit_symbol "caml_absf32_mask")) (res i 0)
+  | Lop (Floatop (width, ((Iaddf | Isubf | Imulf | Idivf) as floatop))) ->
+    instr_for_floatop width floatop (arg i 1) (res i 0)
+  | Lop Opaque -> assert (Reg.equal_location i.arg.(0).loc i.res.(0).loc)
+  | Lop (Specific (Ilea addr)) -> I.lea (addressing addr NONE i 0) (res i 0)
+  | Lop (Specific (Ioffset_loc (n, addr))) ->
+    I.add (int n) (addressing addr QWORD i 0)
+  | Lop (Specific (Ifloatarithmem (Float64, op, addr))) ->
+    let address = addressing addr REAL8 i 1 in
+    let dest = res i 0 in
+    Address_sanitizer.emit_sanitize ~dependencies:[| dest |] ~address Double
+      Load;
+    instr_for_floatarithmem Float64 op address dest
+  | Lop (Specific (Ifloatarithmem (Float32, op, addr))) ->
+    let address = addressing addr REAL4 i 1 in
+    let dest = res i 0 in
+    Address_sanitizer.emit_sanitize ~dependencies:[| dest |] ~address
+      (Single { reg = Float32 })
+      Load;
+    instr_for_floatarithmem Float32 op address dest
+  | Lop (Specific (Ibswap { bitwidth = Sixteen })) ->
+    I.xchg ah al;
+    I.movzx (res16 i 0) (res i 0)
+  | Lop (Specific (Ibswap { bitwidth = Thirtytwo })) -> I.bswap (res32 i 0)
+  | Lop (Specific (Ibswap { bitwidth = Sixtyfour })) -> I.bswap (res i 0)
+  | Lop (Specific Isextend32) -> I.movsxd (arg32 i 0) (res i 0)
+  | Lop (Specific Izextend32) -> I.mov (arg32 i 0) (res32 i 0)
+  | Lop (Intop (Iclz { arg_is_non_zero })) ->
+    (* CR-someday gyorsh: can we do it at selection? mshinwell: We need to
+       address this and the similar CRs below. My feeling is that we should try
+       to do this earlier, based on previous experience with similar things, but
+       maybe the change should be left for later. mshinwell: The current
+       situation is fine for now. *)
+    if Arch.Extension.enabled LZCNT
+    then I.lzcnt (arg i 0) (res i 0)
+    else if arg_is_non_zero
+    then (
+      (* No need to handle that bsr is undefined on 0 input. *)
+      I.bsr (arg i 0) (res i 0);
+      (* We need (63 - result_of_bsr), which can be done with xor. *)
+      I.xor (int 63) (res i 0))
+    else
+      let lbl_z = new_label () in
+      let lbl_nz = new_label () in
+      I.bsr (arg i 0) (res i 0);
+      I.je (label lbl_z);
+      I.xor (int 63) (res i 0);
+      I.jmp (label lbl_nz);
+      def_label lbl_z;
+      I.mov (int 64) (res i 0);
+      def_label lbl_nz
+  | Lop (Intop (Ictz { arg_is_non_zero })) ->
     (* CR-someday gyorsh: can we do it at selection? *)
-    if Arch.Extension.enabled BMI then begin
-      I.tzcnt (arg i 0) (res i 0)
-    end else if arg_is_non_zero then begin
+    if Arch.Extension.enabled BMI
+    then I.tzcnt (arg i 0) (res i 0)
+    else if arg_is_non_zero
+    then
       (* No need to handle that bsf is undefined on 0 input. *)
       I.bsf (arg i 0) (res i 0)
-    end else begin
+    else
       let lbl_nz = new_label () in
       I.bsf (arg i 0) (res i 0);
       I.jne (label lbl_nz);
       I.mov (int 64) (res i 0);
       def_label lbl_nz
-    end
-  | Lop(Intop Ipopcnt) ->
-      assert (Arch.Extension.enabled POPCNT);
-      I.popcnt (arg i 0) (res i 0)
-  | Lop(Csel tst) ->
+  | Lop (Intop Ipopcnt) ->
+    assert (Arch.Extension.enabled POPCNT);
+    I.popcnt (arg i 0) (res i 0)
+  | Lop (Csel tst) ->
     let len = Array.length i.arg in
     let ifso = i.arg.(len - 2) in
     let ifnot = i.arg.(len - 1) in
     assert (Reg.same_loc ifnot i.res.(0));
-    let taken c =
-      I.cmov c (reg ifso) (res i 0)
-    in
+    let taken c = I.cmov c (reg ifso) (res i 0) in
     emit_test i tst ~taken
-  | Lop(Specific Irdtsc) ->
+  | Lop (Specific Irdtsc) -> (
     I.rdtsc ();
     let rdx = Reg64 RDX in
     (* The instruction fills in the low 32 bits of the result registers. *)
     (* Combine edx and eax into a single 64-bit result. *)
-    I.sal (int 32) rdx; (* shift edx to the high part of rdx *)
-    (* On processors that support the Intel 64 architecture,
-       the high-order 32 bits of each of RAX and RDX are cleared. *)
-    (match reg64 i.res.(0) with
-     | RAX -> I.or_ rdx (res i 0) (* combine high and low into rax *)
-     | RDX -> I.or_ rax (res i 0) (* combine high and low into rdx *)
-     | _ ->
-       (* combine high and low into res *)
-       I.mov rax (res i 0);
-       I.or_ rdx (res i 0))
-  | Lop(Specific Irdpmc) ->
+    I.sal (int 32) rdx;
+    (* shift edx to the high part of rdx *)
+    (* On processors that support the Intel 64 architecture, the high-order 32
+       bits of each of RAX and RDX are cleared. *)
+    match reg64 i.res.(0) with
+    | RAX -> I.or_ rdx (res i 0) (* combine high and low into rax *)
+    | RDX -> I.or_ rax (res i 0) (* combine high and low into rdx *)
+    | _ ->
+      (* combine high and low into res *)
+      I.mov rax (res i 0);
+      I.or_ rdx (res i 0))
+  | Lop (Specific Irdpmc) ->
     assert (equal_reg64 (arg64 i 0) RCX);
     I.rdpmc ();
     let rdx = Reg64 RDX in
     (* The instruction fills in the low 32 bits of the result registers. *)
     (* Combine edx and eax into a single 64-bit result. *)
-    I.sal (int 32) rdx; (* shift edx to the high part of rdx *)
-    I.mov eax (res32 i 0); (* zero-extend eax *)
-    I.or_ rdx (res i 0) (* combine high and low into rax *)
-  | Lop (Specific Ilfence) ->
-    I.lfence ()
-  | Lop (Specific Isfence) ->
-    I.sfence ()
-  | Lop (Specific Imfence) ->
-    I.mfence ()
-  | Lop (Specific (Isimd op)) ->
-    emit_simd_instr op i
+    I.sal (int 32) rdx;
+    (* shift edx to the high part of rdx *)
+    I.mov eax (res32 i 0);
+    (* zero-extend eax *)
+    I.or_ rdx (res i 0)
+    (* combine high and low into rax *)
+  | Lop (Specific Ilfence) -> I.lfence ()
+  | Lop (Specific Isfence) -> I.sfence ()
+  | Lop (Specific Imfence) -> I.mfence ()
+  | Lop (Specific (Isimd op)) -> emit_simd_instr op i
   | Lop (Specific (Isimd_mem (op, addressing_mode))) ->
     let address = addressing addressing_mode VEC128 i 1 in
-    Address_sanitizer.emit_sanitize ~dependencies:[| res i 0 |] ~address Onetwentyeight_unaligned Store_modify;
+    Address_sanitizer.emit_sanitize
+      ~dependencies:[| res i 0 |]
+      ~address Onetwentyeight_unaligned Store_modify;
     emit_simd_instr_with_memory_arg op i address
-  | Lop (Static_cast cast) ->
-    emit_static_cast cast i
-  | Lop (Reinterpret_cast cast) ->
-    emit_reinterpret_cast cast i
-  | Lop (Specific Ipause) ->
-    I.pause ()
+  | Lop (Static_cast cast) -> emit_static_cast cast i
+  | Lop (Reinterpret_cast cast) -> emit_reinterpret_cast cast i
+  | Lop (Specific Ipause) -> I.pause ()
   | Lop (Specific (Icldemote addr)) ->
-    let address = (addressing addr QWORD i 0) in
-    (* This isn't really a [Load] or a [Store], but it is
-       closer to [Store] semantically. *)
+    let address = addressing addr QWORD i 0 in
+    (* This isn't really a [Load] or a [Store], but it is closer to [Store]
+       semantically. *)
     Address_sanitizer.emit_sanitize ~address Word_val Store_modify;
     I.cldemote address
-  | Lop (Specific (Iprefetch { is_write; locality; addr; })) ->
-    let address = (addressing addr QWORD i 0) in
+  | Lop (Specific (Iprefetch { is_write; locality; addr })) ->
+    let address = addressing addr QWORD i 0 in
     let memory_access : Address_sanitizer.memory_access =
       if is_write then Store_modify else Load
     in
     (* While it is *technically* legal to issue a prefetch to an invalid
        address, it comes with a performance penalty. Quoting from the Intel
-       Optimization Reference Manual section 9.3.1:
-       > Prefetching to addresses that are not mapped to physical pages can
-         experience non-deterministic performance penalty. For example specifying
-         a NULL pointer (0L) as address for a prefetch can cause long delays.
+       Optimization Reference Manual section 9.3.1: > Prefetching to addresses
+       that are not mapped to physical pages can experience non-deterministic
+       performance penalty. For example specifying a NULL pointer (0L) as
+       address for a prefetch can cause long delays.
 
-       On these grounds I would consider prefetching invalid addresses to usually be
-       a bug, and so we do sanitize such accesses. *)
+       On these grounds I would consider prefetching invalid addresses to
+       usually be a bug, and so we do sanitize such accesses. *)
     Address_sanitizer.emit_sanitize ~address Word_val memory_access;
     let locality =
       match locality with
@@ -2022,10 +2012,9 @@ let emit_instr ~first ~fallthrough i =
       | High -> T0
     in
     I.prefetch is_write locality address
-  | Lop(Begin_region) ->
-      I.mov (domain_field Domainstate.Domain_local_sp) (res i 0)
-  | Lop(End_region) ->
-      I.mov (arg i 0) (domain_field Domainstate.Domain_local_sp)
+  | Lop Begin_region ->
+    I.mov (domain_field Domainstate.Domain_local_sp) (res i 0)
+  | Lop End_region -> I.mov (arg i 0) (domain_field Domainstate.Domain_local_sp)
   | Lop (Name_for_debugger _) -> ()
   | Lcall_op (Lprobe { enabled_at_init; _ }) ->
     let probe_label = new_label () in
@@ -2033,154 +2022,132 @@ let emit_instr ~first ~fallthrough i =
       { probe_label;
         probe_insn = i;
         stack_offset = !stack_offset;
-        num_stack_slots = Stack_class.Tbl.copy num_stack_slots;
+        num_stack_slots = Stack_class.Tbl.copy num_stack_slots
       }
     in
     probes := probe :: !probes;
     def_label probe_label;
-    I.nop (); (* for uprobes and usdt probes as well *)
-    (* A probe site does not directly call the probe handler.  There is an
-       intervening wrapper that deals with getting the arguments to the probe
-       in the correct place and managing the spilling/reloading of live
-       registers.  See [emit_probe_handler_wrapper] below. *)
+    I.nop ();
+    (* for uprobes and usdt probes as well *)
+    (* A probe site does not directly call the probe handler. There is an
+       intervening wrapper that deals with getting the arguments to the probe in
+       the correct place and managing the spilling/reloading of live registers.
+       See [emit_probe_handler_wrapper] below. *)
     emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label
-  | Lop (Probe_is_enabled { name; }) ->
+  | Lop (Probe_is_enabled { name }) ->
     let semaphore_sym = find_or_add_semaphore name None i.dbg in
-    (* Load unsigned 2-byte integer value of the semaphore.
-       According to the documentation [1],
-       semaphores are of type unsigned short.
-       [1] https://sourceware.org/systemtap/wiki/UserSpaceProbeImplementation
-    *)
-    (* OCaml has it's own semaphore, in addition to system tap,
-       to control ocaml probe handlers independently from stap probe handlers.
-       It is placed immediately after stap semaphore, and is the same
-       size - hence offset 2. *)
-    I.mov (addressing (Ibased(semaphore_sym, Global, 2)) WORD i 0) (res16 i 0);
+    (* Load unsigned 2-byte integer value of the semaphore. According to the
+       documentation [1], semaphores are of type unsigned short. [1]
+       https://sourceware.org/systemtap/wiki/UserSpaceProbeImplementation *)
+    (* OCaml has it's own semaphore, in addition to system tap, to control ocaml
+       probe handlers independently from stap probe handlers. It is placed
+       immediately after stap semaphore, and is the same size - hence offset
+       2. *)
+    I.mov (addressing (Ibased (semaphore_sym, Global, 2)) WORD i 0) (res16 i 0);
     (* If the semaphore is 0, then the result is 0, otherwise 1. *)
     I.cmp (int 0) (res16 i 0);
     I.set (cond (Iunsigned Cne)) (res8 i 0);
     I.movzx (res8 i 0) (res i 0)
-  | Lop (Dls_get) ->
+  | Lop Dls_get ->
     if Config.runtime5
     then I.mov (domain_field Domainstate.Domain_dls_root) (res i 0)
-    else Misc.fatal_error "Dls is not supported in runtime4.";
-  | Lreloadretaddr ->
-      ()
-  | Lreturn ->
-      output_epilogue begin fun () ->
-        I.ret ()
-      end
+    else Misc.fatal_error "Dls is not supported in runtime4."
+  | Lreloadretaddr -> ()
+  | Lreturn -> output_epilogue (fun () -> I.ret ())
   | Llabel { label = lbl; section_name } ->
-      emit_Llabel fallthrough lbl section_name
-  | Lbranch lbl ->
-      I.jmp (label lbl)
-  | Lcondbranch(tst, lbl) ->
-      let lbl = label lbl in
-      emit_test i tst ~taken:(fun c -> I.j c lbl)
-  | Lcondbranch3(lbl0, lbl1, lbl2) ->
-      I.cmp (int 1) (arg i 0);
-      begin match lbl0 with
-      | None -> ()
-      | Some lbl -> I.jb (label lbl)
-      end;
-      begin match lbl1 with
-      | None -> ()
-      | Some lbl -> I.je (label lbl)
-      end;
-      begin match lbl2 with
-      | None -> ()
-      | Some lbl -> I.ja (label lbl)
-      end
+    emit_Llabel fallthrough lbl section_name
+  | Lbranch lbl -> I.jmp (label lbl)
+  | Lcondbranch (tst, lbl) ->
+    let lbl = label lbl in
+    emit_test i tst ~taken:(fun c -> I.j c lbl)
+  | Lcondbranch3 (lbl0, lbl1, lbl2) -> (
+    I.cmp (int 1) (arg i 0);
+    (match lbl0 with None -> () | Some lbl -> I.jb (label lbl));
+    (match lbl1 with None -> () | Some lbl -> I.je (label lbl));
+    match lbl2 with None -> () | Some lbl -> I.ja (label lbl))
   | Lswitch jumptbl ->
-      let lbl = emit_label (new_label()) in
-      (* rax and rdx are clobbered by the Lswitch,
-         meaning that no variable that is live across the Lswitch
-         is assigned to rax or rdx.  However, the argument to Lswitch
-         can still be assigned to one of these two registers, so
-         we must be careful not to clobber it before use. *)
-      let (tmp1, tmp2) =
-        if Reg.equal_location i.arg.(0).loc (Reg 0) (* rax *)
-        then (phys_rdx, phys_rax)
-        else (phys_rax, phys_rdx) in
-
-      I.lea (mem64_rip NONE lbl) (reg tmp1);
-      I.movsxd (mem64 DWORD 0 (arg64 i 0) ~scale:4 ~base:(reg64 tmp1))
-               (reg tmp2);
-      I.add (reg tmp2) (reg tmp1);
-      I.jmp (reg tmp1);
-
-      let table =
-        { table_lbl = lbl;
-          elems = jumptbl }
-      in
-      jump_tables := table :: !jump_tables
+    let lbl = emit_label (new_label ()) in
+    (* rax and rdx are clobbered by the Lswitch, meaning that no variable that
+       is live across the Lswitch is assigned to rax or rdx. However, the
+       argument to Lswitch can still be assigned to one of these two registers,
+       so we must be careful not to clobber it before use. *)
+    let tmp1, tmp2 =
+      if Reg.equal_location i.arg.(0).loc (Reg 0) (* rax *)
+      then phys_rdx, phys_rax
+      else phys_rax, phys_rdx
+    in
+    I.lea (mem64_rip NONE lbl) (reg tmp1);
+    I.movsxd (mem64 DWORD 0 (arg64 i 0) ~scale:4 ~base:(reg64 tmp1)) (reg tmp2);
+    I.add (reg tmp2) (reg tmp1);
+    I.jmp (reg tmp1);
+    let table = { table_lbl = lbl; elems = jumptbl } in
+    jump_tables := table :: !jump_tables
   | Lentertrap ->
-      if fp then begin
-        let delta = frame_size () - 16 (* retaddr + rbp *) in
-        I.lea (mem64 NONE delta RSP) rbp
-      end
-  | Ladjust_stack_offset { delta_bytes; } ->
-      cfi_adjust_cfa_offset delta_bytes;
-      stack_offset := !stack_offset + delta_bytes
-  | Lpushtrap { lbl_handler; } ->
-      emit_push_trap_label lbl_handler;
-      let load_label_addr s arg =
-        if !Clflags.pic_code then
-          I.lea (mem64_rip NONE (emit_label s)) arg
-        else
-          I.mov (sym (emit_label s)) arg
-      in
-      load_label_addr lbl_handler r11;
-      I.push r11;
-      cfi_adjust_cfa_offset 8;
-      I.push (domain_field Domainstate.Domain_exn_handler);
-      cfi_adjust_cfa_offset 8;
-      I.mov rsp (domain_field Domainstate.Domain_exn_handler);
-      stack_offset := !stack_offset + 16;
+    if fp
+    then
+      let delta = frame_size () - 16 (* retaddr + rbp *) in
+      I.lea (mem64 NONE delta RSP) rbp
+  | Ladjust_stack_offset { delta_bytes } ->
+    cfi_adjust_cfa_offset delta_bytes;
+    stack_offset := !stack_offset + delta_bytes
+  | Lpushtrap { lbl_handler } ->
+    emit_push_trap_label lbl_handler;
+    let load_label_addr s arg =
+      if !Clflags.pic_code
+      then I.lea (mem64_rip NONE (emit_label s)) arg
+      else I.mov (sym (emit_label s)) arg
+    in
+    load_label_addr lbl_handler r11;
+    I.push r11;
+    cfi_adjust_cfa_offset 8;
+    I.push (domain_field Domainstate.Domain_exn_handler);
+    cfi_adjust_cfa_offset 8;
+    I.mov rsp (domain_field Domainstate.Domain_exn_handler);
+    stack_offset := !stack_offset + 16
   | Lpoptrap ->
-      emit_pop_trap_label ();
+    emit_pop_trap_label ();
+    I.pop (domain_field Domainstate.Domain_exn_handler);
+    cfi_adjust_cfa_offset (-8);
+    I.add (int 8) rsp;
+    cfi_adjust_cfa_offset (-8);
+    stack_offset := !stack_offset - 16
+  | Lraise k -> (
+    match k with
+    | Lambda.Raise_regular ->
+      I.mov (int 0) (domain_field Domainstate.Domain_backtrace_pos);
+      emit_call (Cmm.global_symbol "caml_raise_exn");
+      record_frame Reg.Set.empty (Dbg_raise i.dbg)
+    | Lambda.Raise_reraise ->
+      emit_call
+        (Cmm.global_symbol
+           (if Config.runtime5 then "caml_reraise_exn" else "caml_raise_exn"));
+      record_frame Reg.Set.empty (Dbg_raise i.dbg)
+    | Lambda.Raise_notrace ->
+      I.mov (domain_field Domainstate.Domain_exn_handler) rsp;
       I.pop (domain_field Domainstate.Domain_exn_handler);
-      cfi_adjust_cfa_offset (-8);
-      I.add (int 8) rsp;
-      cfi_adjust_cfa_offset (-8);
-      stack_offset := !stack_offset - 16
-  | Lraise k ->
-      begin match k with
-      | Lambda.Raise_regular ->
-          I.mov (int 0) (domain_field Domainstate.Domain_backtrace_pos);
-          emit_call (Cmm.global_symbol "caml_raise_exn");
-          record_frame Reg.Set.empty (Dbg_raise i.dbg)
-      | Lambda.Raise_reraise ->
-          emit_call (Cmm.global_symbol
-            (if Config.runtime5 then "caml_reraise_exn" else "caml_raise_exn"));
-          record_frame Reg.Set.empty (Dbg_raise i.dbg)
-      | Lambda.Raise_notrace ->
-          I.mov (domain_field Domainstate.Domain_exn_handler) rsp;
-          I.pop (domain_field Domainstate.Domain_exn_handler);
-          I.pop r11;
-          I.jmp r11
-    end
-  | Lstackcheck { max_frame_size_bytes; } ->
-    emit_stack_check ~size_in_bytes:max_frame_size_bytes ~save_registers:(not first)
+      I.pop r11;
+      I.jmp r11)
+  | Lstackcheck { max_frame_size_bytes } ->
+    emit_stack_check ~size_in_bytes:max_frame_size_bytes
+      ~save_registers:(not first)
 
 let emit_instr ~first ~fallthrough i =
   try emit_instr ~first ~fallthrough i
-  with exn -> (
+  with exn ->
     Format.eprintf "Exception whilst emitting instruction:@ %a\n"
       Printlinear.instr i;
     raise exn
-  )
 
 let rec emit_all ~first ~fallthrough i =
   match i.desc with
   | Lend -> ()
   | _ ->
-      (try emit_instr ~first ~fallthrough i
-       with exn -> (
-         Format.eprintf "Exception whilst emitting instruction:@ %a\n"
-           Printlinear.instr i;
-         raise exn));
-      emit_all ~first:false ~fallthrough:(Linear.has_fallthrough i.desc) i.next
+    (try emit_instr ~first ~fallthrough i
+     with exn ->
+       Format.eprintf "Exception whilst emitting instruction:@ %a\n"
+         Printlinear.instr i;
+       raise exn);
+    emit_all ~first:false ~fallthrough:(Linear.has_fallthrough i.desc) i.next
 
 let all_functions = ref []
 
@@ -2188,11 +2155,10 @@ let emit_function_type_and_size fun_name =
   match system with
   | S_gnu | S_linux ->
     D.type_ (emit_symbol fun_name) "@function";
-    if not !Flambda_backend_flags.basic_block_sections then
-    D.size (emit_symbol fun_name)
-      (ConstSub (
-         ConstThis,
-         ConstLabel (emit_symbol fun_name)))
+    if not !Flambda_backend_flags.basic_block_sections
+    then
+      D.size (emit_symbol fun_name)
+        (ConstSub (ConstThis, ConstLabel (emit_symbol fun_name)))
   | _ -> ()
 
 (* Emission of a function declaration *)
@@ -2212,44 +2178,41 @@ let fundecl fundecl =
   local_realloc_sites := [];
   clear_safety_checks ();
   clear_stack_realloc ();
-  Stack_class.Tbl.copy_values ~from:fundecl.fun_num_stack_slots ~to_:num_stack_slots;
+  Stack_class.Tbl.copy_values ~from:fundecl.fun_num_stack_slots
+    ~to_:num_stack_slots;
   prologue_required := fundecl.fun_prologue_required;
   frame_required := fundecl.fun_frame_required;
   all_functions := fundecl :: !all_functions;
-  current_basic_block_section :=
-    Option.value fundecl.fun_section_name ~default:"";
+  current_basic_block_section
+    := Option.value fundecl.fun_section_name ~default:"";
   emit_function_or_basic_block_section_name ();
   D.align ~data:false 16;
   add_def_symbol fundecl.fun_name;
   if is_macosx system
-  && not !Clflags.output_c_object
-  && is_generic_function fundecl.fun_name
+     && (not !Clflags.output_c_object)
+     && is_generic_function fundecl.fun_name
   then (* PR#4690 *)
     D.private_extern (emit_symbol fundecl.fun_name)
-  else
-    global_maybe_protected (emit_symbol fundecl.fun_name);
-  (* Even if the function name is Local, still emit an
-     actual linker symbol for it. This provides symbols
-     for perf, gdb, and similar tools *)
+  else global_maybe_protected (emit_symbol fundecl.fun_name);
+  (* Even if the function name is Local, still emit an actual linker symbol for
+     it. This provides symbols for perf, gdb, and similar tools *)
   D.label (emit_symbol fundecl.fun_name);
   D.label (label_name (emit_symbol fundecl.fun_name));
   emit_debug_info fundecl.fun_dbg;
   cfi_startproc ();
-  if Config.runtime5 && (not Config.no_stack_checks) && String.equal !Clflags.runtime_variant "d" then begin
-    emit_call (Cmm.global_symbol "caml_assert_stack_invariants");
-  end;
+  if Config.runtime5
+     && (not Config.no_stack_checks)
+     && String.equal !Clflags.runtime_variant "d"
+  then emit_call (Cmm.global_symbol "caml_assert_stack_invariants");
   emit_all ~first:true ~fallthrough:true fundecl.fun_body;
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
   emit_call_safety_errors ();
   emit_stack_realloc ();
-  if !frame_required then begin
-    let n = frame_size() - 8 - (if fp then 8 else 0) in
-    if n <> 0
-    then begin
-      cfi_adjust_cfa_offset (-n);
-    end;
-  end;
+  (if !frame_required
+  then
+    let n = frame_size () - 8 - if fp then 8 else 0 in
+    if n <> 0 then cfi_adjust_cfa_offset (-n));
   Option.iter def_label fun_end_label;
   cfi_endproc ();
   emit_function_type_and_size fundecl.fun_name
@@ -2257,24 +2220,24 @@ let fundecl fundecl =
 (* Emission of data *)
 
 let emit_item = function
-  | Cdefine_symbol s ->
-    begin match s.sym_global with
-    | Local ->
-      _label (label_name (emit_symbol s.sym_name))
+  | Cdefine_symbol s -> (
+    match s.sym_global with
+    | Local -> _label (label_name (emit_symbol s.sym_name))
     | Global ->
       global_maybe_protected (emit_symbol s.sym_name);
       add_def_symbol s.sym_name;
       _label (emit_symbol s.sym_name);
-      _label (label_name (emit_symbol s.sym_name))
-    end
+      _label (label_name (emit_symbol s.sym_name)))
   | Cint8 n -> D.byte (const n)
   | Cint16 n -> D.word (const n)
   | Cint32 n -> D.long (const_nat n)
   | Cint n -> D.qword (const_nat n)
-  | Csingle f -> D.long  (Const (Int64.of_int32 (Int32.bits_of_float f)))
+  | Csingle f -> D.long (Const (Int64.of_int32 (Int32.bits_of_float f)))
   | Cdouble f -> D.qword (Const (Int64.bits_of_float f))
   (* SIMD vectors respect little-endian byte order *)
-  | Cvec128 {high; low} -> D.qword (Const low); D.qword (Const high)
+  | Cvec128 { high; low } ->
+    D.qword (Const low);
+    D.qword (Const high)
   | Csymbol_address s ->
     add_used_symbol s.sym_name;
     D.qword (ConstLabel (emit_cmm_symbol s))
@@ -2295,8 +2258,9 @@ let data l =
 let reset_all () =
   X86_proc.reset_asm_code ();
   Emitaux.reset ();
-  reset_debug_info();                   (* PR#5603 *)
-  reset_imp_table();
+  reset_debug_info ();
+  (* PR#5603 *)
+  reset_imp_table ();
   reset_probes ();
   stapsdt_base_emitted := false;
   reset_traps ();
@@ -2305,17 +2269,15 @@ let reset_all () =
 
 let begin_assembly unix =
   reset_all ();
-
-  if !Flambda_backend_flags.internal_assembler &&
-     !Emitaux.binary_backend_available then
-    X86_proc.register_internal_assembler (Internal_assembler.assemble unix);
-
+  if !Flambda_backend_flags.internal_assembler
+     && !Emitaux.binary_backend_available
+  then X86_proc.register_internal_assembler (Internal_assembler.assemble unix);
   let code_begin = Cmm_helpers.make_symbol "code_begin" in
   let code_end = Cmm_helpers.make_symbol "code_end" in
   Emitaux.Dwarf_helpers.begin_dwarf ~build_asm_directives ~code_begin ~code_end
     ~file_emitter:D.file;
-
-  if is_win64 system then begin
+  if is_win64 system
+  then (
     D.extrn "caml_call_gc" NEAR;
     D.extrn "caml_c_call" NEAR;
     D.extrn "caml_allocN" NEAR;
@@ -2323,17 +2285,15 @@ let begin_assembly unix =
     D.extrn "caml_alloc2" NEAR;
     D.extrn "caml_alloc3" NEAR;
     D.extrn "caml_ml_array_bound_error" NEAR;
-    D.extrn "caml_raise_exn" NEAR;
-  end;
-
-  if !Clflags.dlcode || Arch.win64 then begin
+    D.extrn "caml_raise_exn" NEAR);
+  if !Clflags.dlcode || Arch.win64
+  then (
     (* from amd64.S; could emit these constants on demand *)
-    begin match system with
-    | S_macosx -> D.section ["__TEXT";"__literal16"] None ["16byte_literals"]
+    (match system with
+    | S_macosx -> D.section ["__TEXT"; "__literal16"] None ["16byte_literals"]
     | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
     | S_win64 -> D.data ()
-    | _ -> D.section [".rodata.cst16"] (Some "aM") ["@progbits";"16"]
-    end;
+    | _ -> D.section [".rodata.cst16"] (Some "aM") ["@progbits"; "16"]);
     D.align ~data:true 16;
     _label (emit_symbol "caml_negf_mask");
     D.qword (Const 0x8000000000000000L);
@@ -2348,36 +2308,31 @@ let begin_assembly unix =
     D.align ~data:true 16;
     _label (emit_symbol "caml_absf32_mask");
     D.qword (Const 0xFFFFFFFF7FFFFFFFL);
-    D.qword (Const 0xFFFFFFFFFFFFFFFFL);
-  end;
-
+    D.qword (Const 0xFFFFFFFFFFFFFFFFL));
   D.data ();
   emit_global_label "data_begin";
-
   emit_named_text_section code_begin;
   emit_global_label_for_symbol code_begin;
-  if is_macosx system then I.nop (); (* PR#4690 *)
-
+  if is_macosx system then I.nop ();
+  (* PR#4690 *)
   D.label (emit_cmm_symbol call_gc_local_sym);
   cfi_startproc ();
   I.jmp (rel_plt (Cmm.global_symbol "caml_call_gc"));
   cfi_endproc ();
-
   ()
 
 let make_stack_loc ~offset n (r : Reg.t) =
-  (* Use "Outgoing" stack locations, instead of "Local",
-     because [slot_offset] emits (Outgoing n) directly
-     as offset [n] from the stack pointer,
-     rather than a calculation relative to the stack frame,
-     which is incorrect for naked floats (arising from live variables, not
-     probe arguments) in the wrapper's frame. *)
+  (* Use "Outgoing" stack locations, instead of "Local", because [slot_offset]
+     emits (Outgoing n) directly as offset [n] from the stack pointer, rather
+     than a calculation relative to the stack frame, which is incorrect for
+     naked floats (arising from live variables, not probe arguments) in the
+     wrapper's frame. *)
   let loc = Stack (Outgoing (offset + n)) in
   (* Manufacture stack entry with this register's type *)
   Reg.at_location r.typ loc
 
-(* CR mshinwell: Not now, but after code review, it would be better to
-   move this code so it's contiguous with the other probe code above. *)
+(* CR mshinwell: Not now, but after code review, it would be better to move this
+   code so it's contiguous with the other probe code above. *)
 
 (*= Calls to probe handler wrappers do not follow the standard calling
    convention for OCaml.  Instead, all registers are callee saved: the wrapper
@@ -2436,22 +2391,30 @@ let size_of_regs regs =
     regs 0
 
 let stack_locations ~offset regs =
-  let _, locs = Array.fold_right (fun r (n, offsets) ->
-    let next = n + match r.Reg.typ with
-      | Int | Val | Addr -> size_int
-      | Float | Float32 ->
-        (* Float32 slots still take up a full word *)
-        size_float
-      | Vec128 | Valx2 -> size_vec128 in
-    next, (make_stack_loc n r ~offset :: offsets)) regs (0, []) in
+  let _, locs =
+    Array.fold_right
+      (fun r (n, offsets) ->
+        let next =
+          n
+          +
+          match r.Reg.typ with
+          | Int | Val | Addr -> size_int
+          | Float | Float32 ->
+            (* Float32 slots still take up a full word *)
+            size_float
+          | Vec128 | Valx2 -> size_vec128
+        in
+        next, make_stack_loc n r ~offset :: offsets)
+      regs (0, [])
+  in
   locs |> Array.of_list
 
 let emit_probe_handler_wrapper p =
   let wrap_label = probe_handler_wrapper_name p.probe_label in
   let probe_name, handler_code_sym =
     match p.probe_insn.desc with
-    | Lcall_op (Lprobe { name; handler_code_sym; enabled_at_init = _; }) ->
-       name, handler_code_sym
+    | Lcall_op (Lprobe { name; handler_code_sym; enabled_at_init = _ }) ->
+      name, handler_code_sym
     | _ -> assert false
   in
   (*= Restore stack frame info as it was at the probe site, so we can easily
@@ -2468,16 +2431,15 @@ let emit_probe_handler_wrapper p =
   D.align ~data:false 16;
   _label wrap_label;
   cfi_startproc ();
-  if fp then begin
+  if fp
+  then (
     push rbp;
-    I.mov rsp rbp;
-  end;
+    I.mov rsp rbp);
   (*= Prepare to call the handler: calculate and allocate stack space.
      Compute the size of stack slots for all live hard registers. *)
   let live =
     Reg.Set.elements p.probe_insn.live
-    |> List.filter Reg.is_reg
-    |> Array.of_list
+    |> List.filter Reg.is_reg |> Array.of_list
   in
   let live_offset = size_of_regs live in
   (* Compute the size of stack slots for spilling all arguments of the probe. *)
@@ -2492,28 +2454,33 @@ let emit_probe_handler_wrapper p =
   let wrapper_frame_size k = 8 + (if fp then 8 else 0) + k in
   let k = live_offset + aux_offset + tmp_offset + loc_offset in
   assert (k mod 8 = 0);
-  let padding = if ((wrapper_frame_size k) mod 16) = 0 then 0 else 8 in
+  let padding = if wrapper_frame_size k mod 16 = 0 then 0 else 8 in
   let n = k + padding in
   (* Allocate stack space *)
-  if Config.runtime5 && (not Config.no_stack_checks) && (n >= Stack_check.stack_threshold_size) then
-    emit_stack_check ~size_in_bytes:n ~save_registers:true;
+  if Config.runtime5
+     && (not Config.no_stack_checks)
+     && n >= Stack_check.stack_threshold_size
+  then emit_stack_check ~size_in_bytes:n ~save_registers:true;
   emit_stack_offset n;
   (* Save all live hard registers *)
   let offset = aux_offset + tmp_offset + loc_offset in
   let saved_live = stack_locations ~offset live in
   Array.iteri (fun i reg -> move reg saved_live.(i)) live;
-  (* Spill r15 to free it to be used as a temporary register for stack to
-     stack copying. *)
+  (* Spill r15 to free it to be used as a temporary register for stack to stack
+     copying. *)
   let offset = tmp_offset + loc_offset in
-  let saved_r15 = make_stack_loc 0 (Reg.dummy) ~offset in
+  let saved_r15 = make_stack_loc 0 Reg.dummy ~offset in
   I.mov r15 (reg saved_r15);
-  (* Spill all arguments of the probe.  Some of these may already be on the
+  (* Spill all arguments of the probe. Some of these may already be on the
      stack, in which case a temporary is used for the move. *)
   let saved_args = stack_locations ~offset:loc_offset p.probe_insn.arg in
-  Array.iteri (fun i reg -> move_allowing_stack_to_stack reg (saved_args.(i)))
+  Array.iteri
+    (fun i reg -> move_allowing_stack_to_stack reg saved_args.(i))
     p.probe_insn.arg;
   (* Load probe arguments to correct locations for the handler *)
-  Array.iteri (fun i reg -> move_allowing_stack_to_stack saved_args.(i) reg) loc_args;
+  Array.iteri
+    (fun i reg -> move_allowing_stack_to_stack saved_args.(i) reg)
+    loc_args;
   (* Reload spilled registers used as temporaries *)
   I.mov (reg saved_r15) r15;
   (* Emit call to handler *)
@@ -2522,17 +2489,17 @@ let emit_probe_handler_wrapper p =
   (* Record a frame description for the wrapper *)
   let label = new_label () in
   let live_offset =
-    Array.fold_right (fun (r:Reg.t) acc ->
-      match r.loc with
-      | Stack (Outgoing k) ->
-        (match r.typ with
-        | Val -> k::acc
-        | Int | Float | Vec128 | Float32 -> acc
-        | Valx2 -> k::k+Arch.size_addr::acc
-        | Addr -> Misc.fatal_error ("bad GC root " ^ Reg.name r))
-      | _ -> assert false)
-    saved_live
-    []
+    Array.fold_right
+      (fun (r : Reg.t) acc ->
+        match r.loc with
+        | Stack (Outgoing k) -> (
+          match r.typ with
+          | Val -> k :: acc
+          | Int | Float | Vec128 | Float32 -> acc
+          | Valx2 -> k :: (k + Arch.size_addr) :: acc
+          | Addr -> Misc.fatal_error ("bad GC root " ^ Reg.name r))
+        | _ -> assert false)
+      saved_live []
   in
   record_frame_descr ~label ~frame_size:(wrapper_frame_size n) ~live_offset
     (Dbg_other Debuginfo.none);
@@ -2541,15 +2508,14 @@ let emit_probe_handler_wrapper p =
      and free stack space. *)
   Array.iteri (fun i reg -> move saved_live.(i) reg) live;
   emit_stack_offset (-n);
-  if fp then begin
-    pop rbp
-  end;
+  if fp then pop rbp;
   I.ret ();
   cfi_endproc ();
   emit_function_type_and_size wrap_label
 
 let emit_stapsdt_base_section () =
-  if not !stapsdt_base_emitted then begin
+  if not !stapsdt_base_emitted
+  then (
     stapsdt_base_emitted := true;
     D.section [".stapsdt.base"] (Some "aG")
       ["\"progbits\""; ".stapsdt.base"; "comdat"];
@@ -2557,22 +2523,19 @@ let emit_stapsdt_base_section () =
     D.hidden "_.stapsdt.base";
     D.label "_.stapsdt.base";
     D.space 1;
-    D.size "_.stapsdt.base" (const 1)
-  end
+    D.size "_.stapsdt.base" (const 1))
 
 let emit_elf_note ~owner ~typ ~emit_desc =
   D.align ~data:true 4;
-  let a = new_label() in
-  let b = new_label() in
-  let c = new_label() in
-  let d = new_label() in
-  D.long (ConstSub (ConstLabel (emit_label b),
-                    ConstLabel(emit_label a)));
-  D.long (ConstSub (ConstLabel (emit_label d),
-                    ConstLabel (emit_label c)));
+  let a = new_label () in
+  let b = new_label () in
+  let c = new_label () in
+  let d = new_label () in
+  D.long (ConstSub (ConstLabel (emit_label b), ConstLabel (emit_label a)));
+  D.long (ConstSub (ConstLabel (emit_label d), ConstLabel (emit_label c)));
   D.long (const_32 typ);
   def_label a;
-  D.bytes (owner^"\000");
+  D.bytes (owner ^ "\000");
   def_label b;
   D.align ~data:true 4;
   def_label c;
@@ -2584,20 +2547,20 @@ let emit_probe_notes0 () =
   let is_macosx_system =
     match system with
     | S_macosx -> (* CR-someday gyorsh: emit dtrace format on mac *) true
-    | S_gnu | S_solaris | S_linux_elf | S_bsd_elf
-    | S_beos | S_linux  -> false
-    | S_cygwin | S_mingw | S_mingw64 | S_win64 | S_win32 | S_unknown
-    | S_freebsd| S_netbsd | S_openbsd ->
+    | S_gnu | S_solaris | S_linux_elf | S_bsd_elf | S_beos | S_linux -> false
+    | S_cygwin | S_mingw | S_mingw64 | S_win64 | S_win32 | S_unknown | S_freebsd
+    | S_netbsd | S_openbsd ->
       Misc.fatal_error "emit_probe_notes: unexpected system"
   in
   (match is_macosx_system with
-   | false -> D.section [".note.stapsdt"] (Some "?") [ "\"note\"" ]
-   | true -> D.section ["__DATA";"__note_stapsdt"] None ["regular"]);
+  | false -> D.section [".note.stapsdt"] (Some "?") ["\"note\""]
+  | true -> D.section ["__DATA"; "__note_stapsdt"] None ["regular"]);
   let stap_arg arg =
     let arg_name =
       match arg.loc with
       | Stack s ->
-        Printf.sprintf "%d(%%rsp)" (slot_offset s (Stack_class.of_machtype arg.Reg.typ))
+        Printf.sprintf "%d(%%rsp)"
+          (slot_offset s (Stack_class.of_machtype arg.Reg.typ))
       | Reg reg -> Proc.register_name arg.Reg.typ reg
       | Unknown ->
         Misc.fatal_errorf "Cannot create probe: illegal argument: %a"
@@ -2608,14 +2571,12 @@ let emit_probe_notes0 () =
   let describe_one_probe p =
     let probe_name, enabled_at_init =
       match p.probe_insn.desc with
-      | Lcall_op (Lprobe { name; enabled_at_init; handler_code_sym=_; }) ->
-         name, enabled_at_init
+      | Lcall_op (Lprobe { name; enabled_at_init; handler_code_sym = _ }) ->
+        name, enabled_at_init
       | _ -> assert false
     in
     let args =
-      Array.fold_right (fun arg acc -> (stap_arg arg)::acc)
-        p.probe_insn.arg
-        []
+      Array.fold_right (fun arg acc -> stap_arg arg :: acc) p.probe_insn.arg []
       |> String.concat " "
     in
     let semsym =
@@ -2625,50 +2586,48 @@ let emit_probe_notes0 () =
     let emit_desc () =
       D.qword (ConstLabel (emit_label p.probe_label));
       (match is_macosx_system with
-       | false -> D.qword (ConstLabel "_.stapsdt.base")
-       | true -> D.qword (const 0));
+      | false -> D.qword (ConstLabel "_.stapsdt.base")
+      | true -> D.qword (const 0));
       D.qword (ConstLabel semaphore_label);
       D.bytes "ocaml_1\000";
       D.bytes (probe_name ^ "\000");
       D.bytes (args ^ "\000")
     in
-    emit_elf_note ~owner:"stapsdt" ~typ:3l ~emit_desc;
+    emit_elf_note ~owner:"stapsdt" ~typ:3l ~emit_desc
   in
   List.iter describe_one_probe !probes;
   (match is_macosx_system with
-   | false ->
-     emit_stapsdt_base_section ();
-     D.section [".probes"] (Some "wa") ["\"progbits\""]
-   | true ->
-     D.section ["__TEXT";"__probes"] None ["regular"]);
+  | false ->
+    emit_stapsdt_base_section ();
+    D.section [".probes"] (Some "wa") ["\"progbits\""]
+  | true -> D.section ["__TEXT"; "__probes"] None ["regular"]);
   D.align ~data:true 2;
-  String.Map.iter (fun _ (label, enabled_at_init) ->
-      (* Unresolved weak symbols have a zero value regardless
-         of the following initialization. *)
+  String.Map.iter
+    (fun _ (label, enabled_at_init) ->
+      (* Unresolved weak symbols have a zero value regardless of the following
+         initialization. *)
       let enabled_at_init = Option.value enabled_at_init ~default:false in
       D.weak label;
       D.hidden label;
       _label label;
-      D.word (const 0); (* for systemtap probes *)
-      D.word (const (Bool.to_int enabled_at_init)); (* for ocaml probes *)
+      D.word (const 0);
+      (* for systemtap probes *)
+      D.word (const (Bool.to_int enabled_at_init));
+      (* for ocaml probes *)
       add_def_symbol label)
     !probe_semaphores
 
 let emit_probe_notes () =
-  match !probes with
-  | [] -> ()
-  | _ -> emit_probe_notes0 ()
+  match !probes with [] -> () | _ -> emit_probe_notes0 ()
 
 let emit_trap_notes () =
   (* Don't emit trap notes on windows and macos systems *)
   let is_system_supported =
     match system with
-    | S_macosx -> false  (* can be supported with a symbol *)
-    | S_gnu | S_solaris | S_linux_elf | S_bsd_elf
-    | S_beos | S_linux -> true
-    | S_cygwin | S_mingw | S_mingw64 | S_win64 | S_win32 | S_unknown ->
-      false
-    | S_freebsd| S_netbsd | S_openbsd ->
+    | S_macosx -> false (* can be supported with a symbol *)
+    | S_gnu | S_solaris | S_linux_elf | S_bsd_elf | S_beos | S_linux -> true
+    | S_cygwin | S_mingw | S_mingw64 | S_win64 | S_win32 | S_unknown -> false
+    | S_freebsd | S_netbsd | S_openbsd ->
       (* Probably works, as these are ELF-based, but untested. *)
       false
   in
@@ -2682,62 +2641,54 @@ let emit_trap_notes () =
     emit_labels traps.push_traps;
     emit_labels traps.pop_traps
   in
-  if is_system_supported && !Arch.trap_notes &&
-     not (Label.Set.is_empty traps.enter_traps) then begin
-    D.section [".note.ocaml_eh"] (Some "?") [ "\"note\"" ];
+  if is_system_supported && !Arch.trap_notes
+     && not (Label.Set.is_empty traps.enter_traps)
+  then (
+    D.section [".note.ocaml_eh"] (Some "?") ["\"note\""];
     emit_elf_note ~owner:"OCaml" ~typ:1l ~emit_desc;
     (* Reuse stapsdt base section for calcluating addresses after pre-link *)
     emit_stapsdt_base_section ();
     (* Switch back to Data section *)
-    D.data ()
-  end
+    D.data ())
 
 let end_assembly () =
-  if not (Misc.Stdlib.List.is_empty !float_constants) then begin
-    begin match system with
-    | S_macosx -> D.section ["__TEXT";"__literal8"] None ["8byte_literals"]
+  if not (Misc.Stdlib.List.is_empty !float_constants)
+  then (
+    (match system with
+    | S_macosx -> D.section ["__TEXT"; "__literal8"] None ["8byte_literals"]
     | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
     | S_win64 -> D.data ()
-    | _ -> D.section [".rodata.cst8"] (Some "aM") ["@progbits";"8"]
-    end;
+    | _ -> D.section [".rodata.cst8"] (Some "aM") ["@progbits"; "8"]);
     D.align ~data:true 8;
-    List.iter (fun (cst,lbl) -> emit_float_constant cst lbl) !float_constants;
-  end;
-  if not (Misc.Stdlib.List.is_empty !vec128_constants) then begin
-    begin match system with
-    | S_macosx -> D.section ["__TEXT";"__literal16"] None ["16byte_literals"]
+    List.iter (fun (cst, lbl) -> emit_float_constant cst lbl) !float_constants);
+  if not (Misc.Stdlib.List.is_empty !vec128_constants)
+  then (
+    (match system with
+    | S_macosx -> D.section ["__TEXT"; "__literal16"] None ["16byte_literals"]
     | S_mingw64 | S_cygwin -> D.section [".rdata"] (Some "dr") []
     | S_win64 -> D.data ()
-    | _ -> D.section [".rodata.cst16"] (Some "aM") ["@progbits";"16"]
-    end;
+    | _ -> D.section [".rodata.cst16"] (Some "aM") ["@progbits"; "16"]);
     D.align ~data:true 16;
-    List.iter (fun (cst,lbl) -> emit_vec128_constant cst lbl) !vec128_constants;
-  end;
-
+    List.iter (fun (cst, lbl) -> emit_vec128_constant cst lbl) !vec128_constants);
   (* Emit probe handler wrappers *)
   List.iter emit_probe_handler_wrapper !probes;
-
   emit_named_text_section (Cmm_helpers.make_symbol "jump_tables");
   emit_jump_tables ();
-
   let code_end = Cmm_helpers.make_symbol "code_end" in
   emit_named_text_section code_end;
   if is_macosx system then I.nop ();
   (* suppress "ld warning: atom sorting error" *)
-
   emit_global_label_for_symbol code_end;
-
-  emit_imp_table();
-
+  emit_imp_table ();
   D.data ();
-  D.qword (const 0);  (* PR#6329 *)
+  D.qword (const 0);
+  (* PR#6329 *)
   emit_global_label "data_end";
   D.qword (const 0);
-
   D.text ();
-  D.align ~data:true 8;                            (* PR#7591 *)
+  D.align ~data:true 8;
+  (* PR#7591 *)
   emit_global_label "frametable";
-
   let setcnt = ref 0 in
   emit_frames
     { efa_code_label = (fun l -> D.qword (ConstLabel (emit_label l)));
@@ -2749,62 +2700,52 @@ let end_assembly () =
       efa_align = D.align ~data:true;
       efa_label_rel =
         (fun lbl ofs ->
-           let c =
-             ConstAdd (
-               ConstSub(ConstLabel(emit_label lbl), ConstThis),
-               const_32 ofs
-             ) in
-           if is_macosx system then begin
-             incr setcnt;
-             let s = Printf.sprintf "L$set$%d" !setcnt in
-             D.setvar (s, c);
-             D.long (ConstLabel s)
-           end else
-             D.long c
-        );
+          let c =
+            ConstAdd
+              (ConstSub (ConstLabel (emit_label lbl), ConstThis), const_32 ofs)
+          in
+          if is_macosx system
+          then (
+            incr setcnt;
+            let s = Printf.sprintf "L$set$%d" !setcnt in
+            D.setvar (s, c);
+            D.long (ConstLabel s))
+          else D.long c);
       efa_def_label = (fun l -> _label (emit_label l));
       efa_string = (fun s -> D.bytes (s ^ "\000"))
     };
-
-  begin match system with
+  (match system with
   | S_linux | S_freebsd | S_netbsd | S_openbsd ->
     let frametable = emit_symbol (Cmm_helpers.make_symbol "frametable") in
     D.size frametable (ConstSub (ConstThis, ConstLabel frametable))
-  | _ -> ()
-  end;
-
+  | _ -> ());
   D.data ();
   emit_probe_notes ();
   emit_trap_notes ();
-
-  if is_linux system then
+  if is_linux system
+  then
     (* Mark stack as non-executable, PR#4564 *)
-    D.section [".note.GNU-stack"] (Some "") [ "%progbits" ];
-
-  if is_win64 system then begin
+    D.section [".note.GNU-stack"] (Some "") ["%progbits"];
+  if is_win64 system
+  then (
     D.comment "External functions";
     String.Set.iter
       (fun s ->
-         if not (String.Set.mem s !symbols_defined) then
-           D.extrn (emit_symbol s) NEAR)
+        if not (String.Set.mem s !symbols_defined)
+        then D.extrn (emit_symbol s) NEAR)
       !symbols_used;
     symbols_used := String.Set.empty;
-    symbols_defined := String.Set.empty;
-  end;
-
+    symbols_defined := String.Set.empty);
   let asm =
-    if !X86_proc.create_asm_file then
+    if !X86_proc.create_asm_file
+    then
       Some
-        (
-         (if X86_proc.masm then X86_masm.generate_asm
-          else X86_gas.generate_asm) !Emitaux.output_channel
-        )
-    else
-      None
+        ((if X86_proc.masm then X86_masm.generate_asm else X86_gas.generate_asm)
+           !Emitaux.output_channel)
+    else None
   in
-  if not !Flambda_backend_flags.internal_assembler then
-    Emitaux.Dwarf_helpers.emit_dwarf ();
+  if not !Flambda_backend_flags.internal_assembler
+  then Emitaux.Dwarf_helpers.emit_dwarf ();
   X86_proc.generate_code asm;
   (* The internal assembler does not work if reset_all is called here *)
-  if not !Flambda_backend_flags.internal_assembler then
-    reset_all ()
+  if not !Flambda_backend_flags.internal_assembler then reset_all ()

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -640,7 +640,7 @@ let output_test_zero arg =
 
 let emit_float_test (width : Cmm.float_width)
                     cmp i ~(taken:X86_ast.condition -> unit) =
-  (* Effect of comisd on flags and conditional branches:
+  (*= Effect of comisd on flags and conditional branches:
                      ZF PF CF  cond. branches taken
         unordered     1  1  1  je, jb, jbe, jp
         >             0  0  0  jne, jae, ja
@@ -2379,7 +2379,7 @@ let make_stack_loc ~offset n (r : Reg.t) =
 (* CR mshinwell: Not now, but after code review, it would be better to
    move this code so it's contiguous with the other probe code above. *)
 
-(* Calls to probe handler wrappers do not follow the standard calling
+(*= Calls to probe handler wrappers do not follow the standard calling
    convention for OCaml.  Instead, all registers are callee saved: the wrapper
    saves and restores all registers that are live across its (unique) call site.
 
@@ -2454,7 +2454,7 @@ let emit_probe_handler_wrapper p =
        name, handler_code_sym
     | _ -> assert false
   in
-  (* Restore stack frame info as it was at the probe site, so we can easily
+  (*= Restore stack frame info as it was at the probe site, so we can easily
      refer to slots in the corresponding frame.  (As per the comment above,
      recall that the wrapper does however have its own frame.) *)
   frame_required := true;
@@ -2472,7 +2472,7 @@ let emit_probe_handler_wrapper p =
     push rbp;
     I.mov rsp rbp;
   end;
-  (* Prepare to call the handler: calculate and allocate stack space.
+  (*= Prepare to call the handler: calculate and allocate stack space.
      Compute the size of stack slots for all live hard registers. *)
   let live =
     Reg.Set.elements p.probe_insn.live
@@ -2484,7 +2484,7 @@ let emit_probe_handler_wrapper p =
   let aux_offset = 8 (* for saving r15 *) in
   let tmp_offset = size_of_regs p.probe_insn.arg in
   let loc_args, loc_offset = Proc.loc_arguments (Reg.typv p.probe_insn.arg) in
-  (* Ensure the stack is aligned.
+  (*= Ensure the stack is aligned.
      Assuming that the stack at the probe site is 16-byte aligned,
      [loc_arguments] ensures that [loc_offset] is 16-byte aligned.
      All temporaries are 8 bytes long, the return address is already pushed,

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -179,7 +179,7 @@ end [@warning "-32"]  = struct
    ()
 
   (* See [Proc.int_reg_name]. *)
-  let int_reg_name_to_arch_index =
+  let[@ocamlformat "disable"] int_reg_name_to_arch_index =
   [| 0;  1;  2; 3; 4; 5; 6 ; 7;    (* 0 - 7 *)
      8; 9; 10; 11; 12; 13; 14; 15; (* 8 - 15 *)
      19; 20; 21; 22; 23; 24; 25;   (* 16 - 22 *)
@@ -525,6 +525,7 @@ type gc_call =
   { gc_lbl: label;                      (* Entry label *)
     gc_return_lbl: label;               (* Where to branch after GC *)
     gc_frame_lbl: label }               (* Label of frame descriptor *)
+[@@ocamlformat "disable"]
 
 let call_gc_sites = ref ([] : gc_call list)
 
@@ -1057,7 +1058,7 @@ let assembly_code_for_allocation i ~local ~n ~far ~dbginfo =
     if !fastcode_flag then begin
       let lbl_after_alloc = Cmm.new_label() in
       let lbl_call_gc = Cmm.new_label() in
-      (* n is at most Max_young_whsize * 8, i.e. currently 0x808,
+      (*= n is at most Max_young_whsize * 8, i.e. currently 0x808,
          so it is reasonable to assume n < 0x1_000.  This makes
          the generated code simpler. *)
       assert (16 <= n && n < 0x1_000 && n land 0x7 = 0);
@@ -1377,7 +1378,7 @@ let emit_instr i =
           DSL.ins I.BL [| DSL.emit_symbol "caml_c_call" |];
           record_frame i.live (Dbg_other i.dbg)
         end else begin
-          (* store ocaml stack in the frame pointer register
+          (*= store ocaml stack in the frame pointer register
              NB: no need to store previous x29 because OCaml frames don't
              maintain frame pointer *)
           if Config.runtime5 then begin
@@ -1684,7 +1685,7 @@ let emit_instr i =
         for j = 0 to Array.length jumptbl - 1 do
             DSL.ins I.B [| DSL.emit_label jumptbl.(j) |]
         done
-(* Alternative:
+(*= Alternative:
         let lbltbl = Cmm.new_label() in
         emit_printf "	adr	%a, %a\n" femit_reg reg_tmp1 femit_label lbltbl;
         emit_printf "	ldr	%a, [%a, %a, lsl #2]\n" femit_wreg reg_tmp2 femit_reg reg_tmp1 femit_reg i.arg.(0);

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -18,8 +18,8 @@
 (* Emission of ARM assembly code, 64-bit mode *)
 
 (* Correctness: carefully consider any use of [Config], [Clflags],
-   [Flambda_backend_flags] and shared variables.
-   For details, see [asmgen.mli]. *)
+   [Flambda_backend_flags] and shared variables. For details, see
+   [asmgen.mli]. *)
 
 (* CR-soon mshinwell/mslater: needs updating for locals + effects *)
 
@@ -30,7 +30,6 @@ open Reg
 open! Operation
 open Linear
 open Emitaux
-
 module I = Arm64_ast.Instruction_name
 
 (* Tradeoff between code size and code speed *)
@@ -40,21 +39,26 @@ let fastcode_flag = ref true
 (* Names for special regs *)
 
 let reg_domain_state_ptr = phys_reg Int 25 (* x28 *)
-let reg_trap_ptr = phys_reg Int 23 (* x26 *)
-let reg_alloc_ptr = phys_reg Int 24 (* x27 *)
-let reg_tmp1 = phys_reg Int 26 (* x16 *)
-let reg_x8 = phys_reg Int 8 (* x8 *)
-let reg_stack_arg_begin = phys_reg Int 17  (* x20 *)
-let reg_stack_arg_end  = phys_reg Int 18 (* x21 *)
 
+let reg_trap_ptr = phys_reg Int 23 (* x26 *)
+
+let reg_alloc_ptr = phys_reg Int 24 (* x27 *)
+
+let reg_tmp1 = phys_reg Int 26 (* x16 *)
+
+let reg_x8 = phys_reg Int 8 (* x8 *)
+
+let reg_stack_arg_begin = phys_reg Int 17 (* x20 *)
+
+let reg_stack_arg_end = phys_reg Int 18 (* x21 *)
 
 (* Output a label *)
 
-let label_prefix =
-  if macosx then "L" else ".L"
+let label_prefix = if macosx then "L" else ".L"
 
 let femit_label out lbl =
-    femit_string out label_prefix; femit_string out (Label.to_string lbl)
+  femit_string out label_prefix;
+  femit_string out (Label.to_string lbl)
 
 (* Symbols *)
 
@@ -67,19 +71,15 @@ let femit_symbol out s =
 (* Object types *)
 
 let emit_symbol_type emit_lbl_or_sym lbl_or_sym ty =
-  if not macosx then begin
-    emit_printf "	.type	%a, %%%a\n" emit_lbl_or_sym lbl_or_sym femit_string ty
-  end
-
+  if not macosx
+  then
+    emit_printf "\t.type\t%a, %%%a\n" emit_lbl_or_sym lbl_or_sym femit_string ty
 
 let emit_symbol_size sym =
-  if not macosx then begin
-    emit_printf "	.size	%a, .-%a\n" femit_symbol sym femit_symbol sym
-  end
-
+  if not macosx
+  then emit_printf "\t.size\t%a, .-%a\n" femit_symbol sym femit_symbol sym
 
 (* Likewise, but with the 32-bit name of the register *)
-
 
 (* Layout of the stack frame *)
 
@@ -92,13 +92,10 @@ let prologue_required = ref false
 let contains_calls = ref false
 
 let initial_stack_offset () =
-  Proc.initial_stack_offset ~contains_calls:!contains_calls
-    ~num_stack_slots
+  Proc.initial_stack_offset ~contains_calls:!contains_calls ~num_stack_slots
 
 let frame_size () =
-  Proc.frame_size
-    ~stack_offset:!stack_offset
-    ~contains_calls:!contains_calls
+  Proc.frame_size ~stack_offset:!stack_offset ~contains_calls:!contains_calls
     ~num_stack_slots
 
 let slot_offset loc stack_class =
@@ -114,69 +111,115 @@ let slot_offset loc stack_class =
 (* Output an addressing mode *)
 
 module DSL : sig
-
   val check_reg : Cmm.machtype_component -> Reg.t -> unit
 
   val mem : base:Arm64_ast.Reg.t -> Arm64_ast.Operand.t
+
   val mem_offset : base:Arm64_ast.Reg.t -> offset:int -> Arm64_ast.Operand.t
+
   val mem_pre : base:Arm64_ast.Reg.t -> offset:int -> Arm64_ast.Operand.t
+
   val mem_post : base:Arm64_ast.Reg.t -> offset:int -> Arm64_ast.Operand.t
+
   val cond : Arm64_ast.Instruction_name.Cond.t -> Arm64_ast.Operand.t
-  val float_cond : Arm64_ast.Instruction_name.Float_cond.t -> Arm64_ast.Operand.t
+
+  val float_cond :
+    Arm64_ast.Instruction_name.Float_cond.t -> Arm64_ast.Operand.t
 
   val emit_reg : Reg.t -> Arm64_ast.Operand.t
+
   val emit_reg_d : Reg.t -> Arm64_ast.Operand.t
+
   val emit_reg_s : Reg.t -> Arm64_ast.Operand.t
+
   val emit_reg_w : Reg.t -> Arm64_ast.Operand.t
+
   val emit_reg_v2d : Reg.t -> Arm64_ast.Operand.t
+
   val imm : int -> Arm64_ast.Operand.t
+
   val imm_float : float -> Arm64_ast.Operand.t
+
   val imm_nativeint : nativeint -> Arm64_ast.Operand.t
 
   (* some common registers *)
-  val sp: Arm64_ast.Operand.t
-  val xzr: Arm64_ast.Operand.t
-  val wzr: Arm64_ast.Operand.t
+  val sp : Arm64_ast.Operand.t
+
+  val xzr : Arm64_ast.Operand.t
+
+  val wzr : Arm64_ast.Operand.t
+
   val reg_x_30 : Arm64_ast.Operand.t
+
   val reg_x_29 : Arm64_ast.Operand.t
+
   val reg_s_7 : Arm64_ast.Operand.t
 
   (* translate registers before producing the operand *)
   val emit_mem : Reg.t -> Arm64_ast.Operand.t
-  val emit_mem_offset : Reg.t -> int -> Arm64_ast.Operand.t
-  val emit_mem_pre : Reg.t -> int -> Arm64_ast.Operand.t
-  val emit_mem_post : Reg.t -> int -> Arm64_ast.Operand.t
-  val emit_mem_sp_offset : int -> Arm64_ast.Operand.t
-  val emit_addressing : addressing_mode -> Reg.t -> Arm64_ast.Operand.t
-  val emit_mem_symbol : ?offset:int -> ?reloc:Arm64_ast.Symbol.reloc_directive -> Reg.t -> string -> Arm64_ast.Operand.t
-  val emit_mem_label : ?offset:int -> ?reloc:Arm64_ast.Symbol.reloc_directive -> Reg.t -> label -> Arm64_ast.Operand.t
 
-  val emit_shift : Arm64_ast.Operand.Shift.Kind.t -> int ->  Arm64_ast.Operand.t
+  val emit_mem_offset : Reg.t -> int -> Arm64_ast.Operand.t
+
+  val emit_mem_pre : Reg.t -> int -> Arm64_ast.Operand.t
+
+  val emit_mem_post : Reg.t -> int -> Arm64_ast.Operand.t
+
+  val emit_mem_sp_offset : int -> Arm64_ast.Operand.t
+
+  val emit_addressing : addressing_mode -> Reg.t -> Arm64_ast.Operand.t
+
+  val emit_mem_symbol :
+    ?offset:int ->
+    ?reloc:Arm64_ast.Symbol.reloc_directive ->
+    Reg.t ->
+    string ->
+    Arm64_ast.Operand.t
+
+  val emit_mem_label :
+    ?offset:int ->
+    ?reloc:Arm64_ast.Symbol.reloc_directive ->
+    Reg.t ->
+    label ->
+    Arm64_ast.Operand.t
+
+  val emit_shift : Arm64_ast.Operand.Shift.Kind.t -> int -> Arm64_ast.Operand.t
 
   (* Output a stack reference *)
   val emit_stack : Reg.t -> Arm64_ast.Operand.t
-  val emit_label : ?offset:int -> ?reloc:Arm64_ast.Symbol.reloc_directive -> label -> Arm64_ast.Operand.t
-  val emit_symbol : ?offset:int -> ?reloc:Arm64_ast.Symbol.reloc_directive -> string -> Arm64_ast.Operand.t
-  val emit_immediate_symbol : ?offset:int -> ?reloc:Arm64_ast.Symbol.reloc_directive -> string -> Arm64_ast.Operand.t
+
+  val emit_label :
+    ?offset:int ->
+    ?reloc:Arm64_ast.Symbol.reloc_directive ->
+    label ->
+    Arm64_ast.Operand.t
+
+  val emit_symbol :
+    ?offset:int ->
+    ?reloc:Arm64_ast.Symbol.reloc_directive ->
+    string ->
+    Arm64_ast.Operand.t
+
+  val emit_immediate_symbol :
+    ?offset:int ->
+    ?reloc:Arm64_ast.Symbol.reloc_directive ->
+    string ->
+    Arm64_ast.Operand.t
+
   val ins : I.t -> Arm64_ast.Operand.t array -> unit
+
   val labeled_ins : label -> I.t -> Arm64_ast.Operand.t array -> unit
 
-
   val simd_instr : Simd.operation -> Linear.instruction -> unit
-  val simd_instr_size : Simd.operation -> int
 
-end [@warning "-32"]  = struct
+  val simd_instr_size : Simd.operation -> int
+end [@warning "-32"] = struct
   include Arm64_ast.DSL
 
-
-
-
-
   let check_reg typ reg =
-   (* same type and not on stack *)
-   assert (Cmm.equal_machtype_component typ reg.typ);
-   assert (Reg.is_reg reg);
-   ()
+    (* same type and not on stack *)
+    assert (Cmm.equal_machtype_component typ reg.typ);
+    assert (Reg.is_reg reg);
+    ()
 
   (* See [Proc.int_reg_name]. *)
   let[@ocamlformat "disable"] int_reg_name_to_arch_index =
@@ -184,36 +227,32 @@ end [@warning "-32"]  = struct
      8; 9; 10; 11; 12; 13; 14; 15; (* 8 - 15 *)
      19; 20; 21; 22; 23; 24; 25;   (* 16 - 22 *)
      26; 27; 28;                   (* 23 - 25 *)
-     16; 17; |]                    (* 26 - 27 *)
+     16; 17; |]
+  (* 26 - 27 *)
 
   let reg_name_to_arch_index reg_class name_index =
     match reg_class with
-    | 0  (* general-purpose registers *) -> int_reg_name_to_arch_index.(name_index)
-    | 1  (* neon registers *) -> name_index
+    | 0 (* general-purpose registers *) ->
+      int_reg_name_to_arch_index.(name_index)
+    | 1 (* neon registers *) -> name_index
     | _ -> assert false
 
   let reg_index reg =
     match reg with
-    | {loc = Reg r; _} ->
+    | { loc = Reg r; _ } ->
       let reg_class = Proc.register_class reg in
       let name_index = r - Proc.first_available_register.(reg_class) in
       reg_name_to_arch_index reg_class name_index
-    | {loc = (Stack _ | Unknown); _}  -> fatal_error "Emit.reg"
-
+    | { loc = Stack _ | Unknown; _ } -> fatal_error "Emit.reg"
 
   let translate_reg reg =
     let index = reg_index reg in
     (* use machtype to select register name *)
     match reg.typ with
-    | Val | Int | Addr ->
-      Arm64_ast.Reg.reg_x index
-    | Float ->
-      Arm64_ast.Reg.reg_d index
-    | Float32 ->
-      Arm64_ast.Reg.reg_s index
-    | Vec128
-    | Valx2 ->
-      Arm64_ast.Reg.reg_q index
+    | Val | Int | Addr -> Arm64_ast.Reg.reg_x index
+    | Float -> Arm64_ast.Reg.reg_d index
+    | Float32 -> Arm64_ast.Reg.reg_s index
+    | Vec128 | Valx2 -> Arm64_ast.Reg.reg_q index
 
   let emit_reg_v2s reg = reg_v2s (reg_index reg)
 
@@ -231,60 +270,57 @@ end [@warning "-32"]  = struct
     let index = reg_index reg in
     (* use machtype to select register name *)
     match reg.typ with
-    | Val | Int | Addr ->
-      reg_x index
-    | Float ->
-      reg_d index
-    | Float32 ->
-      reg_s index
-    | Vec128
-    | Valx2 ->
-      reg_q index
+    | Val | Int | Addr -> reg_x index
+    | Float -> reg_d index
+    | Float32 -> reg_s index
+    | Vec128 | Valx2 -> reg_q index
 
   let reg_x_30 = reg_x 30
+
   let reg_x_29 = reg_x 29
+
   let reg_s_7 = reg_s 7
 
-  let convert_symbol_representation (s: string) =
-    if macosx then "_" ^ Emitaux.symbol_to_string s else Emitaux.symbol_to_string s
+  let convert_symbol_representation (s : string) =
+    if macosx
+    then "_" ^ Emitaux.symbol_to_string s
+    else Emitaux.symbol_to_string s
 
-  let convert_label_representation (lbl: label) =
+  let convert_label_representation (lbl : label) =
     label_prefix ^ Label.to_string lbl
 
-  let emit_label ?offset ?reloc (s: label) =
+  let emit_label ?offset ?reloc (s : label) =
     let l = convert_label_representation s in
     symbol (Arm64_ast.Symbol.create ?offset ?reloc l)
 
-  let emit_symbol ?offset ?reloc (s: string)  =
+  let emit_symbol ?offset ?reloc (s : string) =
     let sym = convert_symbol_representation s in
     symbol (Arm64_ast.Symbol.create ?offset ?reloc sym)
 
-  let emit_immediate_symbol ?offset ?reloc (s: string)  =
+  let emit_immediate_symbol ?offset ?reloc (s : string) =
     let sym = convert_symbol_representation s in
     symbol (Arm64_ast.Symbol.create ?offset ?reloc sym)
 
-  let emit_mem r =
-    mem ~base:(translate_reg r)
+  let emit_mem r = mem ~base:(translate_reg r)
 
-  let emit_mem_offset r ofs =
-    mem_offset ~base:(translate_reg r) ~offset:ofs
+  let emit_mem_offset r ofs = mem_offset ~base:(translate_reg r) ~offset:ofs
 
-  let emit_mem_pre r ofs =
-    mem_pre ~base:(translate_reg r) ~offset:ofs
+  let emit_mem_pre r ofs = mem_pre ~base:(translate_reg r) ~offset:ofs
 
-  let emit_mem_post r ofs =
-    mem_post ~base:(translate_reg r) ~offset:ofs
+  let emit_mem_post r ofs = mem_post ~base:(translate_reg r) ~offset:ofs
 
-  let emit_mem_sp_offset ofs =
-    mem_offset ~base:Arm64_ast.Reg.sp ~offset:ofs
+  let emit_mem_sp_offset ofs = mem_offset ~base:Arm64_ast.Reg.sp ~offset:ofs
 
   let emit_addressing addr r =
     match addr with
-    | Iindexed ofs ->
-      mem_offset ~base:(translate_reg r) ~offset:ofs
-    | Ibased(s, ofs) ->
-      assert (not !Clflags.dlcode);  (* see selection.ml *)
-      let sym = Arm64_ast.Symbol.create ~reloc:LOWER_TWELVE ~offset:ofs (convert_symbol_representation s) in
+    | Iindexed ofs -> mem_offset ~base:(translate_reg r) ~offset:ofs
+    | Ibased (s, ofs) ->
+      assert (not !Clflags.dlcode);
+      (* see selection.ml *)
+      let sym =
+        Arm64_ast.Symbol.create ~reloc:LOWER_TWELVE ~offset:ofs
+          (convert_symbol_representation s)
+      in
       mem_symbol ~base:(translate_reg r) ~symbol:sym
 
   let emit_mem_symbol ?offset ?reloc r s =
@@ -297,39 +333,34 @@ end [@warning "-32"]  = struct
     let base = translate_reg r in
     mem_symbol ~base ~symbol:(Arm64_ast.Symbol.create ?offset ?reloc sym)
 
-  let emit_stack (r: Reg.t) =
+  let emit_stack (r : Reg.t) =
     match r.loc with
     | Stack (Domainstate n) ->
-        let ofs = n + Domainstate.(idx_of_field Domain_extra_params) * 8 in
-        mem_offset ~base:(translate_reg reg_domain_state_ptr) ~offset:ofs
+      let ofs = n + (Domainstate.(idx_of_field Domain_extra_params) * 8) in
+      mem_offset ~base:(translate_reg reg_domain_state_ptr) ~offset:ofs
     | Stack ((Local _ | Incoming _ | Outgoing _) as s) ->
-        let ofs = slot_offset s (Stack_class.of_machtype r.typ) in
-        emit_mem_sp_offset ofs
+      let ofs = slot_offset s (Stack_class.of_machtype r.typ) in
+      emit_mem_sp_offset ofs
     | Reg _ | Unknown -> fatal_error "Emit.emit_stack"
 
   let emit_shift kind amount = shift ~kind ~amount
 
   let check_instr (register_behavior : Simd_proc.register_behavior) i =
-    (* Ensure that operation size and register size match.
-       On arm64, operation size is encoded solely into the operands
-       (unlike amd64 where the opcode itself usually indicates operation size). *)
+    (* Ensure that operation size and register size match. On arm64, operation
+       size is encoded solely into the operands (unlike amd64 where the opcode
+       itself usually indicates operation size). *)
     match register_behavior with
     | Rf32x2_Rf32x2_to_Rf32x2 ->
       (* float32x2 is represented as Float machtype *)
       check_reg Float i.arg.(0);
       check_reg Float i.arg.(1);
-      check_reg Float i.res.(0);
-    | Rf32x4_Rf32x4_to_Ri32x4
-    | Rf32x4_Rf32x4_to_Rf32x4
-    | Rf64x2_Rf64x2_to_Rf64x2
-    | Ri64x2_Ri64x2_to_Ri64x2  ->
+      check_reg Float i.res.(0)
+    | Rf32x4_Rf32x4_to_Ri32x4 | Rf32x4_Rf32x4_to_Rf32x4
+    | Rf64x2_Rf64x2_to_Rf64x2 | Ri64x2_Ri64x2_to_Ri64x2 ->
       check_reg Vec128 i.arg.(0);
       check_reg Vec128 i.arg.(1);
-      check_reg Vec128 i.res.(0);
-    | Ri32x4_to_Ri32x4
-    | Rf32x2_to_Rf64x2
-    | Rf32x4_to_Rf32x4
-    | Rf32x4_to_Ri32x4
+      check_reg Vec128 i.res.(0)
+    | Ri32x4_to_Ri32x4 | Rf32x2_to_Rf64x2 | Rf32x4_to_Rf32x4 | Rf32x4_to_Ri32x4
     | Ri32x4_to_Rf32x4 ->
       check_reg Vec128 i.arg.(0);
       check_reg Vec128 i.res.(0)
@@ -351,17 +382,15 @@ end [@warning "-32"]  = struct
       check_reg Float32 i.arg.(0);
       check_reg Int i.res.(0)
 
-
   let src_operands ops =
-    (* returns a copy of [ops] without the first operand, which is assumed to be the
-       destination operand. *)
+    (* returns a copy of [ops] without the first operand, which is assumed to be
+       the destination operand. *)
     Array.sub ops 1 (Array.length ops - 1)
 
   let emit_regs_binary i =
     [| emit_reg i.res.(0); emit_reg i.arg.(0); emit_reg i.arg.(1) |]
 
-  let emit_regs_unary i =
-    [| emit_reg i.res.(0); emit_reg i.arg.(0); |]
+  let emit_regs_unary i = [| emit_reg i.res.(0); emit_reg i.arg.(0) |]
 
   let ins name ops = print_ins name ops |> Emitaux.emit_string
 
@@ -369,46 +398,51 @@ end [@warning "-32"]  = struct
     Emitaux.emit_printf "%s:" (convert_label_representation lbl);
     print_ins name ops |> Emitaux.emit_string
 
-  let ins_cond name cond ops = print_ins_cond name cond ops |> Emitaux.emit_string
+  let ins_cond name cond ops =
+    print_ins_cond name cond ops |> Emitaux.emit_string
 
   let emit_operands (register_behavior : Simd_proc.register_behavior) i =
     match register_behavior with
     | Rf32x2_Rf32x2_to_Rf32x2 ->
-      (* Special case: f32 argument is represented by machtype Float (to avoid classifying
-         it as a reinterpret cast), and uses vector f32x2 register in the instruction
-         encoding. *)
-      [| emit_reg_v2s i.res.(0); emit_reg_v2s i.arg.(0); emit_reg_v2s i.arg.(1)|]
+      (* Special case: f32 argument is represented by machtype Float (to avoid
+         classifying it as a reinterpret cast), and uses vector f32x2 register
+         in the instruction encoding. *)
+      [| emit_reg_v2s i.res.(0);
+         emit_reg_v2s i.arg.(0);
+         emit_reg_v2s i.arg.(1)
+      |]
     | Rf32x4_Rf32x4_to_Rf32x4 ->
-      [| emit_reg_v4s i.res.(0); emit_reg_v4s i.arg.(0); emit_reg_v4s i.arg.(1)|]
-    | Ri64x2_Ri64x2_to_Ri64x2
-    | Rf64x2_Rf64x2_to_Rf64x2 ->
-      [| emit_reg_v2d i.res.(0); emit_reg_v2d i.arg.(0); emit_reg_v2d i.arg.(1)|]
+      [| emit_reg_v4s i.res.(0);
+         emit_reg_v4s i.arg.(0);
+         emit_reg_v4s i.arg.(1)
+      |]
+    | Ri64x2_Ri64x2_to_Ri64x2 | Rf64x2_Rf64x2_to_Rf64x2 ->
+      [| emit_reg_v2d i.res.(0);
+         emit_reg_v2d i.arg.(0);
+         emit_reg_v2d i.arg.(1)
+      |]
     | Rf32x4_Rf32x4_to_Ri32x4 ->
-      [| emit_reg_v4s i.res.(0); emit_reg_v4s i.arg.(0); emit_reg_v4s i.arg.(1)|]
-    | Ri32x4_to_Ri32x4
-    | Rf32x4_to_Rf32x4
-    | Rf32x4_to_Ri32x4
-    | Ri32x4_to_Rf32x4 ->
-      [| emit_reg_v4s i.res.(0); emit_reg_v4s i.arg.(0); |]
-    | Rf32x2_to_Rf64x2 ->
-      [| emit_reg_v2d i.res.(0); emit_reg_v2s i.arg.(0); |]
-    | Rf32_Rf32_to_Rf32
-    | Rf64_Rf64_to_Rf64 ->
-      emit_regs_binary i
-    | Rf64_to_Rf64
-    | Rf32_to_Rf32
-    | Rf32_to_Ri64 ->
-      emit_regs_unary i
+      [| emit_reg_v4s i.res.(0);
+         emit_reg_v4s i.arg.(0);
+         emit_reg_v4s i.arg.(1)
+      |]
+    | Ri32x4_to_Ri32x4 | Rf32x4_to_Rf32x4 | Rf32x4_to_Ri32x4 | Ri32x4_to_Rf32x4
+      ->
+      [| emit_reg_v4s i.res.(0); emit_reg_v4s i.arg.(0) |]
+    | Rf32x2_to_Rf64x2 -> [| emit_reg_v2d i.res.(0); emit_reg_v2s i.arg.(0) |]
+    | Rf32_Rf32_to_Rf32 | Rf64_Rf64_to_Rf64 -> emit_regs_binary i
+    | Rf64_to_Rf64 | Rf32_to_Rf32 | Rf32_to_Ri64 -> emit_regs_unary i
 
-  let simd_instr_size (op : Simd.operation)  =
+  let simd_instr_size (op : Simd.operation) =
     match op with
     | Min_scalar_f64 | Max_scalar_f64 -> 2
     | Min_scalar_f32 | Max_scalar_f32 -> 2
-    | Round_f32 _ | Round_f64 _ | Round_f32x4 _ | Round_f32_i64
-    | Zip1_f32 | Zip1q_f32 | Zip1q_f64 | Zip2q_f64
-    | Addq_f32|Subq_f32|Mulq_f32|Divq_f32|Minq_f32|Maxq_f32|Recpeq_f32|Sqrtq_f32
-    | Rsqrteq_f32| Cvtq_s32_of_f32|Cvtq_f32_of_s32|Cvt_f64_f32|Paddq_f32
-    | Fmin_f32 | Fmax_f32 | Addq_i64 | Subq_i64 | Cmp_f32 _ | Cmpz_s32 _ -> 1
+    | Round_f32 _ | Round_f64 _ | Round_f32x4 _ | Round_f32_i64 | Zip1_f32
+    | Zip1q_f32 | Zip1q_f64 | Zip2q_f64 | Addq_f32 | Subq_f32 | Mulq_f32
+    | Divq_f32 | Minq_f32 | Maxq_f32 | Recpeq_f32 | Sqrtq_f32 | Rsqrteq_f32
+    | Cvtq_s32_of_f32 | Cvtq_f32_of_s32 | Cvt_f64_f32 | Paddq_f32 | Fmin_f32
+    | Fmax_f32 | Addq_i64 | Subq_i64 | Cmp_f32 _ | Cmpz_s32 _ ->
+      1
 
   let emit_rounding_mode (rm : Simd.Rounding_mode.t) : I.Rounding_mode.t =
     match rm with
@@ -431,48 +465,32 @@ end [@warning "-32"]  = struct
     | LS -> LS
     | HI -> HI
 
-
   let emit_cond (cond : Simd.Cond.t) : I.Cond.t =
-    match cond with
-    | EQ -> EQ
-    | GT -> GT
-    | GE -> GE
-    | LE -> LE
-    | LT -> LT
+    match cond with EQ -> EQ | GT -> GT | GE -> GE | LE -> LE | LT -> LT
 
   let simd_instr (op : Simd.operation) i =
     let b = Simd_proc.register_behavior op in
     check_instr b i;
     let operands = emit_operands b i in
     match op with
-    (* min/max: generate a sequence that matches the weird semantics of amd64 instruction
-       "minss", even when the flag [FPCR.AH] is not set. A separate intrinsics generates
-       fmin/fmax arm64 instructions directly. *)
-    | Min_scalar_f32
-    | Min_scalar_f64 ->
+    (* min/max: generate a sequence that matches the weird semantics of amd64
+       instruction "minss", even when the flag [FPCR.AH] is not set. A separate
+       intrinsics generates fmin/fmax arm64 instructions directly. *)
+    | Min_scalar_f32 | Min_scalar_f64 ->
       ins I.FCMP (src_operands operands);
-      ins_cond I.FCSEL I.Cond.MI operands;
-    | Max_scalar_f32
-    | Max_scalar_f64 ->
+      ins_cond I.FCSEL I.Cond.MI operands
+    | Max_scalar_f32 | Max_scalar_f64 ->
       ins I.FCMP (src_operands operands);
-      ins_cond I.FCSEL I.Cond.GT operands;
+      ins_cond I.FCSEL I.Cond.GT operands
     | Round_f32 rm | Round_f64 rm | Round_f32x4 rm ->
       ins (I.FRINT (emit_rounding_mode rm)) operands
-    | Round_f32_i64 ->
-      ins I.FCVTNS operands
-    | Fmin_f32 ->
-      ins I.FMIN operands
-    | Fmax_f32 ->
-      ins I.FMAX operands
-    | Zip1_f32    | Zip1q_f32
-    | Zip1q_f64  ->
-      ins I.ZIP1 operands
-    | Zip2q_f64  ->
-      ins I.ZIP2 operands
-    | Addq_i64 ->
-      ins I.ADD operands
-    | Subq_i64 ->
-      ins I.SUB operands
+    | Round_f32_i64 -> ins I.FCVTNS operands
+    | Fmin_f32 -> ins I.FMIN operands
+    | Fmax_f32 -> ins I.FMAX operands
+    | Zip1_f32 | Zip1q_f32 | Zip1q_f64 -> ins I.ZIP1 operands
+    | Zip2q_f64 -> ins I.ZIP2 operands
+    | Addq_i64 -> ins I.ADD operands
+    | Subq_i64 -> ins I.SUB operands
     | Addq_f32 -> ins I.FADD operands
     | Subq_f32 -> ins I.FSUB operands
     | Mulq_f32 -> ins I.FMUL operands
@@ -487,7 +505,7 @@ end [@warning "-32"]  = struct
     | Cvt_f64_f32 -> ins I.FCVTL operands
     | Paddq_f32 -> ins I.FADDP operands
     | Cmp_f32 c -> ins (I.FCM (emit_float_cond c)) operands
-    | Cmpz_s32 c -> ins (I.CM (emit_cond c)) (Array.append operands [| imm 0; |])
+    | Cmpz_s32 c -> ins (I.CM (emit_cond c)) (Array.append operands [| imm 0 |])
 end
 
 (* Record live pointers at call points *)
@@ -497,27 +515,26 @@ let record_frame_label live dbg =
   let live_offset = ref [] in
   Reg.Set.iter
     (function
-      | {typ = Val; loc = Reg r} ->
-          live_offset := ((r lsl 1) + 1) :: !live_offset
-      | {typ = Val; loc = Stack s} as reg ->
-          live_offset := slot_offset s (Stack_class.of_machtype reg.typ) :: !live_offset
-      | {typ = Addr} as r ->
-          Misc.fatal_error ("bad GC root " ^ Reg.name r)
-      | { typ = Valx2; } as r ->
-          (* CR mslater: (SIMD) arm64 *)
-          Misc.fatal_error ("Unexpected Valx2 type of reg " ^ Reg.name r)
-      | { typ = Val; loc = Unknown ; } as r ->
-          Misc.fatal_error ("Unknown location " ^ Reg.name r)
+      | { typ = Val; loc = Reg r } ->
+        live_offset := ((r lsl 1) + 1) :: !live_offset
+      | { typ = Val; loc = Stack s } as reg ->
+        live_offset
+          := slot_offset s (Stack_class.of_machtype reg.typ) :: !live_offset
+      | { typ = Addr } as r -> Misc.fatal_error ("bad GC root " ^ Reg.name r)
+      | { typ = Valx2 } as r ->
+        (* CR mslater: (SIMD) arm64 *)
+        Misc.fatal_error ("Unexpected Valx2 type of reg " ^ Reg.name r)
+      | { typ = Val; loc = Unknown } as r ->
+        Misc.fatal_error ("Unknown location " ^ Reg.name r)
       | { typ = Int | Float | Float32 | Vec128; _ } -> ())
     live;
-  record_frame_descr ~label:lbl ~frame_size:(frame_size())
+  record_frame_descr ~label:lbl ~frame_size:(frame_size ())
     ~live_offset:!live_offset dbg;
   lbl
 
 let record_frame live dbg =
   let lbl = record_frame_label live dbg in
   emit_printf "%a:\n" femit_label lbl
-
 
 (* Record calls to the GC -- we've moved them out of the way *)
 
@@ -536,54 +553,69 @@ let emit_call_gc gc =
 (* Record calls to local stack reallocation *)
 
 type local_realloc_call =
-  { lr_lbl: label;
-    lr_return_lbl: label;
-    lr_dbg: Debuginfo.t
+  { lr_lbl : label;
+    lr_return_lbl : label;
+    lr_dbg : Debuginfo.t
   }
 
 let local_realloc_sites = ref ([] : local_realloc_call list)
 
 let emit_local_realloc lr =
   emit_printf "%a:\n" femit_label lr.lr_lbl;
-  emit_printf "	%a\n" (femit_debug_info ~discriminator: 0) lr.lr_dbg;
+  emit_printf "\t%a\n" (femit_debug_info ~discriminator:0) lr.lr_dbg;
   DSL.ins I.BL [| DSL.emit_symbol "caml_call_local_realloc" |];
   DSL.ins I.B [| DSL.emit_label lr.lr_return_lbl |]
 
 (* Local stack reallocation *)
 
-type stack_realloc = {
-  sc_label : Label.t; (* Label of the reallocation code. *)
-  sc_return : Label.t; (* Label to return to after reallocation. *)
-  sc_max_frame_size_in_bytes : int; (* Size for reallocation. *)
-}
+type stack_realloc =
+  { sc_label : Label.t; (* Label of the reallocation code. *)
+    sc_return : Label.t; (* Label to return to after reallocation. *)
+    sc_max_frame_size_in_bytes : int (* Size for reallocation. *)
+  }
 
 let stack_realloc = ref (None : stack_realloc option)
 
-let clear_stack_realloc () =
-  stack_realloc := None
-
+let clear_stack_realloc () = stack_realloc := None
 
 let emit_stack_realloc () =
   match !stack_realloc with
   | None -> ()
-  | Some { sc_label; sc_return; sc_max_frame_size_in_bytes; } ->
+  | Some { sc_label; sc_return; sc_max_frame_size_in_bytes } ->
     emit_printf "%a:\n" femit_label sc_label;
     (* Pass the desired frame size on the stack, since all of the
        argument-passing registers may be in use. *)
-    DSL.ins I.MOV [| DSL.emit_reg reg_tmp1; DSL.imm sc_max_frame_size_in_bytes|];
-    DSL.ins I.STP [| DSL.emit_reg reg_tmp1; DSL.reg_x_30; DSL.mem_pre ~base:Arm64_ast.Reg.sp ~offset:(-16) |];
+    DSL.ins I.MOV
+      [| DSL.emit_reg reg_tmp1; DSL.imm sc_max_frame_size_in_bytes |];
+    DSL.ins I.STP
+      [| DSL.emit_reg reg_tmp1;
+         DSL.reg_x_30;
+         DSL.mem_pre ~base:Arm64_ast.Reg.sp ~offset:(-16)
+      |];
     DSL.ins I.BL [| DSL.emit_symbol "caml_call_realloc_stack" |];
-    DSL.ins I.LDP [| DSL.emit_reg reg_tmp1; DSL.reg_x_30; DSL.mem_post ~base:Arm64_ast.Reg.sp ~offset:16 |];
+    DSL.ins I.LDP
+      [| DSL.emit_reg reg_tmp1;
+         DSL.reg_x_30;
+         DSL.mem_post ~base:Arm64_ast.Reg.sp ~offset:16
+      |];
     DSL.ins I.B [| DSL.emit_label sc_return |]
 
 (* Names of various instructions *)
 
-let cond_for_comparison : integer_comparison -> Arm64_ast.Instruction_name.Cond.t =
-  function
-  | Isigned Ceq -> EQ | Isigned Cne -> NE | Isigned Cle -> LE
-  | Isigned Cge -> GE | Isigned Clt -> LT | Isigned Cgt -> GT
-  | Iunsigned Ceq -> EQ | Iunsigned Cne -> NE | Iunsigned Cle -> LS
-  | Iunsigned Cge -> CS | Iunsigned Clt -> CC | Iunsigned Cgt -> HI
+let cond_for_comparison :
+    integer_comparison -> Arm64_ast.Instruction_name.Cond.t = function
+  | Isigned Ceq -> EQ
+  | Isigned Cne -> NE
+  | Isigned Cle -> LE
+  | Isigned Cge -> GE
+  | Isigned Clt -> LT
+  | Isigned Cgt -> GT
+  | Iunsigned Ceq -> EQ
+  | Iunsigned Cne -> NE
+  | Iunsigned Cle -> LS
+  | Iunsigned Cge -> CS
+  | Iunsigned Clt -> CC
+  | Iunsigned Cgt -> HI
 
 let instr_for_int_operation = function
   | Iadd -> I.ADD
@@ -591,68 +623,69 @@ let instr_for_int_operation = function
   | Imul -> I.MUL
   | Idiv -> I.SDIV
   | Iand -> I.AND
-  | Ior  -> I.ORR
+  | Ior -> I.ORR
   | Ixor -> I.EOR
   | Ilsl -> I.LSL
   | Ilsr -> I.LSR
   | Iasr -> I.ASR
   | Iclz { arg_is_non_zero = _ } -> I.CLZ
   | Ipopcnt -> I.CNT
-  | Ictz _ | Icomp _ | Imod | Imulh _-> assert false
+  | Ictz _ | Icomp _ | Imod | Imulh _ -> assert false
 
-(* Decompose an integer constant into four 16-bit shifted fragments.
-   Omit the fragments that are equal to "default" (16 zeros or 16 ones). *)
+(* Decompose an integer constant into four 16-bit shifted fragments. Omit the
+   fragments that are equal to "default" (16 zeros or 16 ones). *)
 
 let decompose_int default n =
   let rec decomp n pos =
-    if pos >= 64 then [] else begin
+    if pos >= 64
+    then []
+    else
       let frag = Nativeint.logand n 0xFFFFn
-      and rem  = Nativeint.shift_right_logical n 16 in
+      and rem = Nativeint.shift_right_logical n 16 in
       if frag = default
       then decomp rem (pos + 16)
       else (frag, pos) :: decomp rem (pos + 16)
-    end
-  in decomp n 0
+  in
+  decomp n 0
 
 (* Load an integer constant into a register *)
 
 let emit_movk dst (f, p) =
-    DSL.ins I.MOVK [| DSL.emit_reg dst; DSL.imm_nativeint f; DSL.emit_shift LSL p |]
+  DSL.ins I.MOVK
+    [| DSL.emit_reg dst; DSL.imm_nativeint f; DSL.emit_shift LSL p |]
 
 let emit_intconst dst n =
-  if is_logical_immediate n then
-    DSL.ins I.ORR [| DSL.emit_reg dst; DSL.xzr; DSL.imm_nativeint n |]
-  else begin
-    let dz = decompose_int 0x0000n n
-    and dn = decompose_int 0xFFFFn n in
-    if List.length dz <= List.length dn then begin
+  if is_logical_immediate n
+  then DSL.ins I.ORR [| DSL.emit_reg dst; DSL.xzr; DSL.imm_nativeint n |]
+  else
+    let dz = decompose_int 0x0000n n and dn = decompose_int 0xFFFFn n in
+    if List.length dz <= List.length dn
+    then (
       match dz with
-      | [] ->
-          DSL.ins I.MOV [| DSL.emit_reg dst; DSL.xzr |]
+      | [] -> DSL.ins I.MOV [| DSL.emit_reg dst; DSL.xzr |]
       | (f, p) :: l ->
-          DSL.ins I.MOVZ [| DSL.emit_reg dst; DSL.imm_nativeint f; DSL.emit_shift LSL p |];
-          List.iter (emit_movk dst) l
-    end else begin
+        DSL.ins I.MOVZ
+          [| DSL.emit_reg dst; DSL.imm_nativeint f; DSL.emit_shift LSL p |];
+        List.iter (emit_movk dst) l)
+    else
       match dn with
-      | [] ->
-          DSL.ins I.MOVN [| DSL.emit_reg dst; DSL.imm 0 |];
+      | [] -> DSL.ins I.MOVN [| DSL.emit_reg dst; DSL.imm 0 |]
       | (f, p) :: l ->
-          let nf = Nativeint.logxor f 0xFFFFn in
-          DSL.ins I.MOVN [| DSL.emit_reg dst; DSL.imm_nativeint nf; DSL.emit_shift LSL p |];
-          List.iter (emit_movk dst) l
-    end
-  end
+        let nf = Nativeint.logxor f 0xFFFFn in
+        DSL.ins I.MOVN
+          [| DSL.emit_reg dst; DSL.imm_nativeint nf; DSL.emit_shift LSL p |];
+        List.iter (emit_movk dst) l
 
 let num_instructions_for_intconst n =
-  if is_logical_immediate n then 1 else begin
-    let dz = decompose_int 0x0000n n
-    and dn = decompose_int 0xFFFFn n in
+  if is_logical_immediate n
+  then 1
+  else
+    let dz = decompose_int 0x0000n n and dn = decompose_int 0xFFFFn n in
     max 1 (min (List.length dz) (List.length dn))
-  end
 
-(* Recognize float constants appropriate for FMOV dst, #fpimm instruction:
-   "a normalized binary floating point encoding with 1 sign bit, 4
-    bits of fraction and a 3-bit exponent" *)
+(* Recognize float constants appropriate for FMOV dst, #fpimm instruction: "a
+   normalized binary floating point encoding with 1 sign bit, 4 bits of fraction
+   and a 3-bit exponent" *)
 
 let is_immediate_float bits =
   let exp = (Int64.(to_int (shift_right_logical bits 52)) land 0x7FF) - 1023 in
@@ -675,44 +708,43 @@ let emit_stack_adjustment n =
   if ml <> 0 then DSL.ins instr [| DSL.sp; DSL.sp; DSL.imm ml |];
   if n <> 0 then cfi_adjust_cfa_offset (-n)
 
-(* Deallocate the stack frame and reload the return address
-   before a return or tail call *)
+(* Deallocate the stack frame and reload the return address before a return or
+   tail call *)
 
 let output_epilogue f =
-  let n = frame_size() in
-  if !contains_calls then
-    DSL.ins I.LDR [| DSL.reg_x_30; DSL.emit_mem_sp_offset (n - 8)|];
-  if n > 0 then
-    emit_stack_adjustment n;
-  f();
+  let n = frame_size () in
+  if !contains_calls
+  then DSL.ins I.LDR [| DSL.reg_x_30; DSL.emit_mem_sp_offset (n - 8) |];
+  if n > 0 then emit_stack_adjustment n;
+  f ();
   (* reset CFA back because function body may continue *)
   if n > 0 then cfi_adjust_cfa_offset n
 
 (* Output add-immediate / sub-immediate / cmp-immediate instructions *)
 
 let rec emit_addimm rd rs n =
-  if n < 0 then emit_subimm rd rs (-n)
-  else if n <= 0xFFF then
-    DSL.ins I.ADD [| DSL.emit_reg rd; DSL.emit_reg rs; DSL.imm n |]
-  else begin
+  if n < 0
+  then emit_subimm rd rs (-n)
+  else if n <= 0xFFF
+  then DSL.ins I.ADD [| DSL.emit_reg rd; DSL.emit_reg rs; DSL.imm n |]
+  else (
     assert (n <= 0xFFF_FFF);
     let nl = n land 0xFFF and nh = n land 0xFFF_000 in
     DSL.ins I.ADD [| DSL.emit_reg rd; DSL.emit_reg rs; DSL.imm nh |];
-    if nl <> 0 then
-      DSL.ins I.ADD [| DSL.emit_reg rd; DSL.emit_reg rd; DSL.imm nl |]
-  end
+    if nl <> 0
+    then DSL.ins I.ADD [| DSL.emit_reg rd; DSL.emit_reg rd; DSL.imm nl |])
 
 and emit_subimm rd rs n =
-  if n < 0 then emit_addimm rd rs (-n)
-  else if n <= 0xFFF then
-    DSL.ins I.SUB [| DSL.emit_reg rd; DSL.emit_reg rs; DSL.imm n |]
-  else begin
+  if n < 0
+  then emit_addimm rd rs (-n)
+  else if n <= 0xFFF
+  then DSL.ins I.SUB [| DSL.emit_reg rd; DSL.emit_reg rs; DSL.imm n |]
+  else (
     assert (n <= 0xFFF_FFF);
     let nl = n land 0xFFF and nh = n land 0xFFF_000 in
     DSL.ins I.SUB [| DSL.emit_reg rd; DSL.emit_reg rs; DSL.imm nh |];
-    if nl <> 0 then
-      DSL.ins I.SUB [| DSL.emit_reg rd; DSL.emit_reg rd; DSL.imm nl |]
-  end
+    if nl <> 0
+    then DSL.ins I.SUB [| DSL.emit_reg rd; DSL.emit_reg rd; DSL.imm nl |])
 
 let emit_cmpimm rs n =
   if n >= 0
@@ -721,41 +753,47 @@ let emit_cmpimm rs n =
 
 (* Name of current function *)
 let function_name = ref ""
+
 (* Entry point for tail recursive calls *)
 let tailrec_entry_point = ref None
+
 (* Pending floating-point literals *)
 let float_literals = ref ([] : (int64 * label) list)
+
 let vec128_literals = ref ([] : (Cmm.vec128_bits * label) list)
 
 (* Label a floating-point literal *)
 let add_literal p f =
-  try
-    List.assoc f !p
+  try List.assoc f !p
   with Not_found ->
-    let lbl = Cmm.new_label() in
+    let lbl = Cmm.new_label () in
     p := (f, lbl) :: !p;
     lbl
 
 let float_literal f = add_literal float_literals f
+
 let vec128_literal f = add_literal vec128_literals f
 
 (* Emit all pending literals *)
 let emit_literals p align emit_literal =
-  if !p <> [] then begin
-    if macosx then
-    emit_printf "	.section	__TEXT,__literal%a,%abyte_literals\n" femit_int align femit_int align;
-    emit_printf "	.balign	%a\n" femit_int align;
+  if !p <> []
+  then (
+    if macosx
+    then
+      emit_printf "\t.section\t__TEXT,__literal%a,%abyte_literals\n" femit_int
+        align femit_int align;
+    emit_printf "\t.balign\t%a\n" femit_int align;
     List.iter emit_literal !p;
-    p := []
-  end
+    p := [])
 
 let emit_float_literal (f, lbl) =
-     emit_printf "%a:" femit_label lbl; emit_float64_directive ".quad" f
+  emit_printf "%a:" femit_label lbl;
+  emit_float64_directive ".quad" f
 
-let emit_vec128_literal (({ high; low; } : Cmm.vec128_bits), lbl) =
-     emit_printf "%a:\n" femit_label lbl;
-     emit_float64_directive ".quad" low;
-     emit_float64_directive ".quad" high
+let emit_vec128_literal (({ high; low } : Cmm.vec128_bits), lbl) =
+  emit_printf "%a:\n" femit_label lbl;
+  emit_float64_directive ".quad" low;
+  emit_float64_directive ".quad" high
 
 let emit_literals () =
   emit_literals float_literals size_float emit_float_literal;
@@ -764,20 +802,27 @@ let emit_literals () =
 (* Emit code to load the address of a symbol *)
 
 let emit_load_symbol_addr dst s =
-  if macosx then begin
+  if macosx
+  then (
     DSL.ins I.ADRP [| DSL.emit_reg dst; DSL.emit_symbol s ~reloc:GOT_PAGE |];
-    DSL.ins I.LDR [| DSL.emit_reg dst; DSL.emit_mem_symbol ~reloc:GOT_PAGE_OFF dst s |]
-  end else if not !Clflags.dlcode then begin
+    DSL.ins I.LDR
+      [| DSL.emit_reg dst; DSL.emit_mem_symbol ~reloc:GOT_PAGE_OFF dst s |])
+  else if not !Clflags.dlcode
+  then (
     DSL.ins I.ADRP [| DSL.emit_reg dst; DSL.emit_symbol s |];
-    DSL.ins I.ADD [| DSL.emit_reg dst; DSL.emit_reg dst; DSL.emit_immediate_symbol ~reloc:LOWER_TWELVE s |]
-  end else begin
+    DSL.ins I.ADD
+      [| DSL.emit_reg dst;
+         DSL.emit_reg dst;
+         DSL.emit_immediate_symbol ~reloc:LOWER_TWELVE s
+      |])
+  else (
     DSL.ins I.ADRP [| DSL.emit_reg dst; DSL.emit_symbol ~reloc:GOT s |];
-    DSL.ins I.LDR [| DSL.emit_reg dst; DSL.emit_mem_symbol ~reloc:GOT_LOWER_TWELVE dst s |]
-  end
+    DSL.ins I.LDR
+      [| DSL.emit_reg dst; DSL.emit_mem_symbol ~reloc:GOT_LOWER_TWELVE dst s |])
 
-(* The following functions are used for calculating the sizes of the
-   call GC and bounds check points emitted out-of-line from the function
-   body.  See branch_relaxation.mli. *)
+(* The following functions are used for calculating the sizes of the call GC and
+   bounds check points emitted out-of-line from the function body. See
+   branch_relaxation.mli. *)
 
 let num_call_gc_points instr =
   let rec loop instr call_gc =
@@ -785,108 +830,123 @@ let num_call_gc_points instr =
     | Lend -> call_gc
     | Lop (Alloc { mode = Heap; _ }) when !fastcode_flag ->
       loop instr.next (call_gc + 1)
-    | Lop Poll ->
-      loop instr.next (call_gc + 1)
+    | Lop Poll -> loop instr.next (call_gc + 1)
     (* The following four should never be seen, since this function is run
        before branch relaxation. *)
-    | Lop (Specific (Ifar_alloc _))
-    | Lop (Specific Ifar_poll) -> assert false
-    | Lop (Alloc { mode = (Local | Heap); _ })
-    | Lop (Specific
-             (Imuladd|Imulsub|Inegmulf|Imuladdf|Inegmuladdf|Imulsubf|Inegmulsubf|
-              Isqrtf|Imove32|Ishiftarith (_, _)|Ibswap _|Isignext _|Isimd _))
-    | Lop (Move|Spill|Reload|Opaque|Begin_region|End_region|Dls_get|Const_int _|
-           Const_float32 _|Const_float _|Const_symbol _|Const_vec128 _|Stackoffset _|
-           Load _|Store (_, _, _)|Intop _|Intop_imm (_, _)|Intop_atomic _|
-           Floatop (_, _)|Csel _|Reinterpret_cast _|Static_cast _|Probe_is_enabled _|
-           Name_for_debugger _)
-    | Lprologue|Lreloadretaddr|Lreturn|Lentertrap|Lpoptrap|Lcall_op _|Llabel _|
-    Lbranch _|Lcondbranch (_, _)|Lcondbranch3 (_, _, _)|Lswitch _|
-    Ladjust_stack_offset _|Lpushtrap _|Lraise _|Lstackcheck _
-      -> loop instr.next call_gc
+    | Lop (Specific (Ifar_alloc _)) | Lop (Specific Ifar_poll) -> assert false
+    | Lop (Alloc { mode = Local | Heap; _ })
+    | Lop
+        (Specific
+          ( Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf | Imulsubf
+          | Inegmulsubf | Isqrtf | Imove32
+          | Ishiftarith (_, _)
+          | Ibswap _ | Isignext _ | Isimd _ ))
+    | Lop
+        ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
+        | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+        | Const_vec128 _ | Stackoffset _ | Load _
+        | Store (_, _, _)
+        | Intop _
+        | Intop_imm (_, _)
+        | Intop_atomic _
+        | Floatop (_, _)
+        | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
+        | Name_for_debugger _ )
+    | Lprologue | Lreloadretaddr | Lreturn | Lentertrap | Lpoptrap | Lcall_op _
+    | Llabel _ | Lbranch _
+    | Lcondbranch (_, _)
+    | Lcondbranch3 (_, _, _)
+    | Lswitch _ | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _
+    | Lstackcheck _ ->
+      loop instr.next call_gc
   in
   loop instr 0
 
 let max_out_of_line_code_offset ~num_call_gc =
-  if num_call_gc < 1 then 0
-  else begin
+  if num_call_gc < 1
+  then 0
+  else
     let size_of_call_gc = 2 in
     let size_of_last_thing = size_of_call_gc in
-    let total_size = size_of_call_gc*num_call_gc in
+    let total_size = size_of_call_gc * num_call_gc in
     let max_offset = total_size - size_of_last_thing in
     assert (max_offset >= 0);
     max_offset
-  end
 
 module BR = Branch_relaxation.Make (struct
   (* CR-someday mshinwell: B and BL have +/- 128Mb ranges; for the moment we
-     assume we will never exceed this.  It would seem to be most likely to
-     occur for branches between functions; in this case, the linker should be
-     able to insert veneers anyway.  (See section 4.6.7 of the document
-     "ELF for the ARM 64-bit architecture (AArch64)".) *)
+     assume we will never exceed this. It would seem to be most likely to occur
+     for branches between functions; in this case, the linker should be able to
+     insert veneers anyway. (See section 4.6.7 of the document "ELF for the ARM
+     64-bit architecture (AArch64)".) *)
 
   type distance = int
 
   module Cond_branch = struct
-    type t = TB | CB | Bcc
+    type t =
+      | TB
+      | CB
+      | Bcc
 
     let all = [TB; CB; Bcc]
 
-    (* AArch64 instructions are 32 bits wide, so [distance] in this module
-       means units of 32-bit words. *)
+    (* AArch64 instructions are 32 bits wide, so [distance] in this module means
+       units of 32-bit words. *)
     let max_displacement = function
-      | TB -> 32 * 1024 / 4  (* +/- 32Kb *)
-      | CB | Bcc -> 1 * 1024 * 1024 / 4  (* +/- 1Mb *)
+      | TB -> 32 * 1024 / 4 (* +/- 32Kb *)
+      | CB | Bcc -> 1 * 1024 * 1024 / 4 (* +/- 1Mb *)
 
     let classify_instr = function
-      | Lop (Alloc _)
-      | Lop Poll -> Some Bcc
-      (* The various "far" variants in [specific_operation] don't need to
-         return [Some] here, since their code sequences never contain any
-         conditional branches that might need relaxing. *)
-      | Lcondbranch (Itruetest, _)
-      | Lcondbranch (Ifalsetest, _) -> Some CB
+      | Lop (Alloc _) | Lop Poll -> Some Bcc
+      (* The various "far" variants in [specific_operation] don't need to return
+         [Some] here, since their code sequences never contain any conditional
+         branches that might need relaxing. *)
+      | Lcondbranch (Itruetest, _) | Lcondbranch (Ifalsetest, _) -> Some CB
       | Lcondbranch (Iinttest _, _)
       | Lcondbranch (Iinttest_imm _, _)
-      | Lcondbranch (Ifloattest _, _) -> Some Bcc
-      | Lcondbranch (Ioddtest, _)
-      | Lcondbranch (Ieventest, _) -> Some TB
+      | Lcondbranch (Ifloattest _, _) ->
+        Some Bcc
+      | Lcondbranch (Ioddtest, _) | Lcondbranch (Ieventest, _) -> Some TB
       | Lcondbranch3 _ -> Some Bcc
-      | Lop (Specific _|Move|Spill|Reload|Opaque|Begin_region|End_region
-            |Dls_get|Const_int _|
-            Const_float32 _|Const_float _|Const_symbol _|Const_vec128 _|Stackoffset _|
-            Load _|Store (_, _, _)|Intop _|Intop_imm (_, _)|Intop_atomic _|
-            Floatop (_, _)|Csel _|Reinterpret_cast _|Static_cast _|Probe_is_enabled _|
-            Name_for_debugger _)
-      | Lprologue|Lend|Lreloadretaddr|Lreturn|Lentertrap|Lpoptrap|Lcall_op _
-      | Llabel _|Lbranch _|Lswitch _|Ladjust_stack_offset _|Lpushtrap _|Lraise _
-      |Lstackcheck _
-        -> None
+      | Lop
+          ( Specific _ | Move | Spill | Reload | Opaque | Begin_region
+          | End_region | Dls_get | Const_int _ | Const_float32 _ | Const_float _
+          | Const_symbol _ | Const_vec128 _ | Stackoffset _ | Load _
+          | Store (_, _, _)
+          | Intop _
+          | Intop_imm (_, _)
+          | Intop_atomic _
+          | Floatop (_, _)
+          | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
+          | Name_for_debugger _ )
+      | Lprologue | Lend | Lreloadretaddr | Lreturn | Lentertrap | Lpoptrap
+      | Lcall_op _ | Llabel _ | Lbranch _ | Lswitch _ | Ladjust_stack_offset _
+      | Lpushtrap _ | Lraise _ | Lstackcheck _ ->
+        None
   end
 
   let offset_pc_at_branch = 0
 
   let prologue_size () =
     (if initial_stack_offset () > 0 then 2 else 0)
-      + (if !contains_calls then 1 else 0)
+    + if !contains_calls then 1 else 0
 
-  let epilogue_size () =
-    if !contains_calls then 3 else 2
+  let epilogue_size () = if !contains_calls then 3 else 2
 
   let memory_access_size (memory_chunk : Cmm.memory_chunk) =
     match memory_chunk with
     | Single { reg = Float64 } -> 2
     | Single { reg = Float32 } -> 1
-    | Byte_unsigned|Byte_signed|Sixteen_unsigned|Sixteen_signed|
-      Thirtytwo_unsigned|Thirtytwo_signed|Word_int|Word_val|Double|
-      Onetwentyeight_unaligned|Onetwentyeight_aligned -> 1
+    | Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
+    | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val | Double
+    | Onetwentyeight_unaligned | Onetwentyeight_aligned ->
+      1
 
   let instr_size = function
     | Lend -> 0
     | Lprologue -> prologue_size ()
     | Lop (Move | Spill | Reload) -> 1
-    | Lop (Const_int n) ->
-      num_instructions_for_intconst n
+    | Lop (Const_int n) -> num_instructions_for_intconst n
     | Lop (Const_float32 _) -> 2
     | Lop (Const_float _) -> 2
     | Lop (Const_vec128 _) -> 2
@@ -894,17 +954,18 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Intop_atomic _) ->
       (* Never generated; builtins are not yet translated to atomics *)
       assert false
-    | Lcall_op (Lcall_ind) -> 1
+    | Lcall_op Lcall_ind -> 1
     | Lcall_op (Lcall_imm _) -> 1
-    | Lcall_op (Ltailcall_ind) -> epilogue_size ()
+    | Lcall_op Ltailcall_ind -> epilogue_size ()
     | Lcall_op (Ltailcall_imm { func; _ }) ->
       if func.sym_name = !function_name then 1 else epilogue_size ()
-    | Lcall_op (Lextcall {alloc; stack_ofs; func=_; ty_res=_; ty_args=_; returns=_; } ) ->
-      if Config.runtime5 && stack_ofs > 0 then 5
-      else if alloc then 3
-      else 5
+    | Lcall_op
+        (Lextcall
+          { alloc; stack_ofs; func = _; ty_res = _; ty_args = _; returns = _ })
+      ->
+      if Config.runtime5 && stack_ofs > 0 then 5 else if alloc then 3 else 5
     | Lop (Stackoffset _) -> 2
-    | Lop (Load  { memory_chunk; addressing_mode; is_atomic; mutability=_ }) ->
+    | Lop (Load { memory_chunk; addressing_mode; is_atomic; mutability = _ }) ->
       let based = match addressing_mode with Iindexed _ -> 0 | Ibased _ -> 1
       and barrier = if is_atomic then 1 else 0
       and single = memory_access_size memory_chunk in
@@ -915,22 +976,23 @@ module BR = Branch_relaxation.Make (struct
         match memory_chunk, assignment with
         | (Word_int | Word_val), true -> 1
         | (Word_int | Word_val), false -> 0
-        | (Byte_unsigned|Byte_signed|Sixteen_unsigned|Sixteen_signed|
-           Thirtytwo_unsigned|Thirtytwo_signed|Single _|Double|
-           Onetwentyeight_unaligned|Onetwentyeight_aligned),_ -> 0
+        | ( ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
+            | Thirtytwo_unsigned | Thirtytwo_signed | Single _ | Double
+            | Onetwentyeight_unaligned | Onetwentyeight_aligned ),
+            _ ) ->
+          0
       and single = memory_access_size memory_chunk in
       based + barrier + single
     | Lop (Alloc { mode = Local; _ }) -> 9
-    | Lop (Alloc { mode = Heap;_ }) when !fastcode_flag -> 5
+    | Lop (Alloc { mode = Heap; _ }) when !fastcode_flag -> 5
     | Lop (Specific (Ifar_alloc _)) when !fastcode_flag -> 6
     | Lop Poll -> 3
     | Lop (Specific Ifar_poll) -> 4
     | Lop (Alloc { mode = Heap; bytes = num_bytes; _ })
-    | Lop (Specific (Ifar_alloc { bytes = num_bytes; _ })) ->
-      begin match num_bytes with
+    | Lop (Specific (Ifar_alloc { bytes = num_bytes; _ })) -> (
+      match num_bytes with
       | 16 | 24 | 32 -> 1
-      | _ -> 1 + num_instructions_for_intconst (Nativeint.of_int num_bytes)
-      end
+      | _ -> 1 + num_instructions_for_intconst (Nativeint.of_int num_bytes))
     | Lop (Csel _) -> 4
     | Lop (Begin_region | End_region) -> 1
     | Lop (Intop (Icomp _)) -> 2
@@ -941,80 +1003,97 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Intop (Imulh _)) -> 1
     | Lop (Intop (Iclz _)) -> 1
     | Lop (Intop (Ictz _)) -> 2
-    | Lop (Intop (Iadd|Isub|Imul|Idiv|Iand|Ior|Ixor|Ilsl|Ilsr|Iasr|Ipopcnt)) -> 1
-    | Lop (Intop_imm
-             ((Iadd|Isub|Imul|Idiv|Imod|Imulh _|Iand|Ior|Ixor|Ilsl|Ilsr|Iasr
-              | Iclz _ | Ictz _ |Ipopcnt),_)) -> 1
+    | Lop
+        (Intop
+          ( Iadd | Isub | Imul | Idiv | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr
+          | Ipopcnt )) ->
+      1
+    | Lop
+        (Intop_imm
+          ( ( Iadd | Isub | Imul | Idiv | Imod | Imulh _ | Iand | Ior | Ixor
+            | Ilsl | Ilsr | Iasr | Iclz _ | Ictz _ | Ipopcnt ),
+            _ )) ->
+      1
     | Lop (Floatop (Float64, (Iabsf | Inegf))) -> 1
     | Lop (Floatop (Float32, (Iabsf | Inegf))) -> 1
     | Lop (Specific Isqrtf) -> 1
-    | Lop (Reinterpret_cast (Value_of_int | Int_of_value |
-                              Float_of_int64 | Int64_of_float)) -> 1
-    | Lop (Reinterpret_cast (Float32_of_float | Float_of_float32 |
-                              Float32_of_int32 | Int32_of_float32)) -> 1
+    | Lop
+        (Reinterpret_cast
+          (Value_of_int | Int_of_value | Float_of_int64 | Int64_of_float)) ->
+      1
+    | Lop
+        (Reinterpret_cast
+          ( Float32_of_float | Float_of_float32 | Float32_of_int32
+          | Int32_of_float32 )) ->
+      1
     | Lop (Reinterpret_cast V128_of_v128) -> 1
     | Lop (Static_cast (Float_of_int Float64 | Int_of_float Float64)) -> 1
-    | Lop (Static_cast (Float_of_int Float32 | Int_of_float Float32 |
-                         Float_of_float32 | Float32_of_float)) -> 1
+    | Lop
+        (Static_cast
+          ( Float_of_int Float32
+          | Int_of_float Float32
+          | Float_of_float32 | Float32_of_float )) ->
+      1
     | Lop (Static_cast (Scalar_of_v128 (Int8x16 | Int16x8))) -> 2
-    | Lop (Static_cast (Scalar_of_v128 (Int32x4 | Int64x2 | Float32x4 | Float64x2))) -> 1
-    | Lop (Static_cast (V128_of_scalar _ )) -> 1
+    | Lop
+        (Static_cast
+          (Scalar_of_v128 (Int32x4 | Int64x2 | Float32x4 | Float64x2))) ->
+      1
+    | Lop (Static_cast (V128_of_scalar _)) -> 1
     | Lop (Floatop (Float64, (Iaddf | Isubf | Imulf | Idivf))) -> 1
     | Lop (Floatop (Float32, (Iaddf | Isubf | Imulf | Idivf))) -> 1
     | Lop (Specific Inegmulf) -> 1
-    | Lop (Opaque) -> 0
+    | Lop Opaque -> 0
     | Lop (Specific (Imuladdf | Inegmuladdf | Imulsubf | Inegmulsubf)) -> 1
     | Lop (Specific (Ishiftarith _)) -> 1
     | Lop (Specific (Imuladd | Imulsub)) -> 1
-    | Lop (Specific (Ibswap { bitwidth = Sixteen } )) -> 2
-    | Lop (Specific (Ibswap { bitwidth = (Thirtytwo | Sixtyfour) })) -> 1
+    | Lop (Specific (Ibswap { bitwidth = Sixteen })) -> 2
+    | Lop (Specific (Ibswap { bitwidth = Thirtytwo | Sixtyfour })) -> 1
     | Lop (Specific Imove32) -> 1
     | Lop (Specific (Isignext _)) -> 1
     | Lop (Name_for_debugger _) -> 0
     | Lcall_op (Lprobe _) | Lop (Probe_is_enabled _) ->
-      fatal_error ("Probes not supported.")
-    | Lop (Dls_get) -> 1
+      fatal_error "Probes not supported."
+    | Lop Dls_get -> 1
     | Lreloadretaddr -> 0
     | Lreturn -> epilogue_size ()
     | Llabel _ -> 0
     | Lbranch _ -> 1
-    | Lcondbranch (tst, _) ->
-      begin match tst with
+    | Lcondbranch (tst, _) -> (
+      match tst with
       | Itruetest -> 1
       | Ifalsetest -> 1
       | Iinttest _ -> 2
       | Iinttest_imm _ -> 2
       | Ifloattest _ -> 2
       | Ioddtest -> 1
-      | Ieventest -> 1
-      end
-    | Lcondbranch3 (lbl0, lbl1, lbl2) ->
-      1 + begin match lbl0 with None -> 0 | Some _ -> 1 end
-        + begin match lbl1 with None -> 0 | Some _ -> 1 end
-        + begin match lbl2 with None -> 0 | Some _ -> 1 end
+      | Ieventest -> 1)
+    | Lcondbranch3 (lbl0, lbl1, lbl2) -> (
+      1
+      + (match lbl0 with None -> 0 | Some _ -> 1)
+      + (match lbl1 with None -> 0 | Some _ -> 1)
+      + match lbl2 with None -> 0 | Some _ -> 1)
     | Lswitch jumptbl -> 3 + Array.length jumptbl
     | Lentertrap -> 0
     | Ladjust_stack_offset _ -> 0
     | Lpushtrap _ -> 4
     | Lpoptrap -> 1
-    | Lraise k ->
-      begin match k with
+    | Lraise k -> (
+      match k with
       | Lambda.Raise_regular -> 1
       | Lambda.Raise_reraise -> 1
-      | Lambda.Raise_notrace -> 4
-      end
+      | Lambda.Raise_notrace -> 4)
     | Lstackcheck _ -> 5
-    | Lop (Specific (Isimd simd)) ->
-      DSL.simd_instr_size simd
+    | Lop (Specific (Isimd simd)) -> DSL.simd_instr_size simd
 
-  let relax_poll () =
-    Lop (Specific Ifar_poll)
+  let relax_poll () = Lop (Specific Ifar_poll)
 
   let relax_allocation ~num_bytes ~dbginfo =
     Lop (Specific (Ifar_alloc { bytes = num_bytes; dbginfo }))
 end)
 
-let cond_for_float_comparison : Cmm.float_comparison -> Arm64_ast.Instruction_name.Float_cond.t = function
+let cond_for_float_comparison :
+    Cmm.float_comparison -> Arm64_ast.Instruction_name.Float_cond.t = function
   | CFeq -> EQ
   | CFneq -> NE
   | CFlt -> CC
@@ -1029,663 +1108,835 @@ let cond_for_float_comparison : Cmm.float_comparison -> Arm64_ast.Instruction_na
 (* Output the assembly code for allocation. *)
 
 let assembly_code_for_allocation i ~local ~n ~far ~dbginfo =
-  if local then begin
+  if local
+  then (
     let r = i.res.(0) in
     let module DS = Domainstate in
     let domain_local_sp_offset = DS.(idx_of_field Domain_local_sp) * 8 in
     let domain_local_limit_offset = DS.(idx_of_field Domain_local_limit) * 8 in
     let domain_local_top_offset = DS.(idx_of_field Domain_local_top) * 8 in
-    DSL.ins I.LDR [| DSL.emit_reg reg_tmp1; DSL.emit_addressing (Iindexed domain_local_limit_offset) reg_domain_state_ptr |];
-    DSL.ins I.LDR [| DSL.emit_reg  r; DSL.emit_addressing (Iindexed domain_local_sp_offset) reg_domain_state_ptr |];
+    DSL.ins I.LDR
+      [| DSL.emit_reg reg_tmp1;
+         DSL.emit_addressing (Iindexed domain_local_limit_offset)
+           reg_domain_state_ptr
+      |];
+    DSL.ins I.LDR
+      [| DSL.emit_reg r;
+         DSL.emit_addressing (Iindexed domain_local_sp_offset)
+           reg_domain_state_ptr
+      |];
     emit_subimm r r n;
-    DSL.ins I.STR [| DSL.emit_reg  r; DSL.emit_addressing (Iindexed domain_local_sp_offset) reg_domain_state_ptr |];
+    DSL.ins I.STR
+      [| DSL.emit_reg r;
+         DSL.emit_addressing (Iindexed domain_local_sp_offset)
+           reg_domain_state_ptr
+      |];
     DSL.ins I.CMP [| DSL.emit_reg r; DSL.emit_reg reg_tmp1 |];
     let lbl_call = Cmm.new_label () in
     DSL.ins (I.B_cond LT) [| DSL.emit_label lbl_call |];
     let lbl_after_alloc = Cmm.new_label () in
     emit_printf "%a:\n" femit_label lbl_after_alloc;
-    DSL.ins I.LDR [| DSL.emit_reg reg_tmp1; DSL.emit_addressing (Iindexed domain_local_top_offset) reg_domain_state_ptr |];
+    DSL.ins I.LDR
+      [| DSL.emit_reg reg_tmp1;
+         DSL.emit_addressing (Iindexed domain_local_top_offset)
+           reg_domain_state_ptr
+      |];
     DSL.ins I.ADD [| DSL.emit_reg r; DSL.emit_reg r; DSL.emit_reg reg_tmp1 |];
     DSL.ins I.ADD [| DSL.emit_reg r; DSL.emit_reg r; DSL.imm 8 |];
-    local_realloc_sites :=
-      { lr_lbl = lbl_call;
-        lr_dbg = i.dbg;
-        lr_return_lbl = lbl_after_alloc } :: !local_realloc_sites
-  end else begin
-    let lbl_frame =
-      record_frame_label i.live (Dbg_alloc dbginfo)
-    in
-    if !fastcode_flag then begin
-      let lbl_after_alloc = Cmm.new_label() in
-      let lbl_call_gc = Cmm.new_label() in
+    local_realloc_sites
+      := { lr_lbl = lbl_call; lr_dbg = i.dbg; lr_return_lbl = lbl_after_alloc }
+         :: !local_realloc_sites)
+  else
+    let lbl_frame = record_frame_label i.live (Dbg_alloc dbginfo) in
+    if !fastcode_flag
+    then (
+      let lbl_after_alloc = Cmm.new_label () in
+      let lbl_call_gc = Cmm.new_label () in
       (*= n is at most Max_young_whsize * 8, i.e. currently 0x808,
          so it is reasonable to assume n < 0x1_000.  This makes
          the generated code simpler. *)
       assert (16 <= n && n < 0x1_000 && n land 0x7 = 0);
       let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
-      DSL.ins I.LDR [| DSL.emit_reg reg_tmp1; DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr |];
+      DSL.ins I.LDR
+        [| DSL.emit_reg reg_tmp1;
+           DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr
+        |];
       emit_subimm reg_alloc_ptr reg_alloc_ptr n;
       DSL.ins I.CMP [| DSL.emit_reg reg_alloc_ptr; DSL.emit_reg reg_tmp1 |];
-      if not far then begin
-        DSL.ins (I.B_cond CC) [| DSL.emit_label lbl_call_gc |]
-      end else begin
+      (if not far
+      then DSL.ins (I.B_cond CC) [| DSL.emit_label lbl_call_gc |]
+      else
         let lbl = Cmm.new_label () in
         DSL.ins (I.B_cond CS) [| DSL.emit_label lbl |];
         DSL.ins I.B [| DSL.emit_label lbl_call_gc |];
-        emit_printf "%a:\n" femit_label lbl
-      end;
-      DSL.labeled_ins lbl_after_alloc I.ADD [| DSL.emit_reg i.res.(0); DSL.emit_reg reg_alloc_ptr; DSL.imm 8 |];
-      call_gc_sites :=
-        { gc_lbl = lbl_call_gc;
-          gc_return_lbl = lbl_after_alloc;
-          gc_frame_lbl = lbl_frame } :: !call_gc_sites
-    end else begin
-      begin match n with
+        emit_printf "%a:\n" femit_label lbl);
+      DSL.labeled_ins lbl_after_alloc I.ADD
+        [| DSL.emit_reg i.res.(0); DSL.emit_reg reg_alloc_ptr; DSL.imm 8 |];
+      call_gc_sites
+        := { gc_lbl = lbl_call_gc;
+             gc_return_lbl = lbl_after_alloc;
+             gc_frame_lbl = lbl_frame
+           }
+           :: !call_gc_sites)
+    else (
+      (match n with
       | 16 -> DSL.ins I.BL [| DSL.emit_symbol "caml_alloc1" |]
       | 24 -> DSL.ins I.BL [| DSL.emit_symbol "caml_alloc2" |]
       | 32 -> DSL.ins I.BL [| DSL.emit_symbol "caml_alloc3" |]
-      | _  -> emit_intconst reg_x8 (Nativeint.of_int n);
-              DSL.ins I.BL [| DSL.emit_symbol "caml_allocN" |]
-      end;
-      DSL.labeled_ins lbl_frame I.ADD [| DSL.emit_reg i.res.(0); DSL.emit_reg reg_alloc_ptr; DSL.imm 8 |]
-    end
-  end
+      | _ ->
+        emit_intconst reg_x8 (Nativeint.of_int n);
+        DSL.ins I.BL [| DSL.emit_symbol "caml_allocN" |]);
+      DSL.labeled_ins lbl_frame I.ADD
+        [| DSL.emit_reg i.res.(0); DSL.emit_reg reg_alloc_ptr; DSL.imm 8 |])
 
 let assembly_code_for_poll i ~far ~return_label =
   let lbl_frame = record_frame_label i.live (Dbg_alloc []) in
-  let lbl_call_gc = Cmm.new_label() in
-  let lbl_after_poll = match return_label with
-  | None -> Cmm.new_label()
-  | Some lbl -> lbl in
+  let lbl_call_gc = Cmm.new_label () in
+  let lbl_after_poll =
+    match return_label with None -> Cmm.new_label () | Some lbl -> lbl
+  in
   let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
-    DSL.ins I.LDR [| DSL.emit_reg reg_tmp1; DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr |];
-    DSL.ins I.CMP [| DSL.emit_reg reg_alloc_ptr; DSL.emit_reg reg_tmp1 |];
-  if not far then begin
+  DSL.ins I.LDR
+    [| DSL.emit_reg reg_tmp1;
+       DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr
+    |];
+  DSL.ins I.CMP [| DSL.emit_reg reg_alloc_ptr; DSL.emit_reg reg_tmp1 |];
+  (if not far
+  then (
     match return_label with
     | None ->
-        DSL.ins (I.B_cond LS)  [| DSL.emit_label lbl_call_gc |];
-        emit_printf "%a:\n" femit_label lbl_after_poll
+      DSL.ins (I.B_cond LS) [| DSL.emit_label lbl_call_gc |];
+      emit_printf "%a:\n" femit_label lbl_after_poll
     | Some return_label ->
-        DSL.ins (I.B_cond HI)  [| DSL.emit_label return_label |];
-        DSL.ins I.B [| DSL.emit_label lbl_call_gc |];
-  end else begin
+      DSL.ins (I.B_cond HI) [| DSL.emit_label return_label |];
+      DSL.ins I.B [| DSL.emit_label lbl_call_gc |])
+  else
     match return_label with
     | None ->
-        DSL.ins (I.B_cond HI) [| DSL.emit_label lbl_after_poll |];
-        DSL.ins I.B [| DSL.emit_label lbl_call_gc |];
-        emit_printf "%a:\n" femit_label lbl_after_poll
+      DSL.ins (I.B_cond HI) [| DSL.emit_label lbl_after_poll |];
+      DSL.ins I.B [| DSL.emit_label lbl_call_gc |];
+      emit_printf "%a:\n" femit_label lbl_after_poll
     | Some return_label ->
-        let lbl = Cmm.new_label () in
-        DSL.ins (I.B_cond LS) [| DSL.emit_label lbl |];
-        DSL.ins I.B [| DSL.emit_label return_label |];
-        DSL.labeled_ins lbl I.B [| DSL.emit_label lbl_call_gc |]
-  end;
-  call_gc_sites :=
-    { gc_lbl = lbl_call_gc;
-      gc_return_lbl = lbl_after_poll;
-      gc_frame_lbl = lbl_frame; } :: !call_gc_sites
+      let lbl = Cmm.new_label () in
+      DSL.ins (I.B_cond LS) [| DSL.emit_label lbl |];
+      DSL.ins I.B [| DSL.emit_label return_label |];
+      DSL.labeled_ins lbl I.B [| DSL.emit_label lbl_call_gc |]);
+  call_gc_sites
+    := { gc_lbl = lbl_call_gc;
+         gc_return_lbl = lbl_after_poll;
+         gc_frame_lbl = lbl_frame
+       }
+       :: !call_gc_sites
 
 (* Output .text section directive, or named .text.caml.<name> if enabled. *)
 
 let emit_named_text_section func_name =
-  if !Clflags.function_sections then begin
-    emit_printf "	.section .text.caml.%a,%a,%%progbits\n" femit_symbol func_name femit_string_literal "ax"
-  end
-  else
-    emit_printf "	.text\n"
+  if !Clflags.function_sections
+  then
+    emit_printf "\t.section .text.caml.%a,%a,%%progbits\n" femit_symbol
+      func_name femit_string_literal "ax"
+  else emit_printf "\t.text\n"
 
 (* Emit code to load an emitted literal *)
 
 let emit_load_literal dst lbl =
-  if macosx then begin
+  if macosx
+  then (
     DSL.ins I.ADRP [| DSL.emit_reg reg_tmp1; DSL.emit_label ~reloc:PAGE lbl |];
-    DSL.ins I.LDR [| DSL.emit_reg dst; DSL.emit_mem_label ~reloc:PAGE_OFF reg_tmp1 lbl |]
-  end else begin
+    DSL.ins I.LDR
+      [| DSL.emit_reg dst; DSL.emit_mem_label ~reloc:PAGE_OFF reg_tmp1 lbl |])
+  else (
     DSL.ins I.ADRP [| DSL.emit_reg reg_tmp1; DSL.emit_label lbl |];
-    DSL.ins I.LDR [| DSL.emit_reg dst; DSL.emit_mem_label ~reloc:LOWER_TWELVE reg_tmp1 lbl|]
-  end
+    DSL.ins I.LDR
+      [| DSL.emit_reg dst;
+         DSL.emit_mem_label ~reloc:LOWER_TWELVE reg_tmp1 lbl
+      |])
 
 let move (src : Reg.t) (dst : Reg.t) =
   let distinct = not (Reg.same_loc src dst) in
-  if distinct then
-  match src.typ, src.loc, dst.typ, dst.loc with
-  | Float, Reg _, Float, Reg _
-  | Float32, Reg _, Float32, Reg _
-     ->
-     DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg src |]
-  | (Vec128|Valx2), Reg _, (Vec128|Valx2), Reg _ ->
-     DSL.ins I.MOV [| DSL.emit_reg_v2d dst; DSL.emit_reg_v2d src |]
-  | (Int | Val | Addr), Reg _, (Int | Val | Addr), Reg _ ->
+  if distinct
+  then
+    match src.typ, src.loc, dst.typ, dst.loc with
+    | Float, Reg _, Float, Reg _ | Float32, Reg _, Float32, Reg _ ->
+      DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg src |]
+    | (Vec128 | Valx2), Reg _, (Vec128 | Valx2), Reg _ ->
+      DSL.ins I.MOV [| DSL.emit_reg_v2d dst; DSL.emit_reg_v2d src |]
+    | (Int | Val | Addr), Reg _, (Int | Val | Addr), Reg _ ->
       DSL.ins I.MOV [| DSL.emit_reg dst; DSL.emit_reg src |]
-  | _, Reg _, _, Stack _ ->
-     DSL.ins I.STR [| DSL.emit_reg src; DSL.emit_stack dst |]
-  | _, Stack _, _, Reg _ ->
-     DSL.ins I.LDR [| DSL.emit_reg dst; DSL.emit_stack src |]
-  | _, Stack _, _, Stack _ ->
+    | _, Reg _, _, Stack _ ->
+      DSL.ins I.STR [| DSL.emit_reg src; DSL.emit_stack dst |]
+    | _, Stack _, _, Reg _ ->
+      DSL.ins I.LDR [| DSL.emit_reg dst; DSL.emit_stack src |]
+    | _, Stack _, _, Stack _ ->
+      Misc.fatal_errorf "Illegal move between registers (%a to %a)\n"
+        Printreg.reg src Printreg.reg dst
+    | _, Unknown, _, (Reg _ | Stack _ | Unknown)
+    | _, (Reg _ | Stack _), _, Unknown ->
       Misc.fatal_errorf
-      "Illegal move between registers (%a to %a)\n"
-      Printreg.reg src Printreg.reg dst
-  | _, Unknown, _, (Reg _ | Stack _ | Unknown)
-  | _, (Reg _ | Stack _), _, Unknown ->
+        "Illegal move with an unknown register location (%a to %a)\n"
+        Printreg.reg src Printreg.reg dst
+    | (Float | Float32 | Vec128 | Int | Val | Addr | Valx2), Reg _, _, _ ->
       Misc.fatal_errorf
-      "Illegal move with an unknown register location (%a to %a)\n"
-      Printreg.reg src Printreg.reg dst
-  | (Float | Float32 | Vec128 | Int | Val | Addr | Valx2), (Reg _), _, _ ->
-      Misc.fatal_errorf
-       "Illegal move between registers of differing types (%a to %a)\n"
-       Printreg.reg src Printreg.reg dst
+        "Illegal move between registers of differing types (%a to %a)\n"
+        Printreg.reg src Printreg.reg dst
 
 let emit_reinterpret_cast (cast : Cmm.reinterpret_cast) i =
-    let src = i.arg.(0) in
-    let dst = i.res.(0) in
-    let distinct = not (Reg.same_loc src dst) in
-    match cast with
-    | Int64_of_float ->
+  let src = i.arg.(0) in
+  let dst = i.res.(0) in
+  let distinct = not (Reg.same_loc src dst) in
+  match cast with
+  | Int64_of_float ->
+    DSL.check_reg Float src;
+    DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg src |]
+  | Float_of_int64 ->
+    DSL.check_reg Float dst;
+    DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg src |]
+  | Float32_of_int32 ->
+    DSL.check_reg Float32 dst;
+    DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg_w src |]
+  | Int32_of_float32 ->
+    DSL.check_reg Float32 src;
+    DSL.ins I.FMOV [| DSL.emit_reg_w dst; DSL.emit_reg src |]
+  | Float32_of_float ->
+    if distinct
+    then (
       DSL.check_reg Float src;
-      DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg src |]
-    | Float_of_int64 ->
-      DSL.check_reg Float dst;
-      DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg src |]
-    | Float32_of_int32 ->
       DSL.check_reg Float32 dst;
-      DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg_w src |]
-    | Int32_of_float32 ->
+      DSL.ins I.MOV [| DSL.emit_reg_d dst; DSL.emit_reg_d src |])
+  | Float_of_float32 ->
+    if distinct
+    then (
       DSL.check_reg Float32 src;
-      DSL.ins I.FMOV [| DSL.emit_reg_w dst; DSL.emit_reg src |]
-    | Float32_of_float ->
-       if distinct then (
-        DSL.check_reg Float src;
-        DSL.check_reg Float32 dst;
-        DSL.ins I.MOV [| DSL.emit_reg_d dst; DSL.emit_reg_d src |])
-    | Float_of_float32 ->
-      if distinct then (
-        DSL.check_reg Float32 src;
-        DSL.check_reg Float dst;
-        DSL.ins I.MOV [| DSL.emit_reg_d dst; DSL.emit_reg_d src |])
-    | V128_of_v128 ->
-      if distinct then (
-        DSL.check_reg Vec128 src;
-        DSL.check_reg Vec128 dst;
-        DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg src |])
-    | Int_of_value | Value_of_int -> move src dst
+      DSL.check_reg Float dst;
+      DSL.ins I.MOV [| DSL.emit_reg_d dst; DSL.emit_reg_d src |])
+  | V128_of_v128 ->
+    if distinct
+    then (
+      DSL.check_reg Vec128 src;
+      DSL.check_reg Vec128 dst;
+      DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg src |])
+  | Int_of_value | Value_of_int -> move src dst
 
 let emit_static_cast (cast : Cmm.static_cast) i =
-    let dst = i.res.(0) in
-    let src = i.arg.(0) in
-    let distinct = not (Reg.same_loc src dst) in
-    match cast with
-    | Int_of_float Float64 ->
-       DSL.check_reg Float src;
-       DSL.ins I.FCVTZS[| DSL.emit_reg dst; DSL.emit_reg src |]
-    | Int_of_float Float32 ->
-       DSL.check_reg Float32 src;
-       DSL.ins I.FCVTZS[| DSL.emit_reg dst; DSL.emit_reg src |]
-    | Float_of_int Float64 ->
-      DSL.check_reg Float dst;
-      DSL.ins I.SCVTF [| DSL.emit_reg dst; DSL.emit_reg src |];
-    | Float_of_int Float32 ->
-      DSL.check_reg Float32 dst;
-      DSL.ins I.SCVTF [| DSL.emit_reg dst; DSL.emit_reg src |];
-    | Float_of_float32 ->
-      DSL.check_reg Float dst;
-      DSL.check_reg Float32 src;
-      DSL.ins I.FCVT [| DSL.emit_reg dst; DSL.emit_reg src |];
-    | Float32_of_float ->
-      DSL.check_reg Float32 dst;
-      DSL.check_reg Float src;
-      DSL.ins I.FCVT [| DSL.emit_reg dst; DSL.emit_reg src |];
-    | Scalar_of_v128 v ->
-      DSL.check_reg Vec128 src;
-      begin match v with
-       | Int8x16 ->
-         DSL.ins I.FMOV [| DSL.emit_reg_w dst; DSL.emit_reg_s src |];
-         DSL.ins I.UXTB [| DSL.emit_reg dst; DSL.emit_reg_w dst; |];
-       | Int16x8 ->
-         DSL.ins I.FMOV [| DSL.emit_reg_w dst; DSL.emit_reg_s src |];
-         DSL.ins I.UXTH [| DSL.emit_reg dst; DSL.emit_reg_w dst; |];
-       | Int32x4 ->
-         DSL.ins I.FMOV [| DSL.emit_reg_w dst; DSL.emit_reg_s src |]
-       | Int64x2 ->
-         DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg_d src |]
-       | Float32x4 ->
-         if distinct then (
-           DSL.check_reg Float32 dst;
-           DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg_s src |])
-       | Float64x2 ->
-         if distinct then (
-           DSL.check_reg Float dst;
-           DSL.ins I.FMOV [| DSL.emit_reg dst ; DSL.emit_reg_d src |])
-      end
-    | V128_of_scalar v ->
-       DSL.check_reg Vec128 dst;
-       begin match v with
-       | Int8x16 ->
-         DSL.ins I.FMOV [| DSL.emit_reg_s dst; DSL.emit_reg_w src |];
-       | Int16x8 ->
-         DSL.ins I.FMOV [| DSL.emit_reg_s dst; DSL.emit_reg_w src |];
-       | Int32x4 ->
-         DSL.ins I.FMOV [| DSL.emit_reg_s dst; DSL.emit_reg_w src |]
-       | Int64x2 ->
-         DSL.ins I.FMOV [| DSL.emit_reg_d dst; DSL.emit_reg src |]
-       | Float32x4 ->
-         if distinct then (
-           DSL.check_reg Float32 src;
-           DSL.ins I.FMOV [| DSL.emit_reg_s dst; DSL.emit_reg src |])
-       | Float64x2 ->
-         if distinct then (
-           DSL.check_reg Float src;
-           DSL.ins I.FMOV [| DSL.emit_reg_d dst ; DSL.emit_reg src |])
-      end
+  let dst = i.res.(0) in
+  let src = i.arg.(0) in
+  let distinct = not (Reg.same_loc src dst) in
+  match cast with
+  | Int_of_float Float64 ->
+    DSL.check_reg Float src;
+    DSL.ins I.FCVTZS [| DSL.emit_reg dst; DSL.emit_reg src |]
+  | Int_of_float Float32 ->
+    DSL.check_reg Float32 src;
+    DSL.ins I.FCVTZS [| DSL.emit_reg dst; DSL.emit_reg src |]
+  | Float_of_int Float64 ->
+    DSL.check_reg Float dst;
+    DSL.ins I.SCVTF [| DSL.emit_reg dst; DSL.emit_reg src |]
+  | Float_of_int Float32 ->
+    DSL.check_reg Float32 dst;
+    DSL.ins I.SCVTF [| DSL.emit_reg dst; DSL.emit_reg src |]
+  | Float_of_float32 ->
+    DSL.check_reg Float dst;
+    DSL.check_reg Float32 src;
+    DSL.ins I.FCVT [| DSL.emit_reg dst; DSL.emit_reg src |]
+  | Float32_of_float ->
+    DSL.check_reg Float32 dst;
+    DSL.check_reg Float src;
+    DSL.ins I.FCVT [| DSL.emit_reg dst; DSL.emit_reg src |]
+  | Scalar_of_v128 v -> (
+    DSL.check_reg Vec128 src;
+    match v with
+    | Int8x16 ->
+      DSL.ins I.FMOV [| DSL.emit_reg_w dst; DSL.emit_reg_s src |];
+      DSL.ins I.UXTB [| DSL.emit_reg dst; DSL.emit_reg_w dst |]
+    | Int16x8 ->
+      DSL.ins I.FMOV [| DSL.emit_reg_w dst; DSL.emit_reg_s src |];
+      DSL.ins I.UXTH [| DSL.emit_reg dst; DSL.emit_reg_w dst |]
+    | Int32x4 -> DSL.ins I.FMOV [| DSL.emit_reg_w dst; DSL.emit_reg_s src |]
+    | Int64x2 -> DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg_d src |]
+    | Float32x4 ->
+      if distinct
+      then (
+        DSL.check_reg Float32 dst;
+        DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg_s src |])
+    | Float64x2 ->
+      if distinct
+      then (
+        DSL.check_reg Float dst;
+        DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg_d src |]))
+  | V128_of_scalar v -> (
+    DSL.check_reg Vec128 dst;
+    match v with
+    | Int8x16 -> DSL.ins I.FMOV [| DSL.emit_reg_s dst; DSL.emit_reg_w src |]
+    | Int16x8 -> DSL.ins I.FMOV [| DSL.emit_reg_s dst; DSL.emit_reg_w src |]
+    | Int32x4 -> DSL.ins I.FMOV [| DSL.emit_reg_s dst; DSL.emit_reg_w src |]
+    | Int64x2 -> DSL.ins I.FMOV [| DSL.emit_reg_d dst; DSL.emit_reg src |]
+    | Float32x4 ->
+      if distinct
+      then (
+        DSL.check_reg Float32 src;
+        DSL.ins I.FMOV [| DSL.emit_reg_s dst; DSL.emit_reg src |])
+    | Float64x2 ->
+      if distinct
+      then (
+        DSL.check_reg Float src;
+        DSL.ins I.FMOV [| DSL.emit_reg_d dst; DSL.emit_reg src |]))
 
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
-    emit_debug_info i.dbg;
-    match i.desc with
-    | Lend -> ()
-    | Lprologue ->
-      assert (!prologue_required);
-      let n = frame_size() in
-      if n > 0 then
-        emit_stack_adjustment (-n);
-      if !contains_calls then begin
-        cfi_offset ~reg:30 (* return address *) ~offset:(-8);
-        DSL.ins I.STR [| DSL.reg_x_30; DSL.emit_mem_sp_offset (n - 8) |];
-      end
-    | Lop(Intop_atomic _) ->
-      (* Never generated; builtins are not yet translated to atomics *)
-      assert false
-    | Lop (Reinterpret_cast cast) ->
-      emit_reinterpret_cast cast i
-    | Lop (Static_cast cast) ->
-      emit_static_cast cast i
-    | Lop(Move | Spill | Reload) ->
-        move i.arg.(0) i.res.(0)
-    | Lop(Specific Imove32) ->
-        let src = i.arg.(0) and dst = i.res.(0) in
-        if not (Reg.same_loc src dst) then begin
-          match (src, dst) with
-          | {loc = Reg _}, {loc = Reg _} ->
-              DSL.ins I.MOV [| DSL.emit_reg_w dst; DSL.emit_reg_w src |]
-          | {loc = Reg _}, {loc = Stack _} ->
-              DSL.ins I.STR [| DSL.emit_reg_w src; DSL.emit_stack dst |]
-          | {loc = Stack _}, {loc = Reg _} ->
-              DSL.ins I.LDR [| DSL.emit_reg_w dst; DSL.emit_stack src |]
-          | {loc = Stack _}, {loc = Stack _}
-          | _, {loc = Unknown}
-          | {loc = Unknown}, _
-            -> assert false
-        end
-    | Lop(Const_int n) ->
-        emit_intconst i.res.(0) n
-    | Lop (Const_float32 f) ->
-        DSL.check_reg Float32 i.res.(0);
-        if f = 0l then
-          DSL.ins I.FMOV [| DSL.emit_reg i.res.(0); DSL.wzr |]
-        else if is_immediate_float32 f then
-          DSL.ins I.FMOV [| DSL.emit_reg i.res.(0); DSL.imm_float (Int32.float_of_bits f) |]
-        else begin
-          (* float32 constants still take up 8 bytes; we load the lower half. *)
-          let lbl = float_literal (Int64.of_int32 f) in
-          emit_load_literal i.res.(0) lbl
-        end
-    | Lop(Const_float f) ->
-        if f = 0L then
-          DSL.ins I.FMOV [| DSL.emit_reg i.res.(0); DSL.xzr |]
-        else if is_immediate_float f then
-          DSL.ins I.FMOV [| DSL.emit_reg i.res.(0); DSL.imm_float (Int64.float_of_bits f) |]
-        else begin
-          let lbl = float_literal f in
-          emit_load_literal i.res.(0) lbl
-        end
-    | Lop(Const_vec128 ({high; low} as l)) ->
-      DSL.check_reg Vec128 i.res.(0);
-      begin match (high, low) with
-      | 0x0000_0000_0000_0000L, 0x0000_0000_0000_0000L ->
-          let dst = DSL.emit_reg_v2d i.res.(0) in
-          DSL.ins I.MOVI [| dst; DSL.imm 0  |]
-      | _ ->
-          let lbl = vec128_literal l in
-          emit_load_literal i.res.(0) lbl
-      end
-    | Lop(Const_symbol s) ->
-        emit_load_symbol_addr i.res.(0) s.sym_name
-    | Lcall_op(Lcall_ind) ->
-        DSL.ins I.BLR [| DSL.emit_reg i.arg.(0) |];
-        record_frame i.live (Dbg_other i.dbg)
-    | Lcall_op(Lcall_imm { func; }) ->
-        DSL.ins I.BL [| DSL.emit_symbol func.sym_name |];
-        record_frame i.live (Dbg_other i.dbg)
-    | Lcall_op(Ltailcall_ind) ->
-        output_epilogue (fun () -> DSL.ins I.BR [| DSL.emit_reg i.arg.(0) |])
-    | Lcall_op(Ltailcall_imm { func; }) ->
-        if func.sym_name = !function_name then
-          match !tailrec_entry_point with
-          | None -> Misc.fatal_error "jump to missing tailrec entry point"
-          | Some tailrec_entry_point ->
-            DSL.ins I.B [| DSL.emit_label tailrec_entry_point |]
-        else
-          output_epilogue (fun () -> DSL.ins I.B [| DSL.emit_symbol func.sym_name |])
-    | Lcall_op(Lextcall {func; alloc; stack_ofs}) ->
-        if Config.runtime5 && stack_ofs > 0 then begin
-          DSL.ins I.MOV [| DSL.emit_reg reg_stack_arg_begin; DSL.sp |];
-          DSL.ins I.ADD [| DSL.emit_reg reg_stack_arg_end; DSL.sp; DSL.imm (Misc.align stack_ofs 16) |];
-          emit_load_symbol_addr reg_x8 func;
-          DSL.ins I.BL [| DSL.emit_symbol "caml_c_call_stack_args" |];
-          record_frame i.live (Dbg_other i.dbg)
-        end else if alloc then begin
-          emit_load_symbol_addr reg_x8 func;
-          DSL.ins I.BL [| DSL.emit_symbol "caml_c_call" |];
-          record_frame i.live (Dbg_other i.dbg)
-        end else begin
-          (*= store ocaml stack in the frame pointer register
+  emit_debug_info i.dbg;
+  match i.desc with
+  | Lend -> ()
+  | Lprologue ->
+    assert !prologue_required;
+    let n = frame_size () in
+    if n > 0 then emit_stack_adjustment (-n);
+    if !contains_calls
+    then (
+      cfi_offset ~reg:30 (* return address *) ~offset:(-8);
+      DSL.ins I.STR [| DSL.reg_x_30; DSL.emit_mem_sp_offset (n - 8) |])
+  | Lop (Intop_atomic _) ->
+    (* Never generated; builtins are not yet translated to atomics *)
+    assert false
+  | Lop (Reinterpret_cast cast) -> emit_reinterpret_cast cast i
+  | Lop (Static_cast cast) -> emit_static_cast cast i
+  | Lop (Move | Spill | Reload) -> move i.arg.(0) i.res.(0)
+  | Lop (Specific Imove32) -> (
+    let src = i.arg.(0) and dst = i.res.(0) in
+    if not (Reg.same_loc src dst)
+    then
+      match src, dst with
+      | { loc = Reg _ }, { loc = Reg _ } ->
+        DSL.ins I.MOV [| DSL.emit_reg_w dst; DSL.emit_reg_w src |]
+      | { loc = Reg _ }, { loc = Stack _ } ->
+        DSL.ins I.STR [| DSL.emit_reg_w src; DSL.emit_stack dst |]
+      | { loc = Stack _ }, { loc = Reg _ } ->
+        DSL.ins I.LDR [| DSL.emit_reg_w dst; DSL.emit_stack src |]
+      | { loc = Stack _ }, { loc = Stack _ }
+      | _, { loc = Unknown }
+      | { loc = Unknown }, _ ->
+        assert false)
+  | Lop (Const_int n) -> emit_intconst i.res.(0) n
+  | Lop (Const_float32 f) ->
+    DSL.check_reg Float32 i.res.(0);
+    if f = 0l
+    then DSL.ins I.FMOV [| DSL.emit_reg i.res.(0); DSL.wzr |]
+    else if is_immediate_float32 f
+    then
+      DSL.ins I.FMOV
+        [| DSL.emit_reg i.res.(0); DSL.imm_float (Int32.float_of_bits f) |]
+    else
+      (* float32 constants still take up 8 bytes; we load the lower half. *)
+      let lbl = float_literal (Int64.of_int32 f) in
+      emit_load_literal i.res.(0) lbl
+  | Lop (Const_float f) ->
+    if f = 0L
+    then DSL.ins I.FMOV [| DSL.emit_reg i.res.(0); DSL.xzr |]
+    else if is_immediate_float f
+    then
+      DSL.ins I.FMOV
+        [| DSL.emit_reg i.res.(0); DSL.imm_float (Int64.float_of_bits f) |]
+    else
+      let lbl = float_literal f in
+      emit_load_literal i.res.(0) lbl
+  | Lop (Const_vec128 ({ high; low } as l)) -> (
+    DSL.check_reg Vec128 i.res.(0);
+    match high, low with
+    | 0x0000_0000_0000_0000L, 0x0000_0000_0000_0000L ->
+      let dst = DSL.emit_reg_v2d i.res.(0) in
+      DSL.ins I.MOVI [| dst; DSL.imm 0 |]
+    | _ ->
+      let lbl = vec128_literal l in
+      emit_load_literal i.res.(0) lbl)
+  | Lop (Const_symbol s) -> emit_load_symbol_addr i.res.(0) s.sym_name
+  | Lcall_op Lcall_ind ->
+    DSL.ins I.BLR [| DSL.emit_reg i.arg.(0) |];
+    record_frame i.live (Dbg_other i.dbg)
+  | Lcall_op (Lcall_imm { func }) ->
+    DSL.ins I.BL [| DSL.emit_symbol func.sym_name |];
+    record_frame i.live (Dbg_other i.dbg)
+  | Lcall_op Ltailcall_ind ->
+    output_epilogue (fun () -> DSL.ins I.BR [| DSL.emit_reg i.arg.(0) |])
+  | Lcall_op (Ltailcall_imm { func }) ->
+    if func.sym_name = !function_name
+    then
+      match !tailrec_entry_point with
+      | None -> Misc.fatal_error "jump to missing tailrec entry point"
+      | Some tailrec_entry_point ->
+        DSL.ins I.B [| DSL.emit_label tailrec_entry_point |]
+    else
+      output_epilogue (fun () ->
+          DSL.ins I.B [| DSL.emit_symbol func.sym_name |])
+  | Lcall_op (Lextcall { func; alloc; stack_ofs }) ->
+    if Config.runtime5 && stack_ofs > 0
+    then (
+      DSL.ins I.MOV [| DSL.emit_reg reg_stack_arg_begin; DSL.sp |];
+      DSL.ins I.ADD
+        [| DSL.emit_reg reg_stack_arg_end;
+           DSL.sp;
+           DSL.imm (Misc.align stack_ofs 16)
+        |];
+      emit_load_symbol_addr reg_x8 func;
+      DSL.ins I.BL [| DSL.emit_symbol "caml_c_call_stack_args" |];
+      record_frame i.live (Dbg_other i.dbg))
+    else if alloc
+    then (
+      emit_load_symbol_addr reg_x8 func;
+      DSL.ins I.BL [| DSL.emit_symbol "caml_c_call" |];
+      record_frame i.live (Dbg_other i.dbg))
+    else (
+      (*= store ocaml stack in the frame pointer register
              NB: no need to store previous x29 because OCaml frames don't
              maintain frame pointer *)
-          if Config.runtime5 then begin
-            DSL.ins I.MOV [| DSL.reg_x_29; DSL.sp |];
-            cfi_remember_state ();
-            cfi_def_cfa_register ~reg:29;
-            let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
-            DSL.ins I.LDR [| DSL.emit_reg reg_tmp1; DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr |];
-              DSL.ins I.MOV [| DSL.sp; DSL.emit_reg reg_tmp1 |]
-          end;
-          DSL.ins I.BL [| DSL.emit_symbol func |];
-          if Config.runtime5 then begin
-            DSL.ins I.MOV [| DSL.sp; DSL.reg_x_29 |]
-          end;
-          cfi_restore_state ()
-        end
-    | Lop(Stackoffset n) ->
-        assert (n mod 16 = 0);
-        emit_stack_adjustment (-n);
-        stack_offset := !stack_offset + n
-    | Lop(Load { memory_chunk; addressing_mode; is_atomic }) ->
-        assert(memory_chunk = Cmm.Word_int || memory_chunk = Cmm.Word_val || is_atomic = false);
-        let dst = i.res.(0) in
-        let base =
-          match addressing_mode with
-          | Iindexed _ -> i.arg.(0)
-          | Ibased(s, ofs) ->
-              assert (not !Clflags.dlcode);  (* see selection_utils.ml *)
-              DSL.ins I.ADRP [| DSL.emit_reg reg_tmp1; DSL.emit_symbol ~offset:ofs s |];
-              reg_tmp1 in
-        begin match memory_chunk with
-        | Byte_unsigned ->
-            DSL.ins I.LDRB [| DSL.emit_reg_w dst; DSL.emit_addressing addressing_mode base |]
-        | Byte_signed ->
-            DSL.ins I.LDRSB [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
-        | Sixteen_unsigned ->
-            DSL.ins I.LDRH [| DSL.emit_reg_w dst; DSL.emit_addressing addressing_mode base |]
-        | Sixteen_signed ->
-            DSL.ins I.LDRSH [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
-        | Thirtytwo_unsigned ->
-            DSL.ins I.LDR [| DSL.emit_reg_w dst; DSL.emit_addressing addressing_mode base |]
-        | Thirtytwo_signed ->
-            DSL.ins I.LDRSW [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
-        | Single { reg = Float64 } ->
-            DSL.check_reg Float dst;
-            DSL.ins I.LDR [| DSL.reg_s_7; DSL.emit_addressing addressing_mode base |];
-            DSL.ins I.FCVT [| DSL.emit_reg dst; DSL.reg_s_7 |]
-        | Word_int | Word_val ->
-          if is_atomic then begin
-            assert (addressing_mode = Iindexed 0);
-            DSL.ins (I.DMB ISHLD) [| |];
-            DSL.ins I.LDAR [| DSL.emit_reg dst; DSL.emit_mem i.arg.(0) |]
-          end else
-            DSL.ins I.LDR [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
-        | Double ->
-                      DSL.ins I.LDR [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
-        | Single { reg = Float32 } ->
-            DSL.check_reg Float32 dst;
-            DSL.ins I.LDR [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
-        | Onetwentyeight_aligned | Onetwentyeight_unaligned ->
-            (* CR gyorsh: check alignment *)
-            DSL.check_reg Vec128 dst;
-            DSL.ins I.LDR [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
-        end
-    | Lop(Store(size, addr, assignment)) ->
-      (* NB: assignments other than Word_int and Word_val do not follow the
-      Multicore OCaml memory model and so do not emit a barrier *)
-      let src = i.arg.(0) in
-        let base =
-          match addr with
-          | Iindexed _ -> i.arg.(1)
-          | Ibased(s, ofs) ->
-              assert (not !Clflags.dlcode);
-              DSL.ins I.ADRP [| DSL.emit_reg reg_tmp1; DSL.emit_symbol ~offset:ofs s |];
-              reg_tmp1 in
-        begin match size with
-        | Byte_unsigned | Byte_signed ->
-            DSL.ins I.STRB [| DSL.emit_reg_w src; DSL.emit_addressing addr base |]
-        | Sixteen_unsigned | Sixteen_signed ->
-            DSL.ins I.STRH [| DSL.emit_reg_w src; DSL.emit_addressing addr base |]
-        | Thirtytwo_unsigned | Thirtytwo_signed ->
-            DSL.ins I.STR [| DSL.emit_reg_w src; DSL.emit_addressing addr base |]
-        | Single { reg = Float64 } ->
-            DSL.check_reg Float src;
-            DSL.ins I.FCVT [| DSL.reg_s_7; DSL.emit_reg src |];
-            DSL.ins I.STR [| DSL.reg_s_7; DSL.emit_addressing addr base |]
-        | Word_int | Word_val ->
-            (* memory model barrier for non-initializing store *)
-            if assignment then DSL.ins (I.DMB ISHLD) [| |];
-            DSL.ins I.STR [| DSL.emit_reg src; DSL.emit_addressing addr base |]
-        | Double ->
-          DSL.ins I.STR [| DSL.emit_reg src; DSL.emit_addressing addr base |]
-        | Single { reg = Float32 } ->
-          DSL.check_reg Float32 src;
-          DSL.ins I.STR [| DSL.emit_reg src; DSL.emit_addressing addr base |]
-        | Onetwentyeight_aligned | Onetwentyeight_unaligned ->
-          (* CR gyorsh: check alignment *)
-          DSL.check_reg Vec128 src;
-          DSL.ins I.STR [| DSL.emit_reg src; DSL.emit_addressing addr base |]
-        end
-    | Lop(Alloc { bytes = n; dbginfo; mode = Heap }) ->
-        assembly_code_for_allocation i ~n ~local:false ~far:false ~dbginfo
-    | Lop(Specific (Ifar_alloc { bytes = n; dbginfo })) ->
-        assembly_code_for_allocation i ~n ~local:false ~far:true ~dbginfo
-    | Lop(Alloc { bytes = n; dbginfo; mode = Local }) ->
-        assembly_code_for_allocation i ~n ~local:true ~far:false ~dbginfo
-    | Lop(Begin_region) ->
-        let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
-        DSL.ins I.LDR [| DSL.emit_reg i.res.(0); DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr |]
-    | Lop(End_region) ->
-        let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
-        DSL.ins I.STR [| DSL.emit_reg i.arg.(0); DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr |]
-    | Lop(Poll) ->
-        assembly_code_for_poll i ~far:false ~return_label:None
-    | Lop(Specific Ifar_poll) ->
-        assembly_code_for_poll i ~far:true ~return_label:None
-    | Lop(Intop_imm(Iadd, n)) ->
-        emit_addimm i.res.(0) i.arg.(0) n
-    | Lop(Intop_imm(Isub, n)) ->
-        emit_subimm i.res.(0) i.arg.(0) n
-    | Lop(Intop(Icomp cmp)) ->
-        DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
-        DSL.ins I.CSET [| DSL.emit_reg i.res.(0); DSL.cond (cond_for_comparison cmp) |]
-    | Lop(Floatop(Float64, Icompf cmp)) ->
-        DSL.check_reg Float i.arg.(0);
-        DSL.check_reg Float i.arg.(1);
-        let comp = cond_for_float_comparison cmp in
-        DSL.ins I.FCMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
-        DSL.ins I.CSET [| DSL.emit_reg i.res.(0); DSL.float_cond comp |]
-    | Lop(Floatop(Float32, Icompf cmp)) ->
-      DSL.check_reg Float32 i.arg.(0);
-      DSL.check_reg Float32 i.arg.(1);
-        let comp = cond_for_float_comparison cmp in
-        DSL.ins I.FCMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
-        DSL.ins I.CSET [| DSL.emit_reg i.res.(0); DSL.float_cond comp |]
-    | Lop(Intop_imm(Icomp cmp, n)) ->
-        emit_cmpimm i.arg.(0) n;
-        DSL.ins I.CSET [| DSL.emit_reg i.res.(0); DSL.cond (cond_for_comparison cmp) |]
-    | Lop(Intop Imod) ->
-        DSL.ins I.SDIV [| DSL.emit_reg reg_tmp1; DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1)|];
-        DSL.ins I.MSUB [| DSL.emit_reg i.res.(0); DSL.emit_reg reg_tmp1; DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(0)|];
-    | Lop(Intop (Imulh { signed = true })) ->
-        DSL.ins I.SMULH [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1)|]
-    | Lop(Intop (Imulh { signed = false })) ->
-        DSL.ins I.UMULH [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1)|]
-    | Lop(Intop (Ictz _)) ->
-        (* emit_printf "ctz Rd, Rn" is optionally supported from Armv8.7, but rbit and clz
-           are supported in all ARMv8 CPUs. *)
-        DSL.ins I.RBIT [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |];
-        DSL.ins I.CLZ [| DSL.emit_reg i.res.(0); DSL.emit_reg i.res.(0) |];
-    | Lop(Intop (Iclz _ as op)) ->
-        let instr = instr_for_int_operation op in
-        DSL.ins instr [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |]
-    | Lop(Intop ((Iadd|Isub|Imul|Idiv|Iand|Ior|Ixor|Ilsl|Ilsr|Iasr|Ipopcnt) as op)) ->
-        let instr = instr_for_int_operation op in
-        DSL.ins instr [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |]
-    | Lop(Intop_imm(op, n)) ->
-        let instr = instr_for_int_operation op in
-        DSL.ins instr [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.imm n |]
-    | Lop(Specific Isqrtf) ->
-      DSL.ins I.FSQRT [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |]
-    | Lop(Floatop ((Float32 | Float64), Iabsf)) ->
-      DSL.ins I.FABS [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |]
-    | Lop(Floatop ((Float32 | Float64), Inegf)) ->
-      DSL.ins I.FNEG [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |]
-    | Lop(Floatop ((Float32 | Float64), Iaddf)) ->
-      DSL.ins I.FADD [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |]
-    | Lop(Floatop ((Float32 | Float64), Isubf)) ->
-      DSL.ins I.FSUB [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |]
-    | Lop(Floatop ((Float32 | Float64), Imulf)) ->
-      DSL.ins I.FMUL [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |]
-    | Lop(Floatop ((Float32 | Float64), Idivf)) ->
-      DSL.ins I.FDIV [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |]
-    | Lop(Specific Inegmulf) ->
-      DSL.ins I.FNMUL  [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |]
-    | Lop(Specific(Imuladdf)) ->
-      DSL.ins I.FMADD [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(2); DSL.emit_reg i.arg.(0) |]
-    | Lop(Specific(Inegmuladdf)) ->
-      DSL.ins I.FNMADD [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(2); DSL.emit_reg i.arg.(0) |]
-    | Lop(Specific(Imulsubf)) ->
-      DSL.ins I.FMSUB [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(2); DSL.emit_reg i.arg.(0) |]
-    | Lop(Specific(Inegmulsubf)) ->
-      DSL.ins I.FNMSUB [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(2); DSL.emit_reg i.arg.(0) |]
-    | Lop(Opaque) ->
-        assert (i.arg.(0).loc = i.res.(0).loc)
-    | Lop(Specific(Ishiftarith(op, shift))) ->
-        let instr = (match op with
-                       Ishiftadd    -> I.ADD
-                     | Ishiftsub    -> I.SUB) in
-        let shift = if shift >= 0
-          then DSL.emit_shift LSL shift
-          else DSL.emit_shift ASR (-shift) in
-        DSL.ins instr [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1); shift |]
-    | Lop(Specific(Imuladd)) ->
-      DSL.ins I.MADD [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(2) |]
-    | Lop(Specific(Imulsub)) ->
-      DSL.ins I.MSUB [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(2) |]
-    | Lop(Specific(Ibswap { bitwidth })) ->
-        begin match bitwidth with
-        | Sixteen ->
-            DSL.ins I.REV16 [| DSL.emit_reg_w i.res.(0); DSL.emit_reg_w i.arg.(0) |];
-            DSL.ins I.UBFM [| DSL.emit_reg i.res.(0); DSL.emit_reg i.res.(0); DSL.imm 0; DSL.imm 15 |]
-        | Thirtytwo ->
-            DSL.ins I.REV [| DSL.emit_reg_w i.res.(0); DSL.emit_reg_w i.arg.(0) |];
-        | Sixtyfour ->
-            DSL.ins I.REV [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |];
-        end
-    | Lop(Specific(Isignext size)) ->
-        DSL.ins I.SBFM [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.imm 0; DSL.imm (size - 1) |]
-    | Lop(Specific(Isimd simd)) ->
-      DSL.simd_instr simd i
-    | Lop (Name_for_debugger _) -> ()
-    | Lcall_op (Lprobe _) | Lop (Probe_is_enabled _) ->
-      fatal_error ("Probes not supported.")
-    | Lop(Dls_get) ->
-      if Config.runtime5 then
-        let offset = Domainstate.(idx_of_field Domain_dls_root) * 8 in
-        DSL.ins I.LDR [| DSL.emit_reg i.res.(0); DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr |]
-      else Misc.fatal_error "Dls is not supported in runtime4."
-    | Lop (Csel tst) ->
-      let len = Array.length i.arg in
-      let ifso = i.arg.(len - 2) in
-      let ifnot = i.arg.(len - 1) in
-      if Reg.same_loc ifso ifnot then
-        move ifso i.res.(0)
+      if Config.runtime5
+      then (
+        DSL.ins I.MOV [| DSL.reg_x_29; DSL.sp |];
+        cfi_remember_state ();
+        cfi_def_cfa_register ~reg:29;
+        let offset = Domainstate.(idx_of_field Domain_c_stack) * 8 in
+        DSL.ins I.LDR
+          [| DSL.emit_reg reg_tmp1;
+             DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr
+          |];
+        DSL.ins I.MOV [| DSL.sp; DSL.emit_reg reg_tmp1 |]);
+      DSL.ins I.BL [| DSL.emit_symbol func |];
+      if Config.runtime5 then DSL.ins I.MOV [| DSL.sp; DSL.reg_x_29 |];
+      cfi_restore_state ())
+  | Lop (Stackoffset n) ->
+    assert (n mod 16 = 0);
+    emit_stack_adjustment (-n);
+    stack_offset := !stack_offset + n
+  | Lop (Load { memory_chunk; addressing_mode; is_atomic }) -> (
+    assert (
+      memory_chunk = Cmm.Word_int
+      || memory_chunk = Cmm.Word_val
+      || is_atomic = false);
+    let dst = i.res.(0) in
+    let base =
+      match addressing_mode with
+      | Iindexed _ -> i.arg.(0)
+      | Ibased (s, ofs) ->
+        assert (not !Clflags.dlcode);
+        (* see selection_utils.ml *)
+        DSL.ins I.ADRP
+          [| DSL.emit_reg reg_tmp1; DSL.emit_symbol ~offset:ofs s |];
+        reg_tmp1
+    in
+    match memory_chunk with
+    | Byte_unsigned ->
+      DSL.ins I.LDRB
+        [| DSL.emit_reg_w dst; DSL.emit_addressing addressing_mode base |]
+    | Byte_signed ->
+      DSL.ins I.LDRSB
+        [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
+    | Sixteen_unsigned ->
+      DSL.ins I.LDRH
+        [| DSL.emit_reg_w dst; DSL.emit_addressing addressing_mode base |]
+    | Sixteen_signed ->
+      DSL.ins I.LDRSH
+        [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
+    | Thirtytwo_unsigned ->
+      DSL.ins I.LDR
+        [| DSL.emit_reg_w dst; DSL.emit_addressing addressing_mode base |]
+    | Thirtytwo_signed ->
+      DSL.ins I.LDRSW
+        [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
+    | Single { reg = Float64 } ->
+      DSL.check_reg Float dst;
+      DSL.ins I.LDR [| DSL.reg_s_7; DSL.emit_addressing addressing_mode base |];
+      DSL.ins I.FCVT [| DSL.emit_reg dst; DSL.reg_s_7 |]
+    | Word_int | Word_val ->
+      if is_atomic
+      then (
+        assert (addressing_mode = Iindexed 0);
+        DSL.ins (I.DMB ISHLD) [||];
+        DSL.ins I.LDAR [| DSL.emit_reg dst; DSL.emit_mem i.arg.(0) |])
       else
-        begin match tst with
-        | Itruetest ->
-            DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.imm 0 |];
-            DSL.ins I.CSEL [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(2); DSL.cond NE |]
-        | Ifalsetest ->
-            DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.imm 0 |];
-            DSL.ins I.CSEL [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(2); DSL.cond EQ |]
-        | Iinttest cmp ->
-            let comp = cond_for_comparison cmp in
-            DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
-            DSL.ins I.CSEL [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(2); DSL.emit_reg i.arg.(3); DSL.cond comp |]
-        | Iinttest_imm(cmp, n) ->
-            let comp = cond_for_comparison cmp in
-            emit_cmpimm i.arg.(0) n;
-            DSL.ins I.CSEL [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(2); DSL.cond comp |]
-        | Ifloattest ((Float32 | Float64), cmp) ->
-            let comp = cond_for_float_comparison cmp in
-            DSL.ins I.FCMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
-            DSL.ins I.CSEL [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(2); DSL.emit_reg i.arg.(3); DSL.float_cond comp |]
-        | Ioddtest ->
-            DSL.ins I.TST [| DSL.emit_reg i.arg.(0); DSL.imm 1 |];
-            DSL.ins I.CSEL [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(2); DSL.cond NE |]
-        | Ieventest ->
-            DSL.ins I.TST [| DSL.emit_reg i.arg.(0); DSL.imm 1 |];
-            DSL.ins I.CSEL [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(1); DSL.emit_reg i.arg.(2); DSL.cond EQ |]
-        end
-    | Lreloadretaddr ->
-        ()
-    | Lreturn ->
-        output_epilogue (fun () -> DSL.ins I.RET [| |])
-    | Llabel { label = lbl; _ } ->
-        emit_printf "%a:\n" femit_label lbl
-    | Lbranch lbl ->
-        DSL.ins I.B [| DSL.emit_label lbl |]
-    | Lcondbranch(tst, lbl) ->
-        begin match tst with
-        | Itruetest ->
-            DSL.ins I.CBNZ [| DSL.emit_reg i.arg.(0); DSL.emit_label lbl |];
-        | Ifalsetest ->
-            DSL.ins I.CBZ [| DSL.emit_reg i.arg.(0); DSL.emit_label lbl |];
-        | Iinttest cmp ->
-            DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
-            let comp = cond_for_comparison cmp in
-            DSL.ins (I.B_cond comp) [| DSL.emit_label lbl |]
-        | Iinttest_imm(cmp, n) ->
-            emit_cmpimm i.arg.(0) n;
-            let comp = cond_for_comparison cmp in
-            DSL.ins (I.B_cond comp) [| DSL.emit_label lbl |]
-        | Ifloattest ((Float32 | Float64), cmp) ->
-            let comp = cond_for_float_comparison cmp in
-            DSL.ins I.FCMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
-            DSL.ins (I.B_cond_float comp) [| DSL.emit_label lbl |]
-        | Ioddtest ->
-            DSL.ins I.TBNZ [| DSL.emit_reg i.arg.(0); DSL.imm 0; DSL.emit_label lbl |];
-        | Ieventest ->
-            DSL.ins I.TBZ [| DSL.emit_reg i.arg.(0); DSL.imm 0; DSL.emit_label lbl |];
-        end
-    | Lcondbranch3(lbl0, lbl1, lbl2) ->
-        DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.imm 1 |];
-        begin match lbl0 with
-          None -> ()
-        | Some lbl -> DSL.ins (I.B_cond LT) [| DSL.emit_label lbl |]
-        end;
-        begin match lbl1 with
-          None -> ()
-        | Some lbl -> DSL.ins (I.B_cond EQ) [| DSL.emit_label lbl |]
-        end;
-        begin match lbl2 with
-          None -> ()
-        | Some lbl -> DSL.ins (I.B_cond GT) [| DSL.emit_label lbl |]
-        end
-    | Lswitch jumptbl ->
-        let lbltbl = Cmm.new_label() in
-        DSL.ins I.ADR [| DSL.emit_reg reg_tmp1; DSL.emit_label lbltbl |];
-        DSL.ins I.ADD [| DSL.emit_reg reg_tmp1; DSL.emit_reg reg_tmp1; DSL.emit_reg i.arg.(0); DSL.emit_shift LSL 2 |];
-        DSL.ins I.BR [| DSL.emit_reg reg_tmp1 |];
-        emit_printf "%a:" femit_label lbltbl;
-        for j = 0 to Array.length jumptbl - 1 do
-            DSL.ins I.B [| DSL.emit_label jumptbl.(j) |]
-        done
-(*= Alternative:
+        DSL.ins I.LDR
+          [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
+    | Double ->
+      DSL.ins I.LDR
+        [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
+    | Single { reg = Float32 } ->
+      DSL.check_reg Float32 dst;
+      DSL.ins I.LDR
+        [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |]
+    | Onetwentyeight_aligned | Onetwentyeight_unaligned ->
+      (* CR gyorsh: check alignment *)
+      DSL.check_reg Vec128 dst;
+      DSL.ins I.LDR
+        [| DSL.emit_reg dst; DSL.emit_addressing addressing_mode base |])
+  | Lop (Store (size, addr, assignment)) -> (
+    (* NB: assignments other than Word_int and Word_val do not follow the
+       Multicore OCaml memory model and so do not emit a barrier *)
+    let src = i.arg.(0) in
+    let base =
+      match addr with
+      | Iindexed _ -> i.arg.(1)
+      | Ibased (s, ofs) ->
+        assert (not !Clflags.dlcode);
+        DSL.ins I.ADRP
+          [| DSL.emit_reg reg_tmp1; DSL.emit_symbol ~offset:ofs s |];
+        reg_tmp1
+    in
+    match size with
+    | Byte_unsigned | Byte_signed ->
+      DSL.ins I.STRB [| DSL.emit_reg_w src; DSL.emit_addressing addr base |]
+    | Sixteen_unsigned | Sixteen_signed ->
+      DSL.ins I.STRH [| DSL.emit_reg_w src; DSL.emit_addressing addr base |]
+    | Thirtytwo_unsigned | Thirtytwo_signed ->
+      DSL.ins I.STR [| DSL.emit_reg_w src; DSL.emit_addressing addr base |]
+    | Single { reg = Float64 } ->
+      DSL.check_reg Float src;
+      DSL.ins I.FCVT [| DSL.reg_s_7; DSL.emit_reg src |];
+      DSL.ins I.STR [| DSL.reg_s_7; DSL.emit_addressing addr base |]
+    | Word_int | Word_val ->
+      (* memory model barrier for non-initializing store *)
+      if assignment then DSL.ins (I.DMB ISHLD) [||];
+      DSL.ins I.STR [| DSL.emit_reg src; DSL.emit_addressing addr base |]
+    | Double ->
+      DSL.ins I.STR [| DSL.emit_reg src; DSL.emit_addressing addr base |]
+    | Single { reg = Float32 } ->
+      DSL.check_reg Float32 src;
+      DSL.ins I.STR [| DSL.emit_reg src; DSL.emit_addressing addr base |]
+    | Onetwentyeight_aligned | Onetwentyeight_unaligned ->
+      (* CR gyorsh: check alignment *)
+      DSL.check_reg Vec128 src;
+      DSL.ins I.STR [| DSL.emit_reg src; DSL.emit_addressing addr base |])
+  | Lop (Alloc { bytes = n; dbginfo; mode = Heap }) ->
+    assembly_code_for_allocation i ~n ~local:false ~far:false ~dbginfo
+  | Lop (Specific (Ifar_alloc { bytes = n; dbginfo })) ->
+    assembly_code_for_allocation i ~n ~local:false ~far:true ~dbginfo
+  | Lop (Alloc { bytes = n; dbginfo; mode = Local }) ->
+    assembly_code_for_allocation i ~n ~local:true ~far:false ~dbginfo
+  | Lop Begin_region ->
+    let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
+    DSL.ins I.LDR
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr
+      |]
+  | Lop End_region ->
+    let offset = Domainstate.(idx_of_field Domain_local_sp) * 8 in
+    DSL.ins I.STR
+      [| DSL.emit_reg i.arg.(0);
+         DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr
+      |]
+  | Lop Poll -> assembly_code_for_poll i ~far:false ~return_label:None
+  | Lop (Specific Ifar_poll) ->
+    assembly_code_for_poll i ~far:true ~return_label:None
+  | Lop (Intop_imm (Iadd, n)) -> emit_addimm i.res.(0) i.arg.(0) n
+  | Lop (Intop_imm (Isub, n)) -> emit_subimm i.res.(0) i.arg.(0) n
+  | Lop (Intop (Icomp cmp)) ->
+    DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
+    DSL.ins I.CSET
+      [| DSL.emit_reg i.res.(0); DSL.cond (cond_for_comparison cmp) |]
+  | Lop (Floatop (Float64, Icompf cmp)) ->
+    DSL.check_reg Float i.arg.(0);
+    DSL.check_reg Float i.arg.(1);
+    let comp = cond_for_float_comparison cmp in
+    DSL.ins I.FCMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
+    DSL.ins I.CSET [| DSL.emit_reg i.res.(0); DSL.float_cond comp |]
+  | Lop (Floatop (Float32, Icompf cmp)) ->
+    DSL.check_reg Float32 i.arg.(0);
+    DSL.check_reg Float32 i.arg.(1);
+    let comp = cond_for_float_comparison cmp in
+    DSL.ins I.FCMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
+    DSL.ins I.CSET [| DSL.emit_reg i.res.(0); DSL.float_cond comp |]
+  | Lop (Intop_imm (Icomp cmp, n)) ->
+    emit_cmpimm i.arg.(0) n;
+    DSL.ins I.CSET
+      [| DSL.emit_reg i.res.(0); DSL.cond (cond_for_comparison cmp) |]
+  | Lop (Intop Imod) ->
+    DSL.ins I.SDIV
+      [| DSL.emit_reg reg_tmp1;
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1)
+      |];
+    DSL.ins I.MSUB
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg reg_tmp1;
+         DSL.emit_reg i.arg.(1);
+         DSL.emit_reg i.arg.(0)
+      |]
+  | Lop (Intop (Imulh { signed = true })) ->
+    DSL.ins I.SMULH
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1)
+      |]
+  | Lop (Intop (Imulh { signed = false })) ->
+    DSL.ins I.UMULH
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1)
+      |]
+  | Lop (Intop (Ictz _)) ->
+    (* emit_printf "ctz Rd, Rn" is optionally supported from Armv8.7, but rbit
+       and clz are supported in all ARMv8 CPUs. *)
+    DSL.ins I.RBIT [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |];
+    DSL.ins I.CLZ [| DSL.emit_reg i.res.(0); DSL.emit_reg i.res.(0) |]
+  | Lop (Intop (Iclz _ as op)) ->
+    let instr = instr_for_int_operation op in
+    DSL.ins instr [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |]
+  | Lop
+      (Intop
+        (( Iadd | Isub | Imul | Idiv | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr
+         | Ipopcnt ) as op)) ->
+    let instr = instr_for_int_operation op in
+    DSL.ins instr
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1)
+      |]
+  | Lop (Intop_imm (op, n)) ->
+    let instr = instr_for_int_operation op in
+    DSL.ins instr
+      [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0); DSL.imm n |]
+  | Lop (Specific Isqrtf) ->
+    DSL.ins I.FSQRT [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |]
+  | Lop (Floatop ((Float32 | Float64), Iabsf)) ->
+    DSL.ins I.FABS [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |]
+  | Lop (Floatop ((Float32 | Float64), Inegf)) ->
+    DSL.ins I.FNEG [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |]
+  | Lop (Floatop ((Float32 | Float64), Iaddf)) ->
+    DSL.ins I.FADD
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1)
+      |]
+  | Lop (Floatop ((Float32 | Float64), Isubf)) ->
+    DSL.ins I.FSUB
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1)
+      |]
+  | Lop (Floatop ((Float32 | Float64), Imulf)) ->
+    DSL.ins I.FMUL
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1)
+      |]
+  | Lop (Floatop ((Float32 | Float64), Idivf)) ->
+    DSL.ins I.FDIV
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1)
+      |]
+  | Lop (Specific Inegmulf) ->
+    DSL.ins I.FNMUL
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1)
+      |]
+  | Lop (Specific Imuladdf) ->
+    DSL.ins I.FMADD
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(1);
+         DSL.emit_reg i.arg.(2);
+         DSL.emit_reg i.arg.(0)
+      |]
+  | Lop (Specific Inegmuladdf) ->
+    DSL.ins I.FNMADD
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(1);
+         DSL.emit_reg i.arg.(2);
+         DSL.emit_reg i.arg.(0)
+      |]
+  | Lop (Specific Imulsubf) ->
+    DSL.ins I.FMSUB
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(1);
+         DSL.emit_reg i.arg.(2);
+         DSL.emit_reg i.arg.(0)
+      |]
+  | Lop (Specific Inegmulsubf) ->
+    DSL.ins I.FNMSUB
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(1);
+         DSL.emit_reg i.arg.(2);
+         DSL.emit_reg i.arg.(0)
+      |]
+  | Lop Opaque -> assert (i.arg.(0).loc = i.res.(0).loc)
+  | Lop (Specific (Ishiftarith (op, shift))) ->
+    let instr = match op with Ishiftadd -> I.ADD | Ishiftsub -> I.SUB in
+    let shift =
+      if shift >= 0
+      then DSL.emit_shift LSL shift
+      else DSL.emit_shift ASR (-shift)
+    in
+    DSL.ins instr
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1);
+         shift
+      |]
+  | Lop (Specific Imuladd) ->
+    DSL.ins I.MADD
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1);
+         DSL.emit_reg i.arg.(2)
+      |]
+  | Lop (Specific Imulsub) ->
+    DSL.ins I.MSUB
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_reg i.arg.(1);
+         DSL.emit_reg i.arg.(2)
+      |]
+  | Lop (Specific (Ibswap { bitwidth })) -> (
+    match bitwidth with
+    | Sixteen ->
+      DSL.ins I.REV16 [| DSL.emit_reg_w i.res.(0); DSL.emit_reg_w i.arg.(0) |];
+      DSL.ins I.UBFM
+        [| DSL.emit_reg i.res.(0);
+           DSL.emit_reg i.res.(0);
+           DSL.imm 0;
+           DSL.imm 15
+        |]
+    | Thirtytwo ->
+      DSL.ins I.REV [| DSL.emit_reg_w i.res.(0); DSL.emit_reg_w i.arg.(0) |]
+    | Sixtyfour ->
+      DSL.ins I.REV [| DSL.emit_reg i.res.(0); DSL.emit_reg i.arg.(0) |])
+  | Lop (Specific (Isignext size)) ->
+    DSL.ins I.SBFM
+      [| DSL.emit_reg i.res.(0);
+         DSL.emit_reg i.arg.(0);
+         DSL.imm 0;
+         DSL.imm (size - 1)
+      |]
+  | Lop (Specific (Isimd simd)) -> DSL.simd_instr simd i
+  | Lop (Name_for_debugger _) -> ()
+  | Lcall_op (Lprobe _) | Lop (Probe_is_enabled _) ->
+    fatal_error "Probes not supported."
+  | Lop Dls_get ->
+    if Config.runtime5
+    then
+      let offset = Domainstate.(idx_of_field Domain_dls_root) * 8 in
+      DSL.ins I.LDR
+        [| DSL.emit_reg i.res.(0);
+           DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr
+        |]
+    else Misc.fatal_error "Dls is not supported in runtime4."
+  | Lop (Csel tst) -> (
+    let len = Array.length i.arg in
+    let ifso = i.arg.(len - 2) in
+    let ifnot = i.arg.(len - 1) in
+    if Reg.same_loc ifso ifnot
+    then move ifso i.res.(0)
+    else
+      match tst with
+      | Itruetest ->
+        DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.imm 0 |];
+        DSL.ins I.CSEL
+          [| DSL.emit_reg i.res.(0);
+             DSL.emit_reg i.arg.(1);
+             DSL.emit_reg i.arg.(2);
+             DSL.cond NE
+          |]
+      | Ifalsetest ->
+        DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.imm 0 |];
+        DSL.ins I.CSEL
+          [| DSL.emit_reg i.res.(0);
+             DSL.emit_reg i.arg.(1);
+             DSL.emit_reg i.arg.(2);
+             DSL.cond EQ
+          |]
+      | Iinttest cmp ->
+        let comp = cond_for_comparison cmp in
+        DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
+        DSL.ins I.CSEL
+          [| DSL.emit_reg i.res.(0);
+             DSL.emit_reg i.arg.(2);
+             DSL.emit_reg i.arg.(3);
+             DSL.cond comp
+          |]
+      | Iinttest_imm (cmp, n) ->
+        let comp = cond_for_comparison cmp in
+        emit_cmpimm i.arg.(0) n;
+        DSL.ins I.CSEL
+          [| DSL.emit_reg i.res.(0);
+             DSL.emit_reg i.arg.(1);
+             DSL.emit_reg i.arg.(2);
+             DSL.cond comp
+          |]
+      | Ifloattest ((Float32 | Float64), cmp) ->
+        let comp = cond_for_float_comparison cmp in
+        DSL.ins I.FCMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
+        DSL.ins I.CSEL
+          [| DSL.emit_reg i.res.(0);
+             DSL.emit_reg i.arg.(2);
+             DSL.emit_reg i.arg.(3);
+             DSL.float_cond comp
+          |]
+      | Ioddtest ->
+        DSL.ins I.TST [| DSL.emit_reg i.arg.(0); DSL.imm 1 |];
+        DSL.ins I.CSEL
+          [| DSL.emit_reg i.res.(0);
+             DSL.emit_reg i.arg.(1);
+             DSL.emit_reg i.arg.(2);
+             DSL.cond NE
+          |]
+      | Ieventest ->
+        DSL.ins I.TST [| DSL.emit_reg i.arg.(0); DSL.imm 1 |];
+        DSL.ins I.CSEL
+          [| DSL.emit_reg i.res.(0);
+             DSL.emit_reg i.arg.(1);
+             DSL.emit_reg i.arg.(2);
+             DSL.cond EQ
+          |])
+  | Lreloadretaddr -> ()
+  | Lreturn -> output_epilogue (fun () -> DSL.ins I.RET [||])
+  | Llabel { label = lbl; _ } -> emit_printf "%a:\n" femit_label lbl
+  | Lbranch lbl -> DSL.ins I.B [| DSL.emit_label lbl |]
+  | Lcondbranch (tst, lbl) -> (
+    match tst with
+    | Itruetest ->
+      DSL.ins I.CBNZ [| DSL.emit_reg i.arg.(0); DSL.emit_label lbl |]
+    | Ifalsetest ->
+      DSL.ins I.CBZ [| DSL.emit_reg i.arg.(0); DSL.emit_label lbl |]
+    | Iinttest cmp ->
+      DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
+      let comp = cond_for_comparison cmp in
+      DSL.ins (I.B_cond comp) [| DSL.emit_label lbl |]
+    | Iinttest_imm (cmp, n) ->
+      emit_cmpimm i.arg.(0) n;
+      let comp = cond_for_comparison cmp in
+      DSL.ins (I.B_cond comp) [| DSL.emit_label lbl |]
+    | Ifloattest ((Float32 | Float64), cmp) ->
+      let comp = cond_for_float_comparison cmp in
+      DSL.ins I.FCMP [| DSL.emit_reg i.arg.(0); DSL.emit_reg i.arg.(1) |];
+      DSL.ins (I.B_cond_float comp) [| DSL.emit_label lbl |]
+    | Ioddtest ->
+      DSL.ins I.TBNZ [| DSL.emit_reg i.arg.(0); DSL.imm 0; DSL.emit_label lbl |]
+    | Ieventest ->
+      DSL.ins I.TBZ [| DSL.emit_reg i.arg.(0); DSL.imm 0; DSL.emit_label lbl |])
+  | Lcondbranch3 (lbl0, lbl1, lbl2) -> (
+    DSL.ins I.CMP [| DSL.emit_reg i.arg.(0); DSL.imm 1 |];
+    (match lbl0 with
+    | None -> ()
+    | Some lbl -> DSL.ins (I.B_cond LT) [| DSL.emit_label lbl |]);
+    (match lbl1 with
+    | None -> ()
+    | Some lbl -> DSL.ins (I.B_cond EQ) [| DSL.emit_label lbl |]);
+    match lbl2 with
+    | None -> ()
+    | Some lbl -> DSL.ins (I.B_cond GT) [| DSL.emit_label lbl |])
+  | Lswitch jumptbl ->
+    let lbltbl = Cmm.new_label () in
+    DSL.ins I.ADR [| DSL.emit_reg reg_tmp1; DSL.emit_label lbltbl |];
+    DSL.ins I.ADD
+      [| DSL.emit_reg reg_tmp1;
+         DSL.emit_reg reg_tmp1;
+         DSL.emit_reg i.arg.(0);
+         DSL.emit_shift LSL 2
+      |];
+    DSL.ins I.BR [| DSL.emit_reg reg_tmp1 |];
+    emit_printf "%a:" femit_label lbltbl;
+    for j = 0 to Array.length jumptbl - 1 do
+      DSL.ins I.B [| DSL.emit_label jumptbl.(j) |]
+    done
+  (*= Alternative:
         let lbltbl = Cmm.new_label() in
         emit_printf "	adr	%a, %a\n" femit_reg reg_tmp1 femit_label lbltbl;
         emit_printf "	ldr	%a, [%a, %a, lsl #2]\n" femit_wreg reg_tmp2 femit_reg reg_tmp1 femit_reg i.arg.(0);
@@ -1696,67 +1947,83 @@ let emit_instr i =
             emit_printf "	.word	%a - %a\n" femit_label jumptbl.(j) femit_label lbltbl
         done
 *)
-    | Lentertrap ->
-        ()
-    | Ladjust_stack_offset { delta_bytes } ->
-        cfi_adjust_cfa_offset delta_bytes;
-        stack_offset := !stack_offset + delta_bytes
-    | Lpushtrap { lbl_handler; } ->
-        DSL.ins I.ADR [| DSL.emit_reg reg_tmp1; DSL.emit_label lbl_handler |];
-        stack_offset := !stack_offset + 16;
-        DSL.ins I.STP [| DSL.emit_reg reg_trap_ptr; DSL.emit_reg reg_tmp1; DSL.mem_pre ~base:Arm64_ast.Reg.sp ~offset:(-16) |];
-        cfi_adjust_cfa_offset 16;
-        DSL.ins I.MOV [| DSL.emit_reg reg_trap_ptr; DSL.sp |]
-    | Lpoptrap ->
-        DSL.ins I.LDR [| DSL.emit_reg reg_trap_ptr; DSL.mem_post ~base:Arm64_ast.Reg.sp ~offset:16 |];
-        cfi_adjust_cfa_offset (-16);
-        stack_offset := !stack_offset - 16
-    | Lraise k ->
-        begin match k with
-        | Lambda.Raise_regular ->
-          DSL.ins I.BL [| DSL.emit_symbol "caml_raise_exn" |];
-          record_frame Reg.Set.empty (Dbg_raise i.dbg)
-        | Lambda.Raise_reraise ->
-          if Config.runtime5 then
-            DSL.ins I.BL [| DSL.emit_symbol "caml_reraise_exn" |]
-          else
-            DSL.ins I.BL [| DSL.emit_symbol "caml_raise_exn" |];
-          record_frame Reg.Set.empty (Dbg_raise i.dbg)
-        | Lambda.Raise_notrace ->
-          DSL.ins I.MOV [| DSL.sp; DSL.emit_reg reg_trap_ptr |];
-          DSL.ins I.LDP [| DSL.emit_reg reg_trap_ptr; DSL.emit_reg reg_tmp1; DSL.mem ~base:Arm64_ast.Reg.sp; DSL.imm 16 |];
-          DSL.ins I.BR [| DSL.emit_reg reg_tmp1 |];
-      end
-    | Lstackcheck { max_frame_size_bytes; } ->
-      let overflow = Cmm.new_label () and ret = Cmm.new_label () in
-      let threshold_offset =
-        Domainstate.stack_ctx_words * 8 + Stack_check.stack_threshold_size
-      in
-      let f = max_frame_size_bytes + threshold_offset in
-      let offset = Domainstate.(idx_of_field Domain_current_stack) * 8 in
-      DSL.ins I.LDR [| DSL.emit_reg reg_tmp1; DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr |];
-      emit_addimm reg_tmp1 reg_tmp1 f;
-      DSL.ins I.CMP [| DSL.sp; DSL.emit_reg reg_tmp1 |];
-      DSL.ins (I.B_cond CC) [| DSL.emit_label overflow |];
-      emit_printf "%a:" femit_label ret;
-      stack_realloc := Some {
-        sc_label = overflow;
-        sc_return = ret;
-        sc_max_frame_size_in_bytes = max_frame_size_bytes;
-      }
+  | Lentertrap -> ()
+  | Ladjust_stack_offset { delta_bytes } ->
+    cfi_adjust_cfa_offset delta_bytes;
+    stack_offset := !stack_offset + delta_bytes
+  | Lpushtrap { lbl_handler } ->
+    DSL.ins I.ADR [| DSL.emit_reg reg_tmp1; DSL.emit_label lbl_handler |];
+    stack_offset := !stack_offset + 16;
+    DSL.ins I.STP
+      [| DSL.emit_reg reg_trap_ptr;
+         DSL.emit_reg reg_tmp1;
+         DSL.mem_pre ~base:Arm64_ast.Reg.sp ~offset:(-16)
+      |];
+    cfi_adjust_cfa_offset 16;
+    DSL.ins I.MOV [| DSL.emit_reg reg_trap_ptr; DSL.sp |]
+  | Lpoptrap ->
+    DSL.ins I.LDR
+      [| DSL.emit_reg reg_trap_ptr;
+         DSL.mem_post ~base:Arm64_ast.Reg.sp ~offset:16
+      |];
+    cfi_adjust_cfa_offset (-16);
+    stack_offset := !stack_offset - 16
+  | Lraise k -> (
+    match k with
+    | Lambda.Raise_regular ->
+      DSL.ins I.BL [| DSL.emit_symbol "caml_raise_exn" |];
+      record_frame Reg.Set.empty (Dbg_raise i.dbg)
+    | Lambda.Raise_reraise ->
+      if Config.runtime5
+      then DSL.ins I.BL [| DSL.emit_symbol "caml_reraise_exn" |]
+      else DSL.ins I.BL [| DSL.emit_symbol "caml_raise_exn" |];
+      record_frame Reg.Set.empty (Dbg_raise i.dbg)
+    | Lambda.Raise_notrace ->
+      DSL.ins I.MOV [| DSL.sp; DSL.emit_reg reg_trap_ptr |];
+      DSL.ins I.LDP
+        [| DSL.emit_reg reg_trap_ptr;
+           DSL.emit_reg reg_tmp1;
+           DSL.mem ~base:Arm64_ast.Reg.sp;
+           DSL.imm 16
+        |];
+      DSL.ins I.BR [| DSL.emit_reg reg_tmp1 |])
+  | Lstackcheck { max_frame_size_bytes } ->
+    let overflow = Cmm.new_label () and ret = Cmm.new_label () in
+    let threshold_offset =
+      (Domainstate.stack_ctx_words * 8) + Stack_check.stack_threshold_size
+    in
+    let f = max_frame_size_bytes + threshold_offset in
+    let offset = Domainstate.(idx_of_field Domain_current_stack) * 8 in
+    DSL.ins I.LDR
+      [| DSL.emit_reg reg_tmp1;
+         DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr
+      |];
+    emit_addimm reg_tmp1 reg_tmp1 f;
+    DSL.ins I.CMP [| DSL.sp; DSL.emit_reg reg_tmp1 |];
+    DSL.ins (I.B_cond CC) [| DSL.emit_label overflow |];
+    emit_printf "%a:" femit_label ret;
+    stack_realloc
+      := Some
+           { sc_label = overflow;
+             sc_return = ret;
+             sc_max_frame_size_in_bytes = max_frame_size_bytes
+           }
 
 let emit_instr i =
   try emit_instr i
-  with exn -> (
+  with exn ->
     Format.eprintf "Exception whilst emitting instruction:@ %a\n"
       Printlinear.instr i;
     raise exn
-  )
 
 (* Emission of an instruction sequence *)
 
 let rec emit_all i =
-  if i.desc = Lend then () else (emit_instr i; emit_all i.next)
+  if i.desc = Lend
+  then ()
+  else (
+    emit_instr i;
+    emit_all i.next)
 
 (* Emission of a function declaration *)
 
@@ -1774,65 +2041,65 @@ let fundecl fundecl =
   call_gc_sites := [];
   local_realloc_sites := [];
   clear_stack_realloc ();
-  Stack_class.Tbl.copy_values ~from:fundecl.fun_num_stack_slots ~to_:num_stack_slots;
+  Stack_class.Tbl.copy_values ~from:fundecl.fun_num_stack_slots
+    ~to_:num_stack_slots;
   prologue_required := fundecl.fun_prologue_required;
   contains_calls := fundecl.fun_contains_calls;
   emit_named_text_section !function_name;
-  emit_printf "	.align	3\n";
-  emit_printf "	.globl	%a\n" femit_symbol fundecl.fun_name;
+  emit_printf "\t.align\t3\n";
+  emit_printf "\t.globl\t%a\n" femit_symbol fundecl.fun_name;
   emit_symbol_type femit_symbol fundecl.fun_name "function";
   emit_printf "%a:\n" femit_symbol fundecl.fun_name;
   emit_debug_info fundecl.fun_dbg;
-  cfi_startproc();
+  cfi_startproc ();
   let num_call_gc = num_call_gc_points fundecl.fun_body in
   let max_out_of_line_code_offset = max_out_of_line_code_offset ~num_call_gc in
   BR.relax fundecl.fun_body ~max_out_of_line_code_offset;
-
   emit_all fundecl.fun_body;
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
   emit_stack_realloc ();
   assert (List.length !call_gc_sites = num_call_gc);
   (match fun_end_label with
-   | None -> ()
-   | Some fun_end_label -> emit_printf "%a:\n" femit_label fun_end_label);
-
-  cfi_endproc();
+  | None -> ()
+  | Some fun_end_label -> emit_printf "%a:\n" femit_label fun_end_label);
+  cfi_endproc ();
   emit_symbol_type femit_symbol fundecl.fun_name "function";
   emit_symbol_size fundecl.fun_name;
-  emit_literals()
+  emit_literals ()
 
 (* Emission of data *)
 
 let emit_item (d : Cmm.data_item) =
   match d with
   | Cdefine_symbol s ->
-    if !Clflags.dlcode || s.sym_global = Cmm.Global then begin
-      (* GOT relocations against non-global symbols don't seem to work
-         properly: GOT entries are not created for the symbols and the
-         relocations evaluate to random other GOT entries.  For the moment
-         force all symbols to be global. *)
-      emit_printf "	.globl	%a\n" femit_symbol s.sym_name;
-    end;
+    if !Clflags.dlcode || s.sym_global = Cmm.Global
+    then
+      (* GOT relocations against non-global symbols don't seem to work properly:
+         GOT entries are not created for the symbols and the relocations
+         evaluate to random other GOT entries. For the moment force all symbols
+         to be global. *)
+      emit_printf "\t.globl\t%a\n" femit_symbol s.sym_name;
     emit_printf "%a:\n" femit_symbol s.sym_name
-  | Cint8 n -> emit_printf "	.byte	%a\n" femit_int n
-  | Cint16 n -> emit_printf "	.short	%a\n" femit_int n
-  | Cint32 n -> emit_printf "	.long	%a\n" femit_nativeint n
-  | Cint n -> emit_printf "	.quad	%a\n" femit_nativeint n
+  | Cint8 n -> emit_printf "\t.byte\t%a\n" femit_int n
+  | Cint16 n -> emit_printf "\t.short\t%a\n" femit_int n
+  | Cint32 n -> emit_printf "\t.long\t%a\n" femit_nativeint n
+  | Cint n -> emit_printf "\t.quad\t%a\n" femit_nativeint n
   | Csingle f -> emit_float32_directive ".long" (Int32.bits_of_float f)
   | Cdouble f -> emit_float64_directive ".quad" (Int64.bits_of_float f)
-  | Cvec128 { high; low; } ->
-     emit_float64_directive ".quad" low;
-     emit_float64_directive ".quad" high;
-  | Csymbol_address s -> emit_printf "	.quad	%a\n" femit_symbol s.sym_name
-  | Csymbol_offset (s, o) -> emit_printf "	.quad	%a+%a\n" femit_symbol s.sym_name femit_int o
-  | Cstring s -> emit_string_directive "	.ascii  " s
-  | Cskip n -> if n > 0 then emit_printf "	.space	%a\n" femit_int n
-  | Calign n -> emit_printf "	.align	%a\n" femit_int(Misc.log2 n)
+  | Cvec128 { high; low } ->
+    emit_float64_directive ".quad" low;
+    emit_float64_directive ".quad" high
+  | Csymbol_address s -> emit_printf "\t.quad\t%a\n" femit_symbol s.sym_name
+  | Csymbol_offset (s, o) ->
+    emit_printf "\t.quad\t%a+%a\n" femit_symbol s.sym_name femit_int o
+  | Cstring s -> emit_string_directive "\t.ascii  " s
+  | Cskip n -> if n > 0 then emit_printf "\t.space\t%a\n" femit_int n
+  | Calign n -> emit_printf "\t.align\t%a\n" femit_int (Misc.log2 n)
 
 let data l =
-  emit_printf "	.data\n";
-  emit_printf "	.align  3\n";
+  emit_printf "\t.data\n";
+  emit_printf "\t.align  3\n";
   List.iter emit_item l
 
 let emit_line str = emit_string (str ^ "\n")
@@ -1840,15 +2107,13 @@ let emit_line str = emit_string (str ^ "\n")
 let file_emitter ~file_num ~file_name =
   emit_line (Printf.sprintf ".file %d %S" file_num file_name)
 
-let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
-  module Asm_targets.Asm_directives.Make(struct
+let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) =
+  (module Asm_targets.Asm_directives.Make (struct
     let emit_line = emit_line
 
-    let get_file_num file_name =
-      Emitaux.get_file_num ~file_emitter file_name
+    let get_file_num file_name = Emitaux.get_file_num ~file_emitter file_name
 
-    let debugging_comments_in_asm_files =
-      !Flambda_backend_flags.dasm_comments
+    let debugging_comments_in_asm_files = !Flambda_backend_flags.dasm_comments
 
     module D = struct
       type constant =
@@ -1862,15 +2127,18 @@ let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
         | Int64 n -> Int64.to_string n
         | Label s -> s
         | Add (c1, c2) ->
-          Printf.sprintf "(%s + %s)"
-            (string_of_constant c1) (string_of_constant c2)
+          Printf.sprintf "(%s + %s)" (string_of_constant c1)
+            (string_of_constant c2)
         | Sub (c1, c2) ->
-          Printf.sprintf "(%s - %s)"
-            (string_of_constant c1) (string_of_constant c2)
+          Printf.sprintf "(%s - %s)" (string_of_constant c1)
+            (string_of_constant c2)
 
       let const_int64 num = Int64 num
+
       let const_label str = Label str
+
       let const_add c1 c2 = Add (c1, c2)
+
       let const_sub c1 c2 = Sub (c1, c2)
 
       type data_type =
@@ -1885,8 +2153,7 @@ let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
         ignore discriminator;
         emit_line (Printf.sprintf ".loc %d %d %d" file_num line col)
 
-      let comment str =
-        emit_line (Printf.sprintf "; %s" str)
+      let comment str = emit_line (Printf.sprintf "; %s" str)
 
       let label ?data_type str =
         let _ = data_type in
@@ -1894,20 +2161,16 @@ let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
 
       let section ?delayed:_ name flags args =
         match name, flags, args with
-        | [".data" ], _, _ -> emit_line "\t.data"
-        | [".text" ], _, _ -> emit_line "\t.text"
+        | [".data"], _, _ -> emit_line "\t.data"
+        | [".text"], _, _ -> emit_line "\t.text"
         | name, flags, args ->
-          emit_string (Printf.sprintf "\t.section %s"
-            (String.concat "," name));
-          begin match flags with
+          emit_string (Printf.sprintf "\t.section %s" (String.concat "," name));
+          (match flags with
           | None -> ()
-          | Some flags -> emit_string (Printf.sprintf ",%S" flags)
-          end;
-          begin match args with
+          | Some flags -> emit_string (Printf.sprintf ",%S" flags));
+          (match args with
           | [] -> ()
-          | _ ->
-            emit_string (Printf.sprintf ",%s" (String.concat "," args))
-          end;
+          | _ -> emit_string (Printf.sprintf ",%s" (String.concat "," args)));
           emit_string "\n"
 
       let text () = emit_line "\t.text"
@@ -1922,104 +2185,100 @@ let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) = (
       let type_ sym typ_ = emit_line (Printf.sprintf "\t.type %s,%s" sym typ_)
 
       let byte const =
-        emit_line
-          (Printf.sprintf "\t.byte %s" (string_of_constant const))
+        emit_line (Printf.sprintf "\t.byte %s" (string_of_constant const))
 
       let word const =
-        emit_line
-          (Printf.sprintf "\t.short %s" (string_of_constant const))
+        emit_line (Printf.sprintf "\t.short %s" (string_of_constant const))
 
       let long const =
-        emit_line
-          (Printf.sprintf "\t.long %s" (string_of_constant const))
+        emit_line (Printf.sprintf "\t.long %s" (string_of_constant const))
 
       let qword const =
-        emit_line
-          (Printf.sprintf "\t.quad %s" (string_of_constant const))
+        emit_line (Printf.sprintf "\t.quad %s" (string_of_constant const))
 
-      let bytes str =
-        emit_line (Printf.sprintf "\t.ascii %S" str)
+      let bytes str = emit_line (Printf.sprintf "\t.ascii %S" str)
 
       let uleb128 const =
-        emit_line
-          (Printf.sprintf "\t.uleb128 %s" (string_of_constant const))
+        emit_line (Printf.sprintf "\t.uleb128 %s" (string_of_constant const))
 
       let sleb128 const =
-        emit_line
-          (Printf.sprintf "\t.sleb128 %s" (string_of_constant const))
+        emit_line (Printf.sprintf "\t.sleb128 %s" (string_of_constant const))
 
       let direct_assignment var const =
-        emit_line
-          (Printf.sprintf "\t.set %s,%s" var (string_of_constant const))
+        emit_line (Printf.sprintf "\t.set %s,%s" var (string_of_constant const))
     end
-  end)
-)
+  end))
 
 (* Beginning / end of an assembly file *)
 
 let begin_assembly _unix =
-  reset_debug_info();
-  emit_printf "	.file	\"\"\n";  (* PR#7037 *)
+  reset_debug_info ();
+  emit_printf "\t.file\t\"\"\n";
+  (* PR#7037 *)
   let lbl_begin = Cmm_helpers.make_symbol "data_begin" in
-  emit_printf "	.data\n";
-  emit_printf "	.globl	%a\n" femit_symbol lbl_begin;
+  emit_printf "\t.data\n";
+  emit_printf "\t.globl\t%a\n" femit_symbol lbl_begin;
   emit_printf "%a:\n" femit_symbol lbl_begin;
   let lbl_begin = Cmm_helpers.make_symbol "code_begin" in
   emit_named_text_section lbl_begin;
-  emit_printf "	.globl	%a\n" femit_symbol lbl_begin;
+  emit_printf "\t.globl\t%a\n" femit_symbol lbl_begin;
   emit_printf "%a:\n" femit_symbol lbl_begin;
-  (* we need to pad here to avoid collision for the unwind test between
-     the code_begin symbol and the first function. (See also #4690)
-     Alignment is needed to avoid linker warnings for
-     shared_startup__code_{begin,end} (e.g. tests/lib-dynlink-pr4839).
-   *)
-  if macosx then begin
-    DSL.ins I.NOP [| |];
-    emit_printf "	.align	3\n"
-  end;
+  (* we need to pad here to avoid collision for the unwind test between the
+     code_begin symbol and the first function. (See also #4690) Alignment is
+     needed to avoid linker warnings for shared_startup__code_{begin,end} (e.g.
+     tests/lib-dynlink-pr4839). *)
+  if macosx
+  then (
+    DSL.ins I.NOP [||];
+    emit_printf "\t.align\t3\n");
   let lbl_end = Cmm_helpers.make_symbol "code_end" in
-  Emitaux.Dwarf_helpers.begin_dwarf ~build_asm_directives
-    ~code_begin:lbl_begin ~code_end:lbl_end
-    ~file_emitter
+  Emitaux.Dwarf_helpers.begin_dwarf ~build_asm_directives ~code_begin:lbl_begin
+    ~code_end:lbl_end ~file_emitter
 
 let end_assembly () =
   let lbl_end = Cmm_helpers.make_symbol "code_end" in
   emit_named_text_section lbl_end;
-  emit_printf "	.globl	%a\n" femit_symbol lbl_end;
+  emit_printf "\t.globl\t%a\n" femit_symbol lbl_end;
   emit_printf "%a:\n" femit_symbol lbl_end;
   let lbl_end = Cmm_helpers.make_symbol "data_end" in
-  emit_printf "	.data\n";
-  emit_printf "	.quad	0\n";  (* PR#6329 *)
-  emit_printf "	.globl	%a\n" femit_symbol lbl_end;
+  emit_printf "\t.data\n";
+  emit_printf "\t.quad\t0\n";
+  (* PR#6329 *)
+  emit_printf "\t.globl\t%a\n" femit_symbol lbl_end;
   emit_printf "%a:\n" femit_symbol lbl_end;
-  emit_printf "	.quad	0\n";
-  emit_printf "	.align	3\n";  (* #7887 *)
+  emit_printf "\t.quad\t0\n";
+  emit_printf "\t.align\t3\n";
+  (* #7887 *)
   let lbl = Cmm_helpers.make_symbol "frametable" in
-  emit_printf "	.globl	%a\n" femit_symbol lbl;
+  emit_printf "\t.globl\t%a\n" femit_symbol lbl;
   emit_printf "%a:\n" femit_symbol lbl;
   emit_frames
-    { efa_code_label = (fun lbl ->
-                       emit_symbol_type femit_label lbl "function";
-                       emit_printf "	.quad	%a\n" femit_label lbl);
-      efa_data_label = (fun lbl ->
-                       emit_symbol_type femit_label lbl "object";
-                       emit_printf "	.quad	%a\n" femit_label lbl);
-      efa_8 = (fun n -> emit_printf "	.byte	%a\n" femit_int n);
-      efa_16 = (fun n -> emit_printf "	.short	%a\n" femit_int n);
-      efa_32 = (fun n -> emit_printf "	.long	%a\n" femit_int32 n);
-      efa_word = (fun n -> emit_printf "	.quad	%a\n" femit_int n);
-      efa_align = (fun n -> emit_printf "	.align	%a\n" femit_int(Misc.log2 n));
-      efa_label_rel = (fun lbl ofs ->
-                           emit_printf "	.long	%a - . + %a\n" femit_label lbl femit_int32 ofs);
+    { efa_code_label =
+        (fun lbl ->
+          emit_symbol_type femit_label lbl "function";
+          emit_printf "\t.quad\t%a\n" femit_label lbl);
+      efa_data_label =
+        (fun lbl ->
+          emit_symbol_type femit_label lbl "object";
+          emit_printf "\t.quad\t%a\n" femit_label lbl);
+      efa_8 = (fun n -> emit_printf "\t.byte\t%a\n" femit_int n);
+      efa_16 = (fun n -> emit_printf "\t.short\t%a\n" femit_int n);
+      efa_32 = (fun n -> emit_printf "\t.long\t%a\n" femit_int32 n);
+      efa_word = (fun n -> emit_printf "\t.quad\t%a\n" femit_int n);
+      efa_align =
+        (fun n -> emit_printf "\t.align\t%a\n" femit_int (Misc.log2 n));
+      efa_label_rel =
+        (fun lbl ofs ->
+          emit_printf "\t.long\t%a - . + %a\n" femit_label lbl femit_int32 ofs);
       efa_def_label = (fun lbl -> emit_printf "%a:\n" femit_label lbl);
-      efa_string = (fun s -> emit_string_directive "	.asciz	" s) };
+      efa_string = (fun s -> emit_string_directive "\t.asciz\t" s)
+    };
   emit_symbol_type femit_symbol lbl "object";
   emit_symbol_size lbl;
-  if not !Flambda_backend_flags.internal_assembler then
-    Emitaux.Dwarf_helpers.emit_dwarf ();
-  begin match Config.system with
+  if not !Flambda_backend_flags.internal_assembler
+  then Emitaux.Dwarf_helpers.emit_dwarf ();
+  match Config.system with
   | "linux" ->
-      (* Mark stack as non-executable *)
-      emit_printf "	.section	.note.GNU-stack,\"\",%%progbits\n"
+    (* Mark stack as non-executable *)
+    emit_printf "\t.section\t.note.GNU-stack,\"\",%%progbits\n"
   | _ -> ()
-  end


### PR DESCRIPTION
Enables formatting of `emit.ml` in both `arm64` and `amd64`.