### PR TITLE
Remove more fields from `Reg.t`

### DIFF
--- a/backend/reg.ml
+++ b/backend/reg.ml
@@ -41,7 +41,6 @@ type t =
     stamp: int;
     typ: Cmm.machtype_component;
     mutable loc: location;
-    mutable spill: bool;
     mutable spill_cost: int; }
 
 and location =
@@ -59,7 +58,7 @@ type reg = t
 
 let dummy =
   { raw_name = Raw_name.Anon; stamp = 0; typ = Int; loc = Unknown;
-    spill = false; spill_cost = 0;
+    spill_cost = 0;
   }
 
 let currstamp = ref 0
@@ -69,7 +68,6 @@ let hw_reg_list = ref ([] : t list)
 let create ty =
   let r = { raw_name = Raw_name.Anon; stamp = !currstamp; typ = ty;
             loc = Unknown;
-            spill = false;
             spill_cost = 0; } in
   reg_list := r :: !reg_list;
   incr currstamp;
@@ -94,7 +92,6 @@ let clone r =
 
 let at_location ty loc =
   let r = { raw_name = Raw_name.R; stamp = !currstamp; typ = ty; loc;
-            spill = false; 
             spill_cost = 0; } in
   hw_reg_list := r :: !hw_reg_list;
   incr currstamp;
@@ -121,11 +118,7 @@ let is_unknown t =
 let name t =
   match Raw_name.to_string t.raw_name with
   | None -> ""
-  | Some raw_name ->
-      if t.spill then
-        "spilled-" ^ raw_name
-      else
-        raw_name
+  | Some raw_name -> raw_name
 
 let first_virtual_reg_stamp = ref (-1)
 

--- a/backend/reg.ml
+++ b/backend/reg.ml
@@ -40,8 +40,7 @@ type t =
   { mutable raw_name: Raw_name.t;
     stamp: int;
     typ: Cmm.machtype_component;
-    mutable loc: location;
-    mutable spill_cost: int; }
+    mutable loc: location; }
 
 and location =
     Unknown
@@ -57,18 +56,14 @@ and stack_location =
 type reg = t
 
 let dummy =
-  { raw_name = Raw_name.Anon; stamp = 0; typ = Int; loc = Unknown;
-    spill_cost = 0;
-  }
+  { raw_name = Raw_name.Anon; stamp = 0; typ = Int; loc = Unknown; }
 
 let currstamp = ref 0
 let reg_list = ref([] : t list)
 let hw_reg_list = ref ([] : t list)
 
 let create ty =
-  let r = { raw_name = Raw_name.Anon; stamp = !currstamp; typ = ty;
-            loc = Unknown;
-            spill_cost = 0; } in
+  let r = { raw_name = Raw_name.Anon; stamp = !currstamp; typ = ty; loc = Unknown; } in
   reg_list := r :: !reg_list;
   incr currstamp;
   r
@@ -91,8 +86,7 @@ let clone r =
   nr
 
 let at_location ty loc =
-  let r = { raw_name = Raw_name.R; stamp = !currstamp; typ = ty; loc;
-            spill_cost = 0; } in
+  let r = { raw_name = Raw_name.R; stamp = !currstamp; typ = ty; loc; } in
   hw_reg_list := r :: !hw_reg_list;
   incr currstamp;
   r
@@ -148,11 +142,7 @@ let all_registers() = !reg_list
 let num_registers() = !currstamp
 
 let reinit_reg r =
-  r.loc <- Unknown;
-  (* Preserve the very high spill costs introduced by the reloading pass *)
-  if r.spill_cost >= 100000
-  then r.spill_cost <- 100000
-  else r.spill_cost <- 0
+  r.loc <- Unknown
 
 let reinit() =
   List.iter reinit_reg !reg_list

--- a/backend/reg.mli
+++ b/backend/reg.mli
@@ -26,7 +26,6 @@ type t =
     stamp: int;                           (* Unique stamp *)
     typ: Cmm.machtype_component;          (* Type of contents *)
     mutable loc: location;                (* Actual location *)
-    mutable spill: bool;                  (* "true" to force stack allocation  *)
     mutable spill_cost: int; }            (* Estimate of spilling cost *)
 
 and location =

--- a/backend/reg.mli
+++ b/backend/reg.mli
@@ -25,8 +25,7 @@ type t =
   { mutable raw_name: Raw_name.t;         (* Name *)
     stamp: int;                           (* Unique stamp *)
     typ: Cmm.machtype_component;          (* Type of contents *)
-    mutable loc: location;                (* Actual location *)
-    mutable spill_cost: int; }            (* Estimate of spilling cost *)
+    mutable loc: location; }              (* Actual location *)
 
 and location =
     Unknown

--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -142,7 +142,6 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
     log "spilling costs";
     indent ();
     List.iter (Reg.all_registers ()) ~f:(fun (reg : Reg.t) ->
-        reg.Reg.spill <- false;
         log "%a: %d" Printreg.reg reg reg.spill_cost);
     dedent ());
   let hardware_registers, prio_queue =
@@ -211,7 +210,6 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
     | Split_or_spill ->
       (* CR xclerc for xclerc: we should actually try to split. *)
       if debug then log "spilling %a" Printreg.reg reg;
-      reg.Reg.spill <- true;
       spilling := (reg, interval) :: !spilling);
     if debug then dedent ()
   done;
@@ -280,7 +278,6 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
   (match Reg.Set.elements spilling_because_unused with
   | [] -> ()
   | _ :: _ as spilled_nodes ->
-    List.iter spilled_nodes ~f:(fun reg -> reg.Reg.spill <- true);
     (* note: rewrite will remove the `spilling` registers from the "spilled"
        work list and set the field to unknown. *)
     let (_ : bool) = rewrite state cfg_with_infos ~spilled_nodes in

--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -134,16 +134,15 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
     log "main, round #%d" round;
     log_cfg_with_infos cfg_with_infos);
   if debug then log "updating spilling costs";
-  let costs = compute_spill_cost cfg_with_infos ~flat () in
+  let costs = SpillCosts.compute cfg_with_infos ~flat () in
   State.iter_introduced_temporaries state ~f:(fun (reg : Reg.t) ->
-      Reg.Tbl.replace costs reg (Reg.Tbl.find costs reg + 10_000));
+      SpillCosts.add_to_reg costs reg 10_000);
   if debug
   then (
     log "spilling costs";
     indent ();
-    Reg.Tbl.iter
-      (fun (reg : Reg.t) (cost : int) -> log "%a: %d" Printreg.reg reg cost)
-      costs;
+    SpillCosts.iter costs ~f:(fun (reg : Reg.t) (cost : int) ->
+        log "%a: %d" Printreg.reg reg cost);
     dedent ());
   let hardware_registers, prio_queue =
     make_hardware_registers_and_prio_queue cfg_with_infos

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -620,11 +620,11 @@ module Hardware_registers = struct
    fun t ~of_reg ~f ~init ->
     Array.fold_left t.(Proc.register_class of_reg) ~f ~init
 
-  let actual_cost (costs : int Reg.Tbl.t) (reg : Reg.t) : int =
+  let actual_cost (costs : SpillCosts.t) (reg : Reg.t) : int =
     (* CR xclerc for xclerc: it could make sense to give a lower cost to reg
        already spilled (e.g. by the split preprocessing) since they already have
        a stack slot *)
-    Reg.Tbl.find costs reg
+    SpillCosts.for_reg costs reg
 
   let overlap (hardware_reg : Hardware_register.t) (interval : Interval.t) :
       bool =
@@ -668,7 +668,7 @@ module Hardware_registers = struct
             else acc)
     |> Option.map fst
 
-  let find_evictable (t : t) (costs : int Reg.Tbl.t) (reg : Reg.t)
+  let find_evictable (t : t) (costs : SpillCosts.t) (reg : Reg.t)
       (interval : Interval.t) : available =
     let eviction =
       fold_class t ~of_reg:reg ~init:None ~f:(fun acc hardware_reg ->
@@ -731,7 +731,7 @@ module Hardware_registers = struct
       For_eviction { hardware_reg; evicted_regs }
     | None -> Split_or_spill
 
-  let find_available : t -> int Reg.Tbl.t -> Reg.t -> Interval.t -> available =
+  let find_available : t -> SpillCosts.t -> Reg.t -> Interval.t -> available =
    fun t costs reg interval ->
     let with_no_overlap =
       let heuristic =

--- a/backend/regalloc/regalloc_gi_utils.ml
+++ b/backend/regalloc/regalloc_gi_utils.ml
@@ -620,11 +620,11 @@ module Hardware_registers = struct
    fun t ~of_reg ~f ~init ->
     Array.fold_left t.(Proc.register_class of_reg) ~f ~init
 
-  let actual_cost (reg : Reg.t) : int =
+  let actual_cost (costs : int Reg.Tbl.t) (reg : Reg.t) : int =
     (* CR xclerc for xclerc: it could make sense to give a lower cost to reg
        already spilled (e.g. by the split preprocessing) since they already have
        a stack slot *)
-    reg.Reg.spill_cost
+    Reg.Tbl.find costs reg
 
   let overlap (hardware_reg : Hardware_register.t) (interval : Interval.t) :
       bool =
@@ -668,7 +668,8 @@ module Hardware_registers = struct
             else acc)
     |> Option.map fst
 
-  let find_evictable (t : t) (reg : Reg.t) (interval : Interval.t) : available =
+  let find_evictable (t : t) (costs : int Reg.Tbl.t) (reg : Reg.t)
+      (interval : Interval.t) : available =
     let eviction =
       fold_class t ~of_reg:reg ~init:None ~f:(fun acc hardware_reg ->
           if debug
@@ -705,7 +706,8 @@ module Hardware_registers = struct
                      (acc_cost, acc_evictable)
                      { Hardware_register.pseudo_reg; interval = _; evictable }
                    ->
-                  acc_cost + actual_cost pseudo_reg, acc_evictable && evictable)
+                  ( acc_cost + actual_cost costs pseudo_reg,
+                    acc_evictable && evictable ))
             in
             if debug then dedent ();
             if not evictable
@@ -714,7 +716,7 @@ module Hardware_registers = struct
               let evict_cost =
                 match acc with None -> max_int | Some (_, _, c) -> c
               in
-              if cost < evict_cost && cost < actual_cost reg
+              if cost < evict_cost && cost < actual_cost costs reg
               then (
                 if debug
                 then
@@ -729,8 +731,8 @@ module Hardware_registers = struct
       For_eviction { hardware_reg; evicted_regs }
     | None -> Split_or_spill
 
-  let find_available : t -> Reg.t -> Interval.t -> available =
-   fun t reg interval ->
+  let find_available : t -> int Reg.Tbl.t -> Reg.t -> Interval.t -> available =
+   fun t costs reg interval ->
     let with_no_overlap =
       let heuristic =
         match Lazy.force Selection_heuristics.value with
@@ -756,5 +758,5 @@ module Hardware_registers = struct
     | Some hardware_reg -> For_assignment { hardware_reg }
     | None ->
       if debug then log "trying to find an evictable register";
-      find_evictable t reg interval
+      find_evictable t costs reg interval
 end

--- a/backend/regalloc/regalloc_gi_utils.mli
+++ b/backend/regalloc/regalloc_gi_utils.mli
@@ -190,5 +190,5 @@ module Hardware_registers : sig
 
   val of_reg : t -> Reg.t -> Hardware_register.t option
 
-  val find_available : t -> Reg.t -> Interval.t -> available
+  val find_available : t -> int Reg.Tbl.t -> Reg.t -> Interval.t -> available
 end

--- a/backend/regalloc/regalloc_gi_utils.mli
+++ b/backend/regalloc/regalloc_gi_utils.mli
@@ -190,5 +190,5 @@ module Hardware_registers : sig
 
   val of_reg : t -> Reg.t -> Hardware_register.t option
 
-  val find_available : t -> int Reg.Tbl.t -> Reg.t -> Interval.t -> available
+  val find_available : t -> SpillCosts.t -> Reg.t -> Interval.t -> available
 end

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -117,7 +117,7 @@ let equal_move_kind left right =
 let rewrite_gen :
     type s.
     (module State with type t = s) ->
-    (module Utils with type state = s) ->
+    (module Utils) ->
     s ->
     Cfg_with_infos.t ->
     spilled_nodes:Reg.t list ->

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -117,7 +117,7 @@ let equal_move_kind left right =
 let rewrite_gen :
     type s.
     (module State with type t = s) ->
-    (module Utils) ->
+    (module Utils with type state = s) ->
     s ->
     Cfg_with_infos.t ->
     spilled_nodes:Reg.t list ->

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -434,7 +434,7 @@ module SpillCosts = struct
               | Some cost -> int_of_string cost
             in
             (* CR-soon xclerc for xclerc: consider adding an overflow check. *)
-            pow ~base depth
+            Misc.power ~base depth
         in
         let cost = base_cost * cost_multiplier in
         DLL.iter ~f:(fun instr -> update_instr cost instr) block.body;

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -414,6 +414,7 @@ module SpillCosts = struct
     let update_reg (cost : int) (reg : Reg.t) : unit =
       (* CR-soon xclerc for xclerc: consider adding an overflow check. *)
       add_to_reg costs reg cost
+    in
     let update_array (cost : int) (regs : Reg.t array) : unit =
       Array.iter regs ~f:(fun reg -> update_reg cost reg)
     in

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -386,14 +386,6 @@ module SpillCosts = struct
     in
     Reg.Tbl.replace costs reg (curr + delta)
 
-  (* CR-soon xclerc for xclerc: consider adding an overflow check. *)
-  let pow ~base n =
-    let res = ref 1 in
-    for _ = 1 to n do
-      res := !res * base
-    done;
-    !res
-
   let normal_cost = lazy (find_param_value "SPILL_NORMAL_COST")
 
   let cold_cost = lazy (find_param_value "SPILL_COLD_COST")
@@ -441,6 +433,7 @@ module SpillCosts = struct
               | None -> 10
               | Some cost -> int_of_string cost
             in
+            (* CR-soon xclerc for xclerc: consider adding an overflow check. *)
             pow ~base depth
         in
         let cost = base_cost * cost_multiplier in

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -413,12 +413,7 @@ module SpillCosts = struct
     List.iter (Reg.all_registers ()) ~f:(fun reg -> Reg.Tbl.replace costs reg 0);
     let update_reg (cost : int) (reg : Reg.t) : unit =
       (* CR-soon xclerc for xclerc: consider adding an overflow check. *)
-      let curr_cost =
-        (* hardware registers are not in `all_registers` *)
-        match Reg.Tbl.find_opt costs reg with None -> 0 | Some cost -> cost
-      in
-      Reg.Tbl.replace costs reg (curr_cost + cost)
-    in
+      add_to_reg costs reg cost
     let update_array (cost : int) (regs : Reg.t array) : unit =
       Array.iter regs ~f:(fun reg -> update_reg cost reg)
     in

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -117,7 +117,7 @@ val update_live_fields : Cfg_with_layout.t -> liveness -> unit
    [flat] is true, the same weight is given to all uses; if [flat] is false, the
    information about loops is computed and used to give more weight to uses
    inside (nested) loops. *)
-val update_spill_cost : Cfg_with_infos.t -> flat:bool -> unit -> unit
+val compute_spill_cost : Cfg_with_infos.t -> flat:bool -> unit -> int Reg.Tbl.t
 
 val check_length : string -> 'a array -> int -> unit
 

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -113,11 +113,23 @@ val remove_prologue_if_not_required : Cfg_with_layout.t -> unit
 
 val update_live_fields : Cfg_with_layout.t -> liveness -> unit
 
-(* The spill cost is currently the number of occurrences of the register. If
-   [flat] is true, the same weight is given to all uses; if [flat] is false, the
-   information about loops is computed and used to give more weight to uses
-   inside (nested) loops. *)
-val compute_spill_cost : Cfg_with_infos.t -> flat:bool -> unit -> int Reg.Tbl.t
+module SpillCosts : sig
+  type t
+
+  val empty : unit -> t
+
+  val iter : t -> f:(Reg.t -> int -> unit) -> unit
+
+  val for_reg : t -> Reg.t -> int
+
+  val add_to_reg : t -> Reg.t -> int -> unit
+
+  (* The spill cost is currently the number of occurrences of the register. If
+     [flat] is true, the same weight is given to all uses; if [flat] is false,
+     the information about loops is computed and used to give more weight to
+     uses inside (nested) loops. *)
+  val compute : Cfg_with_infos.t -> flat:bool -> unit -> t
+end
 
 val check_length : string -> 'a array -> int -> unit
 

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -229,8 +229,7 @@ end = struct
     }
 
   let to_dummy_reg (t : t) : Reg.t =
-    { Reg.dummy with
-      raw_name = t.for_print.raw_name;
+    { raw_name = t.for_print.raw_name;
       typ = t.for_print.typ;
       stamp = t.for_print.stamp;
       loc = Reg_id.to_loc_lossy t.reg_id

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -764,6 +764,13 @@ let rec log2 n =
 let rec log2_nativeint n =
   if n <= 1n then 0 else 1 + log2_nativeint (Nativeint.shift_right n 1)
 
+let pow ~base n =
+  let res = ref 1 in
+  for _ = 1 to n do
+    res := !res * base
+  done;
+  !res
+
 let align n a =
   if n >= 0 then (n + a - 1) land (-a) else n land (-a)
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -764,7 +764,7 @@ let rec log2 n =
 let rec log2_nativeint n =
   if n <= 1n then 0 else 1 + log2_nativeint (Nativeint.shift_right n 1)
 
-let pow ~base n =
+let power ~base n =
   let res = ref 1 in
   for _ = 1 to n do
     res := !res * base

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -498,6 +498,9 @@ val log2_nativeint: nativeint -> int
     [n = Nativeint.shift_left 1n s]
 *)
 
+val power : base:int -> int -> int
+(** [power ~base x] computes [base**x]. *)
+
 val align: int -> int -> int
        (** [align n a] rounds [n] upwards to a multiple of [a]
            (a power of 2). *)


### PR DESCRIPTION
This pull request is a follow-up to #3835,
removing more fields from `Reg.t` (namely
`spill` and `spill_cost`).