### PR TITLE
Cleanup of the Arm directives code 

### DIFF
--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2101,7 +2101,10 @@ let emit_item (d : Cmm.data_item) =
   | Csymbol_address s -> emit_printf "\t.quad\t%a\n" femit_symbol s.sym_name
   | Csymbol_offset (s, o) ->
     emit_printf "\t.quad\t%a+%a\n" femit_symbol s.sym_name femit_int o
-  | Cstring s -> if String.length s = 0 then emit_string "\n" else emit_string_directive "\t.ascii\t" s
+  | Cstring s ->
+    if String.length s = 0
+    then emit_string "\n"
+    else emit_string_directive "\t.ascii\t" s
   | Cskip n -> if n > 0 then emit_printf "\t.space\t%a\n" femit_int n
   | Calign n -> emit_printf "\t.align\t%a\n" femit_int (Misc.log2 n)
 

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2101,7 +2101,7 @@ let emit_item (d : Cmm.data_item) =
   | Csymbol_address s -> emit_printf "\t.quad\t%a\n" femit_symbol s.sym_name
   | Csymbol_offset (s, o) ->
     emit_printf "\t.quad\t%a+%a\n" femit_symbol s.sym_name femit_int o
-  | Cstring s -> emit_string_directive "\t.ascii\t" s
+  | Cstring s -> if String.length s = 0 then emit_string "\n" else emit_string_directive "\t.ascii\t" s
   | Cskip n -> if n > 0 then emit_printf "\t.space\t%a\n" femit_int n
   | Calign n -> emit_printf "\t.align\t%a\n" femit_int (Misc.log2 n)
 

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2089,10 +2089,10 @@ let emit_item (d : Cmm.data_item) =
          to be global. *)
       emit_printf "\t.globl\t%a\n" femit_symbol s.sym_name;
     emit_printf "%a:\n" femit_symbol s.sym_name
-  | Cint8 n -> emit_printf "\t.byte\t0x%x\n" n
-  | Cint16 n -> emit_printf "\t.short\t0x%x\n" n
-  | Cint32 n -> emit_printf "\t.long\t0x%Lx\n" (Int64.of_nativeint n)
-  | Cint n -> emit_printf "\t.quad\t0x%Lx\n" (Int64.of_nativeint n)
+  | Cint8 n -> emit_printf "\t.byte\t%d\n" n
+  | Cint16 n -> emit_printf "\t.short\t%d\n" n
+  | Cint32 n -> emit_printf "\t.long\t%Ld\n" (Int64.of_nativeint n)
+  | Cint n -> emit_printf "\t.quad\t%Ld\n" (Int64.of_nativeint n)
   | Csingle f -> emit_float32_directive_aux (Int32.bits_of_float f)
   | Cdouble f -> emit_float64_directive_aux (Int64.bits_of_float f)
   | Cvec128 { high; low } ->
@@ -2132,7 +2132,7 @@ let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) =
 
       let rec string_of_constant ~print_as_hex const =
         match const with
-        | Int64 n -> if print_as_hex then Printf.sprintf "0x%Lx" n else Int64.to_string n
+        | Int64 n -> if print_as_hex then Printf.sprintf "%Ld" n else Int64.to_string n
         | Label s -> s
         | Add (c1, c2) ->
           Printf.sprintf "(%s + %s)" (string_of_constant ~print_as_hex c1)
@@ -2269,15 +2269,15 @@ let end_assembly () =
         (fun lbl ->
           emit_symbol_type femit_label lbl "object";
           emit_printf "\t.quad\t%a\n" femit_label lbl);
-      efa_8 = (fun n -> emit_printf "\t.byte\t0x%x\n" n);
-      efa_16 = (fun n -> emit_printf "\t.short\t0x%x\n" n);
-      efa_32 = (fun n -> emit_printf "\t.long\t0x%lx\n" n);
-      efa_word = (fun n -> emit_printf "\t.quad\t0x%x\n" n);
+      efa_8 = (fun n -> emit_printf "\t.byte\t%d\n" n);
+      efa_16 = (fun n -> emit_printf "\t.short\t%d\n" n);
+      efa_32 = (fun n -> emit_printf "\t.long\t%ld\n" n);
+      efa_word = (fun n -> emit_printf "\t.quad\t%d\n" n);
       efa_align =
         (fun n -> emit_printf "\t.align\t%a\n" femit_int (Misc.log2 n));
       efa_label_rel =
         (fun lbl ofs ->
-          emit_printf "\t.long\t(%a + 0x%lx) - .\n" femit_label lbl ofs);
+          emit_printf "\t.long\t(%a + %ld) - .\n" femit_label lbl ofs);
       efa_def_label = (fun lbl -> emit_printf "%a:\n" femit_label lbl);
       efa_string = (fun s -> emit_string_directive "\t.ascii\t" (s ^ "\000"))
     };

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -562,7 +562,7 @@ let local_realloc_sites = ref ([] : local_realloc_call list)
 
 let emit_local_realloc lr =
   emit_printf "%a:\n" femit_label lr.lr_lbl;
-  emit_printf "\t%a" (femit_debug_info ~discriminator:0) lr.lr_dbg;
+  emit_debug_info ~discriminator:0 lr.lr_dbg;
   DSL.ins I.BL [| DSL.emit_symbol "caml_call_local_realloc" |];
   DSL.ins I.B [| DSL.emit_label lr.lr_return_lbl |]
 

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -782,7 +782,7 @@ let emit_literals p align emit_literal =
     then
       emit_printf "\t.section __TEXT,__literal%a,%abyte_literals\n" femit_int
         align femit_int align;
-    emit_printf "\t.balign\t%a\n" femit_int align;
+    emit_printf "\t.align\t%a\n" femit_int (Misc.log2 align);
     List.iter emit_literal !p;
     p := [])
 
@@ -2093,7 +2093,7 @@ let emit_item (d : Cmm.data_item) =
   | Csymbol_address s -> emit_printf "\t.quad\t%a\n" femit_symbol s.sym_name
   | Csymbol_offset (s, o) ->
     emit_printf "\t.quad\t%a+%a\n" femit_symbol s.sym_name femit_int o
-  | Cstring s -> emit_string_directive "\t.ascii  " s
+  | Cstring s -> emit_string_directive "\t.ascii\t" s
   | Cskip n -> if n > 0 then emit_printf "\t.space\t%a\n" femit_int n
   | Calign n -> emit_printf "\t.align\t%a\n" femit_int (Misc.log2 n)
 
@@ -2269,9 +2269,9 @@ let end_assembly () =
         (fun n -> emit_printf "\t.align\t%a\n" femit_int (Misc.log2 n));
       efa_label_rel =
         (fun lbl ofs ->
-          emit_printf "\t.long\t%a - . + %a\n" femit_label lbl femit_int32 ofs);
+          emit_printf "\t.long\t(%a + 0x%lx) - .\n" femit_label lbl ofs);
       efa_def_label = (fun lbl -> emit_printf "%a:\n" femit_label lbl);
-      efa_string = (fun s -> emit_string_directive "\t.asciz\t" s)
+      efa_string = (fun s -> emit_string_directive "\t.ascii\t" (s ^ "\000"))
     };
   emit_symbol_type femit_symbol lbl "object";
   emit_symbol_size lbl;

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -395,7 +395,7 @@ end [@warning "-32"] = struct
   let ins name ops = print_ins name ops |> Emitaux.emit_string
 
   let labeled_ins lbl name ops =
-    Emitaux.emit_printf "%s:" (convert_label_representation lbl);
+    Emitaux.emit_printf "%s:\n" (convert_label_representation lbl);
     print_ins name ops |> Emitaux.emit_string
 
   let ins_cond name cond ops =
@@ -780,14 +780,14 @@ let emit_literals p align emit_literal =
   then (
     if macosx
     then
-      emit_printf "\t.section\t__TEXT,__literal%a,%abyte_literals\n" femit_int
+      emit_printf "\t.section __TEXT,__literal%a,%abyte_literals\n" femit_int
         align femit_int align;
     emit_printf "\t.balign\t%a\n" femit_int align;
     List.iter emit_literal !p;
     p := [])
 
 let emit_float_literal (f, lbl) =
-  emit_printf "%a:" femit_label lbl;
+  emit_printf "%a:\n" femit_label lbl;
   emit_float64_directive ".quad" f
 
 let emit_vec128_literal (({ high; low } : Cmm.vec128_bits), lbl) =
@@ -1932,7 +1932,7 @@ let emit_instr i =
          DSL.emit_shift LSL 2
       |];
     DSL.ins I.BR [| DSL.emit_reg reg_tmp1 |];
-    emit_printf "%a:" femit_label lbltbl;
+    emit_printf "%a:\n" femit_label lbltbl;
     for j = 0 to Array.length jumptbl - 1 do
       DSL.ins I.B [| DSL.emit_label jumptbl.(j) |]
     done
@@ -2001,7 +2001,7 @@ let emit_instr i =
     emit_addimm reg_tmp1 reg_tmp1 f;
     DSL.ins I.CMP [| DSL.sp; DSL.emit_reg reg_tmp1 |];
     DSL.ins (I.B_cond CC) [| DSL.emit_label overflow |];
-    emit_printf "%a:" femit_label ret;
+    emit_printf "%a:\n" femit_label ret;
     stack_realloc
       := Some
            { sc_label = overflow;
@@ -2099,7 +2099,7 @@ let emit_item (d : Cmm.data_item) =
 
 let data l =
   emit_printf "\t.data\n";
-  emit_printf "\t.align  3\n";
+  emit_printf "\t.align\t3\n";
   List.iter emit_item l
 
 let emit_line str = emit_string (str ^ "\n")

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -786,22 +786,22 @@ let emit_literals p align emit_literal =
     List.iter emit_literal !p;
     p := [])
 
-let emit_float64_directive_aux f =
+let emit_float64_directive_with_comment f =
   let comment = Printf.sprintf "\t/* %.12g */" (Int64.float_of_bits f) in
   emit_printf "\t.quad\t%Ld%s\n" f comment
 
-let emit_float32_directive_aux f =
+let emit_float32_directive_with_comment f =
   let comment = Printf.sprintf "\t/* %.12f */" (Int32.float_of_bits f) in
   emit_printf "\t.long\t%ld%s\n" f comment
 
 let emit_float_literal (f, lbl) =
   emit_printf "%a:\n" femit_label lbl;
-  emit_float64_directive_aux f
+  emit_float64_directive_with_comment f
 
 let emit_vec128_literal (({ high; low } : Cmm.vec128_bits), lbl) =
   emit_printf "%a:\n" femit_label lbl;
-  emit_float64_directive_aux low;
-  emit_float64_directive_aux high
+  emit_float64_directive_with_comment low;
+  emit_float64_directive_with_comment high
 
 let emit_literals () =
   emit_literals float_literals size_float emit_float_literal;
@@ -2093,11 +2093,11 @@ let emit_item (d : Cmm.data_item) =
   | Cint16 n -> emit_printf "\t.short\t%d\n" n
   | Cint32 n -> emit_printf "\t.long\t%Ld\n" (Int64.of_nativeint n)
   | Cint n -> emit_printf "\t.quad\t%Ld\n" (Int64.of_nativeint n)
-  | Csingle f -> emit_float32_directive_aux (Int32.bits_of_float f)
-  | Cdouble f -> emit_float64_directive_aux (Int64.bits_of_float f)
+  | Csingle f -> emit_float32_directive_with_comment (Int32.bits_of_float f)
+  | Cdouble f -> emit_float64_directive_with_comment (Int64.bits_of_float f)
   | Cvec128 { high; low } ->
-    emit_float64_directive_aux low;
-    emit_float64_directive_aux high
+    emit_float64_directive_with_comment low;
+    emit_float64_directive_with_comment high
   | Csymbol_address s -> emit_printf "\t.quad\t%a\n" femit_symbol s.sym_name
   | Csymbol_offset (s, o) ->
     emit_printf "\t.quad\t%a+%a\n" femit_symbol s.sym_name femit_int o

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -562,7 +562,7 @@ let local_realloc_sites = ref ([] : local_realloc_call list)
 
 let emit_local_realloc lr =
   emit_printf "%a:\n" femit_label lr.lr_lbl;
-  emit_debug_info ~discriminator:0 lr.lr_dbg;
+  emit_debug_info lr.lr_dbg;
   DSL.ins I.BL [| DSL.emit_symbol "caml_call_local_realloc" |];
   DSL.ins I.B [| DSL.emit_label lr.lr_return_lbl |]
 

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -122,7 +122,8 @@ let emit_bytes_directive directive s =
   done;
   if !pos > 0 then emit_char '\n'
 
-let emit_float64_directive directive x = emit_printf "\t%s\t0x%Lx\n" directive x
+let emit_float64_directive ?(comment = "") directive x =
+  emit_printf "\t%s\t0x%Lx%s\n" directive x comment
 
 let emit_float64_split_directive directive x =
   let lo = Int64.logand x 0xFFFF_FFFFL
@@ -131,7 +132,7 @@ let emit_float64_split_directive directive x =
     (if Arch.big_endian then hi else lo)
     (if Arch.big_endian then lo else hi)
 
-let emit_float32_directive directive x = emit_printf "\t%s\t0x%lx\n" directive x
+let emit_float32_directive ?(comment = "") directive x = emit_printf "\t%s\t0x%lx%s\n" directive x comment
 
 (* Record live pointers at call points *)
 

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -122,8 +122,7 @@ let emit_bytes_directive directive s =
   done;
   if !pos > 0 then emit_char '\n'
 
-let emit_float64_directive directive x =
-  emit_printf "\t%s\t0x%Lx\n" directive x
+let emit_float64_directive directive x = emit_printf "\t%s\t0x%Lx\n" directive x
 
 let emit_float64_split_directive directive x =
   let lo = Int64.logand x 0xFFFF_FFFFL

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -512,8 +512,13 @@ let femit_debug_info ?discriminator out dbg =
       femit_int out file_num;
       femit_char out '\t';
       femit_int out line;
-      femit_char out '\t';
-      femit_int out col;
+      (* PR#7726: Location.none uses column -1, breaks LLVM assembler *)
+      (* If we don't set the optional column field, debug_line program gets the
+         column value from the previous .loc directive. *)
+      if col >= 0
+      then (
+        femit_char out '\t';
+        femit_int out col);
       (match discriminator with
       | None -> ()
       | Some k ->

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -122,8 +122,8 @@ let emit_bytes_directive directive s =
   done;
   if !pos > 0 then emit_char '\n'
 
-let emit_float64_directive ?(comment = "") directive x =
-  emit_printf "\t%s\t0x%Lx%s\n" directive x comment
+let emit_float64_directive directive x =
+  emit_printf "\t%s\t0x%Lx\n" directive x
 
 let emit_float64_split_directive directive x =
   let lo = Int64.logand x 0xFFFF_FFFFL
@@ -132,7 +132,7 @@ let emit_float64_split_directive directive x =
     (if Arch.big_endian then hi else lo)
     (if Arch.big_endian then lo else hi)
 
-let emit_float32_directive ?(comment = "") directive x = emit_printf "\t%s\t0x%lx%s\n" directive x comment
+let emit_float32_directive directive x = emit_printf "\t%s\t0x%lx\n" directive x
 
 (* Record live pointers at call points *)
 

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -508,11 +508,13 @@ let femit_debug_info ?discriminator out dbg =
       femit_char out '\t';
       femit_string_literal out file_name;
       femit_char out '\n')
-    (fun ~file_num ~line ~col:_ ?discriminator () ->
+    (fun ~file_num ~line ~col ?discriminator () ->
       femit_string out "\t.loc\t";
       femit_int out file_num;
       femit_char out '\t';
       femit_int out line;
+      femit_char out '\t';
+      femit_int out col;
       femit_char out '\t';
       (match discriminator with
       | None -> ()

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -515,10 +515,10 @@ let femit_debug_info ?discriminator out dbg =
       femit_int out line;
       femit_char out '\t';
       femit_int out col;
-      femit_char out '\t';
       (match discriminator with
       | None -> ()
       | Some k ->
+        femit_char out '\t';
         femit_string out "discriminator ";
         femit_int out k);
       femit_char out '\n')

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -512,13 +512,11 @@ let femit_debug_info ?discriminator out dbg =
       femit_int out file_num;
       femit_char out '\t';
       femit_int out line;
+      femit_char out '\t';
       (* PR#7726: Location.none uses column -1, breaks LLVM assembler *)
       (* If we don't set the optional column field, debug_line program gets the
          column value from the previous .loc directive. *)
-      if col >= 0
-      then (
-        femit_char out '\t';
-        femit_int out col);
+      if col >= 0 then femit_int out col else femit_int out 0;
       (match discriminator with
       | None -> ()
       | Some k ->

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -54,11 +54,11 @@ val emit_string_directive : string -> string -> unit
 
 val emit_bytes_directive : string -> string -> unit
 
-val emit_float64_directive : ?comment:string -> string -> int64 -> unit
+val emit_float64_directive : string -> int64 -> unit
 
 val emit_float64_split_directive : string -> int64 -> unit
 
-val emit_float32_directive : ?comment:string -> string -> int32 -> unit
+val emit_float32_directive : string -> int32 -> unit
 
 val reset : unit -> unit
 

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -54,11 +54,11 @@ val emit_string_directive : string -> string -> unit
 
 val emit_bytes_directive : string -> string -> unit
 
-val emit_float64_directive : string -> int64 -> unit
+val emit_float64_directive : ?comment:string -> string -> int64 -> unit
 
 val emit_float64_split_directive : string -> int64 -> unit
 
-val emit_float32_directive : string -> int32 -> unit
+val emit_float32_directive : ?comment:string -> string -> int32 -> unit
 
 val reset : unit -> unit
 


### PR DESCRIPTION
This PR makes small changes to the emission of the Arm directives to match a version using the new, shared directives code. The resulting assembly files should be semantically equivalent. The changes include:

- Adding various new lines and consistent spacing using tabs.
- Replacing `balign` with `align`.
- Adding comments to the emission of float constants.
- Printing all numbers as decimals instead of a mix of decimals and hex.
- Replacing `asciz` with `ascii`.
- Printing column information for locations (also affects x86).
- Reordering the expression for emitting distances relative to a label.