### PR TITLE
Move "id" field first

### DIFF
--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -94,13 +94,13 @@ module S = struct
 
   type 'a instruction =
     { desc : 'a;
+      id : InstructionId.t;
       mutable arg : Reg.t array;
       mutable res : Reg.t array;
       mutable dbg : Debuginfo.t;
       mutable fdo : Fdo_info.t;
       mutable live : Reg.Set.t;
       mutable stack_offset : int;
-      id : InstructionId.t;
       mutable irc_work_list : irc_work_list;
       mutable ls_order : int;
       mutable available_before : Reg_availability_set.t option;


### PR DESCRIPTION
Move `Cfg.instruction.id` field after `desc` field. These two fields are the most used and it should be better for performance, but I haven't benchmarked it.