### PR TITLE
Generate and propagate never returns from emit_tuple

### DIFF
--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -30,6 +30,13 @@ module Or_never_returns = struct
   type 'a t =
     | Ok of 'a
     | Never_returns
+
+  module Syntax = struct
+    let ( let* ) x f =
+      match x with Never_returns -> Never_returns | Ok x -> f x
+
+    let ( let** ) x f = match x with Never_returns -> () | Ok x -> f x
+  end
 end
 
 type trap_stack_info =

--- a/backend/select_utils.mli
+++ b/backend/select_utils.mli
@@ -170,6 +170,12 @@ module Or_never_returns : sig
   type 'a t =
     | Ok of 'a
     | Never_returns
+
+  module Syntax : sig
+    val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
+
+    val ( let** ) : 'a t -> ('a -> unit) -> unit
+  end
 end
 
 val debug : bool


### PR DESCRIPTION
In some cases, particularly in dead code (which happens to be a bit more easily to produce with the upcoming match-in-match in some cases, but could happen anyway), `to_cmm` can produce code that makes Selection fails, because emit_tuple refuses to emit code that never returns (e.g. code that raises while evaluating the argument of another raise). This PR simply allows emit_tuple to return `Never_returns`, and the required change to propagate that value upwards until it can be handled.

This PR introduces and uses some monadic lets to make the diff much smaller (most notably, without them, there would need to be dozens of lines of code re-indented because of added `match .. with`). If accepted, a further PR could use these monadic lets at other existing places in the code for more coherence.