### PR TITLE
Infer with-kinds for easy polymorphic variants

### DIFF
--- a/extract_externals/traverse_typed_tree.ml
+++ b/extract_externals/traverse_typed_tree.ml
@@ -228,7 +228,7 @@ let rec value_kind env (subst : value_shape Subst.t) ~visited ~depth ty :
       Block (Some (0, fields))
   | Tvariant row ->
     (* FIXME: we could do something better here *)
-    if Ctype.tvariant_not_immediate row then Or (Imm, Block None) else Imm
+    if Btype.tvariant_not_immediate row then Or (Imm, Block None) else Imm
   | Tarrow _ -> Closure
   | Tobject _ -> Obj
   | Tvar _ | Tunivar _ -> (

--- a/jane/doc/proposals/kind-inference.md
+++ b/jane/doc/proposals/kind-inference.md
@@ -333,6 +333,8 @@ t := λ [[ 'aᵢ : κᵢ ]]. δ : κ ∈ Γ
 ----------------------- T_POLY
 Γ ⊢ ('a : jkind). σ : κ {q}
 
+(* CR layouts v2.8: Some simple cases of polymorphic variants now get more
+   precise kinds in the compiler; update this to reflect that *)
 TODO
 ---------------------------------------- T_POLY_VARIANT
 Γ ⊢ polymorphic_variant : value; ⟪⊤_Ξ⟫ {not_best}

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -137,3 +137,35 @@ Error: The kind of type "[< `A of 'a | `B of 'a * 'a | `C ]" is value
          immutable_data with 'a
          because of the definition of t at line 2, characters 2-83.
 |}]
+
+(* Tunivar-ified row variables *)
+
+type t1 = { f : ('a : value mod portable). ([> `Foo of int] as 'a) -> unit }
+(* CR layouts v2.8: This should be accepted *)
+[%%expect{|
+Line 1, characters 64-65:
+1 | type t1 = { f : ('a : value mod portable). ([> `Foo of int] as 'a) -> unit }
+                                                                    ^
+Error: This alias is bound to type "[> `Foo of int ]"
+       but is used as an instance of type "('a : value mod portable)"
+       The kind of [> `Foo of int ] is value
+         because it's a polymorphic variant type.
+       But the kind of [> `Foo of int ] must be a subkind of
+         value mod portable
+         because of the annotation on the universal variable 'a.
+|}]
+
+type t2 = { f : ('a : value mod portable). ([< `Foo of int] as 'a) -> unit }
+(* CR layouts v2.8: This should be accepted *)
+[%%expect{|
+Line 1, characters 64-65:
+1 | type t2 = { f : ('a : value mod portable). ([< `Foo of int] as 'a) -> unit }
+                                                                    ^
+Error: This alias is bound to type "[< `Foo of int ]"
+       but is used as an instance of type "('a : value mod portable)"
+       The kind of [< `Foo of int ] is value
+         because it's a polymorphic variant type.
+       But the kind of [< `Foo of int ] must be a subkind of
+         value mod portable
+         because of the annotation on the universal variable 'a.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -1,0 +1,139 @@
+(* TEST
+    expect;
+*)
+
+let use_global : 'a @ global -> unit = fun _ -> ()
+let use_unique : 'a @ unique -> unit = fun _ -> ()
+let use_uncontended : 'a @ uncontended -> unit = fun _ -> ()
+let use_portable : 'a @ portable -> unit = fun _ -> ()
+let use_many : 'a @ many -> unit = fun _ -> ()
+[%%expect{|
+val use_global : 'a -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_many : 'a -> unit = <fun>
+|}]
+
+(* Simple cases : closed polymorphic variants with fields *)
+
+type 'a t : immutable_data with 'a = [ `A of 'a ]
+
+[%%expect{|
+type 'a t = [ `A of 'a ]
+|}]
+
+type 'a u : mutable_data with 'a = [ `B of 'a ref ]
+[%%expect{|
+type 'a u = [ `B of 'a ref ]
+|}]
+
+type 'a v : value mod contended with 'a = [ `C of 'a | `D of 'a -> 'a | `E of 'a option ]
+[%%expect{|
+type 'a v = [ `C of 'a | `D of 'a -> 'a | `E of 'a option ]
+|}]
+
+type 'a w : value mod contended with 'a = [ 'a t | 'a v ]
+[%%expect{|
+type 'a w = [ `A of 'a | `C of 'a | `D of 'a -> 'a | `E of 'a option ]
+|}]
+
+let cross_contention (x : int t @ contended) = use_uncontended x
+let cross_portability (x : int t @ nonportable) = use_portable x
+let cross_linearity (x : int t @ once) = use_many x
+[%%expect{|
+val cross_contention : int t @ contended -> unit = <fun>
+val cross_portability : int t -> unit = <fun>
+val cross_linearity : int t @ once -> unit = <fun>
+|}]
+
+let don't_cross_unique (x : int t @ aliased) = use_unique x
+[%%expect{|
+Line 1, characters 58-59:
+1 | let don't_cross_unique (x : int t @ aliased) = use_unique x
+                                                              ^
+Error: This value is "aliased" but expected to be "unique".
+|}]
+
+let don't_cross_locality (x : int t @ local) = use_global x
+[%%expect{|
+Line 1, characters 58-59:
+1 | let don't_cross_locality (x : int t @ local) = use_global x
+                                                              ^
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
+|}]
+
+
+let cross_contention (x : int w @ contended) = use_uncontended x
+[%%expect{|
+val cross_contention : int w @ contended -> unit = <fun>
+|}]
+
+let don't_cross_portability (x : int w @ nonportable) = use_portable x
+[%%expect{|
+Line 1, characters 69-70:
+1 | let don't_cross_portability (x : int w @ nonportable) = use_portable x
+                                                                         ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+(* Quality *)
+
+type 'a record : immutable_data with [ `A of 'a ] = { inner : 'a }
+[%%expect{|
+type 'a record = { inner : 'a; }
+|}]
+
+(* Harder cases: row variables *)
+
+(* CR layouts v2.8: These are both correct, but we could probably infer a more precise kind for both. *)
+type ('a, 'b) t : immediate = [< `X | `Y of 'a] as 'b
+[%%expect{|
+Line 1, characters 0-53:
+1 | type ('a, 'b) t : immediate = [< `X | `Y of 'a] as 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "[< `X | `Y of 'a ]" is value
+         because it's a polymorphic variant type.
+       But the kind of type "[< `X | `Y of 'a ]" must be a subkind of immediate
+         because of the definition of t at line 1, characters 0-53.
+|}]
+type ('a, 'b) u : immediate = [> `X | `Y of 'a] as 'b
+[%%expect{|
+Line 1, characters 0-53:
+1 | type ('a, 'b) u : immediate = [> `X | `Y of 'a] as 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "[> `X | `Y of 'a ]" is value
+         because it's a polymorphic variant type.
+       But the kind of type "[> `X | `Y of 'a ]" must be a subkind of immediate
+         because of the definition of u at line 1, characters 0-53.
+|}]
+
+(* less-than rows *)
+
+let f (x : [< `A of int | `B of string] @ contended) =
+  use_uncontended x
+(* CR layouts v2.8: This should probably be accepted *)
+[%%expect{|
+Line 2, characters 18-19:
+2 |   use_uncontended x
+                      ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a = private [< `A of 'a | `B of ('a * 'a) | `C ]
+end = struct
+  type 'a t = [ `C ]
+end
+[%%expect{|
+Line 2, characters 2-83:
+2 |   type 'a t : immutable_data with 'a = private [< `A of 'a | `B of ('a * 'a) | `C ]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "[< `A of 'a | `B of 'a * 'a | `C ]" is value
+         because it's a polymorphic variant type.
+       But the kind of type "[< `A of 'a | `B of 'a * 'a | `C ]" must be a subkind of
+         immutable_data with 'a
+         because of the definition of t at line 2, characters 2-83.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -162,7 +162,7 @@ Error: The kind of type "[> `X | `Y of 'a ]" is value
 
 let f (x : [< `A of int | `B of string] @ contended) =
   use_uncontended x
-(* CR layouts v2.8: This should probably be accepted *)
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
 Line 2, characters 18-19:
 2 |   use_uncontended x

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -291,3 +291,81 @@ type trec_rec_succeeds =
     [ `X of [ `Loop of 'b | `W of 'a | `Z of 'a -> 'b ] as 'b | `Y of 'b ]
     as 'a
 |}]
+
+(* Future tests for when we start adding row variables to with-bounds. *)
+
+type 'a t1 = [< `A of string | `B of int ] as 'a
+type 'a t2 : immutable_data with 'a t1 = C of string  (* should be rejected, at least until we sort out closed-but-not-static bestness *)
+type t3 : immutable_data with [ `A of string] t1 = C of string  (* should be accepted *)
+[%%expect{|
+type 'a t1 = 'a constraint 'a = [< `A of string | `B of int ]
+type 'a t2 = C of string constraint 'a = [< `A of string | `B of int ]
+type t3 = C of string
+|}]
+
+type 'a t1 = [> `A of string | `B of int ] as 'a
+type 'a t2 : immutable_data with 'a t1 = C of string  (* should be rejected *)
+type t3 : immutable_data with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
+[%%expect{|
+type 'a t1 = 'a constraint 'a = [> `A of string | `B of int ]
+type 'a t2 = C of string constraint 'a = [> `A of string | `B of int ]
+type t3 = C of string
+|}]
+
+module type S = sig
+  type t = private [< `A of string | `B of int ]
+end
+module M1 : S = struct
+  type t = [ `A of string ]
+end
+type t2 : immutable_data with M1.t = C of string  (* should be rejected, at least until we sort out closed-but-not-static bestness *)
+module M2 : S with type t = [ `A of string ] = struct
+  type t = [ `A of string ]
+end
+type t3 : immutable_data with M2.t = C of string (* should be accepted *)
+[%%expect{|
+module type S = sig type t = private [< `A of string | `B of int ] end
+module M1 : S
+type t2 = C of string
+module M2 : sig type t = [ `A of string ] end
+type t3 = C of string
+|}]
+
+type (_, _) eq = Refl : ('a, 'a) eq
+
+(* I'm not sure whether module substitution over a non-static private row type preserves the Tvariant structure; so I made this harder case, too *)
+let sneaky (x : (M1.t, [ `A of string ]) eq) = match x with
+  | Refl -> let open struct
+    type t4 : immutable_data with M1.t = C of string  (* not sure what will happen, but we should eventually accept *)
+  end in ()
+[%%expect{|
+type (_, _) eq = Refl : ('a, 'a) eq
+val sneaky : (M1.t, [ `A of string ]) eq -> unit = <fun>
+|}]
+
+module type S = sig
+  type t = private [> `A of string | `B of int ]
+end
+module M1 : S = struct
+  type t = [ `A of string | `B of int | `C of (int -> int) ref ]
+end
+type t2 : immutable_data with M1.t = C of string  (* should be rejected *)
+module M2 : S with type t = [ `A of string | `B of int ] = struct
+  type t = [ `A of string | `B of int ]
+end
+type t3 : immutable_data with M2.t = C of string (* should be accepted *)
+[%%expect{|
+module type S = sig type t = private [> `A of string | `B of int ] end
+module M1 : S
+type t2 = C of string
+module M2 : sig type t = [ `A of string | `B of int ] end
+type t3 = C of string
+|}]
+
+let sneaky (x : (M1.t, [ `A of string | `B of int ]) eq) = match x with
+  | Refl -> let open struct
+    type t4 : immutable_data with M1.t = C of string  (* not sure what will happen, but we should eventually accept *)
+  end in ()
+[%%expect{|
+val sneaky : (M1.t, [ `A of string | `B of int ]) eq -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -236,7 +236,7 @@ Line 1, characters 0-71:
 1 | type trec_fails : immutable_data = [ `C | `D of 'a * unit -> 'a ] as 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "[ `C | `D of 'a * unit -> 'a ] as 'a" is
-         value mod immutable
+         value mod immutable non_float
          because it's a polymorphic variant type.
        But the kind of type "[ `C | `D of 'a * unit -> 'a ] as 'a" must be a subkind of
          immutable_data
@@ -258,7 +258,7 @@ Lines 1-2, characters 0-80:
 2 |   [ `X of 'b | `Y of [ `Z of ('a -> 'b) | `W of 'a | `Loop of 'b ] as 'b ] as 'a
 Error: The kind of type "[ `X of
                             [ `Loop of 'b | `W of 'a | `Z of 'a -> 'b ] as 'b
-                        | `Y of 'b ] as 'a" is value mod immutable
+                        | `Y of 'b ] as 'a" is value mod immutable non_float
          because it's a polymorphic variant type.
        But the kind of type "[ `X of
                                 [ `Loop of 'b | `W of 'a | `Z of 'a -> 'b ]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -270,17 +270,9 @@ type t = [ `bar | `foo ]
 
 type t
 type u : immutable_data with t = [`foo of t]
-(* CR layouts v2.8: we can do better for polymorphic variants *)
 [%%expect {|
 type t
-Line 2, characters 0-44:
-2 | type u : immutable_data with t = [`foo of t]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "[ `foo of t ]" is value mod non_float
-         because it's a polymorphic variant type.
-       But the kind of type "[ `foo of t ]" must be a subkind of immutable_data
-         with t
-         because of the definition of u at line 2, characters 0-44.
+type u = [ `foo of t ]
 |}]
 
 type (_, _) eq = Eq : ('a, 'a) eq

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -218,17 +218,14 @@ Error: Signature mismatch:
        Modules do not match:
          sig type a = [ `a of string | `b ] type t end
        is not included in
-         sig
-           type a = [ `a of string | `b ]
-           type t : value mod global with a
-         end
+         sig type a = [ `a of string | `b ] type t : value mod unyielding end
        Type declarations do not match:
          type t
        is not included in
-         type t : value mod global with a
+         type t : value mod unyielding
        The kind of the first is value
          because of the definition of t at line 6, characters 2-8.
-       But the kind of the first must be a subkind of value mod global with a
+       But the kind of the first must be a subkind of value mod unyielding
          because of the definition of t at line 3, characters 2-34.
 |}]
 
@@ -240,33 +237,11 @@ end = struct
   type 'a t constraint 'a = [< `a of string | `b]
 end
 [%%expect {|
-Lines 4-7, characters 6-3:
-4 | ......struct
-5 |   type 'a u = [< `a of string | `b] as 'a
-6 |   type 'a t constraint 'a = [< `a of string | `b]
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           type 'a u = 'a constraint 'a = [< `a of string | `b ]
-           type 'a t constraint 'a = [< `a of string | `b ]
-         end
-       is not included in
-         sig
-           type 'a u = 'a constraint 'a = [< `a of string | `b ]
-           type 'a t : value mod global with [< `a of string | `b ] u
-             constraint 'a = [< `a of string | `b ]
-         end
-       Type declarations do not match:
-         type 'a t constraint 'a = [< `a of string | `b ]
-       is not included in
-         type 'a t : value mod global with [< `a of string | `b ] u
-           constraint 'a = [< `a of string | `b ]
-       The kind of the first is value
-         because of the definition of t at line 6, characters 2-49.
-       But the kind of the first must be a subkind of value mod global
-         with [< `a of string | `b ] u
-         because of the definition of t at line 3, characters 2-40.
+module M :
+  sig
+    type 'a u = 'a constraint 'a = [< `a of string | `b ]
+    type 'a t constraint 'a = [< `a of string | `b ]
+  end
 |}]
 
 module M : sig
@@ -277,33 +252,11 @@ end = struct
   type 'a t constraint 'a = [> `a of string | `b]
 end
 [%%expect {|
-Lines 4-7, characters 6-3:
-4 | ......struct
-5 |   type 'a u = [> `a of string | `b] as 'a
-6 |   type 'a t constraint 'a = [> `a of string | `b]
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           type 'a u = 'a constraint 'a = [> `a of string | `b ]
-           type 'a t constraint 'a = [> `a of string | `b ]
-         end
-       is not included in
-         sig
-           type 'a u = 'a constraint 'a = [> `a of string | `b ]
-           type 'a t : value mod portable with [> `a of string | `b ] u
-             constraint 'a = [> `a of string | `b ]
-         end
-       Type declarations do not match:
-         type 'a t constraint 'a = [> `a of string | `b ]
-       is not included in
-         type 'a t : value mod portable with [> `a of string | `b ] u
-           constraint 'a = [> `a of string | `b ]
-       The kind of the first is value
-         because of the definition of t at line 6, characters 2-49.
-       But the kind of the first must be a subkind of value mod portable
-         with [> `a of string | `b ] u
-         because of the definition of t at line 3, characters 2-42.
+module M :
+  sig
+    type 'a u = 'a constraint 'a = [> `a of string | `b ]
+    type 'a t constraint 'a = [> `a of string | `b ]
+  end
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -237,11 +237,33 @@ end = struct
   type 'a t constraint 'a = [< `a of string | `b]
 end
 [%%expect {|
-module M :
-  sig
-    type 'a u = 'a constraint 'a = [< `a of string | `b ]
-    type 'a t constraint 'a = [< `a of string | `b ]
-  end
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type 'a u = [< `a of string | `b] as 'a
+6 |   type 'a t constraint 'a = [< `a of string | `b]
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type 'a u = 'a constraint 'a = [< `a of string | `b ]
+           type 'a t constraint 'a = [< `a of string | `b ]
+         end
+       is not included in
+         sig
+           type 'a u = 'a constraint 'a = [< `a of string | `b ]
+           type 'a t : value mod global with [< `a of string | `b ] u
+             constraint 'a = [< `a of string | `b ]
+         end
+       Type declarations do not match:
+         type 'a t constraint 'a = [< `a of string | `b ]
+       is not included in
+         type 'a t : value mod global with [< `a of string | `b ] u
+           constraint 'a = [< `a of string | `b ]
+       The kind of the first is value
+         because of the definition of t at line 6, characters 2-49.
+       But the kind of the first must be a subkind of value mod global
+         with [< `a of string | `b ] u
+         because of the definition of t at line 3, characters 2-40.
 |}]
 
 module M : sig
@@ -252,11 +274,33 @@ end = struct
   type 'a t constraint 'a = [< `a of (int -> int) | `b]
 end
 [%%expect {|
-module M :
-  sig
-    type 'a u = 'a constraint 'a = [< `a of int -> int | `b ]
-    type 'a t constraint 'a = [< `a of int -> int | `b ]
-  end
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type 'a u = [< `a of (int -> int) | `b] as 'a
+6 |   type 'a t constraint 'a = [< `a of (int -> int) | `b]
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type 'a u = 'a constraint 'a = [< `a of int -> int | `b ]
+           type 'a t constraint 'a = [< `a of int -> int | `b ]
+         end
+       is not included in
+         sig
+           type 'a u = 'a constraint 'a = [< `a of int -> int | `b ]
+           type 'a t : value mod portable with [< `a of int -> int | `b ] u
+             constraint 'a = [< `a of int -> int | `b ]
+         end
+       Type declarations do not match:
+         type 'a t constraint 'a = [< `a of int -> int | `b ]
+       is not included in
+         type 'a t : value mod portable with [< `a of int -> int | `b ] u
+           constraint 'a = [< `a of int -> int | `b ]
+       The kind of the first is value
+         because of the definition of t at line 6, characters 2-55.
+       But the kind of the first must be a subkind of value mod portable
+         with [< `a of int -> int | `b ] u
+         because of the definition of t at line 3, characters 2-42.
 |}]
 
 module M : sig
@@ -267,11 +311,33 @@ end = struct
   type 'a t constraint 'a = [> `a of string | `b]
 end
 [%%expect {|
-module M :
-  sig
-    type 'a u = 'a constraint 'a = [> `a of string | `b ]
-    type 'a t constraint 'a = [> `a of string | `b ]
-  end
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type 'a u = [> `a of string | `b] as 'a
+6 |   type 'a t constraint 'a = [> `a of string | `b]
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type 'a u = 'a constraint 'a = [> `a of string | `b ]
+           type 'a t constraint 'a = [> `a of string | `b ]
+         end
+       is not included in
+         sig
+           type 'a u = 'a constraint 'a = [> `a of string | `b ]
+           type 'a t : value mod portable with [> `a of string | `b ] u
+             constraint 'a = [> `a of string | `b ]
+         end
+       Type declarations do not match:
+         type 'a t constraint 'a = [> `a of string | `b ]
+       is not included in
+         type 'a t : value mod portable with [> `a of string | `b ] u
+           constraint 'a = [> `a of string | `b ]
+       The kind of the first is value
+         because of the definition of t at line 6, characters 2-49.
+       But the kind of the first must be a subkind of value mod portable
+         with [> `a of string | `b ] u
+         because of the definition of t at line 3, characters 2-42.
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -245,6 +245,21 @@ module M :
 |}]
 
 module M : sig
+  type 'a u = [< `a of (int -> int) | `b] as 'a
+  type 'a t : value mod portable with 'a u
+end = struct
+  type 'a u = [< `a of (int -> int) | `b] as 'a
+  type 'a t constraint 'a = [< `a of (int -> int) | `b]
+end
+[%%expect {|
+module M :
+  sig
+    type 'a u = 'a constraint 'a = [< `a of int -> int | `b ]
+    type 'a t constraint 'a = [< `a of int -> int | `b ]
+  end
+|}]
+
+module M : sig
   type 'a u = [> `a of string | `b] as 'a
   type 'a t : value mod portable with 'a u
 end = struct

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -149,5 +149,5 @@ module I : functor (X : sig end) -> sig type t = Priv(X).t end
 
 module IndirectPriv = I(struct end);;
 [%%expect{|
-module IndirectPriv : sig type t : value mod immutable with int end
+module IndirectPriv : sig type t : value mod immutable non_float with int end
 |}]

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -80,20 +80,20 @@ module IndirectPub : sig type t = [ `Foo of 'a ] as 'a end
    if we were unrolling the abbrev.  *)
 module IndirectPriv = I(struct end);;
 [%%expect{|
-module IndirectPriv : sig type t : value mod non_float end
+module IndirectPriv : sig type t : immutable_data end
 |}]
 
 (* These two behave as though a functor was defined *)
 module DirectPrivEta =
   (functor (X : sig end) -> Priv(X))(struct end);;
 [%%expect{|
-module DirectPrivEta : sig type t : value mod non_float end
+module DirectPrivEta : sig type t : immutable_data with t end
 |}]
 
 module DirectPrivEtaUnit =
   (functor (_ : sig end) -> Priv)(struct end)(struct end);;
 [%%expect{|
-module DirectPrivEtaUnit : sig type t : value mod non_float end
+module DirectPrivEtaUnit : sig type t : immutable_data with t end
 |}]
 
 (*** Test proposed by Jacques in
@@ -149,5 +149,5 @@ module I : functor (X : sig end) -> sig type t = Priv(X).t end
 
 module IndirectPriv = I(struct end);;
 [%%expect{|
-module IndirectPriv : sig type t : value mod non_float end
+module IndirectPriv : sig type t : value mod immutable with int end
 |}]

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -86,6 +86,7 @@ module IndirectPriv : sig type t : immutable_data end
 (* These two behave as though a functor was defined *)
 module DirectPrivEta =
   (functor (X : sig end) -> Priv(X))(struct end);;
+(* CR layouts v2.8: examine the interaction between kinds and nondep. *)
 [%%expect{|
 module DirectPrivEta : sig type t : immutable_data with t end
 |}]
@@ -148,6 +149,7 @@ module I : functor (X : sig end) -> sig type t = Priv(X).t end
 |}]
 
 module IndirectPriv = I(struct end);;
+(* CR layouts v2.8: normalize away [with int]. *)
 [%%expect{|
 module IndirectPriv : sig type t : value mod immutable non_float with int end
 |}]

--- a/tools/debug_printers.ml
+++ b/tools/debug_printers.ml
@@ -1,5 +1,6 @@
 let type_expr = Printtyp.raw_type_expr
 let row_field = Printtyp.raw_field
+let row_desc = Printtyp.raw_row_desc
 let ident = Ident.print_with_scope
 let path = Path.print
 let ctype_global_state = Ctype.print_global_state

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -175,6 +175,17 @@ let static_row row =
     (fun (_,f) -> match row_field_repr f with Reither _ -> false | _ -> true)
     (row_fields row)
 
+let tvariant_not_immediate row =
+  (* if all labels are devoid of arguments, not a pointer *)
+  (* CR layouts v5: Polymorphic variants with all void args can probably
+     be immediate, but we don't allow them to have void args right now. *)
+  not (row_closed row)
+  || List.exists
+    (fun (_,field) -> match row_field_repr field with
+      | Rpresent (Some _) | Reither (false, _, _) -> true
+      | _ -> false)
+    (row_fields row)
+
 let hash_variant s =
   let accu = ref 0 in
   for i = 0 to String.length s - 1 do

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -106,6 +106,9 @@ val merge_fixed_explanation:
 
 val static_row: row_desc -> bool
         (* Return whether the row is static or not *)
+val tvariant_not_immediate: row_desc -> bool
+        (* Return whether the polymorphic variant is non-immediate
+           (i.e., has arguments or is open) *)
 val hash_variant: label -> int
         (* Hash function for variant tags *)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2319,7 +2319,7 @@ let rec estimate_type_jkind ~expand_component env ty =
   | Tlink _ | Tsubst _ -> assert false
   | Tvariant row ->
      if tvariant_not_immediate row
-     then Jkind.for_non_float ~why:Polymorphic_variant
+     then Jkind.for_boxed_row row
      else Jkind.Builtin.immediate ~why:Immediate_polymorphic_variant
   | Tunivar { jkind } -> Jkind.disallow_right jkind
   | Tpoly (ty, _) ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2250,16 +2250,6 @@ let get_unboxed_type_approximation env ty =
   match get_unboxed_type_representation env ty with
   | Ok ty | Error ty -> ty
 
-let tvariant_not_immediate row =
-  (* if all labels are devoid of arguments, not a pointer *)
-  (* CR layouts v5: Polymorphic variants with all void args can probably
-     be immediate, but we don't allow them to have void args right now. *)
-  not (row_closed row)
-  || List.exists
-    (fun (_,field) -> match row_field_repr field with
-      | Rpresent (Some _) | Reither (false, _, _) -> true
-      | _ -> false)
-    (row_fields row)
 
 (* forward declarations *)
 let type_equal' = ref (fun _ _ _ -> Misc.fatal_error "type_equal")
@@ -2318,9 +2308,7 @@ let rec estimate_type_jkind ~expand_component env ty =
   | Tnil -> Jkind.Builtin.value ~why:Tnil
   | Tlink _ | Tsubst _ -> assert false
   | Tvariant row ->
-     if tvariant_not_immediate row
-     then Jkind.for_boxed_row row
-     else Jkind.Builtin.immediate ~why:Immediate_polymorphic_variant
+     Jkind.for_boxed_row row
   | Tunivar { jkind } -> Jkind.disallow_right jkind
   | Tpoly (ty, _) ->
     let jkind_of_type = !type_jkind_purely_if_principal' env in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -598,10 +598,6 @@ val contained_without_boxing : Env.t -> type_expr -> type_expr list
        (or "without indirection" or "flatly"); in the case of [@@unboxed]
        existentials, these types might have free variables*)
 
-(* Given the row from a variant type, determine if it is immediate.  Currently
-   just checks that all constructors have no arguments, doesn't consider
-   void. *)
-val tvariant_not_immediate : row_desc -> bool
 
 (* Cheap upper bound on jkind.  Will not expand unboxed types - call
    [type_jkind] if that's needed. *)

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -997,7 +997,7 @@ module Layout_and_axes = struct
                  so if we saw one already, we don't need to expand it again. *)
               Skip)
           | Tvar _ | Tarrow _ | Tunboxed_tuple _ | Tobject _ | Tfield _ | Tnil
-          | Tunivar _ | Tpackage _ ->
+          | Tunivar _ | Tpackage _ | Tof_kind _ ->
             (* these cases either cannot be infinitely recursive or their jkinds
                do not have with_bounds *)
             (* CR layouts v2.8: Some of these might get with-bounds someday. We

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -986,12 +986,12 @@ module Layout_and_axes = struct
                 Continue
                   { t with constr = Path.Map.add p (fuel - 1, args) constr }
               else Stop { t with fuel_status = Ran_out_of_fuel })
-          | Tvariant row -> (
-            let id = get_id (row_more row) in
-            match Numbers.Int.Set.mem id seen_row_var with
+          | Tvariant _ -> (
+            let row_var_id = get_id (Btype.proxy ty) in
+            match Numbers.Int.Set.mem row_var_id seen_row_var with
             | false ->
               Continue
-                { t with seen_row_var = Numbers.Int.Set.add id seen_row_var }
+                { t with seen_row_var = Numbers.Int.Set.add row_var_id seen_row_var }
             | true ->
               (* For our purposes, row variables are like constructors with no arguments,
                  so if we saw one already, we don't need to expand it again. *)

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2436,12 +2436,12 @@ let for_open_boxed_row =
 let for_boxed_row row =
   if Btype.tvariant_not_immediate row
   then
-    let base = Builtin.immutable_data ~why:Polymorphic_variant in
     if not (Btype.static_row row)
     then
       (* CR layouts v2.8: We can probably do a fair bit better here in most cases *)
       for_open_boxed_row
     else
+      let base = Builtin.immutable_data ~why:Polymorphic_variant in
       Btype.fold_row
         (fun jkind type_expr ->
           add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -991,7 +991,9 @@ module Layout_and_axes = struct
             match Numbers.Int.Set.mem row_var_id seen_row_var with
             | false ->
               Continue
-                { t with seen_row_var = Numbers.Int.Set.add row_var_id seen_row_var }
+                { t with
+                  seen_row_var = Numbers.Int.Set.add row_var_id seen_row_var
+                }
             | true ->
               (* For our purposes, row variables are like constructors with no arguments,
                  so if we saw one already, we don't need to expand it again. *)
@@ -2429,11 +2431,11 @@ let for_boxed_row row =
      else
        Btype.fold_row
          (fun jkind type_expr ->
-           add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr jkind)
+           add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr
+             jkind)
          base row)
     |> mark_best
-  else
-    Builtin.immediate ~why:Immediate_polymorphic_variant
+  else Builtin.immediate ~why:Immediate_polymorphic_variant
 
 let for_arrow =
   fresh_jkind

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2405,6 +2405,21 @@ let for_boxed_tuple elts =
     elts
     (Builtin.immutable_data ~why:Tuple |> mark_best)
 
+let for_boxed_row row =
+  let base = Builtin.immutable_data ~why:Polymorphic_variant in
+  if not (Btype.static_row row)
+  then
+    (* CR layouts v2.8: We can probably do a fair bit better here in most cases *)
+    Builtin.value ~why:Polymorphic_variant
+  else
+    Btype.fold_row
+      (fun jkind type_expr ->
+        add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr jkind)
+      base row
+    (* We know it's best because we checked it was static, above, so we're not dealing
+       with a "less-than" or "greater-than" polymorphic variant *)
+    |> mark_best
+
 let for_arrow =
   fresh_jkind
     { layout = Sort (Base Value);

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2419,17 +2419,21 @@ let for_boxed_tuple elts =
     (Builtin.immutable_data ~why:Tuple |> mark_best)
 
 let for_boxed_row row =
-  (let base = Builtin.immutable_data ~why:Polymorphic_variant in
-   if not (Btype.static_row row)
-   then
-     (* CR layouts v2.8: We can probably do a fair bit better here in most cases *)
-     Builtin.value ~why:Polymorphic_variant
-   else
-     Btype.fold_row
-       (fun jkind type_expr ->
-         add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr jkind)
-       base row)
-  |> mark_best
+  if Btype.tvariant_not_immediate row
+  then
+    (let base = Builtin.immutable_data ~why:Polymorphic_variant in
+     if not (Btype.static_row row)
+     then
+       (* CR layouts v2.8: We can probably do a fair bit better here in most cases *)
+       Builtin.value ~why:Polymorphic_variant
+     else
+       Btype.fold_row
+         (fun jkind type_expr ->
+           add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr jkind)
+         base row)
+    |> mark_best
+  else
+    Builtin.immediate ~why:Immediate_polymorphic_variant
 
 let for_arrow =
   fresh_jkind

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2406,19 +2406,17 @@ let for_boxed_tuple elts =
     (Builtin.immutable_data ~why:Tuple |> mark_best)
 
 let for_boxed_row row =
-  let base = Builtin.immutable_data ~why:Polymorphic_variant in
-  if not (Btype.static_row row)
-  then
-    (* CR layouts v2.8: We can probably do a fair bit better here in most cases *)
-    Builtin.value ~why:Polymorphic_variant
-  else
-    Btype.fold_row
-      (fun jkind type_expr ->
-        add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr jkind)
-      base row
-    (* We know it's best because we checked it was static, above, so we're not dealing
-       with a "less-than" or "greater-than" polymorphic variant *)
-    |> mark_best
+  (let base = Builtin.immutable_data ~why:Polymorphic_variant in
+   if not (Btype.static_row row)
+   then
+     (* CR layouts v2.8: We can probably do a fair bit better here in most cases *)
+     Builtin.value ~why:Polymorphic_variant
+   else
+     Btype.fold_row
+       (fun jkind type_expr ->
+         add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr jkind)
+       base row)
+  |> mark_best
 
 let for_arrow =
   fresh_jkind

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -503,7 +503,7 @@ val for_boxed_variant : Types.constructor_declaration list -> Types.jkind_l
 (** Choose an appropriate jkind for a boxed tuple type. *)
 val for_boxed_tuple : (string option * Types.type_expr) list -> Types.jkind_l
 
-(** Choose an appropriate jkind for a (known to be non-immediate) row type *)
+(** Choose an appropriate jkind for a row type. *)
 val for_boxed_row : Types.row_desc -> Types.jkind_l
 
 (** The jkind of an arrow type. *)

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -503,6 +503,9 @@ val for_boxed_variant : Types.constructor_declaration list -> Types.jkind_l
 (** Choose an appropriate jkind for a boxed tuple type. *)
 val for_boxed_tuple : (string option * Types.type_expr) list -> Types.jkind_l
 
+(** Choose an appropriate jkind for a (known to be non-immediate) row type *)
+val for_boxed_row : Types.row_desc -> Types.jkind_l
+
 (** The jkind of an arrow type. *)
 val for_arrow : Types.jkind_l
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -662,6 +662,22 @@ and raw_lid_type_list tl =
   raw_list (fun ppf (lid, typ) ->
              fprintf ppf "(@,%a,@,%a)" longident lid raw_type typ)
     tl
+and raw_row_desc ppf row =
+  let Row {fields; more; name; fixed; closed} = row_repr row in
+  fprintf ppf
+    "@[<hov1>{@[%s@,%a;@]@ @[%s@,%a;@]@ %s%B;@ %s%a;@ @[<1>%s%t@]}@]"
+    "row_fields="
+    (raw_list (fun ppf (l, f) ->
+       fprintf ppf "@[%s,@ %a@]" l raw_field f))
+    fields
+    "row_more=" raw_type more
+    "row_closed=" closed
+    "row_fixed=" raw_row_fixed fixed
+    "row_name="
+    (fun ppf ->
+       match name with None -> fprintf ppf "None"
+                     | Some(p,tl) ->
+                       fprintf ppf "Some(@,%a,@,%a)" path p raw_type_list tl)
 and raw_type_desc ppf = function
     Tvar { name; jkind } ->
       fprintf ppf "Tvar (@,%a,@,%a)"
@@ -704,21 +720,7 @@ and raw_type_desc ppf = function
         raw_type t
         raw_type_list tl
   | Tvariant row ->
-      let Row {fields; more; name; fixed; closed} = row_repr row in
-      fprintf ppf
-        "@[<hov1>{@[%s@,%a;@]@ @[%s@,%a;@]@ %s%B;@ %s%a;@ @[<1>%s%t@]}@]"
-        "row_fields="
-        (raw_list (fun ppf (l, f) ->
-          fprintf ppf "@[%s,@ %a@]" l raw_field f))
-        fields
-        "row_more=" raw_type more
-        "row_closed=" closed
-        "row_fixed=" raw_row_fixed fixed
-        "row_name="
-        (fun ppf ->
-          match name with None -> fprintf ppf "None"
-          | Some(p,tl) ->
-              fprintf ppf "Some(@,%a,@,%a)" path p raw_type_list tl)
+    raw_row_desc ppf row
   | Tpackage (p, fl) ->
       fprintf ppf "@[<hov1>Tpackage(@,%a,@,%a)@]" path p
         raw_lid_type_list fl

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -41,6 +41,7 @@ val strings_of_paths: namespace -> Path.t list -> string list
     (** Print a list of paths, using the same naming context to
         avoid name collisions *)
 
+val raw_row_desc : formatter -> row_desc -> unit
 val raw_type_expr: formatter -> type_expr -> unit
 val raw_field : formatter -> row_field -> unit
 val string_of_label: Types.arg_label -> string

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -599,7 +599,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
                       non_consts = [0, Constructor_uniform fields] }))
   | Tvariant row ->
     num_nodes_visited,
-    if Ctype.tvariant_not_immediate row
+    if Btype.tvariant_not_immediate row
     then non_nullable Pgenval
     else non_nullable Pintval
   | _ ->


### PR DESCRIPTION
In the case that a polymorphic variant is *static*, meaning it's closed and its row variable isn't bound, it's easy enough to infer a more precise kind for it than `value` - we just treat it like a regular (boxed) variant, adding all its mentioned types (given by `Btype.fold_row`) to the with-bounds. Since it's static, we can also mark it best