### PR TITLE
Reintroduce support for OCAMLRUNPARAM=H=1 (force hugepages)

### DIFF
--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -106,7 +106,7 @@ extern int caml_format_timestamp(char* buf, size_t sz, int formatted);
 
 /* Memory management platform-specific operations */
 
-void *caml_plat_mem_map(uintnat, int, const char*);
+void *caml_plat_mem_map(uintnat size, uintnat flags, const char* name);
 void *caml_plat_mem_commit(void *, uintnat, const char*);
 void caml_plat_mem_decommit(void *, uintnat, const char*);
 void caml_plat_mem_unmap(void *, uintnat);

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -440,7 +440,8 @@ uintnat caml_mem_round_up_mapping_size(uintnat size);
    caml_plat_pagesize. The size given to caml_mem_unmap and caml_mem_decommit
    must match the size given to caml_mem_map/caml_mem_commit for mem.
 */
-void* caml_mem_map(uintnat size, int reserve_only, const char* name);
+enum { CAML_MAP_RESERVE_ONLY = 1 << 0, CAML_MAP_NO_HUGETLB = 1 << 1 };
+void* caml_mem_map(uintnat size, uintnat flags, const char* name);
 void* caml_mem_commit(void* mem, uintnat size, const char* name);
 void caml_mem_decommit(void* mem, uintnat size, const char* name);
 void caml_mem_unmap(void* mem, uintnat size);

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -56,6 +56,7 @@ struct caml_params {
   uintnat cleanup_on_exit;
   uintnat event_trace;
   uintnat max_domains;
+  uintnat use_hugetlb_pages;
 };
 
 extern const struct caml_params* const caml_params;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -837,7 +837,7 @@ static void reserve_minor_heaps_from_stw_single(void) {
   minor_heap_reservation_bsize = minor_heap_max_bsz * caml_params->max_domains;
 
   /* reserve memory space for minor heaps */
-  heaps_base = caml_mem_map(minor_heap_reservation_bsize, 1 /* reserve_only */, "minor reservation");
+  heaps_base = caml_mem_map(minor_heap_reservation_bsize, CAML_MAP_RESERVE_ONLY, "minor reservation");
   if (heaps_base == NULL)
     caml_fatal_error("Not enough heap memory to reserve minor heaps");
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -217,7 +217,8 @@ Caml_inline struct stack_info* alloc_for_stack (mlsize_t wosize)
 #else
   const char* mapping_name = "stack";
 #endif
-  stack = caml_mem_map(len, 0, mapping_name);
+  /* These mappings should never use HugeTLB pages, due to the guard page */
+  stack = caml_mem_map(len, CAML_MAP_NO_HUGETLB, mapping_name);
   if (stack == NULL) {
     return NULL;
   }

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -571,7 +571,7 @@ CAMLprim value caml_runtime_parameters (value unit)
   char *no_tweaks = "";
   /* keep in sync with runtime4 and with parse_ocamlrunparam */
   value res = caml_alloc_sprintf
-    ("b=%d,c="F_Z",d="F_Z",e="F_Z",i="F_Z",l="F_Z
+    ("b=%d,c="F_Z",d="F_Z",e="F_Z",H="F_Z",i="F_Z",l="F_Z
      ",m="F_Z",M="F_Z",n="F_Z",o="F_Z",O="F_Z
      ",p="F_Z",s="F_Z",t="F_Z",v="F_Z",V="F_Z
      ",W="F_Z"%s",
@@ -581,7 +581,7 @@ CAMLprim value caml_runtime_parameters (value unit)
        /* d */ caml_params->max_domains,
        /* e */ caml_params->runtime_events_log_wsize,
        /* h is runtime 4 init heap size */
-       /* H is runtime 4 huge pages */
+       /* H */ caml_params->use_hugetlb_pages,
        /* i */ caml_major_heap_increment,
        /* l */ caml_max_stack_wsize,
        /* m */ caml_custom_minor_ratio,

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -400,9 +400,9 @@ uintnat caml_mem_round_up_mapping_size(uintnat size)
 
 #define Is_page_aligned(size) ((size & (caml_plat_pagesize - 1)) == 0)
 
-void* caml_mem_map(uintnat size, int reserve_only, const char* name)
+void* caml_mem_map(uintnat size, uintnat flags, const char* name)
 {
-  void* mem = caml_plat_mem_map(size, reserve_only, name);
+  void* mem = caml_plat_mem_map(size, flags, name);
 
   if (mem == 0) {
     CAML_GC_MESSAGE(ADDRSPACE,

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -77,6 +77,7 @@ static void init_startup_params(void)
   params.init_max_stack_wsz = Max_stack_def;
   params.max_domains = Max_domains_def;
   params.runtime_events_log_wsize = Default_runtime_events_log_wsize;
+  params.use_hugetlb_pages = 0;
 
 #ifdef DEBUG
   // Silenced in flambda-backend to make it easier to run tests that
@@ -152,7 +153,7 @@ static void parse_ocamlrunparam(char_os* opt)
       case 'd': scanmult (opt, &params.max_domains); break;
       case 'e': scanmult (opt, &params.runtime_events_log_wsize); break;
       case 'h': break; /* init heap size in runtime 4 */
-      case 'H': break; /* use huge pages in runtime 4 */
+      case 'H': scanmult (opt, &params.use_hugetlb_pages); break;
       case 'i': scanmult (opt, &params.init_major_heap_increment); break;
       case 'l': scanmult (opt, &params.init_max_stack_wsz); break;
       case 'm': scanmult (opt, &params.init_custom_minor_ratio); break;

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -73,6 +73,7 @@
 #include "caml/io.h"
 #include "caml/alloc.h"
 #include "caml/platform.h"
+#include "caml/startup_aux.h"
 
 #ifndef S_ISREG
 #define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
@@ -536,9 +537,11 @@ static void* mmap_named(void* addr, size_t length, int prot, int flags,
 }
 #endif
 
-void *caml_plat_mem_map(uintnat size, int reserve_only, const char* name)
+void *caml_plat_mem_map(uintnat size, uintnat caml_flags, const char* name)
 {
   uintnat alignment = caml_plat_hugepagesize;
+  uintnat reserve_only = caml_flags & CAML_MAP_RESERVE_ONLY;
+  uintnat no_hugetlb = caml_flags & CAML_MAP_NO_HUGETLB;
 #ifdef WITH_ADDRESS_SANITIZER
   return aligned_alloc(alignment, (size + (alignment - 1)) & ~(alignment - 1));
 #else
@@ -554,6 +557,15 @@ void *caml_plat_mem_map(uintnat size, int reserve_only, const char* name)
 
     return mem;
   }
+
+#ifdef HAS_HUGE_PAGES
+  if (caml_params->use_hugetlb_pages && !reserve_only && !no_hugetlb) {
+    /* If requested, try mapping with MAP_HUGETLB */
+    mem = mmap_named(0, size, prot, flags | MAP_HUGETLB, -1, 0, name);
+    if (mem == MAP_FAILED) mem = NULL;
+    return mem;
+  }
+#endif
 
   /* Sensible kernels (on Linux, that means >= 6.7) will always provide aligned
      mappings. To avoid penalising such kernels, try mapping the exact desired
@@ -599,9 +611,10 @@ static void* map_fixed(void* mem, uintnat size, int prot, const char* name)
    done using mprotect, since Cygwin's mmap doesn't implement the required
    functions for committing using mmap. */
 
-void *caml_plat_mem_map(uintnat size, int reserve_only, const char* name)
+void *caml_plat_mem_map(uintnat size, uintnat flags, const char* name)
 {
   void* mem;
+  uintnat reserve_only = flags & CAML_MAP_RESERVE_ONLY;
 
   mem = mmap(0, size, reserve_only ? PROT_NONE : (PROT_READ | PROT_WRITE),
              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);


### PR DESCRIPTION
This adds support for passing the `MAP_HUGETLB` flag to `mmap` when expanding the heap, to use configured static huge pages (on Linux). This is a feature of OCaml 4 currently missing in OCaml 5.