### PR TITLE
Avoid polymorphic comparisons (backend)

### DIFF
--- a/backend/amd64/stack_class.ml
+++ b/backend/amd64/stack_class.ml
@@ -1,5 +1,7 @@
 [@@@ocaml.warning "+a-30-40-41-42"]
 
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+
 module T = struct
   type t =
     | Int64

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -643,7 +643,7 @@ let decompose_int default n =
     else
       let frag = Nativeint.logand n 0xFFFFn
       and rem = Nativeint.shift_right_logical n 16 in
-      if frag = default
+      if Nativeint.equal frag default
       then decomp rem (pos + 16)
       else (frag, pos) :: decomp rem (pos + 16)
   in
@@ -691,12 +691,13 @@ let num_instructions_for_intconst n =
 let is_immediate_float bits =
   let exp = (Int64.(to_int (shift_right_logical bits 52)) land 0x7FF) - 1023 in
   let mant = Int64.logand bits 0xF_FFFF_FFFF_FFFFL in
-  exp >= -3 && exp <= 4 && Int64.logand mant 0xF_0000_0000_0000L = mant
+  exp >= -3 && exp <= 4
+  && Int64.equal (Int64.logand mant 0xF_0000_0000_0000L) mant
 
 let is_immediate_float32 bits =
   let exp = (Int32.(to_int (shift_right_logical bits 23)) land 0x7F) - 63 in
   let mant = Int32.logand bits 0x7F_FFFFl in
-  exp >= -3 && exp <= 4 && Int32.logand mant 0x78_0000l = mant
+  exp >= -3 && exp <= 4 && Int32.equal (Int32.logand mant 0x78_0000l) mant
 
 (* Adjust sp (up or down) by the given byte amount *)
 
@@ -777,7 +778,7 @@ let vec128_literal f = add_literal vec128_literals f
 
 (* Emit all pending literals *)
 let emit_literals p align emit_literal =
-  if !p <> []
+  if not (Misc.Stdlib.List.is_empty !p)
   then (
     if macosx
     then
@@ -959,7 +960,7 @@ module BR = Branch_relaxation.Make (struct
     | Lcall_op (Lcall_imm _) -> 1
     | Lcall_op Ltailcall_ind -> epilogue_size ()
     | Lcall_op (Ltailcall_imm { func; _ }) ->
-      if func.sym_name = !function_name then 1 else epilogue_size ()
+      if String.equal func.sym_name !function_name then 1 else epilogue_size ()
     | Lcall_op
         (Lextcall
           { alloc; stack_ofs; func = _; ty_res = _; ty_args = _; returns = _ })
@@ -1420,7 +1421,7 @@ let emit_instr i =
   | Lop (Const_int n) -> emit_intconst i.res.(0) n
   | Lop (Const_float32 f) ->
     DSL.check_reg Float32 i.res.(0);
-    if f = 0l
+    if Int32.equal f 0l
     then DSL.ins I.FMOV [| DSL.emit_reg i.res.(0); DSL.wzr |]
     else if is_immediate_float32 f
     then
@@ -1431,7 +1432,7 @@ let emit_instr i =
       let lbl = float_literal (Int64.of_int32 f) in
       emit_load_literal i.res.(0) lbl
   | Lop (Const_float f) ->
-    if f = 0L
+    if Int64.equal f 0L
     then DSL.ins I.FMOV [| DSL.emit_reg i.res.(0); DSL.xzr |]
     else if is_immediate_float f
     then
@@ -1459,7 +1460,7 @@ let emit_instr i =
   | Lcall_op Ltailcall_ind ->
     output_epilogue (fun () -> DSL.ins I.BR [| DSL.emit_reg i.arg.(0) |])
   | Lcall_op (Ltailcall_imm { func }) ->
-    if func.sym_name = !function_name
+    if String.equal func.sym_name !function_name
     then
       match !tailrec_entry_point with
       | None -> Misc.fatal_error "jump to missing tailrec entry point"
@@ -1509,9 +1510,9 @@ let emit_instr i =
     stack_offset := !stack_offset + n
   | Lop (Load { memory_chunk; addressing_mode; is_atomic }) -> (
     assert (
-      memory_chunk = Cmm.Word_int
-      || memory_chunk = Cmm.Word_val
-      || is_atomic = false);
+      Cmm.equal_memory_chunk memory_chunk Cmm.Word_int
+      || Cmm.equal_memory_chunk memory_chunk Cmm.Word_val
+      || not is_atomic);
     let dst = i.res.(0) in
     let base =
       match addressing_mode with
@@ -1549,7 +1550,7 @@ let emit_instr i =
     | Word_int | Word_val ->
       if is_atomic
       then (
-        assert (addressing_mode = Iindexed 0);
+        assert (Arch.equal_addressing_mode addressing_mode (Iindexed 0));
         DSL.ins (I.DMB ISHLD) [||];
         DSL.ins I.LDAR [| DSL.emit_reg dst; DSL.emit_mem i.arg.(0) |])
       else
@@ -1757,7 +1758,7 @@ let emit_instr i =
          DSL.emit_reg i.arg.(2);
          DSL.emit_reg i.arg.(0)
       |]
-  | Lop Opaque -> assert (i.arg.(0).loc = i.res.(0).loc)
+  | Lop Opaque -> assert (Reg.equal_location i.arg.(0).loc i.res.(0).loc)
   | Lop (Specific (Ishiftarith (op, shift))) ->
     let instr = match op with Ishiftadd -> I.ADD | Ishiftsub -> I.SUB in
     let shift =
@@ -2020,7 +2021,8 @@ let emit_instr i =
 (* Emission of an instruction sequence *)
 
 let rec emit_all i =
-  if i.desc = Lend
+  (* CR-soon xclerc for xclerc: get rid of polymorphic compare. *)
+  if Stdlib.compare i.desc Lend = 0
   then ()
   else (
     emit_instr i;
@@ -2074,7 +2076,7 @@ let fundecl fundecl =
 let emit_item (d : Cmm.data_item) =
   match d with
   | Cdefine_symbol s ->
-    if !Clflags.dlcode || s.sym_global = Cmm.Global
+    if !Clflags.dlcode || Cmm.equal_is_global s.sym_global Cmm.Global
     then
       (* GOT relocations against non-global symbols don't seem to work properly:
          GOT entries are not created for the symbols and the relocations

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -31,6 +31,7 @@ open! Operation
 open Linear
 open Emitaux
 module I = Arm64_ast.Instruction_name
+open! Int_replace_polymorphic_compare
 
 (* Tradeoff between code size and code speed *)
 

--- a/backend/arm64/stack_class.ml
+++ b/backend/arm64/stack_class.ml
@@ -1,6 +1,6 @@
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-open! Int_replace_polymorphic_compare
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
 
 module T = struct
   type t =

--- a/backend/arm64/stack_class.ml
+++ b/backend/arm64/stack_class.ml
@@ -1,5 +1,7 @@
 [@@@ocaml.warning "+a-30-40-41-42"]
 
+open! Int_replace_polymorphic_compare
+
 module T = struct
   type t =
     | Int64

--- a/backend/asm_targets/asm_directives_intf.ml
+++ b/backend/asm_targets/asm_directives_intf.ml
@@ -23,6 +23,9 @@
  * SOFTWARE.                                                                      *
  *                                                                                *
  **********************************************************************************)
+
+open! Int_replace_polymorphic_compare
+
 module type Arg = sig
   val emit_line : string -> unit
 

--- a/backend/cfg/cfg_cse_target_intf.ml
+++ b/backend/cfg/cfg_cse_target_intf.ml
@@ -18,6 +18,8 @@
 (** Interface to be satisfied by target-specific code, for common subexpression
     elimination. *)
 
+open! Int_replace_polymorphic_compare
+
 (** Classification of operations *)
 
 type op_class =

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -29,6 +29,8 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+
 module S = struct
   type func_call_operation =
     | Indirect

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -25,6 +25,7 @@
  **********************************************************************************)
 [@@@ocaml.warning "+a-30-40-41-42"]
 
+open! Int_replace_polymorphic_compare
 module C = Cfg
 module CL = Cfg_with_layout
 module DLL = Flambda_backend_utils.Doubly_linked_list

--- a/backend/cfg_selectgen_target_intf.ml
+++ b/backend/cfg_selectgen_target_intf.ml
@@ -23,6 +23,8 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
+open! Int_replace_polymorphic_compare
+
 (** Interface to be satisfied by target-specific code, for instruction
     selection. *)
 

--- a/backend/debug/compute_ranges_intf.ml
+++ b/backend/debug/compute_ranges_intf.ml
@@ -25,6 +25,7 @@
     It is suggested that those unfamiliar with this module start by reading the
     documentation on module type [S], below. *)
 
+open! Int_replace_polymorphic_compare
 module L = Linear
 
 module type S_key = sig

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/debug_loc_table.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/debug_loc_table.ml
@@ -14,6 +14,8 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+
 type t = Dwarf_4_location_list.t list ref
 
 let create () : t = ref []

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/debug_ranges_table.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/debug_ranges_table.ml
@@ -14,6 +14,8 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+
 type t = Dwarf_4_range_list.t list ref
 
 let create () : t = ref []

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list.ml
@@ -14,6 +14,7 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
 open Asm_targets
 
 type t =

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_location_list_entry.ml
@@ -14,6 +14,7 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+open! Int_replace_polymorphic_compare
 open Asm_targets
 
 module Location_list_entry = struct
@@ -147,4 +148,5 @@ let compare_ascending_vma t1 t2 =
   | Base_address_selection_entry _, Location_list_entry _ -> -1
   | Location_list_entry _, Base_address_selection_entry _ -> 1
   | Location_list_entry entry1, Location_list_entry entry2 ->
-    compare entry1.beginning_address_label entry2.beginning_address_label
+    Asm_label.compare entry1.beginning_address_label
+      entry2.beginning_address_label

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list.ml
@@ -14,6 +14,7 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
 open Asm_targets
 
 type t =

--- a/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list_entry.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_4/dwarf_4_range_list_entry.ml
@@ -14,6 +14,7 @@
 
 [@@@ocaml.warning "+a-4-30-40-41-42"]
 
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
 open Asm_targets
 
 module Range_list_entry = struct
@@ -118,4 +119,5 @@ let compare_ascending_vma t1 t2 =
   | Base_address_selection_entry _, Range_list_entry _ -> -1
   | Range_list_entry _, Base_address_selection_entry _ -> 1
   | Range_list_entry entry1, Range_list_entry entry2 ->
-    compare entry1.beginning_address_label entry2.beginning_address_label
+    Asm_label.compare entry1.beginning_address_label
+      entry2.beginning_address_label

--- a/backend/internal_assembler/section_table.ml
+++ b/backend/internal_assembler/section_table.ml
@@ -23,6 +23,7 @@
 (* CR mshinwell: fix properly using -enable-dev PR's changes *)
 [@@@ocaml.warning "-27-32"]
 
+open! Int_replace_polymorphic_compare
 module Section_name = X86_proc.Section_name
 
 type section_body =

--- a/backend/stack_class_utils.ml
+++ b/backend/stack_class_utils.ml
@@ -1,5 +1,6 @@
 [@@@ocaml.warning "+a-30-40-41-42"]
 
+open! Int_replace_polymorphic_compare
 module List = ListLabels
 
 (** Definition of stack classes for a given backend.


### PR DESCRIPTION
This pull request adds `open! Int_replace_polymorphic_compare`
to the backend files that did not already have it.