### PR TITLE
Remove IRC-related fields from `Reg.t`

### DIFF
--- a/backend/reg.mli
+++ b/backend/reg.mli
@@ -15,21 +15,6 @@
 
 (* Pseudo-registers *)
 
-(* CR xclerc for xclerc: double check all constructors are actually used. *)
-type irc_work_list =
-  | Unknown_list
-  | Precolored
-  | Initial
-  | Simplify
-  | Freeze
-  | Spill
-  | Spilled
-  | Coalesced
-  | Colored
-  | Select_stack
-val equal_irc_work_list : irc_work_list -> irc_work_list -> bool
-val string_of_irc_work_list : irc_work_list -> string
-
 module Raw_name : sig
   type t
   val create_from_var : Backend_var.t -> t
@@ -41,12 +26,7 @@ type t =
     stamp: int;                           (* Unique stamp *)
     typ: Cmm.machtype_component;          (* Type of contents *)
     mutable loc: location;                (* Actual location *)
-    mutable irc_work_list: irc_work_list; (* Current work list (IRC only) *)
-    mutable irc_color : int option;       (* Current color (IRC only) *)
-    mutable irc_alias : t option;         (* Current alias (IRC only) *)
     mutable spill: bool;                  (* "true" to force stack allocation  *)
-    mutable interf: t list;               (* Other regs live simultaneously *)
-    mutable degree: int;                  (* Number of other regs live sim. *)
     mutable spill_cost: int; }            (* Estimate of spilling cost *)
 
 and location =

--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -8,13 +8,15 @@ module State = Regalloc_gi_state
 module Utils = struct
   include Regalloc_gi_utils
 
+  type state = State.t
+
   let debug = debug
 
   let invariants = invariants
 
-  let is_spilled reg = reg.Reg.spill
+  let is_spilled _state reg = reg.Reg.spill
 
-  let set_spilled _reg = ()
+  let set_spilled _state _reg = ()
 end
 
 let rewrite : State.t -> Cfg_with_infos.t -> spilled_nodes:Reg.t list -> bool =

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -42,37 +42,16 @@ let precondition : Cfg_with_layout.t -> unit =
       : unit =
     ArrayLabels.iter regs ~f:(register_must_not_be_on_stack id)
   in
-  (* CR xclerc for xclerc: the check below should not be in this function, since
-     it is IRC-specific *)
-  let register_must_be_on_unknown_list (id : InstructionId.t) (reg : Reg.t) :
-      unit =
-    match reg.Reg.irc_work_list with
-    | Unknown_list -> ()
-    | Precolored -> ()
-    | Initial | Simplify | Freeze | Spill | Spilled | Coalesced | Colored
-    | Select_stack ->
-      fatal "instruction %a has a register (%a) already in a work list (%S)"
-        InstructionId.format id Printreg.reg reg
-        (Reg.string_of_irc_work_list reg.Reg.irc_work_list)
-  in
-  let register_must_be_on_unknown_list (id : InstructionId.t)
-      (regs : Reg.t array) : unit =
-    ArrayLabels.iter regs ~f:(register_must_be_on_unknown_list id)
-  in
   Cfg_with_layout.iter_instructions cfg_with_layout
     ~instruction:(fun instr ->
       let id = instr.id in
       desc_is_neither_spill_or_reload id instr.desc;
       registers_must_not_be_on_stack id instr.arg;
-      registers_must_not_be_on_stack id instr.res;
-      register_must_be_on_unknown_list id instr.arg;
-      register_must_be_on_unknown_list id instr.res)
+      registers_must_not_be_on_stack id instr.res)
     ~terminator:(fun term ->
       let id = term.id in
       registers_must_not_be_on_stack id term.arg;
-      registers_must_not_be_on_stack id term.res;
-      register_must_be_on_unknown_list id term.arg;
-      register_must_be_on_unknown_list id term.res);
+      registers_must_not_be_on_stack id term.res);
   let fun_num_stack_slots =
     (Cfg_with_layout.cfg cfg_with_layout).fun_num_stack_slots
   in

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -394,7 +394,9 @@ module Utils = struct
   let invariants = invariants
 
   let is_spilled state reg =
-    WorkList.equal (State.work_list state reg) WorkList.Spilled
+    match State.work_list_opt state reg with
+    | None -> false
+    | Some work_list -> WorkList.equal work_list WorkList.Spilled
 
   let set_spilled _state reg = reg.Reg.spill <- true
 end

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -395,7 +395,11 @@ module Utils = struct
 
   let is_spilled state reg =
     match State.work_list_opt state reg with
-    | None -> false
+    | None ->
+      (* Freshly-created may not have been added to the map yet; such registers
+         would morally be in the "unknown" work list, hence returning
+         `false`. *)
+      false
     | Some work_list -> WorkList.equal work_list WorkList.Spilled
 
   let set_spilled _state reg = reg.Reg.spill <- true

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -99,7 +99,7 @@ let make_work_list : State.t -> unit =
     log "make_work_list";
     indent ());
   State.iter_and_clear_initial state ~f:(fun reg ->
-      let deg = reg.Reg.degree in
+      let deg = State.degree state reg in
       if debug
       then (
         log "- %a has degree=%s (k=%d)" Printreg.reg reg (Degree.to_string deg)
@@ -128,8 +128,8 @@ let simplify : State.t -> unit =
 
 let ok : State.t -> Reg.t -> Reg.t -> bool =
  fun state t r ->
-  Reg.equal_irc_work_list t.Reg.irc_work_list Reg.Precolored
-  || t.Reg.degree < k t
+  WorkList.equal (State.work_list state t) WorkList.Precolored
+  || State.degree state t < k t
   || State.mem_adj_set state t r
 
 let all_adjacent_are_ok : State.t -> Reg.t -> Reg.t -> bool =
@@ -145,7 +145,7 @@ let conservative : State.t -> Reg.t -> Reg.t -> bool =
     then (
       Reg.Tbl.replace seen reg ();
       let k = k reg in
-      if reg.Reg.degree >= k
+      if State.degree state reg >= k
       then (
         incr i;
         if !i >= k then raise_notrace False))
@@ -171,7 +171,7 @@ let combine : State.t -> Reg.t -> Reg.t -> unit =
   State.iter_adjacent state v ~f:(fun t ->
       State.add_edge state t u;
       State.decr_degree state t);
-  if State.mem_freeze_work_list state u && u.Reg.degree >= k u
+  if State.mem_freeze_work_list state u && State.degree state u >= k u
   then (
     State.remove_freeze_work_list state u;
     State.add_spill_work_list state u)
@@ -180,7 +180,7 @@ let add_work_list : State.t -> Reg.t -> unit =
  fun state reg ->
   (* note: the test that `reg` is not precolored is redundant since precolored
      registers have an infinite degree. *)
-  if reg.Reg.degree < k reg && not (State.is_move_related state reg)
+  if State.degree state reg < k reg && not (State.is_move_related state reg)
   then (
     State.remove_freeze_work_list state reg;
     State.add_simplify_work_list state reg)
@@ -244,7 +244,7 @@ let freeze_moves : State.t -> Reg.t -> unit =
       in
       State.remove_active_moves state m;
       State.add_frozen_moves state m;
-      if v.Reg.degree < k v && State.is_empty_node_moves state v
+      if State.degree state v < k v && State.is_empty_node_moves state v
       then (
         State.remove_freeze_work_list state v;
         State.add_simplify_work_list state v))
@@ -281,7 +281,7 @@ let select_spilling_register_using_heuristics : State.t -> Reg.t =
       if debug
       then
         log "register %a has spill cost %d" Printreg.reg reg reg.Reg.spill_cost;
-      (float reg.Reg.spill_cost /. float reg.Reg.degree)
+      (float reg.Reg.spill_cost /. float (State.degree state reg))
       (* note: while this magic constant is questionable, it is key to not favor
          the introduced temporaries which, by construct, have very few
          occurrences. *)
@@ -352,7 +352,7 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
           let alias = State.find_alias state hd in
           if State.is_precolored_or_colored state alias
           then (
-            match alias.Reg.irc_color with
+            match State.color state alias with
             | None -> assert false
             | Some color ->
               if debug then log "color %d is not available" color;
@@ -377,23 +377,26 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
         State.add_colored_nodes state n;
         let c = first_avail + reg_first_avail in
         if debug then log "coloring with %d" c;
-        n.Reg.irc_color <- Some c);
+        State.set_color state n (Some c));
       if debug then dedent ());
   State.iter_coalesced_nodes state ~f:(fun n ->
       let alias = State.find_alias state n in
-      n.Reg.irc_color <- alias.Reg.irc_color);
+      State.set_color state n (State.color state alias));
   if debug then dedent ()
 
 module Utils = struct
   include Regalloc_irc_utils
 
+  type state = State.t
+
   let debug = debug
 
   let invariants = invariants
 
-  let is_spilled reg = Reg.equal_irc_work_list reg.Reg.irc_work_list Reg.Spilled
+  let is_spilled state reg =
+    WorkList.equal (State.work_list state reg) WorkList.Spilled
 
-  let set_spilled reg = reg.Reg.spill <- true
+  let set_spilled _state reg = reg.Reg.spill <- true
 end
 
 (* Returns `true` if new temporaries have been introduced. *)
@@ -553,7 +556,9 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
     (module Utils)
     state
     ~f:(fun () ->
-      update_register_locations ();
-      Reg.Set.iter (fun reg -> reg.Reg.degree <- 0) (all_precolored_regs ()))
+      State.update_register_locations state;
+      Reg.Set.iter
+        (fun reg -> State.set_degree state reg 0)
+        (all_precolored_regs ()))
     cfg_with_infos;
   cfg_with_infos

--- a/backend/regalloc/regalloc_irc_state.ml
+++ b/backend/regalloc/regalloc_irc_state.ml
@@ -212,6 +212,8 @@ let[@inline] reset state ~new_inst_temporaries ~new_block_temporaries =
 
 let[@inline] work_list state reg = Reg.Tbl.find state.reg_work_list reg
 
+let[@inline] work_list_opt state reg = Reg.Tbl.find_opt state.reg_work_list reg
+
 let[@inline] color state reg = Reg.Tbl.find state.reg_color reg
 
 let[@inline] set_color state reg color =

--- a/backend/regalloc/regalloc_irc_state.ml
+++ b/backend/regalloc/regalloc_irc_state.ml
@@ -60,7 +60,7 @@ type t =
 let max_capacity = 1024
 
 let[@inline] make ~initial ~stack_slots ~last_used () =
-  let num_registers = List.length initial in
+  let num_registers = List.length (Reg.all_registers ()) in
   let reg_work_list = Reg.Tbl.create num_registers in
   let reg_color = Reg.Tbl.create num_registers in
   let reg_alias = Reg.Tbl.create num_registers in

--- a/backend/regalloc/regalloc_irc_state.mli
+++ b/backend/regalloc/regalloc_irc_state.mli
@@ -22,6 +22,16 @@ val reset :
   new_block_temporaries:Reg.t list ->
   unit
 
+val work_list : t -> Reg.t -> WorkList.t
+
+val color : t -> Reg.t -> Color.t option
+
+val set_color : t -> Reg.t -> Color.t option -> unit
+
+val degree : t -> Reg.t -> int
+
+val set_degree : t -> Reg.t -> int -> unit
+
 val is_precolored : t -> Reg.t -> bool
 
 val is_precolored_or_colored : t -> Reg.t -> bool
@@ -143,5 +153,7 @@ val mem_inst_temporaries : t -> Reg.t -> bool
 val mem_all_introduced_temporaries : t -> Reg.t -> bool
 
 val diff_all_introduced_temporaries : t -> Reg.Set.t -> Reg.Set.t
+
+val update_register_locations : t -> unit
 
 val invariant : t -> unit

--- a/backend/regalloc/regalloc_irc_state.mli
+++ b/backend/regalloc/regalloc_irc_state.mli
@@ -24,6 +24,8 @@ val reset :
 
 val work_list : t -> Reg.t -> WorkList.t
 
+val work_list_opt : t -> Reg.t -> WorkList.t option
+
 val color : t -> Reg.t -> Color.t option
 
 val set_color : t -> Reg.t -> Color.t option -> unit

--- a/backend/regalloc/regalloc_irc_utils.mli
+++ b/backend/regalloc/regalloc_irc_utils.mli
@@ -18,6 +18,25 @@ val log_body_and_terminator :
 
 val log_cfg_with_infos : Cfg_with_infos.t -> unit
 
+module WorkList : sig
+  (* CR xclerc for xclerc: double check all constructors are actually used. *)
+  type t =
+    | Unknown_list
+    | Precolored
+    | Initial
+    | Simplify
+    | Freeze
+    | Spill
+    | Spilled
+    | Coalesced
+    | Colored
+    | Select_stack
+
+  val equal : t -> t -> bool
+
+  val to_string : t -> string
+end
+
 module Color : sig
   type t = int
 end
@@ -65,8 +84,6 @@ val is_move_instruction : Instruction.t -> bool
 val all_precolored_regs : unit -> Reg.Set.t
 
 val k : Reg.t -> int
-
-val update_register_locations : unit -> unit
 
 module Spilling_heuristics : sig
   type t =

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -10,13 +10,15 @@ let snapshot_for_fatal = ref None
 module Utils = struct
   include Regalloc_ls_utils
 
+  type state = State.t
+
   let debug = debug
 
   let invariants = invariants
 
-  let is_spilled reg = reg.Reg.spill
+  let is_spilled _state reg = reg.Reg.spill
 
-  let set_spilled _reg = ()
+  let set_spilled _state _reg = ()
 end
 
 let rewrite :

--- a/backend/regalloc/regalloc_rewrite.mli
+++ b/backend/regalloc/regalloc_rewrite.mli
@@ -11,6 +11,8 @@ module type State = sig
 end
 
 module type Utils = sig
+  type state
+
   val debug : bool
 
   val invariants : bool Lazy.t
@@ -28,10 +30,10 @@ module type Utils = sig
     unit
 
   (* Tests whether the passed register is marked as "spilled". *)
-  val is_spilled : Reg.t -> bool
+  val is_spilled : state -> Reg.t -> bool
 
   (* Sets the passed register as "spilled". *)
-  val set_spilled : Reg.t -> unit
+  val set_spilled : state -> Reg.t -> unit
 end
 
 (* This is the `rewrite` function from IRC, parametrized by state, functions for
@@ -46,7 +48,7 @@ end
    will be empty. *)
 val rewrite_gen :
   (module State with type t = 's) ->
-  (module Utils) ->
+  (module Utils with type state = 's) ->
   's ->
   Cfg_with_infos.t ->
   spilled_nodes:Reg.t list ->


### PR DESCRIPTION
As per title, IRC will use maps (in the state
to store the values).