### PR TITLE
Not-best, precise kinds for closed (not just static) rows

### DIFF
--- a/jane/doc/proposals/kind-inference.md
+++ b/jane/doc/proposals/kind-inference.md
@@ -333,6 +333,8 @@ t := λ [[ 'aᵢ : κᵢ ]]. δ : κ ∈ Γ
 ----------------------- T_POLY
 Γ ⊢ ('a : jkind). σ : κ {q}
 
+(* CR layouts v2.8: Some simple cases of polymorphic variants now get more
+   precise kinds in the compiler; update this to reflect that *)
 TODO
 ---------------------------------------- T_POLY_VARIANT
 Γ ⊢ polymorphic_variant : value; ⟪⊤_Ξ⟫ {not_best}

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -137,3 +137,35 @@ Error: The kind of type "[< `A of 'a | `B of 'a * 'a | `C ]" is value
          immutable_data with 'a
          because of the definition of t at line 2, characters 2-83.
 |}]
+
+(* Tunivar-ified row variables *)
+
+type t1 = { f : ('a : value mod portable). ([> `Foo of int] as 'a) -> unit }
+(* CR layouts v2.8: This should be accepted *)
+[%%expect{|
+Line 1, characters 64-65:
+1 | type t1 = { f : ('a : value mod portable). ([> `Foo of int] as 'a) -> unit }
+                                                                    ^
+Error: This alias is bound to type "[> `Foo of int ]"
+       but is used as an instance of type "('a : value mod portable)"
+       The kind of [> `Foo of int ] is value
+         because it's a polymorphic variant type.
+       But the kind of [> `Foo of int ] must be a subkind of
+         value mod portable
+         because of the annotation on the universal variable 'a.
+|}]
+
+type t2 = { f : ('a : value mod portable). ([< `Foo of int] as 'a) -> unit }
+(* CR layouts v2.8: This should be accepted *)
+[%%expect{|
+Line 1, characters 64-65:
+1 | type t2 = { f : ('a : value mod portable). ([< `Foo of int] as 'a) -> unit }
+                                                                    ^
+Error: This alias is bound to type "[< `Foo of int ]"
+       but is used as an instance of type "('a : value mod portable)"
+       The kind of [< `Foo of int ] is value
+         because it's a polymorphic variant type.
+       But the kind of [< `Foo of int ] must be a subkind of
+         value mod portable
+         because of the annotation on the universal variable 'a.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -1,0 +1,139 @@
+(* TEST
+    expect;
+*)
+
+let use_global : 'a @ global -> unit = fun _ -> ()
+let use_unique : 'a @ unique -> unit = fun _ -> ()
+let use_uncontended : 'a @ uncontended -> unit = fun _ -> ()
+let use_portable : 'a @ portable -> unit = fun _ -> ()
+let use_many : 'a @ many -> unit = fun _ -> ()
+[%%expect{|
+val use_global : 'a -> unit = <fun>
+val use_unique : 'a @ unique -> unit = <fun>
+val use_uncontended : 'a -> unit = <fun>
+val use_portable : 'a @ portable -> unit = <fun>
+val use_many : 'a -> unit = <fun>
+|}]
+
+(* Simple cases : closed polymorphic variants with fields *)
+
+type 'a t : immutable_data with 'a = [ `A of 'a ]
+
+[%%expect{|
+type 'a t = [ `A of 'a ]
+|}]
+
+type 'a u : mutable_data with 'a = [ `B of 'a ref ]
+[%%expect{|
+type 'a u = [ `B of 'a ref ]
+|}]
+
+type 'a v : value mod contended with 'a = [ `C of 'a | `D of 'a -> 'a | `E of 'a option ]
+[%%expect{|
+type 'a v = [ `C of 'a | `D of 'a -> 'a | `E of 'a option ]
+|}]
+
+type 'a w : value mod contended with 'a = [ 'a t | 'a v ]
+[%%expect{|
+type 'a w = [ `A of 'a | `C of 'a | `D of 'a -> 'a | `E of 'a option ]
+|}]
+
+let cross_contention (x : int t @ contended) = use_uncontended x
+let cross_portability (x : int t @ nonportable) = use_portable x
+let cross_linearity (x : int t @ once) = use_many x
+[%%expect{|
+val cross_contention : int t @ contended -> unit = <fun>
+val cross_portability : int t -> unit = <fun>
+val cross_linearity : int t @ once -> unit = <fun>
+|}]
+
+let don't_cross_unique (x : int t @ aliased) = use_unique x
+[%%expect{|
+Line 1, characters 58-59:
+1 | let don't_cross_unique (x : int t @ aliased) = use_unique x
+                                                              ^
+Error: This value is "aliased" but expected to be "unique".
+|}]
+
+let don't_cross_locality (x : int t @ local) = use_global x
+[%%expect{|
+Line 1, characters 58-59:
+1 | let don't_cross_locality (x : int t @ local) = use_global x
+                                                              ^
+Error: This value escapes its region.
+  Hint: This argument cannot be local,
+  because it is an argument in a tail call.
+|}]
+
+
+let cross_contention (x : int w @ contended) = use_uncontended x
+[%%expect{|
+val cross_contention : int w @ contended -> unit = <fun>
+|}]
+
+let don't_cross_portability (x : int w @ nonportable) = use_portable x
+[%%expect{|
+Line 1, characters 69-70:
+1 | let don't_cross_portability (x : int w @ nonportable) = use_portable x
+                                                                         ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+(* Quality *)
+
+type 'a record : immutable_data with [ `A of 'a ] = { inner : 'a }
+[%%expect{|
+type 'a record = { inner : 'a; }
+|}]
+
+(* Harder cases: row variables *)
+
+(* CR layouts v2.8: These are both correct, but we could probably infer a more precise kind for both. *)
+type ('a, 'b) t : immediate = [< `X | `Y of 'a] as 'b
+[%%expect{|
+Line 1, characters 0-53:
+1 | type ('a, 'b) t : immediate = [< `X | `Y of 'a] as 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "[< `X | `Y of 'a ]" is value
+         because it's a polymorphic variant type.
+       But the kind of type "[< `X | `Y of 'a ]" must be a subkind of immediate
+         because of the definition of t at line 1, characters 0-53.
+|}]
+type ('a, 'b) u : immediate = [> `X | `Y of 'a] as 'b
+[%%expect{|
+Line 1, characters 0-53:
+1 | type ('a, 'b) u : immediate = [> `X | `Y of 'a] as 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "[> `X | `Y of 'a ]" is value
+         because it's a polymorphic variant type.
+       But the kind of type "[> `X | `Y of 'a ]" must be a subkind of immediate
+         because of the definition of u at line 1, characters 0-53.
+|}]
+
+(* less-than rows *)
+
+let f (x : [< `A of int | `B of string] @ contended) =
+  use_uncontended x
+(* CR layouts v2.8: This should probably be accepted *)
+[%%expect{|
+Line 2, characters 18-19:
+2 |   use_uncontended x
+                      ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+module M : sig
+  type 'a t : immutable_data with 'a = private [< `A of 'a | `B of ('a * 'a) | `C ]
+end = struct
+  type 'a t = [ `C ]
+end
+[%%expect{|
+Line 2, characters 2-83:
+2 |   type 'a t : immutable_data with 'a = private [< `A of 'a | `B of ('a * 'a) | `C ]
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "[< `A of 'a | `B of 'a * 'a | `C ]" is value
+         because it's a polymorphic variant type.
+       But the kind of type "[< `A of 'a | `B of 'a * 'a | `C ]" must be a subkind of
+         immutable_data with 'a
+         because of the definition of t at line 2, characters 2-83.
+|}]

--- a/tools/debug_printers.ml
+++ b/tools/debug_printers.ml
@@ -1,5 +1,6 @@
 let type_expr = Printtyp.raw_type_expr
 let row_field = Printtyp.raw_field
+let row_desc = Printtyp.raw_row_desc
 let ident = Ident.print_with_scope
 let path = Path.print
 let ctype_global_state = Ctype.print_global_state

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2319,7 +2319,7 @@ let rec estimate_type_jkind ~expand_component env ty =
   | Tlink _ | Tsubst _ -> assert false
   | Tvariant row ->
      if tvariant_not_immediate row
-     then Jkind.Builtin.value ~why:Polymorphic_variant
+     then Jkind.for_boxed_row row
      else Jkind.Builtin.immediate ~why:Immediate_polymorphic_variant
   | Tunivar { jkind } -> Jkind.disallow_right jkind
   | Tpoly (ty, _) ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2228,24 +2228,22 @@ let for_boxed_tuple elts =
     (Builtin.immutable_data ~why:Tuple |> mark_best)
 
 let for_boxed_row row =
-  let base = Builtin.immutable_data ~why:Polymorphic_variant in
-  if not (Btype.static_row row)
-  then
-    (* CR layouts v2.8: We can probably do a fair bit better here in most cases *)
-    Builtin.value ~why:Polymorphic_variant
-  else
-    Btype.fold_row
-      (fun jkind type_expr ->
-         add_with_bounds
-           ~modality:Mode.Modality.Value.Const.id
-           ~type_expr
-           jkind
-      )
-      base
-      row
-    (* We know it's best because we checked it was static, above, so we're not dealing
-       with a "less-than" or "greater-than" polymorphic variant *)
-    |> mark_best
+  (let base = Builtin.immutable_data ~why:Polymorphic_variant in
+   if not (Btype.static_row row)
+   then
+     (* CR layouts v2.8: We can probably do a fair bit better here in most cases *)
+     Builtin.value ~why:Polymorphic_variant
+   else
+     Btype.fold_row
+       (fun jkind type_expr ->
+          add_with_bounds
+            ~modality:Mode.Modality.Value.Const.id
+            ~type_expr
+            jkind
+       )
+       base
+       row
+  ) |> mark_best
 
 let for_arrow =
   fresh_jkind

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2227,6 +2227,26 @@ let for_boxed_tuple elts =
     elts
     (Builtin.immutable_data ~why:Tuple |> mark_best)
 
+let for_boxed_row row =
+  let base = Builtin.immutable_data ~why:Polymorphic_variant in
+  if not (Btype.static_row row)
+  then
+    (* CR layouts v2.8: We can probably do a fair bit better here in most cases *)
+    Builtin.value ~why:Polymorphic_variant
+  else
+    Btype.fold_row
+      (fun jkind type_expr ->
+         add_with_bounds
+           ~modality:Mode.Modality.Value.Const.id
+           ~type_expr
+           jkind
+      )
+      base
+      row
+    (* We know it's best because we checked it was static, above, so we're not dealing
+       with a "less-than" or "greater-than" polymorphic variant *)
+    |> mark_best
+
 let for_arrow =
   fresh_jkind
     { layout = Sort (Base Value);

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -495,6 +495,9 @@ val for_boxed_variant : Types.constructor_declaration list -> Types.jkind_l
 (** Choose an appropriate jkind for a boxed tuple type. *)
 val for_boxed_tuple : (string option * Types.type_expr) list -> Types.jkind_l
 
+(** Choose an appropriate jkind for a (known to be non-immediate) row type *)
+val for_boxed_row : Types.row_desc -> Types.jkind_l
+
 (** The jkind of an arrow type. *)
 val for_arrow : Types.jkind_l
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -661,6 +661,22 @@ and raw_lid_type_list tl =
   raw_list (fun ppf (lid, typ) ->
              fprintf ppf "(@,%a,@,%a)" longident lid raw_type typ)
     tl
+and raw_row_desc ppf row =
+  let Row {fields; more; name; fixed; closed} = row_repr row in
+  fprintf ppf
+    "@[<hov1>{@[%s@,%a;@]@ @[%s@,%a;@]@ %s%B;@ %s%a;@ @[<1>%s%t@]}@]"
+    "row_fields="
+    (raw_list (fun ppf (l, f) ->
+       fprintf ppf "@[%s,@ %a@]" l raw_field f))
+    fields
+    "row_more=" raw_type more
+    "row_closed=" closed
+    "row_fixed=" raw_row_fixed fixed
+    "row_name="
+    (fun ppf ->
+       match name with None -> fprintf ppf "None"
+                     | Some(p,tl) ->
+                       fprintf ppf "Some(@,%a,@,%a)" path p raw_type_list tl)
 and raw_type_desc ppf = function
     Tvar { name; jkind } ->
       fprintf ppf "Tvar (@,%a,@,%a)"
@@ -703,21 +719,7 @@ and raw_type_desc ppf = function
         raw_type t
         raw_type_list tl
   | Tvariant row ->
-      let Row {fields; more; name; fixed; closed} = row_repr row in
-      fprintf ppf
-        "@[<hov1>{@[%s@,%a;@]@ @[%s@,%a;@]@ %s%B;@ %s%a;@ @[<1>%s%t@]}@]"
-        "row_fields="
-        (raw_list (fun ppf (l, f) ->
-          fprintf ppf "@[%s,@ %a@]" l raw_field f))
-        fields
-        "row_more=" raw_type more
-        "row_closed=" closed
-        "row_fixed=" raw_row_fixed fixed
-        "row_name="
-        (fun ppf ->
-          match name with None -> fprintf ppf "None"
-          | Some(p,tl) ->
-              fprintf ppf "Some(@,%a,@,%a)" path p raw_type_list tl)
+    raw_row_desc ppf row
   | Tpackage (p, fl) ->
       fprintf ppf "@[<hov1>Tpackage(@,%a,@,%a)@]" path p
         raw_lid_type_list fl

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -41,6 +41,7 @@ val strings_of_paths: namespace -> Path.t list -> string list
     (** Print a list of paths, using the same naming context to
         avoid name collisions *)
 
+val raw_row_desc : formatter -> row_desc -> unit
 val raw_type_expr: formatter -> type_expr -> unit
 val raw_field : formatter -> row_field -> unit
 val string_of_label: Types.arg_label -> string


### PR DESCRIPTION
Closed but non-static rows (written like [< stuff ...]) can have with-bounds
too, they just can't have best kinds, since they can be substituted later to
something lower.