### PR TITLE
Simplify the `Utils` module (register allocation)

### DIFF
--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -4,14 +4,7 @@ open! Int_replace_polymorphic_compare
 open! Regalloc_utils
 open! Regalloc_gi_utils
 module State = Regalloc_gi_state
-
-module Utils = struct
-  include Regalloc_gi_utils
-
-  type state = State.t
-
-  let is_spilled _state reg = reg.Reg.spill
-end
+module Utils = Regalloc_gi_utils
 
 let rewrite : State.t -> Cfg_with_infos.t -> spilled_nodes:Reg.t list -> bool =
  fun state cfg_with_infos ~spilled_nodes ->

--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -10,13 +10,7 @@ module Utils = struct
 
   type state = State.t
 
-  let debug = debug
-
-  let invariants = invariants
-
   let is_spilled _state reg = reg.Reg.spill
-
-  let set_spilled _state _reg = ()
 end
 
 let rewrite : State.t -> Cfg_with_infos.t -> spilled_nodes:Reg.t list -> bool =

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -389,10 +389,6 @@ module Utils = struct
 
   type state = State.t
 
-  let debug = debug
-
-  let invariants = invariants
-
   let is_spilled state reg =
     match State.work_list_opt state reg with
     | None ->
@@ -401,8 +397,6 @@ module Utils = struct
          `false`. *)
       false
     | Some work_list -> WorkList.equal work_list WorkList.Spilled
-
-  let set_spilled _state _reg = ()
 end
 
 (* Returns `true` if new temporaries have been introduced. *)

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -384,20 +384,7 @@ let assign_colors : State.t -> Cfg_with_layout.t -> unit =
       State.set_color state n (State.color state alias));
   if debug then dedent ()
 
-module Utils = struct
-  include Regalloc_irc_utils
-
-  type state = State.t
-
-  let is_spilled state reg =
-    match State.work_list_opt state reg with
-    | None ->
-      (* Freshly-created may not have been added to the map yet; such registers
-         would morally be in the "unknown" work list, hence returning
-         `false`. *)
-      false
-    | Some work_list -> WorkList.equal work_list WorkList.Spilled
-end
+module Utils = Regalloc_irc_utils
 
 (* Returns `true` if new temporaries have been introduced. *)
 let rewrite :

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -402,7 +402,7 @@ module Utils = struct
       false
     | Some work_list -> WorkList.equal work_list WorkList.Spilled
 
-  let set_spilled _state reg = reg.Reg.spill <- true
+  let set_spilled _state _reg = ()
 end
 
 (* Returns `true` if new temporaries have been introduced. *)

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -12,13 +12,7 @@ module Utils = struct
 
   type state = State.t
 
-  let debug = debug
-
-  let invariants = invariants
-
   let is_spilled _state reg = reg.Reg.spill
-
-  let set_spilled _state _reg = ()
 end
 
 let rewrite :

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -7,13 +7,7 @@ module State = Regalloc_ls_state
 
 let snapshot_for_fatal = ref None
 
-module Utils = struct
-  include Regalloc_ls_utils
-
-  type state = State.t
-
-  let is_spilled _state reg = reg.Reg.spill
-end
+module Utils = Regalloc_ls_utils
 
 let rewrite :
     State.t ->

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -16,10 +16,6 @@ end
 module type Utils = sig
   type state
 
-  val debug : bool
-
-  val invariants : bool Lazy.t
-
   val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
 
   val indent : unit -> unit
@@ -33,8 +29,6 @@ module type Utils = sig
     unit
 
   val is_spilled : state -> Reg.t -> bool
-
-  val set_spilled : state -> Reg.t -> unit
 end
 
 type direction =
@@ -138,7 +132,7 @@ let rewrite_gen :
   let should_coalesce_temp_spills_and_reloads =
     Lazy.force Regalloc_utils.block_temporaries && block_temporaries
   in
-  if Utils.debug
+  if debug
   then (
     Utils.log "rewrite";
     Utils.indent ());
@@ -146,16 +140,15 @@ let rewrite_gen :
   let spilled_map : Reg.t Reg.Tbl.t =
     List.fold_left spilled_nodes ~init:(Reg.Tbl.create 17)
       ~f:(fun spilled_map reg ->
-        if Utils.debug then assert (Utils.is_spilled state reg);
+        if debug then assert (Utils.is_spilled state reg);
         let spilled = Reg.create reg.Reg.typ in
-        Utils.set_spilled state spilled;
         (* for printing *)
         spilled.Reg.raw_name <- reg.Reg.raw_name;
         let slot =
           Regalloc_stack_slots.get_or_create (State.stack_slots state) reg
         in
         spilled.Reg.loc <- Reg.(Stack (Local slot));
-        if Utils.debug
+        if debug
         then Utils.log "spilling %a to %a" Printreg.reg reg Printreg.reg spilled;
         Reg.Tbl.replace spilled_map reg spilled;
         spilled_map)
@@ -167,7 +160,7 @@ let rewrite_gen :
       make_temporary ~same_class_and_base_name_as:reg ~name_prefix:"temp"
     in
     new_inst_temporaries := res :: !new_inst_temporaries;
-    if Utils.debug
+    if debug
     then
       Utils.log "adding temporary %a (to %s %a)" Printreg.reg res
         (Move.to_string move) Printreg.reg reg;
@@ -239,7 +232,7 @@ let rewrite_gen :
   in
   let liveness = Cfg_with_infos.liveness cfg_with_infos in
   Cfg.iter_blocks (Cfg_with_infos.cfg cfg_with_infos) ~f:(fun label block ->
-      if Utils.debug
+      if debug
       then (
         Utils.log "body of #%a, before:" Label.format label;
         Utils.indent ();
@@ -307,14 +300,14 @@ let rewrite_gen :
       then
         coalesce_temp_spills_and_reloads block ~new_inst_temporaries
           ~new_block_temporaries;
-      if Utils.debug
+      if debug
       then (
         Utils.log "and after:";
         Utils.indent ();
         Utils.log_body_and_terminator block.body block.terminator liveness;
         Utils.dedent ();
         Utils.log "end"));
-  if Utils.debug then Utils.dedent ();
+  if debug then Utils.dedent ();
   !new_inst_temporaries, !new_block_temporaries, !block_insertion
 
 (* CR-soon xclerc for xclerc: investigate exactly why this threshold is
@@ -332,10 +325,10 @@ let prelude :
  fun (module Utils) ~on_fatal_callback cfg_with_infos ->
   let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg_with_infos in
   on_fatal ~f:on_fatal_callback;
-  if Utils.debug
+  if debug
   then Utils.log "run (%S)" (Cfg_with_layout.cfg cfg_with_layout).fun_name;
   Reg.reinit ();
-  if Utils.debug && Lazy.force Utils.invariants
+  if debug && Lazy.force invariants
   then (
     Utils.log "precondition";
     Regalloc_invariants.precondition cfg_with_layout);
@@ -346,7 +339,7 @@ let prelude :
        the same results without computing the union. *)
     Reg.Set.cardinal cfg_infos.arg
   in
-  if Utils.debug then Utils.log "#temporaries(before):%d" num_temporaries;
+  if debug then Utils.log "#temporaries(before):%d" num_temporaries;
   if num_temporaries >= threshold_split_live_ranges
      || Flambda2_ui.Flambda_features.classic_mode ()
   then cfg_infos, Regalloc_stack_slots.make ()
@@ -379,7 +372,7 @@ let postlude :
     ();
   Regalloc_stack_slots.update_cfg_with_layout (State.stack_slots state)
     cfg_with_layout;
-  if Utils.debug
+  if debug
   then (
     Utils.indent ();
     Stack_class.Tbl.iter
@@ -391,7 +384,7 @@ let postlude :
   remove_prologue_if_not_required cfg_with_layout;
   update_live_fields cfg_with_layout (Cfg_with_infos.liveness cfg_with_infos);
   f ();
-  if Utils.debug && Lazy.force Utils.invariants
+  if debug && Lazy.force invariants
   then (
     Utils.log "postcondition";
     Regalloc_invariants.postcondition_liveness cfg_with_infos)

--- a/backend/regalloc/regalloc_rewrite.mli
+++ b/backend/regalloc/regalloc_rewrite.mli
@@ -11,8 +11,6 @@ module type State = sig
 end
 
 module type Utils = sig
-  type state
-
   val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
 
   val indent : unit -> unit
@@ -24,9 +22,6 @@ module type Utils = sig
     Cfg.terminator Cfg.instruction ->
     liveness ->
     unit
-
-  (* Tests whether the passed register is marked as "spilled". *)
-  val is_spilled : state -> Reg.t -> bool
 end
 
 (* This is the `rewrite` function from IRC, parametrized by state, functions for
@@ -41,7 +36,7 @@ end
    will be empty. *)
 val rewrite_gen :
   (module State with type t = 's) ->
-  (module Utils with type state = 's) ->
+  (module Utils) ->
   's ->
   Cfg_with_infos.t ->
   spilled_nodes:Reg.t list ->

--- a/backend/regalloc/regalloc_rewrite.mli
+++ b/backend/regalloc/regalloc_rewrite.mli
@@ -13,10 +13,6 @@ end
 module type Utils = sig
   type state
 
-  val debug : bool
-
-  val invariants : bool Lazy.t
-
   val log : ?no_eol:unit -> ('a, Format.formatter, unit) format -> 'a
 
   val indent : unit -> unit
@@ -31,9 +27,6 @@ module type Utils = sig
 
   (* Tests whether the passed register is marked as "spilled". *)
   val is_spilled : state -> Reg.t -> bool
-
-  (* Sets the passed register as "spilled". *)
-  val set_spilled : state -> Reg.t -> unit
 end
 
 (* This is the `rewrite` function from IRC, parametrized by state, functions for


### PR DESCRIPTION
This pull request simplifies the `Utils`
module used in register allocation by
tweaking the `rewrite_gen` function.
Instead of storing whether a register
is spilled or not, the function now uses
the passed `spilled_nodes` parameter.