### PR TITLE
Separability axis basics

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1261,7 +1261,7 @@ type 'a abstract
 Lines 2-3, characters 0-67:
 2 | type existential_abstract : immutable_data with (type : value mod portable) abstract =
 3 |   | Mk : ('a : value mod portable) abstract -> existential_abstract
-Error: The kind of type "existential_abstract" is value
+Error: The kind of type "existential_abstract" is non_float_value
          because it's a boxed variant type.
        But the kind of type "existential_abstract" must be a subkind of
          immutable_data with (type : value mod portable) abstract

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1261,7 +1261,7 @@ type 'a abstract
 Lines 2-3, characters 0-67:
 2 | type existential_abstract : immutable_data with (type : value mod portable) abstract =
 3 |   | Mk : ('a : value mod portable) abstract -> existential_abstract
-Error: The kind of type "existential_abstract" is non_float_value
+Error: The kind of type "existential_abstract" is value mod non_float
          because it's a boxed variant type.
        But the kind of type "existential_abstract" must be a subkind of
          immutable_data with (type : value mod portable) abstract

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -213,7 +213,7 @@ Error: The layout of type "a" is value
          because of the definition of b at line 2, characters 0-30.
 |}]
 
-type a : value mod global aliased many immutable stateless external_ unyielding
+type a : value mod global aliased many immutable stateless external_ unyielding non_float
 type b : value mod local unique once contended nonportable internal = a
 [%%expect{|
 type a : immediate
@@ -273,8 +273,8 @@ Error: Layout void is more experimental than allowed by the enabled layouts exte
 |}]
 
 type a : immediate
-type b : value mod global aliased many immutable stateless unyielding external_ = a
-type c : value mod global aliased many immutable stateless unyielding external_
+type b : value mod global aliased many immutable stateless unyielding external_ non_float = a
+type c : value mod global aliased many immutable stateless unyielding external_ non_float
 type d : immediate = c
 [%%expect{|
 type a : immediate
@@ -284,8 +284,8 @@ type d = c
 |}]
 
 type a : immediate64
-type b : value mod global aliased many immutable stateless unyielding external64 = a
-type c : value mod global aliased many immutable stateless unyielding external64
+type b : value mod global aliased many immutable stateless unyielding external64 non_float = a
+type c : value mod global aliased many immutable stateless unyielding external64 non_float
 type d : immediate64 = c
 [%%expect{|
 type a : immediate64
@@ -1173,11 +1173,11 @@ type 'a t = { x : 'a @@ global many portable aliased contended; } [@@unboxed]
    [layout_of], we'll be able to give a better jkind to [@@unboxed] types, and
    this will likely improve. *)
 
-type 'a t : value mod global immutable stateless many aliased unyielding =
+type 'a t : value mod global immutable stateless many aliased unyielding non_float =
   Foo of 'a @@ global immutable stateless many aliased [@@unboxed]
 [%%expect {|
 Lines 1-2, characters 0-66:
-1 | type 'a t : value mod global immutable stateless many aliased unyielding =
+1 | type 'a t : value mod global immutable stateless many aliased unyielding non_float =
 2 |   Foo of 'a @@ global immutable stateless many aliased [@@unboxed]
 Error: The kind of type "t" is value
          because it instantiates an unannotated type parameter of t,
@@ -1271,7 +1271,7 @@ Error: The kind of type "t" is immutable_data with 'a @@ unyielding
 type ('a : value mod aliased) t = ('a : value mod global)
 type ('a : immediate) t = ('a : value)
 type ('a : value) t = ('a : immediate)
-type ('a : value mod external_ stateless many unyielding) t = ('a : value mod immutable global aliased)
+type ('a : value mod external_ stateless many unyielding non_float) t = ('a : value mod immutable global aliased)
 type ('a : value) t = ('a : any)
 type ('a : value) t = ('a : value)
 type ('a : bits32 mod aliased) t = ('a : any mod global)
@@ -1666,8 +1666,8 @@ Error: This expression has type "int t" but an expression was expected of type
 (*********************************)
 (* Test 15: extensible variants *)
 
-(* The best kind an extensible variant can get is [value] *)
-type extensible : value = ..
+(* The best kind an extensible variant can get is [non_float_value] *)
+type extensible : non_float_value = ..
 [%%expect{|
 type extensible = ..
 |}]
@@ -1676,10 +1676,10 @@ type extensible = ..
 module M : sig
   type t : immediate with extensible
 end = struct
-  type t
+  type t : non_float_value
 end
 [%%expect{|
-module M : sig type t end
+module M : sig type t : non_float_value end
 |}]
 
 (*********************************)
@@ -1721,8 +1721,8 @@ Error: This expression has type "int t" but an expression was expected of type
 (*********************************)
 (* Test 17: extensible variants *)
 
-(* The best kind an extensible variant can get is [value] *)
-type extensible : value = ..
+(* The best kind an extensible variant can get is [non_float_value] *)
+type extensible : non_float_value = ..
 [%%expect{|
 type extensible = ..
 |}]
@@ -1731,8 +1731,8 @@ type extensible = ..
 module M : sig
   type t : immediate with extensible
 end = struct
-  type t
+  type t : non_float_value
 end
 [%%expect{|
-module M : sig type t end
+module M : sig type t : non_float_value end
 |}]

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1438,7 +1438,7 @@ Line 1, characters 41-51:
                                              ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod aliased)"
-       The kind of <  > is value mod global many
+       The kind of <  > is value mod global many non_float
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod aliased
          because of the annotation on the wildcard _ at line 1, characters 19-36.
@@ -1451,7 +1451,7 @@ Line 1, characters 42-52:
                                               ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod portable)"
-       The kind of <  > is value mod global many
+       The kind of <  > is value mod global many non_float
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod portable
          because of the annotation on the wildcard _ at line 1, characters 19-37.
@@ -1464,7 +1464,7 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod contended)"
-       The kind of <  > is value mod global many
+       The kind of <  > is value mod global many non_float
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod contended
          because of the annotation on the wildcard _ at line 1, characters 19-38.
@@ -1477,7 +1477,7 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod external_)"
-       The kind of <  > is value mod global many
+       The kind of <  > is value mod global many non_float
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod external_
          because of the annotation on the wildcard _ at line 1, characters 19-38.
@@ -1666,8 +1666,8 @@ Error: This expression has type "int t" but an expression was expected of type
 (*********************************)
 (* Test 15: extensible variants *)
 
-(* The best kind an extensible variant can get is [non_float_value] *)
-type extensible : non_float_value = ..
+(* The best kind an extensible variant can get is [value mod non_float] *)
+type extensible : value mod non_float = ..
 [%%expect{|
 type extensible = ..
 |}]
@@ -1676,10 +1676,10 @@ type extensible = ..
 module M : sig
   type t : immediate with extensible
 end = struct
-  type t : non_float_value
+  type t : value mod non_float
 end
 [%%expect{|
-module M : sig type t : non_float_value end
+module M : sig type t : value mod non_float end
 |}]
 
 (*********************************)
@@ -1721,8 +1721,8 @@ Error: This expression has type "int t" but an expression was expected of type
 (*********************************)
 (* Test 17: extensible variants *)
 
-(* The best kind an extensible variant can get is [non_float_value] *)
-type extensible : non_float_value = ..
+(* The best kind an extensible variant can get is [value mod non_float] *)
+type extensible : value mod non_float = ..
 [%%expect{|
 type extensible = ..
 |}]
@@ -1731,8 +1731,8 @@ type extensible = ..
 module M : sig
   type t : immediate with extensible
 end = struct
-  type t : non_float_value
+  type t : value mod non_float
 end
 [%%expect{|
-module M : sig type t : non_float_value end
+module M : sig type t : value mod non_float end
 |}]

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -632,7 +632,7 @@ Line 1, characters 0-54:
 1 | type ('a : immutable_data) t = Flat | Nested of 'a t t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t is value
+       The kind of 'a t is non_float_value
          because it's a boxed variant type.
        But the kind of 'a t must be a subkind of immutable_data
          because of the annotation on 'a in the declaration of the type t.

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -632,7 +632,7 @@ Line 1, characters 0-54:
 1 | type ('a : immutable_data) t = Flat | Nested of 'a t t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error:
-       The kind of 'a t is non_float_value
+       The kind of 'a t is value mod non_float
          because it's a boxed variant type.
        But the kind of 'a t must be a subkind of immutable_data
          because of the annotation on 'a in the declaration of the type t.

--- a/testsuite/tests/typing-jkind-bounds/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/modalities.ml
@@ -146,4 +146,5 @@ Error: This expression has type "(string -> string) t"
 
        The first mode-crosses less than the second along:
          nullability: mod non_null with string -> string ≰ mod non_null
+         separability: mod non_float with string -> string ≰ mod separable
 |}]

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -94,7 +94,7 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) option" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) option is value mod immutable
+       The kind of (unit -> unit) option is non_float_value mod immutable
          because it's a boxed variant type.
        But the kind of (unit -> unit) option must be a subkind of
          value mod portable
@@ -312,7 +312,7 @@ Line 1, characters 14-33:
                   ^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) list" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) list is value mod immutable
+       The kind of (unit -> unit) list is non_float_value mod immutable
          because it's a boxed variant type.
        But the kind of (unit -> unit) list must be a subkind of
          value mod portable
@@ -523,7 +523,7 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) iarray" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) iarray is value mod immutable
+       The kind of (unit -> unit) iarray is non_float_value mod immutable
          because it is the primitive value type iarray.
        But the kind of (unit -> unit) iarray must be a subkind of
          value mod portable

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -94,7 +94,7 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) option" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) option is non_float_value mod immutable
+       The kind of (unit -> unit) option is value mod immutable non_float
          because it's a boxed variant type.
        But the kind of (unit -> unit) option must be a subkind of
          value mod portable
@@ -312,7 +312,7 @@ Line 1, characters 14-33:
                   ^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) list" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) list is non_float_value mod immutable
+       The kind of (unit -> unit) list is value mod immutable non_float
          because it's a boxed variant type.
        But the kind of (unit -> unit) list must be a subkind of
          value mod portable
@@ -523,7 +523,7 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) iarray" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) iarray is non_float_value mod immutable
+       The kind of (unit -> unit) iarray is value mod immutable non_float
          because it is the primitive value type iarray.
        But the kind of (unit -> unit) iarray must be a subkind of
          value mod portable

--- a/testsuite/tests/typing-jkind-bounds/printing.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing.ml
@@ -201,7 +201,7 @@ Line 3, characters 11-25:
                ^^^^^^^^^^^^^^
 Error: This type "(int -> int) u" should be an instance of type
          "('a : immutable_data)"
-       The kind of (int -> int) u is value mod portable immutable
+       The kind of (int -> int) u is non_float_value mod portable immutable
          because of the definition of u at line 1, characters 0-33.
        But the kind of (int -> int) u must be a subkind of immutable_data
          because of the definition of t at line 2, characters 0-28.

--- a/testsuite/tests/typing-jkind-bounds/printing.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing.ml
@@ -201,7 +201,7 @@ Line 3, characters 11-25:
                ^^^^^^^^^^^^^^
 Error: This type "(int -> int) u" should be an instance of type
          "('a : immutable_data)"
-       The kind of (int -> int) u is non_float_value mod portable immutable
+       The kind of (int -> int) u is value mod portable immutable non_float
          because of the definition of u at line 1, characters 0-33.
        But the kind of (int -> int) u must be a subkind of immutable_data
          because of the definition of t at line 2, characters 0-28.

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -156,7 +156,7 @@ type t : immutable_data = { x : unit -> unit }
 Line 1, characters 0-46:
 1 | type t : immutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod immutable
+Error: The kind of type "t" is non_float_value mod immutable
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -189,7 +189,7 @@ type t : mutable_data = { x : unit -> unit }
 Line 1, characters 0-44:
 1 | type t : mutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod immutable
+Error: The kind of type "t" is non_float_value mod immutable
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -285,7 +285,7 @@ type 'a t : immutable_data with 'a = { x : 'a -> 'a }
 Line 1, characters 0-53:
 1 | type 'a t : immutable_data with 'a = { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod immutable
+Error: The kind of type "t" is non_float_value mod immutable
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.
@@ -625,7 +625,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is value mod immutable
+       The kind of (unit -> unit) t is non_float_value mod immutable
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable
@@ -650,7 +650,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is value mod immutable
+       The kind of (unit -> unit) t is non_float_value mod immutable
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod external_
@@ -745,7 +745,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is value mod immutable
+       The kind of (unit -> unit) t is non_float_value mod immutable
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -156,7 +156,7 @@ type t : immutable_data = { x : unit -> unit }
 Line 1, characters 0-46:
 1 | type t : immutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is non_float_value mod immutable
+Error: The kind of type "t" is value mod immutable non_float
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -189,7 +189,7 @@ type t : mutable_data = { x : unit -> unit }
 Line 1, characters 0-44:
 1 | type t : mutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is non_float_value mod immutable
+Error: The kind of type "t" is value mod immutable non_float
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -285,7 +285,7 @@ type 'a t : immutable_data with 'a = { x : 'a -> 'a }
 Line 1, characters 0-53:
 1 | type 'a t : immutable_data with 'a = { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is non_float_value mod immutable
+Error: The kind of type "t" is value mod immutable non_float
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.
@@ -625,7 +625,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is non_float_value mod immutable
+       The kind of (unit -> unit) t is value mod immutable non_float
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable
@@ -650,7 +650,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is non_float_value mod immutable
+       The kind of (unit -> unit) t is value mod immutable non_float
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod external_
@@ -745,7 +745,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is non_float_value mod immutable
+       The kind of (unit -> unit) t is value mod immutable non_float
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -276,7 +276,7 @@ type t
 Line 2, characters 0-44:
 2 | type u : immutable_data with t = [`foo of t]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "[ `foo of t ]" is value
+Error: The kind of type "[ `foo of t ]" is non_float_value
          because it's a polymorphic variant type.
        But the kind of type "[ `foo of t ]" must be a subkind of immutable_data
          with t

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -276,7 +276,7 @@ type t
 Line 2, characters 0-44:
 2 | type u : immutable_data with t = [`foo of t]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "[ `foo of t ]" is non_float_value
+Error: The kind of type "[ `foo of t ]" is value mod non_float
          because it's a polymorphic variant type.
        But the kind of type "[ `foo of t ]" must be a subkind of immutable_data
          with t

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -160,7 +160,7 @@ type t : immutable_data = Foo of (unit -> unit)
 Line 1, characters 0-47:
 1 | type t : immutable_data = Foo of (unit -> unit)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod immutable
+Error: The kind of type "t" is non_float_value mod immutable
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -193,7 +193,7 @@ type t : mutable_data = Foo of { x : unit -> unit }
 Line 1, characters 0-51:
 1 | type t : mutable_data = Foo of { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod immutable
+Error: The kind of type "t" is non_float_value mod immutable
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -289,7 +289,7 @@ type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
 Line 1, characters 0-60:
 1 | type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value mod immutable
+Error: The kind of type "t" is non_float_value mod immutable
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.
@@ -628,7 +628,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is value mod immutable
+       The kind of (unit -> unit) t is non_float_value mod immutable
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable
@@ -653,7 +653,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is value mod immutable
+       The kind of (unit -> unit) t is non_float_value mod immutable
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod external_
@@ -748,7 +748,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is value mod immutable
+       The kind of (unit -> unit) t is non_float_value mod immutable
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -160,7 +160,7 @@ type t : immutable_data = Foo of (unit -> unit)
 Line 1, characters 0-47:
 1 | type t : immutable_data = Foo of (unit -> unit)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is non_float_value mod immutable
+Error: The kind of type "t" is value mod immutable non_float
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -193,7 +193,7 @@ type t : mutable_data = Foo of { x : unit -> unit }
 Line 1, characters 0-51:
 1 | type t : mutable_data = Foo of { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is non_float_value mod immutable
+Error: The kind of type "t" is value mod immutable non_float
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -289,7 +289,7 @@ type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
 Line 1, characters 0-60:
 1 | type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is non_float_value mod immutable
+Error: The kind of type "t" is value mod immutable non_float
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.
@@ -628,7 +628,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is non_float_value mod immutable
+       The kind of (unit -> unit) t is value mod immutable non_float
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable
@@ -653,7 +653,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: This expression has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is non_float_value mod immutable
+       The kind of (unit -> unit) t is value mod immutable non_float
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod external_
@@ -748,7 +748,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is non_float_value mod immutable
+       The kind of (unit -> unit) t is value mod immutable non_float
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
          value mod portable

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -660,11 +660,11 @@ type t = Immutable.t
 module Value = F(struct type t end)
 type t : immutable_data = Value.t
 [%%expect {|
-module Value : sig type t end
+module Value : sig type t : non_float_value end
 Line 2, characters 0-33:
 2 | type t : immutable_data = Value.t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "Value.t" is value
+Error: The kind of type "Value.t" is non_float_value
          because of the definition of t at line 2, characters 2-34.
        But the kind of type "Value.t" must be a subkind of immutable_data
          because of the definition of t at line 2, characters 0-33.

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -660,11 +660,11 @@ type t = Immutable.t
 module Value = F(struct type t end)
 type t : immutable_data = Value.t
 [%%expect {|
-module Value : sig type t : non_float_value end
+module Value : sig type t : value mod non_float end
 Line 2, characters 0-33:
 2 | type t : immutable_data = Value.t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "Value.t" is non_float_value
+Error: The kind of type "Value.t" is value mod non_float
          because of the definition of t at line 2, characters 2-34.
        But the kind of type "Value.t" must be a subkind of immutable_data
          because of the definition of t at line 2, characters 0-33.

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -394,7 +394,7 @@ Line 1, characters 13-18:
 1 | type fails = float accepts_nonfloat
                  ^^^^^
 Error: This type "float" should be an instance of type "('a : any mod non_float)"
-       The kind of float is immutable_separable_value
+       The kind of float is value mod many unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of any mod non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-46.

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -1,0 +1,705 @@
+(* TEST
+ expect;
+*)
+
+(* Tests for the separability jkind axis. *)
+
+(* Basic subkinding relation. *)
+
+type t_nonsep : any mod non_separable
+type t_sep : any mod separable
+type t_nonfloat : any mod non_float
+
+[%%expect{|
+type t_nonsep : any
+type t_sep : any mod separable
+type t_nonfloat : any mod non_float
+|}]
+
+type ('a :  any mod non_separable) accepts_nonsep
+type ('a : any mod separable) accepts_sep
+type ('a : any mod non_float) accepts_nonfloat
+
+[%%expect{|
+type ('a : any) accepts_nonsep
+type ('a : any mod separable) accepts_sep
+type ('a : any mod non_float) accepts_nonfloat
+|}]
+
+type succeeds = t_nonsep accepts_nonsep
+type succeeds = t_sep accepts_nonsep
+type succeeds = t_nonfloat accepts_nonsep
+
+[%%expect{|
+type succeeds = t_nonsep accepts_nonsep
+type succeeds = t_sep accepts_nonsep
+type succeeds = t_nonfloat accepts_nonsep
+|}]
+
+type fails = t_nonsep accepts_sep
+[%%expect{|
+Line 1, characters 13-21:
+1 | type fails = t_nonsep accepts_sep
+                 ^^^^^^^^
+Error: This type "t_nonsep" should be an instance of type
+         "('a : any mod separable)"
+       The kind of t_nonsep is any
+         because of the definition of t_nonsep at line 1, characters 0-37.
+       But the kind of t_nonsep must be a subkind of any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}]
+
+type succeeds = t_sep accepts_sep
+type succeeds = t_nonfloat accepts_sep
+
+
+[%%expect{|
+type succeeds = t_sep accepts_sep
+type succeeds = t_nonfloat accepts_sep
+|}]
+
+type fails = t_nonsep accepts_nonfloat
+[%%expect{|
+Line 1, characters 13-21:
+1 | type fails = t_nonsep accepts_nonfloat
+                 ^^^^^^^^
+Error: This type "t_nonsep" should be an instance of type
+         "('a : any mod non_float)"
+       The kind of t_nonsep is any
+         because of the definition of t_nonsep at line 1, characters 0-37.
+       But the kind of t_nonsep must be a subkind of any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}]
+
+type fails = t_sep accepts_nonfloat
+[%%expect{|
+Line 1, characters 13-18:
+1 | type fails = t_sep accepts_nonfloat
+                 ^^^^^
+Error: This type "t_sep" should be an instance of type "('a : any mod non_float)"
+       The kind of t_sep is any mod separable
+         because of the definition of t_sep at line 2, characters 0-30.
+       But the kind of t_sep must be a subkind of any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}]
+
+type succeeds = t_nonfloat accepts_nonfloat
+
+[%%expect{|
+type succeeds = t_nonfloat accepts_nonfloat
+|}]
+
+(* Testing separability for various base jkinds. *)
+
+(* [value_or_null] is non-separable: *)
+type t_von : value_or_null
+
+type succeeds = t_von accepts_nonsep
+[%%expect{|
+type t_von : value_or_null
+type succeeds = t_von accepts_nonsep
+|}]
+
+type fails = t_von accepts_sep
+
+[%%expect{|
+Line 1, characters 13-18:
+1 | type fails = t_von accepts_sep
+                 ^^^^^
+Error: This type "t_von" should be an instance of type "('a : any mod separable)"
+       The kind of t_von is value_or_null
+         because of the definition of t_von at line 1, characters 0-26.
+       But the kind of t_von must be a subkind of any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}]
+
+type fails = t_von accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 13-18:
+1 | type fails = t_von accepts_nonfloat
+                 ^^^^^
+Error: This type "t_von" should be an instance of type "('a : any mod non_float)"
+       The kind of t_von is value_or_null
+         because of the definition of t_von at line 1, characters 0-26.
+       But the kind of t_von must be a subkind of any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}]
+
+(* [value] is separable *)
+type t_val : value
+
+type succeeds = t_val accepts_nonsep
+type succeeds = t_val accepts_sep
+
+[%%expect{|
+type t_val
+type succeeds = t_val accepts_nonsep
+type succeeds = t_val accepts_sep
+|}]
+
+type fails = t_val accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 13-18:
+1 | type fails = t_val accepts_nonfloat
+                 ^^^^^
+Error: This type "t_val" should be an instance of type "('a : any mod non_float)"
+       The kind of t_val is value
+         because of the definition of t_val at line 1, characters 0-18.
+       But the kind of t_val must be a subkind of any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}]
+
+(* [any] is non-separable *)
+type t_any : any
+
+type succeeds = t_any accepts_nonsep
+
+[%%expect{|
+type t_any : any
+type succeeds = t_any accepts_nonsep
+|}]
+
+type fails = t_any accepts_sep
+
+[%%expect{|
+Line 1, characters 13-18:
+1 | type fails = t_any accepts_sep
+                 ^^^^^
+Error: This type "t_any" should be an instance of type "('a : any mod separable)"
+       The kind of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the kind of t_any must be a subkind of any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}]
+
+type fails = t_any accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 13-18:
+1 | type fails = t_any accepts_nonfloat
+                 ^^^^^
+Error: This type "t_any" should be an instance of type "('a : any mod non_float)"
+       The kind of t_any is any
+         because of the definition of t_any at line 1, characters 0-16.
+       But the kind of t_any must be a subkind of any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}]
+
+(* [any_non_null] is separable *)
+type t_ann : any_non_null
+type succeeds = t_ann accepts_nonsep
+type succeeds = t_ann accepts_sep
+[%%expect{|
+type t_ann : any_non_null
+type succeeds = t_ann accepts_nonsep
+type succeeds = t_ann accepts_sep
+|}]
+
+type fails = t_ann accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 13-18:
+1 | type fails = t_ann accepts_nonfloat
+                 ^^^^^
+Error: This type "t_ann" should be an instance of type "('a : any mod non_float)"
+       The kind of t_ann is any_non_null
+         because of the definition of t_ann at line 1, characters 0-25.
+       But the kind of t_ann must be a subkind of any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}]
+
+(* Testing additional non-float jkinds *)
+
+(* [non_float_value] is non-float *)
+type t_nfv : non_float_value
+type succeeds = t_nfv accepts_nonsep
+type succeeds = t_nfv accepts_sep
+type succeeds = t_nfv accepts_nonfloat
+
+[%%expect{|
+type t_nfv : non_float_value
+type succeeds = t_nfv accepts_nonsep
+type succeeds = t_nfv accepts_sep
+type succeeds = t_nfv accepts_nonfloat
+|}]
+
+(* [immutable_data] is non-float *)
+type t_imm : immutable_data
+type succeeds = t_imm accepts_nonsep
+type succeeds = t_imm accepts_sep
+type succeeds = t_imm accepts_nonfloat
+
+[%%expect{|
+type t_imm : immutable_data
+type succeeds = t_imm accepts_nonsep
+type succeeds = t_imm accepts_sep
+type succeeds = t_imm accepts_nonfloat
+|}]
+
+(* [mutable_data] is non-float *)
+type t_mut : mutable_data
+type succeeds = t_mut accepts_nonsep
+type succeeds = t_mut accepts_sep
+type succeeds = t_mut accepts_nonfloat
+
+[%%expect{|
+type t_mut : mutable_data
+type succeeds = t_mut accepts_nonsep
+type succeeds = t_mut accepts_sep
+type succeeds = t_mut accepts_nonfloat
+|}]
+
+(* [sync_data] is non-float *)
+type t_sync : sync_data
+type succeeds = t_sync accepts_nonsep
+type succeeds = t_sync accepts_sep
+type succeeds = t_sync accepts_nonfloat
+
+[%%expect{|
+type t_sync : sync_data
+type succeeds = t_sync accepts_nonsep
+type succeeds = t_sync accepts_sep
+type succeeds = t_sync accepts_nonfloat
+|}]
+
+(* [immediate] is non-float *)
+type t_imm : immediate
+type succeeds = t_imm accepts_nonsep
+type succeeds = t_imm accepts_sep
+type succeeds = t_imm accepts_nonfloat
+
+[%%expect{|
+type t_imm : immediate
+type succeeds = t_imm accepts_nonsep
+type succeeds = t_imm accepts_sep
+type succeeds = t_imm accepts_nonfloat
+|}]
+
+(* [immediate64] is non-float *)
+type t_imm64 : immediate64
+type succeeds = t_imm64 accepts_nonsep
+type succeeds = t_imm64 accepts_sep
+type succeeds = t_imm64 accepts_nonfloat
+
+[%%expect{|
+type t_imm64 : immediate64
+type succeeds = t_imm64 accepts_nonsep
+type succeeds = t_imm64 accepts_sep
+type succeeds = t_imm64 accepts_nonfloat
+|}]
+
+(* Testing non-value layouts. *)
+
+(* [bits32] is non-float *)
+type t_b32 : bits32
+type succeeds = t_b32 accepts_nonsep
+type succeeds = t_b32 accepts_sep
+type succeeds = t_b32 accepts_nonfloat
+
+[%%expect{|
+type t_b32 : bits32
+type succeeds = t_b32 accepts_nonsep
+type succeeds = t_b32 accepts_sep
+type succeeds = t_b32 accepts_nonfloat
+|}]
+
+(* [bits64] is non-float *)
+type t_b64 : bits64
+type succeeds = t_b64 accepts_nonsep
+type succeeds = t_b64 accepts_sep
+type succeeds = t_b64 accepts_nonfloat
+
+[%%expect{|
+type t_b64 : bits64
+type succeeds = t_b64 accepts_nonsep
+type succeeds = t_b64 accepts_sep
+type succeeds = t_b64 accepts_nonfloat
+|}]
+
+   (* [word] is non-float *)
+type t_word : word
+type succeeds = t_word accepts_nonsep
+type succeeds = t_word accepts_sep
+type succeeds = t_word accepts_nonfloat
+
+[%%expect{|
+type t_word : word
+type succeeds = t_word accepts_nonsep
+type succeeds = t_word accepts_sep
+type succeeds = t_word accepts_nonfloat
+|}]
+
+(* [vec128] is non-float *)
+type t_vec : vec128
+type succeeds = t_vec accepts_nonsep
+type succeeds = t_vec accepts_sep
+type succeeds = t_vec accepts_nonfloat
+
+[%%expect{|
+type t_vec : vec128
+type succeeds = t_vec accepts_nonsep
+type succeeds = t_vec accepts_sep
+type succeeds = t_vec accepts_nonfloat
+|}]
+
+(* Testing non-value float layouts. *)
+(* "non_float" in the separability axis refers to "legacy" OCaml float heap blocks,
+    so float32/float64 layouts are still non_float. *)
+
+(* [float32] is non-float *)
+type t_f32 : float32
+type succeeds = t_f32 accepts_nonsep
+type succeeds = t_f32 accepts_sep
+type succeeds = t_f32 accepts_nonfloat
+
+[%%expect{|
+type t_f32 : float32
+type succeeds = t_f32 accepts_nonsep
+type succeeds = t_f32 accepts_sep
+type succeeds = t_f32 accepts_nonfloat
+|}]
+
+(* [float64] is non-float *)
+type t_f64 : float64
+type succeeds = t_f64 accepts_nonsep
+type succeeds = t_f64 accepts_sep
+type succeeds = t_f64 accepts_nonfloat
+
+[%%expect{|
+type t_f64 : float64
+type succeeds = t_f64 accepts_nonsep
+type succeeds = t_f64 accepts_sep
+type succeeds = t_f64 accepts_nonfloat
+|}]
+
+(* Test basic types. *)
+
+type succeeds = int accepts_nonfloat
+type succeeds = string accepts_nonfloat
+type succeeds = unit option accepts_nonfloat
+
+[%%expect{|
+type succeeds = int accepts_nonfloat
+type succeeds = string accepts_nonfloat
+type succeeds = unit option accepts_nonfloat
+|}]
+
+(* Floats are separable: *)
+
+type fails = float accepts_nonfloat
+[%%expect{|
+Line 1, characters 13-18:
+1 | type fails = float accepts_nonfloat
+                 ^^^^^
+Error: This type "float" should be an instance of type "('a : any mod non_float)"
+       The kind of float is immutable_separable_value
+         because it is the primitive type float.
+       But the kind of float must be a subkind of any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}]
+
+type succeeds = float accepts_sep
+[%%expect{|
+type succeeds = float accepts_sep
+|}]
+
+(* Separability is a shallow property: lists or arrays of floats are non-float: *)
+
+type succeeds = float list accepts_nonfloat
+type succeeds = float array accepts_nonfloat
+
+[%%expect{|
+type succeeds = float list accepts_nonfloat
+type succeeds = float array accepts_nonfloat
+|}]
+
+(* Records and variants are all non-float: *)
+
+type t1 = { f1 : string; f2: int }
+type t2 = { f1 : float; f2 : float }
+type t3 = { f1 : float }
+type t4 = { f1 : string; f2 : string; f3 : int }
+type t5 = { f1 : string; f2 : float; f3: int64#; f4: int32# }
+[%%expect{|
+type t1 = { f1 : string; f2 : int; }
+type t2 = { f1 : float; f2 : float; }
+type t3 = { f1 : float; }
+type t4 = { f1 : string; f2 : string; f3 : int; }
+type t5 = { f1 : string; f2 : float; f3 : int64#; f4 : int32#; }
+|}]
+
+type succeeds = t1 accepts_nonfloat
+type succeeds = t2 accepts_nonfloat
+type succeeds = t3 accepts_nonfloat
+type succeeds = t4 accepts_nonfloat
+type succeeds = t5 accepts_nonfloat
+
+[%%expect{|
+type succeeds = t1 accepts_nonfloat
+type succeeds = t2 accepts_nonfloat
+type succeeds = t3 accepts_nonfloat
+type succeeds = t4 accepts_nonfloat
+type succeeds = t5 accepts_nonfloat
+|}]
+
+type t1 = | A | B | C
+type t2 = | A | B of string | C of { f1 : float; f2 : int }
+type t3 = | A of { f1: int64#; f2: float# } | B of int32#
+
+[%%expect{|
+type t1 = A | B | C
+type t2 = A | B of string | C of { f1 : float; f2 : int; }
+type t3 = A of { f1 : int64#; f2 : float#; } | B of int32#
+|}]
+
+type succeeds = t1 accepts_nonfloat
+type succeeds = t2 accepts_nonfloat
+type succeeds = t3 accepts_nonfloat
+
+[%%expect{|
+type succeeds = t1 accepts_nonfloat
+type succeeds = t2 accepts_nonfloat
+type succeeds = t3 accepts_nonfloat
+|}]
+
+type t1 = [ `A | `B | `C ]
+type t2 = [ `A of string | `B ]
+type succeeds = t1 accepts_nonfloat
+type succeeds = t2 accepts_nonfloat
+
+[%%expect{|
+type t1 = [ `A | `B | `C ]
+type t2 = [ `A of string | `B ]
+type succeeds = t1 accepts_nonfloat
+type succeeds = t2 accepts_nonfloat
+|}]
+
+(* [or_null] and separability. *)
+
+(* ['a or_null] is not separable: *)
+
+type 'a fails = 'a or_null accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 16-26:
+1 | type 'a fails = 'a or_null accepts_nonfloat
+                    ^^^^^^^^^^
+Error: This type "'a or_null" should be an instance of type
+         "('b : any mod non_float)"
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a or_null must be a subkind of any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}]
+
+type 'a fails = 'a or_null accepts_sep
+
+[%%expect{|
+Line 1, characters 16-26:
+1 | type 'a fails = 'a or_null accepts_sep
+                    ^^^^^^^^^^
+Error: This type "'a or_null" should be an instance of type
+         "('b : any mod separable)"
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a or_null must be a subkind of any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}]
+
+type 'a succeds = 'a or_null accepts_nonsep
+
+[%%expect{|
+type 'a succeds = 'a or_null accepts_nonsep
+|}]
+
+(* CR layouts v3: [or_null] should be able accept non-separable values? *)
+
+type t_nonsep_val : value_or_null mod non_null
+type fails = t_nonsep_val or_null
+
+[%%expect{|
+type t_nonsep_val : value_or_null mod non_null
+Line 2, characters 13-25:
+2 | type fails = t_nonsep_val or_null
+                 ^^^^^^^^^^^^
+Error: This type "t_nonsep_val" should be an instance of type "('a : value)"
+       The kind of t_nonsep_val is value_or_null mod non_null
+         because of the definition of t_nonsep_val at line 1, characters 0-46.
+       But the kind of t_nonsep_val must be a subkind of value
+         because the type argument of or_null has kind value.
+|}]
+
+(* CR layouts: ['a or_null] where 'a is non-float should be non-float. *)
+
+type ('a : non_float_value) should_succeed = 'a or_null accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 45-55:
+1 | type ('a : non_float_value) should_succeed = 'a or_null accepts_nonfloat
+                                                 ^^^^^^^^^^
+Error: This type "'a or_null" should be an instance of type
+         "('b : any mod non_float)"
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a or_null must be a subkind of any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}]
+
+type ('a : non_float_value) should_succeed = 'a or_null accepts_sep
+[%%expect{|
+Line 1, characters 45-55:
+1 | type ('a : non_float_value) should_succeed = 'a or_null accepts_sep
+                                                 ^^^^^^^^^^
+Error: This type "'a or_null" should be an instance of type
+         "('b : any mod separable)"
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a or_null must be a subkind of any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}]
+
+type ('a : non_float_value) succeeds = 'a or_null accepts_nonsep
+
+[%%expect{|
+type ('a : non_float_value) succeeds = 'a or_null accepts_nonsep
+|}]
+
+(* CR with-kinds: fix error reporting difference. *)
+(* [float or_null] is not separable: *)
+
+type fails = float or_null accepts_sep
+
+[%%expect{|
+Line 1, characters 13-26:
+1 | type fails = float or_null accepts_sep
+                 ^^^^^^^^^^^^^
+Error: This type "float or_null" should be an instance of type
+         "('a : any mod separable)"
+       The kind of float or_null is
+         value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float or_null must be a subkind of any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}, Principal{|
+Line 1, characters 13-26:
+1 | type fails = float or_null accepts_sep
+                 ^^^^^^^^^^^^^
+Error: This type "float or_null" should be an instance of type
+         "('a : any mod separable)"
+       The kind of float or_null is immediate_or_null with float
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float or_null must be a subkind of any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}]
+
+(* Separability and arrays: *)
+
+(* Arrays accept separable values: *)
+
+type fails = t_nonsep_val array
+
+[%%expect{|
+Line 1, characters 13-25:
+1 | type fails = t_nonsep_val array
+                 ^^^^^^^^^^^^
+Error: This type "t_nonsep_val" should be an instance of type
+         "('a : any_non_null)"
+       The kind of t_nonsep_val is value_or_null mod non_null
+         because of the definition of t_nonsep_val at line 1, characters 0-46.
+       But the kind of t_nonsep_val must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}]
+
+type ('a : value mod separable) succeeds = 'a array
+
+[%%expect{|
+type 'a succeeds = 'a array
+|}]
+
+(* CR layouts v3: Arrays should accept [value_or_null mod separable] elements. *)
+
+type ('a : value_or_null mod separable) should_succeed = 'a array
+
+[%%expect{|
+type 'a should_succeed = 'a array
+|}]
+
+(* Arrays should not accept [float or_null]s: *)
+
+type fails = float or_null array
+
+[%%expect{|
+Line 1, characters 13-26:
+1 | type fails = float or_null array
+                 ^^^^^^^^^^^^^
+Error: This type "float or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of float or_null is
+         value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 13-26:
+1 | type fails = float or_null array
+                 ^^^^^^^^^^^^^
+Error: This type "float or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of float or_null is immediate_or_null with float
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}]
+
+(* CR layouts v3: arrays should accepts non-float [or_null] values. *)
+
+type should_succeed = string or_null array
+
+[%%expect{|
+Line 1, characters 22-36:
+1 | type should_succeed = string or_null array
+                          ^^^^^^^^^^^^^^
+Error: This type "string or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of string or_null is
+         value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of string or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 22-36:
+1 | type should_succeed = string or_null array
+                          ^^^^^^^^^^^^^^
+Error: This type "string or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of string or_null is immediate_or_null with string
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of string or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}]
+
+type should_succeed = int or_null array
+
+[%%expect{|
+Line 1, characters 22-33:
+1 | type should_succeed = int or_null array
+                          ^^^^^^^^^^^
+Error: This type "int or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of int or_null is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 22-33:
+1 | type should_succeed = int or_null array
+                          ^^^^^^^^^^^
+Error: This type "int or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of int or_null is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}]

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -212,19 +212,6 @@ Error: This type "t_ann" should be an instance of type "('a : any mod non_float)
 
 (* Testing additional non-float jkinds *)
 
-(* [non_float_value] is non-float *)
-type t_nfv : non_float_value
-type succeeds = t_nfv accepts_nonsep
-type succeeds = t_nfv accepts_sep
-type succeeds = t_nfv accepts_nonfloat
-
-[%%expect{|
-type t_nfv : non_float_value
-type succeeds = t_nfv accepts_nonsep
-type succeeds = t_nfv accepts_sep
-type succeeds = t_nfv accepts_nonfloat
-|}]
-
 (* [immutable_data] is non-float *)
 type t_imm : immutable_data
 type succeeds = t_imm accepts_nonsep
@@ -533,12 +520,12 @@ Error: This type "t_nonsep_val" should be an instance of type "('a : value)"
 
 (* CR layouts v3.4: ['a or_null] where 'a is non-float should be non-float. *)
 
-type ('a : non_float_value) should_succeed = 'a or_null accepts_nonfloat
+type ('a : value mod non_float) should_succeed = 'a or_null accepts_nonfloat
 
 [%%expect{|
-Line 1, characters 45-55:
-1 | type ('a : non_float_value) should_succeed = 'a or_null accepts_nonfloat
-                                                 ^^^^^^^^^^
+Line 1, characters 49-59:
+1 | type ('a : value mod non_float) should_succeed = 'a or_null accepts_nonfloat
+                                                     ^^^^^^^^^^
 Error: This type "'a or_null" should be an instance of type
          "('b : any mod non_float)"
        The kind of 'a or_null is immediate_or_null with 'a
@@ -547,11 +534,11 @@ Error: This type "'a or_null" should be an instance of type
          because of the definition of accepts_nonfloat at line 3, characters 0-46.
 |}]
 
-type ('a : non_float_value) should_succeed = 'a or_null accepts_sep
+type ('a : value mod non_float) should_succeed = 'a or_null accepts_sep
 [%%expect{|
-Line 1, characters 45-55:
-1 | type ('a : non_float_value) should_succeed = 'a or_null accepts_sep
-                                                 ^^^^^^^^^^
+Line 1, characters 49-59:
+1 | type ('a : value mod non_float) should_succeed = 'a or_null accepts_sep
+                                                     ^^^^^^^^^^
 Error: This type "'a or_null" should be an instance of type
          "('b : any mod separable)"
        The kind of 'a or_null is immediate_or_null with 'a
@@ -560,10 +547,10 @@ Error: This type "'a or_null" should be an instance of type
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
 
-type ('a : non_float_value) succeeds = 'a or_null accepts_nonsep
+type ('a : value mod non_float) succeeds = 'a or_null accepts_nonsep
 
 [%%expect{|
-type ('a : non_float_value) succeeds = 'a or_null accepts_nonsep
+type ('a : value mod non_float) succeeds = 'a or_null accepts_nonsep
 |}]
 
 (* CR layouts v2.8: fix error reporting difference. *)

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -531,7 +531,7 @@ Error: This type "t_nonsep_val" should be an instance of type "('a : value)"
          because the type argument of or_null has kind value.
 |}]
 
-(* CR layouts: ['a or_null] where 'a is non-float should be non-float. *)
+(* CR layouts v3.4: ['a or_null] where 'a is non-float should be non-float. *)
 
 type ('a : non_float_value) should_succeed = 'a or_null accepts_nonfloat
 

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -653,7 +653,7 @@ Error: This type "float or_null" should be an instance of type
          because it's the type argument to the array type.
 |}]
 
-(* CR layouts v3: arrays should accepts non-float [or_null] values. *)
+(* CR layouts v3.4: arrays should accepts non-float [or_null] values. *)
 
 type should_succeed = string or_null array
 

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -6,6 +6,8 @@
 
 (* Basic subkinding relation. *)
 
+(* CR layouts v3.4: [mod non_separable] doesn't do anything
+   and should raise a warning. *)
 type t_nonsep : any mod non_separable
 type t_sep : any mod separable
 type t_nonfloat : any mod non_float
@@ -605,12 +607,56 @@ type ('a : value mod separable) succeeds = 'a array
 type 'a succeeds = 'a array
 |}]
 
-(* CR layouts v3.4: Arrays should accept [value_or_null mod separable] elements. *)
+(* CR layouts v3.4: Arrays should accept [value_or_null mod separable] elements.
+   This is currently inferred as accepting [non_null] values. *)
 
-type ('a : value_or_null mod separable) should_succeed = 'a array
+type should_succeed = int or_null array
 
 [%%expect{|
-type 'a should_succeed = 'a array
+Line 1, characters 22-33:
+1 | type should_succeed = int or_null array
+                          ^^^^^^^^^^^
+Error: This type "int or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of int or_null is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 22-33:
+1 | type should_succeed = int or_null array
+                          ^^^^^^^^^^^
+Error: This type "int or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of int or_null is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}]
+
+type should_succeed = string or_null array
+
+[%%expect{|
+Line 1, characters 22-36:
+1 | type should_succeed = string or_null array
+                          ^^^^^^^^^^^^^^
+Error: This type "string or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of string or_null is
+         value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of string or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 22-36:
+1 | type should_succeed = string or_null array
+                          ^^^^^^^^^^^^^^
+Error: This type "string or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of string or_null is immediate_or_null with string
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of string or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
 |}]
 
 (* Arrays should not accept [float or_null]s: *)

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -774,6 +774,16 @@ Error: This type "int or_null smth" should be an instance of type
          because of the definition of bounded at line 3, characters 0-29.
 |}]
 
+
+type 'a t : value mod non_float with 'a
+type ('a : value mod non_float) req_non_float
+type test = float t req_non_float
+[%%expect{|
+type 'a t : value mod non_float
+type ('a : value mod non_float) req_non_float
+type test = float t req_non_float
+|}]
+
 (* Separability and [@@unboxed]. *)
 
 type unbx = { unbx : t_nonsep_val } [@@unboxed]

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -318,7 +318,7 @@ type succeeds = t_b64 accepts_sep
 type succeeds = t_b64 accepts_nonfloat
 |}]
 
-   (* [word] is non-float *)
+(* [word] is non-float *)
 type t_word : word
 type succeeds = t_word accepts_nonsep
 type succeeds = t_word accepts_sep

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -566,7 +566,7 @@ type ('a : non_float_value) succeeds = 'a or_null accepts_nonsep
 type ('a : non_float_value) succeeds = 'a or_null accepts_nonsep
 |}]
 
-(* CR with-kinds: fix error reporting difference. *)
+(* CR layouts v2.8: fix error reporting difference. *)
 (* [float or_null] is not separable: *)
 
 type fails = float or_null accepts_sep

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -514,7 +514,7 @@ type 'a succeds = 'a or_null accepts_nonsep
 type 'a succeds = 'a or_null accepts_nonsep
 |}]
 
-(* CR layouts v3: [or_null] should be able accept non-separable values? *)
+(* CR layouts v3.4: [or_null] should be able accept non-separable values? *)
 
 type t_nonsep_val : value_or_null mod non_null
 type fails = t_nonsep_val or_null

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -618,7 +618,7 @@ type ('a : value mod separable) succeeds = 'a array
 type 'a succeeds = 'a array
 |}]
 
-(* CR layouts v3: Arrays should accept [value_or_null mod separable] elements. *)
+(* CR layouts v3.4: Arrays should accept [value_or_null mod separable] elements. *)
 
 type ('a : value_or_null mod separable) should_succeed = 'a array
 

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -1124,7 +1124,9 @@ type t : immediate & ((float64 mod global) & immediate)
 let f_external_kind_annot_mode_crosses_local_2
   : local_ t -> t = fun x -> x
 [%%expect{|
-type t : value mod global & (float64 mod global & value mod global)
+type t
+  : non_float_value mod global
+    & (float64 mod global & non_float_value mod global)
 val f_external_kind_annot_mode_crosses_local_2 : local_ t -> t = <fun>
 |}]
 

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -1125,8 +1125,8 @@ let f_external_kind_annot_mode_crosses_local_2
   : local_ t -> t = fun x -> x
 [%%expect{|
 type t
-  : non_float_value mod global
-    & (float64 mod global & non_float_value mod global)
+  : value mod global non_float
+    & (float64 mod global & value mod global non_float)
 val f_external_kind_annot_mode_crosses_local_2 : local_ t -> t = <fun>
 |}]
 

--- a/testsuite/tests/typing-layouts-products/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-products/basics_alpha.ml
@@ -20,27 +20,27 @@
    now.  This test shows the current behavior. *)
 
 (* Should be allowed *)
-type t1 : any mod non_null
+type t1 : any mod non_null separable
 type t2 : value
-type t3 : any mod non_null = #(t1 * t2);;
+type t3 : any mod non_null separable = #(t1 * t2);;
 [%%expect{|
 type t1 : any_non_null
 type t2
 type t3 = #(t1 * t2)
 |}]
 
-type t1 : any mod non_null
+type t1 : any mod non_null separable
 type t2 : value
-type t3 : any & value mod non_null = #(t1 * t2);;
+type t3 : any & value mod non_null separable = #(t1 * t2);;
 [%%expect{|
 type t1 : any_non_null
 type t2
 type t3 = #(t1 * t2)
 |}]
 
-type t1 : any mod non_null
+type t1 : any mod non_null separable
 type t2 : value
-type t3 : (any mod non_null) & (value mod non_null) = #(t1 * t2);;
+type t3 : (any mod non_null separable) & (value mod non_null separable) = #(t1 * t2);;
 [%%expect{|
 type t1 : any_non_null
 type t2
@@ -48,8 +48,8 @@ type t3 = #(t1 * t2)
 |}]
 
 type t1 : any
-type t2 : any mod non_null
-type t3 : any & (any mod non_null) = #(t1 * t2);;
+type t2 : any mod non_null separable
+type t3 : any & (any mod non_null separable) = #(t1 * t2);;
 [%%expect{|
 type t1 : any
 type t2 : any_non_null
@@ -58,54 +58,54 @@ type t3 = #(t1 * t2)
 
 (* Should not be allowed. *)
 type t1 : any
-type t2 : any mod non_null
-type t3 : any mod non_null = #(t1 * t2);;
+type t2 : any mod non_null separable
+type t3 : any mod non_null separable = #(t1 * t2);;
 [%%expect{|
 type t1 : any
 type t2 : any_non_null
-Line 3, characters 0-39:
-3 | type t3 : any mod non_null = #(t1 * t2);;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 3, characters 0-49:
+3 | type t3 : any mod non_null separable = #(t1 * t2);;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "#(t1 * t2)" is
-         any_non_null mod everything with t1 with t2
-         & any_non_null mod everything with t1 with t2
+         any_non_null mod everything mod non_float with t1 with t2
+         & any_non_null mod everything mod non_float with t1 with t2
          because it is an unboxed tuple.
        But the kind of type "#(t1 * t2)" must be a subkind of any_non_null
-         because of the definition of t3 at line 3, characters 0-39.
+         because of the definition of t3 at line 3, characters 0-49.
 |}]
 
 type t1 : any
-type t2 : any mod non_null
-type t3 : any & any mod non_null = #(t1 * t2);;
+type t2 : any mod non_null separable
+type t3 : any & any mod non_null separable = #(t1 * t2);;
 [%%expect{|
 type t1 : any
 type t2 : any_non_null
-Line 3, characters 0-45:
-3 | type t3 : any & any mod non_null = #(t1 * t2);;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 3, characters 0-55:
+3 | type t3 : any & any mod non_null separable = #(t1 * t2);;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "#(t1 * t2)" is
-         any_non_null mod everything with t1 with t2
-         & any_non_null mod everything with t1 with t2
+         any_non_null mod everything mod non_float with t1 with t2
+         & any_non_null mod everything mod non_float with t1 with t2
          because it is an unboxed tuple.
        But the kind of type "#(t1 * t2)" must be a subkind of
          any_non_null & any_non_null
-         because of the definition of t3 at line 3, characters 0-45.
+         because of the definition of t3 at line 3, characters 0-55.
 |}]
 
 type t1 : any
-type t2 : any mod non_null
-type t3 : (any mod non_null) & (any mod non_null) = #(t1 * t2);;
+type t2 : any mod non_null separable
+type t3 : (any mod non_null separable) & (any mod non_null separable) = #(t1 * t2);;
 [%%expect{|
 type t1 : any
 type t2 : any_non_null
-Line 3, characters 0-62:
-3 | type t3 : (any mod non_null) & (any mod non_null) = #(t1 * t2);;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 3, characters 0-82:
+3 | type t3 : (any mod non_null separable) & (any mod non_null separable) = #(t1 * t2);;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "#(t1 * t2)" is
-         any_non_null mod everything with t1 with t2
-         & any_non_null mod everything with t1 with t2
+         any_non_null mod everything mod non_float with t1 with t2
+         & any_non_null mod everything mod non_float with t1 with t2
          because it is an unboxed tuple.
        But the kind of type "#(t1 * t2)" must be a subkind of
          any_non_null & any_non_null
-         because of the definition of t3 at line 3, characters 0-62.
+         because of the definition of t3 at line 3, characters 0-82.
 |}]

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -770,7 +770,8 @@ Line 1, characters 0-61:
 1 | type q : any mod portable = #{ x : int -> int; y : int -> q }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "q" is
-         value mod aliased immutable & value mod aliased immutable
+         non_float_value mod aliased immutable
+         & non_float_value mod aliased immutable
          because it is an unboxed record.
        But the kind of type "q" must be a subkind of
          value_or_null mod portable & value_or_null mod portable

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -770,8 +770,8 @@ Line 1, characters 0-61:
 1 | type q : any mod portable = #{ x : int -> int; y : int -> q }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "q" is
-         non_float_value mod aliased immutable
-         & non_float_value mod aliased immutable
+         value mod aliased immutable non_float
+         & value mod aliased immutable non_float
          because it is an unboxed record.
        But the kind of type "q" must be a subkind of
          value_or_null mod portable & value_or_null mod portable

--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -61,9 +61,9 @@ type t2 = #(int * float#) array
 type t3 = #(float# * int * int64# * bool) array
 type t4 : immediate & immediate
 type t4a = t4 array
-type t5 : value & float64
+type t5 : non_float_value & float64
 type t5a = t5 array
-type t6 : bits64 & value & float64 & value
+type t6 : bits64 & non_float_value & float64 & non_float_value
 type t6a = t6 array
 |}]
 

--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -61,9 +61,9 @@ type t2 = #(int * float#) array
 type t3 = #(float# * int * int64# * bool) array
 type t4 : immediate & immediate
 type t4a = t4 array
-type t5 : non_float_value & float64
+type t5 : value mod non_float & float64
 type t5a = t5 array
-type t6 : bits64 & non_float_value & float64 & non_float_value
+type t6 : bits64 & value mod non_float & float64 & value mod non_float
 type t6a = t6 array
 |}]
 

--- a/testsuite/tests/typing-layouts-products/unboxed_records_alpha.ml
+++ b/testsuite/tests/typing-layouts-products/unboxed_records_alpha.ml
@@ -46,18 +46,18 @@ Error: The definition of "bad" is recursive without boxing:
    [testsuite/tests/typing-layouts-products/basics_alpha.ml]. *)
 
 (* [t3] is allowed for unboxed tuples, and disallowed for (un)boxed records *)
-type t1 : any mod non_null
+type t1 : any mod non_null separable
 type t2 : value
-type t3 : any mod non_null = #{ t1 : t1 ; t2 : t2};;
+type t3 : any mod non_null separable = #{ t1 : t1 ; t2 : t2};;
 [%%expect{|
 type t1 : any_non_null
 type t2
-Line 3, characters 32-41:
-3 | type t3 : any mod non_null = #{ t1 : t1 ; t2 : t2};;
-                                    ^^^^^^^^^
+Line 3, characters 42-51:
+3 | type t3 : any mod non_null separable = #{ t1 : t1 ; t2 : t2};;
+                                              ^^^^^^^^^
 Error: Unboxed record element types must have a representable layout.
        The layout of t1 is any
-         because of the definition of t1 at line 1, characters 0-26.
+         because of the definition of t1 at line 1, characters 0-36.
        But the layout of t1 must be representable
          because it is the type of record field t1.
 |}]
@@ -65,47 +65,47 @@ Error: Unboxed record element types must have a representable layout.
 (* CR layouts v7.2: once [any] is allowed in unboxed record declarations, check
    that [non_null] behaves correctly in the following tests. *)
 
-type t1 : any mod non_null
+type t1 : any mod non_null separable
 type t2 : value
-type t3 : any & value mod non_null = #{ t1 : t1 ; t2 : t2};;
+type t3 : any & value mod non_null separable = #{ t1 : t1 ; t2 : t2};;
 [%%expect{|
 type t1 : any_non_null
 type t2
-Line 3, characters 40-49:
-3 | type t3 : any & value mod non_null = #{ t1 : t1 ; t2 : t2};;
-                                            ^^^^^^^^^
+Line 3, characters 50-59:
+3 | type t3 : any & value mod non_null separable = #{ t1 : t1 ; t2 : t2};;
+                                                      ^^^^^^^^^
 Error: Unboxed record element types must have a representable layout.
        The layout of t1 is any
-         because of the definition of t1 at line 1, characters 0-26.
+         because of the definition of t1 at line 1, characters 0-36.
        But the layout of t1 must be representable
          because it is the type of record field t1.
 |}]
 
-type t1 : any mod non_null
+type t1 : any mod non_null separable
 type t2 : value
-type t3 : (any mod non_null) & (value mod non_null) = #{ t1 : t1 ; t2 : t2};;
+type t3 : (any mod non_null separable) & (value mod non_null separable) = #{ t1 : t1 ; t2 : t2};;
 [%%expect{|
 type t1 : any_non_null
 type t2
-Line 3, characters 57-66:
-3 | type t3 : (any mod non_null) & (value mod non_null) = #{ t1 : t1 ; t2 : t2};;
-                                                             ^^^^^^^^^
+Line 3, characters 77-86:
+3 | type t3 : (any mod non_null separable) & (value mod non_null separable) = #{ t1 : t1 ; t2 : t2};;
+                                                                                 ^^^^^^^^^
 Error: Unboxed record element types must have a representable layout.
        The layout of t1 is any
-         because of the definition of t1 at line 1, characters 0-26.
+         because of the definition of t1 at line 1, characters 0-36.
        But the layout of t1 must be representable
          because it is the type of record field t1.
 |}]
 
 type t1 : any
-type t2 : any mod non_null
-type t3 : any & (any mod non_null) = #{ t1 : t1 ; t2 : t2 };;
+type t2 : any mod non_null separable
+type t3 : any & (any mod non_null separable) = #{ t1 : t1 ; t2 : t2 };;
 [%%expect{|
 type t1 : any
 type t2 : any_non_null
-Line 3, characters 40-49:
-3 | type t3 : any & (any mod non_null) = #{ t1 : t1 ; t2 : t2 };;
-                                            ^^^^^^^^^
+Line 3, characters 50-59:
+3 | type t3 : any & (any mod non_null separable) = #{ t1 : t1 ; t2 : t2 };;
+                                                      ^^^^^^^^^
 Error: Unboxed record element types must have a representable layout.
        The layout of t1 is any
          because of the definition of t1 at line 1, characters 0-13.
@@ -115,14 +115,14 @@ Error: Unboxed record element types must have a representable layout.
 
 (* Should not be allowed for either unboxed tuples or (un)boxed records. *)
 type t1 : any
-type t2 : any mod non_null
-type t3 : any mod non_null = #{ t1 : t1 ; t2 : t2 };;
+type t2 : any mod non_null separable
+type t3 : any mod non_null separable = #{ t1 : t1 ; t2 : t2 };;
 [%%expect{|
 type t1 : any
 type t2 : any_non_null
-Line 3, characters 32-41:
-3 | type t3 : any mod non_null = #{ t1 : t1 ; t2 : t2 };;
-                                    ^^^^^^^^^
+Line 3, characters 42-51:
+3 | type t3 : any mod non_null separable = #{ t1 : t1 ; t2 : t2 };;
+                                              ^^^^^^^^^
 Error: Unboxed record element types must have a representable layout.
        The layout of t1 is any
          because of the definition of t1 at line 1, characters 0-13.
@@ -131,14 +131,14 @@ Error: Unboxed record element types must have a representable layout.
 |}]
 
 type t1 : any
-type t2 : any mod non_null
-type t3 : any & any mod non_null = #{ t1 : t1 ; t2 : t2 };;
+type t2 : any mod non_null separable
+type t3 : any & any mod non_null separable = #{ t1 : t1 ; t2 : t2 };;
 [%%expect{|
 type t1 : any
 type t2 : any_non_null
-Line 3, characters 38-47:
-3 | type t3 : any & any mod non_null = #{ t1 : t1 ; t2 : t2 };;
-                                          ^^^^^^^^^
+Line 3, characters 48-57:
+3 | type t3 : any & any mod non_null separable = #{ t1 : t1 ; t2 : t2 };;
+                                                    ^^^^^^^^^
 Error: Unboxed record element types must have a representable layout.
        The layout of t1 is any
          because of the definition of t1 at line 1, characters 0-13.
@@ -147,14 +147,14 @@ Error: Unboxed record element types must have a representable layout.
 |}]
 
 type t1 : any
-type t2 : any mod non_null
-type t3 : (any mod non_null) & (any mod non_null) = #{ t1 : t1 ; t2 : t2 };;
+type t2 : any mod non_null separable
+type t3 : (any mod non_null separable) & (any mod non_null separable) = #{ t1 : t1 ; t2 : t2 };;
 [%%expect{|
 type t1 : any
 type t2 : any_non_null
-Line 3, characters 55-64:
-3 | type t3 : (any mod non_null) & (any mod non_null) = #{ t1 : t1 ; t2 : t2 };;
-                                                           ^^^^^^^^^
+Line 3, characters 75-84:
+3 | type t3 : (any mod non_null separable) & (any mod non_null separable) = #{ t1 : t1 ; t2 : t2 };;
+                                                                               ^^^^^^^^^
 Error: Unboxed record element types must have a representable layout.
        The layout of t1 is any
          because of the definition of t1 at line 1, characters 0-13.

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -1886,7 +1886,7 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value mod aliased immutable
+       The kind of 'a -> 'b is non_float_value mod aliased immutable
          because it's a function type.
        But the kind of 'a -> 'b must be a subkind of immediate
          because of the definition of t35 at line 1, characters 0-30.
@@ -2876,7 +2876,7 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression is used as a function, but its type "'a"
        has kind "bits64", which cannot be the kind of a function.
-       (Functions always have kind "value mod aliased immutable".)
+       (Functions always have kind "non_float_value mod aliased immutable".)
 |}]
 
 let f (x : ('a : value mod portable)) = x ()
@@ -2887,7 +2887,7 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression is used as a function, but its type "'a"
        has kind "value mod portable", which cannot be the kind of a function.
-       (Functions always have kind "value mod aliased immutable".)
+       (Functions always have kind "non_float_value mod aliased immutable".)
 |}]
 
 let f (x : ('a : value)) = x ()

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -1886,7 +1886,7 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is non_float_value mod aliased immutable
+       The kind of 'a -> 'b is value mod aliased immutable non_float
          because it's a function type.
        But the kind of 'a -> 'b must be a subkind of immediate
          because of the definition of t35 at line 1, characters 0-30.
@@ -2876,7 +2876,7 @@ Line 1, characters 28-29:
                                 ^
 Error: This expression is used as a function, but its type "'a"
        has kind "bits64", which cannot be the kind of a function.
-       (Functions always have kind "non_float_value mod aliased immutable".)
+       (Functions always have kind "value mod aliased immutable non_float".)
 |}]
 
 let f (x : ('a : value mod portable)) = x ()
@@ -2887,7 +2887,7 @@ Line 1, characters 40-41:
                                             ^
 Error: This expression is used as a function, but its type "'a"
        has kind "value mod portable", which cannot be the kind of a function.
-       (Functions always have kind "non_float_value mod aliased immutable".)
+       (Functions always have kind "value mod aliased immutable non_float".)
 |}]
 
 let f (x : ('a : value)) = x ()

--- a/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -1812,7 +1812,7 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value mod aliased immutable
+       The kind of 'a -> 'b is non_float_value mod aliased immutable
          because it's a function type.
        But the kind of 'a -> 'b must be a subkind of immediate
          because of the definition of t35 at line 1, characters 0-30.

--- a/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -1812,7 +1812,7 @@ Line 2, characters 19-31:
 2 | let f35 : 'a t35 = fun () -> ()
                        ^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is non_float_value mod aliased immutable
+       The kind of 'a -> 'b is value mod aliased immutable non_float
          because it's a function type.
        But the kind of 'a -> 'b must be a subkind of immediate
          because of the definition of t35 at line 1, characters 0-30.

--- a/testsuite/tests/typing-layouts/datatypes.ml
+++ b/testsuite/tests/typing-layouts/datatypes.ml
@@ -339,7 +339,7 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type "float" but an expression was expected of type
          "('a : immediate)"
-       The kind of float is immutable_data
+       The kind of float is immutable_separable_value
          because it is the primitive type float.
        But the kind of float must be a subkind of immediate
          because of the definition of s6 at line 2, characters 0-35.

--- a/testsuite/tests/typing-layouts/datatypes.ml
+++ b/testsuite/tests/typing-layouts/datatypes.ml
@@ -339,7 +339,7 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type "float" but an expression was expected of type
          "('a : immediate)"
-       The kind of float is immutable_separable_value
+       The kind of float is value mod many unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of immediate
          because of the definition of s6 at line 2, characters 0-35.

--- a/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -325,7 +325,7 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type "float" but an expression was expected of type
          "('a : immediate)"
-       The kind of float is immutable_data
+       The kind of float is immutable_separable_value
          because it is the primitive type float.
        But the kind of float must be a subkind of immediate
          because of the definition of s6 at line 2, characters 0-35.

--- a/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -325,7 +325,7 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type "float" but an expression was expected of type
          "('a : immediate)"
-       The kind of float is immutable_separable_value
+       The kind of float is value mod many unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of immediate
          because of the definition of s6 at line 2, characters 0-35.

--- a/testsuite/tests/typing-modal-kinds/everything.ml
+++ b/testsuite/tests/typing-modal-kinds/everything.ml
@@ -4,14 +4,14 @@
 
 (* The kinds [value] and [float64] don't mode cross, but the kinds [value mod
    everything] and [float64 mod everything] cross everything (ignoring
-   nullability) *)
+   nullability and separability) *)
 type t_value : value
 type t_value_mod_e : value mod everything
 type t_float64 : float64
 type t_float64_mod_e : float64 mod everything
 [%%expect{|
 type t_value
-type t_value_mod_e : immediate
+type t_value_mod_e : immediate_or_null mod non_null separable
 type t_float64 : float64
 type t_float64_mod_e : float64 mod everything
 |}]
@@ -294,11 +294,16 @@ type t : immediate & immediate
 
 type t : value & float64 mod everything
 [%%expect{|
-type t : immediate & float64 mod everything
+type t
+  : immediate_or_null mod non_null separable
+    & float64 mod global aliased many stateless immutable external_
 |}]
 
 type t : value & (immediate & bits64) & float32 mod everything
 [%%expect{|
 type t
-  : immediate & (immediate & bits64 mod everything) & float32 mod everything
+  : immediate_or_null mod non_null separable
+    & (immediate_or_null mod non_null separable
+      & bits64 mod global aliased many stateless immutable external_)
+    & float32 mod global aliased many stateless immutable external_
 |}]

--- a/testsuite/tests/typing-modal-kinds/unboxed.ml
+++ b/testsuite/tests/typing-modal-kinds/unboxed.ml
@@ -214,6 +214,7 @@ Error: This expression has type "(int -> int) t"
 
        The first mode-crosses less than the second along:
          nullability: mod non_null with int -> int ≰ mod non_null
+         separability: mod non_float with int -> int ≰ mod separable
 |}]
 (* CR layouts v2.8: fix principality *)
 
@@ -243,6 +244,7 @@ Error: This type "(int -> int) t" should be an instance of type
 
        The first mode-crosses less than the second along:
          nullability: mod non_null with int -> int ≰ mod non_null
+         separability: mod non_float with int -> int ≰ mod separable
 |}]
 (* CR layouts v2.8: fix principality *)
 

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -80,20 +80,20 @@ module IndirectPub : sig type t = [ `Foo of 'a ] as 'a end
    if we were unrolling the abbrev.  *)
 module IndirectPriv = I(struct end);;
 [%%expect{|
-module IndirectPriv : sig type t end
+module IndirectPriv : sig type t : non_float_value end
 |}]
 
 (* These two behave as though a functor was defined *)
 module DirectPrivEta =
   (functor (X : sig end) -> Priv(X))(struct end);;
 [%%expect{|
-module DirectPrivEta : sig type t end
+module DirectPrivEta : sig type t : non_float_value end
 |}]
 
 module DirectPrivEtaUnit =
   (functor (_ : sig end) -> Priv)(struct end)(struct end);;
 [%%expect{|
-module DirectPrivEtaUnit : sig type t end
+module DirectPrivEtaUnit : sig type t : non_float_value end
 |}]
 
 (*** Test proposed by Jacques in
@@ -149,5 +149,5 @@ module I : functor (X : sig end) -> sig type t = Priv(X).t end
 
 module IndirectPriv = I(struct end);;
 [%%expect{|
-module IndirectPriv : sig type t end
+module IndirectPriv : sig type t : non_float_value end
 |}]

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -80,20 +80,20 @@ module IndirectPub : sig type t = [ `Foo of 'a ] as 'a end
    if we were unrolling the abbrev.  *)
 module IndirectPriv = I(struct end);;
 [%%expect{|
-module IndirectPriv : sig type t : non_float_value end
+module IndirectPriv : sig type t : value mod non_float end
 |}]
 
 (* These two behave as though a functor was defined *)
 module DirectPrivEta =
   (functor (X : sig end) -> Priv(X))(struct end);;
 [%%expect{|
-module DirectPrivEta : sig type t : non_float_value end
+module DirectPrivEta : sig type t : value mod non_float end
 |}]
 
 module DirectPrivEtaUnit =
   (functor (_ : sig end) -> Priv)(struct end)(struct end);;
 [%%expect{|
-module DirectPrivEtaUnit : sig type t : non_float_value end
+module DirectPrivEtaUnit : sig type t : value mod non_float end
 |}]
 
 (*** Test proposed by Jacques in
@@ -149,5 +149,5 @@ module I : functor (X : sig end) -> sig type t = Priv(X).t end
 
 module IndirectPriv = I(struct end);;
 [%%expect{|
-module IndirectPriv : sig type t : non_float_value end
+module IndirectPriv : sig type t : value mod non_float end
 |}]

--- a/testsuite/tests/typing-signatures/nondep_regression.ml
+++ b/testsuite/tests/typing-signatures/nondep_regression.ml
@@ -13,5 +13,5 @@ module H = Make (struct type t end)
 [%%expect{|
 type 'a seq = 'a list
 module Make : functor (A : sig type t end) -> sig type t = A.t seq end
-module H : sig type t end
+module H : sig type t : non_float_value end
 |}]

--- a/testsuite/tests/typing-signatures/nondep_regression.ml
+++ b/testsuite/tests/typing-signatures/nondep_regression.ml
@@ -13,5 +13,5 @@ module H = Make (struct type t end)
 [%%expect{|
 type 'a seq = 'a list
 module Make : functor (A : sig type t end) -> sig type t = A.t seq end
-module H : sig type t : non_float_value end
+module H : sig type t : value mod non_float end
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1607,7 +1607,7 @@ let copy_sep ~copy_scope ~fixed ~(visited : type_expr TypeHash.t) sch =
             if keep then
               (add_delayed_copy t ty;
                Tvar { name = None;
-                      jkind = Jkind.Builtin.value ~why:Polymorphic_variant })
+                      jkind = Jkind.Builtin.non_float_value ~why:Polymorphic_variant })
             else
             let more' = copy_rec ~may_share:false more in
             let fixed' = fixed && (is_Tvar more || is_Tunivar more) in
@@ -2319,7 +2319,7 @@ let rec estimate_type_jkind ~expand_component env ty =
   | Tlink _ | Tsubst _ -> assert false
   | Tvariant row ->
      if tvariant_not_immediate row
-     then Jkind.Builtin.value ~why:Polymorphic_variant
+     then Jkind.Builtin.non_float_value ~why:Polymorphic_variant
      else Jkind.Builtin.immediate ~why:Immediate_polymorphic_variant
   | Tunivar { jkind } -> Jkind.disallow_right jkind
   | Tpoly (ty, _) ->
@@ -2335,7 +2335,7 @@ let rec estimate_type_jkind ~expand_component env ty =
     Jkind.round_up ~jkind_of_type |>
     Jkind.disallow_right
   | Tof_kind jkind -> Jkind.disallow_right jkind
-  | Tpackage _ -> Jkind.Builtin.value ~why:First_class_module
+  | Tpackage _ -> Jkind.Builtin.non_float_value ~why:First_class_module
 
 and close_open_jkind ~expand_component ~is_open env jkind =
   if is_open (* if the type has free variables, we can't let these leak into

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1607,7 +1607,7 @@ let copy_sep ~copy_scope ~fixed ~(visited : type_expr TypeHash.t) sch =
             if keep then
               (add_delayed_copy t ty;
                Tvar { name = None;
-                      jkind = Jkind.Builtin.non_float_value ~why:Polymorphic_variant })
+                      jkind = Jkind.for_non_float ~why:Polymorphic_variant })
             else
             let more' = copy_rec ~may_share:false more in
             let fixed' = fixed && (is_Tvar more || is_Tunivar more) in
@@ -2319,7 +2319,7 @@ let rec estimate_type_jkind ~expand_component env ty =
   | Tlink _ | Tsubst _ -> assert false
   | Tvariant row ->
      if tvariant_not_immediate row
-     then Jkind.Builtin.non_float_value ~why:Polymorphic_variant
+     then Jkind.for_non_float ~why:Polymorphic_variant
      else Jkind.Builtin.immediate ~why:Immediate_polymorphic_variant
   | Tunivar { jkind } -> Jkind.disallow_right jkind
   | Tpoly (ty, _) ->
@@ -2335,7 +2335,7 @@ let rec estimate_type_jkind ~expand_component env ty =
     Jkind.round_up ~jkind_of_type |>
     Jkind.disallow_right
   | Tof_kind jkind -> Jkind.disallow_right jkind
-  | Tpackage _ -> Jkind.Builtin.non_float_value ~why:First_class_module
+  | Tpackage _ -> Jkind.for_non_float ~why:First_class_module
 
 and close_open_jkind ~expand_component ~is_open env jkind =
   if is_open (* if the type has free variables, we can't let these leak into

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2349,8 +2349,7 @@ let for_non_float ~(why : History.value_creation_reason) =
   in
   fresh_jkind
     { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
-    ~annotation:(mk_annot "non_float_value")
-    ~why:(Value_creation why)
+    ~annotation:None ~why:(Value_creation why)
 
 let for_boxed_variant cstrs =
   let open Types in

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1302,7 +1302,8 @@ module Const = struct
         name = "any mod everything"
       }
 
-    (* CR layouts v3: replace with [any_separable] when or_null arrays are implemented. *)
+    (* CR layouts v3: replace with [any_separable] when
+       [or_null array]s are implemented. *)
     let any_non_null =
       { jkind =
           mk_jkind Any ~mode_crossing:false ~nullability:Non_null
@@ -1310,7 +1311,8 @@ module Const = struct
         name = "any_non_null"
       }
 
-    (* CR layouts v3: replace with [any_separable] when or_null arrays are implemented. *)
+    (* CR layouts v3: replace with [any_separable] when
+       [or_null array]s are implemented. *)
     let any_non_null_mod_everything =
       { jkind =
           mk_jkind Any ~mode_crossing:true ~nullability:Non_null
@@ -1393,7 +1395,8 @@ module Const = struct
         name = "mutable_data"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: replace with [any_separable] when
+       [or_null array]s are implemented. *)
     let void =
       { jkind =
           mk_jkind (Base Void) ~mode_crossing:false ~nullability:Non_null
@@ -1408,7 +1411,8 @@ module Const = struct
         name = "immediate"
       }
 
-    (* CR layouts v3: change to [Non_float] once [or_null] accounts for separability. *)
+    (* CR layouts v3: replace with [any_separable] when
+       [or_null array]s are implemented. *)
     let immediate_or_null =
       { jkind =
           mk_jkind (Base Value) ~mode_crossing:true ~nullability:Maybe_null
@@ -1456,7 +1460,8 @@ module Const = struct
         name = "immediate64"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let float64 =
       { jkind =
           mk_jkind (Base Float64) ~mode_crossing:false ~nullability:Non_null
@@ -1466,7 +1471,8 @@ module Const = struct
         name = "float64"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let kind_of_unboxed_float =
       { jkind =
           mk_jkind (Base Float64) ~mode_crossing:true ~nullability:Non_null
@@ -1476,7 +1482,8 @@ module Const = struct
         name = "float64 mod everything"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let float32 =
       { jkind =
           mk_jkind (Base Float32) ~mode_crossing:false ~nullability:Non_null
@@ -1486,7 +1493,8 @@ module Const = struct
         name = "float32"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let kind_of_unboxed_float32 =
       { jkind =
           mk_jkind (Base Float32) ~mode_crossing:true ~nullability:Non_null
@@ -1496,7 +1504,8 @@ module Const = struct
         name = "float32 mod everything"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let word =
       { jkind =
           mk_jkind (Base Word) ~mode_crossing:false ~nullability:Non_null
@@ -1504,7 +1513,8 @@ module Const = struct
         name = "word"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let kind_of_unboxed_nativeint =
       { jkind =
           mk_jkind (Base Word) ~mode_crossing:true ~nullability:Non_null
@@ -1512,7 +1522,8 @@ module Const = struct
         name = "word mod everything"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let bits32 =
       { jkind =
           mk_jkind (Base Bits32) ~mode_crossing:false ~nullability:Non_null
@@ -1520,7 +1531,8 @@ module Const = struct
         name = "bits32"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let kind_of_unboxed_int32 =
       { jkind =
           mk_jkind (Base Bits32) ~mode_crossing:true ~nullability:Non_null
@@ -1528,7 +1540,8 @@ module Const = struct
         name = "bits32 mod everything"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let bits64 =
       { jkind =
           mk_jkind (Base Bits64) ~mode_crossing:false ~nullability:Non_null
@@ -1536,7 +1549,8 @@ module Const = struct
         name = "bits64"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let kind_of_unboxed_int64 =
       { jkind =
           mk_jkind (Base Bits64) ~mode_crossing:true ~nullability:Non_null
@@ -1544,7 +1558,8 @@ module Const = struct
         name = "bits64 mod everything"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let vec128 =
       { jkind =
           mk_jkind (Base Vec128) ~mode_crossing:false ~nullability:Non_null
@@ -1552,7 +1567,8 @@ module Const = struct
         name = "vec128"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when
+       [or_null array]s are implemented. *)
     let kind_of_unboxed_128bit_vectors =
       { jkind =
           mk_jkind (Base Vec128) ~mode_crossing:true ~nullability:Non_null

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1357,24 +1357,6 @@ module Const = struct
         name = "immutable_data"
       }
 
-    let immutable_separable_value =
-      { jkind =
-          { layout = Base Value;
-            mod_bounds =
-              Mod_bounds.create ~locality:Locality.Const.max
-                ~linearity:Linearity.Const.min
-                ~portability:Portability.Const.min ~yielding:Yielding.Const.min
-                ~uniqueness:Uniqueness.Const_op.max
-                ~contention:Contention.Const_op.min
-                ~statefulness:Statefulness.Const.min
-                ~visibility:Visibility.Const_op.min ~externality:Externality.max
-                ~nullability:Nullability.Non_null
-                ~separability:Jkind_axis.Separability.Separable;
-            with_bounds = No_with_bounds
-          };
-        name = "immutable_separable_value"
-      }
-
     let non_float_value =
       { jkind =
           mk_jkind (Base Value) ~mode_crossing:false ~nullability:Non_null
@@ -1594,7 +1576,6 @@ module Const = struct
         value_or_null_mod_everything;
         value;
         non_float_value;
-        immutable_separable_value;
         immutable_data;
         sync_data;
         mutable_data;
@@ -1868,7 +1849,6 @@ module Const = struct
       | "value_or_null" -> Builtin.value_or_null.jkind
       | "value" -> Builtin.value.jkind
       | "non_float_value" -> Builtin.non_float_value.jkind
-      | "immutable_separable_value" -> Builtin.immutable_separable_value.jkind
       | "void" -> Builtin.void.jkind
       | "immediate64" -> Builtin.immediate64.jkind
       | "immediate" -> Builtin.immediate.jkind
@@ -2061,9 +2041,6 @@ module Jkind_desc = struct
 
     let non_float_value = of_const Const.Builtin.non_float_value.jkind
 
-    let immutable_separable_value =
-      of_const Const.Builtin.immutable_separable_value.jkind
-
     let immutable_data = of_const Const.Builtin.immutable_data.jkind
 
     let sync_data = of_const Const.Builtin.sync_data.jkind
@@ -2161,11 +2138,6 @@ module Builtin = struct
 
   let value ~(why : History.value_creation_reason) =
     fresh_jkind Jkind_desc.Builtin.value ~annotation:(mk_annot "value")
-      ~why:(Value_creation why)
-
-  let immutable_separable_value ~(why : History.value_creation_reason) =
-    fresh_jkind Jkind_desc.Builtin.immutable_separable_value
-      ~annotation:(mk_annot "immutable_separable_value")
       ~why:(Value_creation why)
 
   let non_float_value ~(why : History.value_creation_reason) =
@@ -2445,6 +2417,23 @@ let for_object =
       with_bounds = No_with_bounds
     }
     ~annotation:None ~why:(Value_creation Object)
+
+let for_float ident =
+  fresh_jkind
+    { layout = Sort (Base Value);
+      mod_bounds =
+        Mod_bounds.create ~locality:Locality.Const.max
+          ~linearity:Linearity.Const.min ~portability:Portability.Const.min
+          ~yielding:Yielding.Const.min ~uniqueness:Uniqueness.Const_op.max
+          ~contention:Contention.Const_op.min
+          ~statefulness:Statefulness.Const.min
+          ~visibility:Visibility.Const_op.min ~externality:Externality.max
+          ~nullability:Nullability.Non_null
+          ~separability:Jkind_axis.Separability.Separable;
+      with_bounds = No_with_bounds
+    }
+    ~annotation:None ~why:(Primitive ident)
+  |> mark_best
 
 (******************************)
 (* elimination and defaulting *)

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1351,7 +1351,7 @@ module Const = struct
                 ~statefulness:Statefulness.Const.min
                 ~visibility:Visibility.Const_op.min ~externality:Externality.max
                 ~nullability:Nullability.Non_null
-                ~separability:Jkind_axis.Separability.Non_float;
+                ~separability:Separability.Non_float;
             with_bounds = No_with_bounds
           };
         name = "immutable_data"
@@ -1360,7 +1360,7 @@ module Const = struct
     let non_float_value =
       { jkind =
           mk_jkind (Base Value) ~mode_crossing:false ~nullability:Non_null
-            ~separability:Jkind_axis.Separability.Non_float;
+            ~separability:Separability.Non_float;
         name = "non_float_value"
       }
 
@@ -2024,7 +2024,8 @@ module Jkind_desc = struct
     let layout, sort = Layout.of_new_sort_var () in
     ( { layout;
         mod_bounds =
-          Mod_bounds.set_nullability nullability_upper_bound Mod_bounds.max
+          Mod_bounds.max
+          |> Mod_bounds.set_nullability nullability_upper_bound
           |> Mod_bounds.set_separability separability_upper_bound;
         with_bounds = No_with_bounds
       },
@@ -2413,7 +2414,7 @@ let for_object =
         Mod_bounds.create ~linearity ~locality ~uniqueness ~portability
           ~contention ~yielding ~statefulness ~visibility
           ~externality:Externality.max ~nullability:Non_null
-          ~separability:Separability.Separable;
+          ~separability:Separability.Non_float;
       with_bounds = No_with_bounds
     }
     ~annotation:None ~why:(Value_creation Object)
@@ -2428,8 +2429,7 @@ let for_float ident =
           ~contention:Contention.Const_op.min
           ~statefulness:Statefulness.Const.min
           ~visibility:Visibility.Const_op.min ~externality:Externality.max
-          ~nullability:Nullability.Non_null
-          ~separability:Jkind_axis.Separability.Separable;
+          ~nullability:Nullability.Non_null ~separability:Separability.Separable;
       with_bounds = No_with_bounds
     }
     ~annotation:None ~why:(Primitive ident)

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2336,18 +2336,16 @@ let for_unboxed_record lbls =
   Builtin.product ~why:Unboxed_record tys_modalities layouts
 
 let for_non_float ~(why : History.value_creation_reason) =
+  let mod_bounds =
+    Mod_bounds.create ~locality:Locality.Const.max
+      ~linearity:Linearity.Const.max ~portability:Portability.Const.max
+      ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
+      ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
+      ~visibility:Visibility.Const_op.max ~externality:Externality.max
+      ~nullability:Nullability.Non_null ~separability:Separability.Non_float
+  in
   fresh_jkind
-    { layout = Sort (Base Value);
-      mod_bounds =
-        Mod_bounds.create ~locality:Locality.Const.max
-          ~linearity:Linearity.Const.max ~portability:Portability.Const.max
-          ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
-          ~contention:Contention.Const_op.max
-          ~statefulness:Statefulness.Const.max
-          ~visibility:Visibility.Const_op.max ~externality:Externality.max
-          ~nullability:Nullability.Non_null ~separability:Separability.Non_float;
-      with_bounds = No_with_bounds
-    }
+    { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
     ~annotation:(mk_annot "non_float_value")
     ~why:(Value_creation why)
 
@@ -2436,18 +2434,16 @@ let for_object =
     ~annotation:None ~why:(Value_creation Object)
 
 let for_float ident =
+  let mod_bounds =
+    Mod_bounds.create ~locality:Locality.Const.max
+      ~linearity:Linearity.Const.min ~portability:Portability.Const.min
+      ~yielding:Yielding.Const.min ~uniqueness:Uniqueness.Const_op.max
+      ~contention:Contention.Const_op.min ~statefulness:Statefulness.Const.min
+      ~visibility:Visibility.Const_op.min ~externality:Externality.max
+      ~nullability:Nullability.Non_null ~separability:Separability.Separable
+  in
   fresh_jkind
-    { layout = Sort (Base Value);
-      mod_bounds =
-        Mod_bounds.create ~locality:Locality.Const.max
-          ~linearity:Linearity.Const.min ~portability:Portability.Const.min
-          ~yielding:Yielding.Const.min ~uniqueness:Uniqueness.Const_op.max
-          ~contention:Contention.Const_op.min
-          ~statefulness:Statefulness.Const.min
-          ~visibility:Visibility.Const_op.min ~externality:Externality.max
-          ~nullability:Nullability.Non_null ~separability:Separability.Separable;
-      with_bounds = No_with_bounds
-    }
+    { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
     ~annotation:None ~why:(Primitive ident)
   |> mark_best
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -347,6 +347,7 @@ end
 
 module Externality = Externality
 module Nullability = Nullability
+module Separability = Jkind_axis.Separability
 
 module History = struct
   include Jkind_intf.History
@@ -393,7 +394,8 @@ let raise ~loc err = raise (Error.User_error (loc, err))
 
 (* Returns the set of axes that is relevant under a given modality. For example,
    under the [global] modality, the locality axis is *not* relevant. *)
-let relevant_axes_of_modality ~relevant_for_nullability ~modality =
+let relevant_axes_of_modality ~relevant_for_nullability
+    ~relevant_for_separability ~modality =
   Axis_set.create ~f:(fun ~axis:(Pack axis) ->
       match axis with
       | Modal axis ->
@@ -412,6 +414,10 @@ let relevant_axes_of_modality ~relevant_for_nullability ~modality =
       | Nonmodal Nullability -> (
         match relevant_for_nullability with
         | `Relevant -> true
+        | `Irrelevant -> false)
+      | Nonmodal Separability -> (
+        match relevant_for_separability with
+        | `Relevant -> true
         | `Irrelevant -> false))
 
 module Mod_bounds = struct
@@ -423,6 +429,7 @@ module Mod_bounds = struct
       ~contention:Contention.min ~yielding:Yielding.min
       ~statefulness:Statefulness.min ~visibility:Visibility.min
       ~externality:Externality.min ~nullability:Nullability.min
+      ~separability:Separability.min
 
   let max =
     create ~locality:Locality.max ~linearity:Linearity.max
@@ -430,6 +437,7 @@ module Mod_bounds = struct
       ~contention:Contention.max ~yielding:Yielding.max
       ~statefulness:Statefulness.max ~visibility:Visibility.max
       ~externality:Externality.max ~nullability:Nullability.max
+      ~separability:Separability.max
 
   let join t1 t2 =
     let locality = Locality.join (locality t1) (locality t2) in
@@ -442,8 +450,9 @@ module Mod_bounds = struct
     let visibility = Visibility.join (visibility t1) (visibility t2) in
     let externality = Externality.join (externality t1) (externality t2) in
     let nullability = Nullability.join (nullability t1) (nullability t2) in
+    let separability = Separability.join (separability t1) (separability t2) in
     create ~locality ~linearity ~uniqueness ~portability ~contention ~yielding
-      ~statefulness ~visibility ~externality ~nullability
+      ~statefulness ~visibility ~externality ~nullability ~separability
 
   let meet t1 t2 =
     let locality = Locality.meet (locality t1) (locality t2) in
@@ -456,8 +465,9 @@ module Mod_bounds = struct
     let visibility = Visibility.meet (visibility t1) (visibility t2) in
     let externality = Externality.meet (externality t1) (externality t2) in
     let nullability = Nullability.meet (nullability t1) (nullability t2) in
+    let separability = Separability.meet (separability t1) (separability t2) in
     create ~locality ~linearity ~uniqueness ~portability ~contention ~yielding
-      ~statefulness ~visibility ~externality ~nullability
+      ~statefulness ~visibility ~externality ~nullability ~separability
 
   let less_or_equal t1 t2 =
     let[@inline] axis_less_or_equal ~le ~axis a b : Sub_result.t =
@@ -501,8 +511,13 @@ module Mod_bounds = struct
          (axis_less_or_equal ~le:Externality.le
             ~axis:(Pack (Nonmodal Externality)) (externality t1)
             (externality t2))
-    @@ axis_less_or_equal ~le:Nullability.le ~axis:(Pack (Nonmodal Nullability))
-         (nullability t1) (nullability t2)
+    @@ Sub_result.combine
+         (axis_less_or_equal ~le:Nullability.le
+            ~axis:(Pack (Nonmodal Nullability)) (nullability t1)
+            (nullability t2))
+    @@ axis_less_or_equal ~le:Separability.le
+         ~axis:(Pack (Nonmodal Separability)) (separability t1)
+         (separability t2)
 
   let equal t1 t2 =
     Locality.equal (locality t1) (locality t2)
@@ -515,6 +530,7 @@ module Mod_bounds = struct
     && Visibility.equal (visibility t1) (visibility t2)
     && Externality.equal (externality t1) (externality t2)
     && Nullability.equal (nullability t1) (nullability t2)
+    && Separability.equal (separability t1) (separability t2)
 
   let[@inline] get (type a) ~(axis : a Axis.t) t : a =
     match axis with
@@ -528,6 +544,7 @@ module Mod_bounds = struct
     | Modal (Monadic Visibility) -> visibility t
     | Nonmodal Externality -> externality t
     | Nonmodal Nullability -> nullability t
+    | Nonmodal Separability -> separability t
 
   (** Get all axes that are set to max *)
   let get_max_axes t =
@@ -565,6 +582,9 @@ module Mod_bounds = struct
     |> add_if
          (Nullability.le Nullability.max (nullability t))
          (Nonmodal Nullability)
+    |> add_if
+         (Separability.le Separability.max (separability t))
+         (Nonmodal Separability)
 
   let for_arrow =
     create ~linearity:Linearity.max ~locality:Locality.max
@@ -572,6 +592,7 @@ module Mod_bounds = struct
       ~contention:Contention.min ~yielding:Yielding.max
       ~statefulness:Statefulness.max ~visibility:Visibility.min
       ~externality:Externality.max ~nullability:Nullability.Non_null
+      ~separability:Separability.Non_float
 
   let to_mode_crossing t =
     Mode.Crossing.of_bounds
@@ -620,7 +641,11 @@ module With_bounds = struct
       in
       let irrelevant_axes = Axis_set.complement relevant_axes in
       (* nullability is always implicitly irrelevant since it isn't deep *)
-      Axis_set.remove irrelevant_axes (Nonmodal Nullability)
+      let irrelevant_axes =
+        Axis_set.remove irrelevant_axes (Nonmodal Nullability)
+      in
+      (* same for separability *)
+      Axis_set.remove irrelevant_axes (Nonmodal Separability)
   end
 
   let to_best_eff_map = function
@@ -727,10 +752,11 @@ module With_bounds = struct
       With_bounds (With_bounds_types.singleton type_expr type_info)
     | With_bounds bounds -> With_bounds (add_bound type_expr type_info bounds)
 
-  let add_modality ~relevant_for_nullability ~modality ~type_expr
-      (t : (allowed * 'r) t) : (allowed * 'r) t =
+  let add_modality ~relevant_for_nullability ~relevant_for_separability
+      ~modality ~type_expr (t : (allowed * 'r) t) : (allowed * 'r) t =
     let relevant_axes =
-      relevant_axes_of_modality ~relevant_for_nullability ~modality
+      relevant_axes_of_modality ~relevant_for_nullability
+        ~relevant_for_separability ~modality
     in
     match t with
     | No_with_bounds ->
@@ -1020,6 +1046,7 @@ module Layout_and_axes = struct
                 ~visibility:(value_for_axis ~axis:(Modal (Monadic Visibility)))
                 ~externality:(value_for_axis ~axis:(Nonmodal Externality))
                 ~nullability:(value_for_axis ~axis:(Nonmodal Nullability))
+                ~separability:(value_for_axis ~axis:(Nonmodal Separability))
             in
             let found_jkind_for_ty new_ctl b_upper_bounds b_with_bounds quality
                 : Mod_bounds.t * (l * r2) with_bounds * Fuel_status.t =
@@ -1250,49 +1277,65 @@ module Const = struct
         name : string
       }
 
-    let mk_jkind ~mode_crossing ~nullability (layout : Layout.Const.t) =
+    let mk_jkind ~mode_crossing ~nullability ~separability
+        (layout : Layout.Const.t) =
       let mod_bounds =
         (match mode_crossing with
         | true -> Mod_bounds.min
         | false -> Mod_bounds.max)
         |> Mod_bounds.set_nullability nullability
+        |> Mod_bounds.set_separability separability
       in
       { layout; mod_bounds; with_bounds = No_with_bounds }
 
     let any =
-      { jkind = mk_jkind Any ~mode_crossing:false ~nullability:Maybe_null;
+      { jkind =
+          mk_jkind Any ~mode_crossing:false ~nullability:Maybe_null
+            ~separability:Non_separable;
         name = "any"
       }
 
     let any_mod_everything =
-      { jkind = mk_jkind Any ~mode_crossing:true ~nullability:Maybe_null;
+      { jkind =
+          mk_jkind Any ~mode_crossing:true ~nullability:Maybe_null
+            ~separability:Non_separable;
         name = "any mod everything"
       }
 
+    (* CR layouts v3: replace with [any_separable] when or_null arrays are implemented. *)
     let any_non_null =
-      { jkind = mk_jkind Any ~mode_crossing:false ~nullability:Non_null;
+      { jkind =
+          mk_jkind Any ~mode_crossing:false ~nullability:Non_null
+            ~separability:Separable;
         name = "any_non_null"
       }
 
+    (* CR layouts v3: replace with [any_separable] when or_null arrays are implemented. *)
     let any_non_null_mod_everything =
-      { jkind = mk_jkind Any ~mode_crossing:true ~nullability:Non_null;
+      { jkind =
+          mk_jkind Any ~mode_crossing:true ~nullability:Non_null
+            ~separability:Separable;
         name = "any_non_null mod everything"
       }
 
     let value_or_null =
       { jkind =
-          mk_jkind (Base Value) ~mode_crossing:false ~nullability:Maybe_null;
+          mk_jkind (Base Value) ~mode_crossing:false ~nullability:Maybe_null
+            ~separability:Non_separable;
         name = "value_or_null"
       }
 
     let value_or_null_mod_everything =
       { jkind =
-          mk_jkind (Base Value) ~mode_crossing:true ~nullability:Maybe_null;
+          mk_jkind (Base Value) ~mode_crossing:true ~nullability:Maybe_null
+            ~separability:Non_separable;
         name = "value_or_null mod everything"
       }
 
     let value =
-      { jkind = mk_jkind (Base Value) ~mode_crossing:false ~nullability:Non_null;
+      { jkind =
+          mk_jkind (Base Value) ~mode_crossing:false ~nullability:Non_null
+            ~separability:Separable;
         name = "value"
       }
 
@@ -1307,10 +1350,36 @@ module Const = struct
                 ~contention:Contention.Const_op.min
                 ~statefulness:Statefulness.Const.min
                 ~visibility:Visibility.Const_op.min ~externality:Externality.max
-                ~nullability:Nullability.Non_null;
+                ~nullability:Nullability.Non_null
+                ~separability:Jkind_axis.Separability.Non_float;
             with_bounds = No_with_bounds
           };
         name = "immutable_data"
+      }
+
+    let immutable_separable_value =
+      { jkind =
+          { layout = Base Value;
+            mod_bounds =
+              Mod_bounds.create ~locality:Locality.Const.max
+                ~linearity:Linearity.Const.min
+                ~portability:Portability.Const.min ~yielding:Yielding.Const.min
+                ~uniqueness:Uniqueness.Const_op.max
+                ~contention:Contention.Const_op.min
+                ~statefulness:Statefulness.Const.min
+                ~visibility:Visibility.Const_op.min ~externality:Externality.max
+                ~nullability:Nullability.Non_null
+                ~separability:Jkind_axis.Separability.Separable;
+            with_bounds = No_with_bounds
+          };
+        name = "immutable_separable_value"
+      }
+
+    let non_float_value =
+      { jkind =
+          mk_jkind (Base Value) ~mode_crossing:false ~nullability:Non_null
+            ~separability:Jkind_axis.Separability.Non_float;
+        name = "non_float_value"
       }
 
     let sync_data =
@@ -1324,7 +1393,8 @@ module Const = struct
                 ~contention:Contention.Const_op.min
                 ~statefulness:Statefulness.Const.min
                 ~visibility:Visibility.Const_op.max ~externality:Externality.max
-                ~nullability:Nullability.Non_null;
+                ~nullability:Nullability.Non_null
+                ~separability:Separability.Non_float;
             with_bounds = No_with_bounds
           };
         name = "sync_data"
@@ -1341,26 +1411,33 @@ module Const = struct
                 ~uniqueness:Uniqueness.Const_op.max
                 ~statefulness:Statefulness.Const.min
                 ~visibility:Visibility.Const_op.max ~externality:Externality.max
-                ~nullability:Nullability.Non_null;
+                ~nullability:Nullability.Non_null
+                ~separability:Separability.Non_float;
             with_bounds = No_with_bounds
           };
         name = "mutable_data"
       }
 
-    (* CR layouts v3: change to [or_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let void =
-      { jkind = mk_jkind (Base Void) ~mode_crossing:false ~nullability:Non_null;
+      { jkind =
+          mk_jkind (Base Void) ~mode_crossing:false ~nullability:Non_null
+            ~separability:Non_float;
         name = "void"
       }
 
     let immediate =
-      { jkind = mk_jkind (Base Value) ~mode_crossing:true ~nullability:Non_null;
+      { jkind =
+          mk_jkind (Base Value) ~mode_crossing:true ~nullability:Non_null
+            ~separability:Non_float;
         name = "immediate"
       }
 
+    (* CR layouts v3: change to [Non_float] once [or_null] accounts for separability. *)
     let immediate_or_null =
       { jkind =
-          mk_jkind (Base Value) ~mode_crossing:true ~nullability:Maybe_null;
+          mk_jkind (Base Value) ~mode_crossing:true ~nullability:Maybe_null
+            ~separability:Non_separable;
         name = "immediate_or_null"
       }
 
@@ -1404,82 +1481,107 @@ module Const = struct
         name = "immediate64"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let float64 =
       { jkind =
-          mk_jkind (Base Float64) ~mode_crossing:false ~nullability:Non_null;
+          mk_jkind (Base Float64) ~mode_crossing:false ~nullability:Non_null
+            ~separability:Non_float;
+        (* [separability] is intentionally [Non_float]:
+           only boxed floats are relevant for separability. *)
         name = "float64"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let kind_of_unboxed_float =
       { jkind =
-          mk_jkind (Base Float64) ~mode_crossing:true ~nullability:Non_null;
+          mk_jkind (Base Float64) ~mode_crossing:true ~nullability:Non_null
+            ~separability:Non_float;
+        (* [separability] is intentionally [Non_float]:
+           only boxed floats are relevant for separability. *)
         name = "float64 mod everything"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let float32 =
       { jkind =
-          mk_jkind (Base Float32) ~mode_crossing:false ~nullability:Non_null;
+          mk_jkind (Base Float32) ~mode_crossing:false ~nullability:Non_null
+            ~separability:Non_float;
+        (* [separability] is intentionally [Non_float]:
+           only boxed floats are relevant for separability. *)
         name = "float32"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let kind_of_unboxed_float32 =
       { jkind =
-          mk_jkind (Base Float32) ~mode_crossing:true ~nullability:Non_null;
+          mk_jkind (Base Float32) ~mode_crossing:true ~nullability:Non_null
+            ~separability:Non_float;
+        (* [separability] is intentionally [Non_float]:
+           only boxed floats are relevant for separability. *)
         name = "float32 mod everything"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let word =
-      { jkind = mk_jkind (Base Word) ~mode_crossing:false ~nullability:Non_null;
+      { jkind =
+          mk_jkind (Base Word) ~mode_crossing:false ~nullability:Non_null
+            ~separability:Non_float;
         name = "word"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let kind_of_unboxed_nativeint =
-      { jkind = mk_jkind (Base Word) ~mode_crossing:true ~nullability:Non_null;
+      { jkind =
+          mk_jkind (Base Word) ~mode_crossing:true ~nullability:Non_null
+            ~separability:Non_float;
         name = "word mod everything"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let bits32 =
       { jkind =
-          mk_jkind (Base Bits32) ~mode_crossing:false ~nullability:Non_null;
+          mk_jkind (Base Bits32) ~mode_crossing:false ~nullability:Non_null
+            ~separability:Non_float;
         name = "bits32"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let kind_of_unboxed_int32 =
-      { jkind = mk_jkind (Base Bits32) ~mode_crossing:true ~nullability:Non_null;
+      { jkind =
+          mk_jkind (Base Bits32) ~mode_crossing:true ~nullability:Non_null
+            ~separability:Non_float;
         name = "bits32 mod everything"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let bits64 =
       { jkind =
-          mk_jkind (Base Bits64) ~mode_crossing:false ~nullability:Non_null;
+          mk_jkind (Base Bits64) ~mode_crossing:false ~nullability:Non_null
+            ~separability:Non_float;
         name = "bits64"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let kind_of_unboxed_int64 =
-      { jkind = mk_jkind (Base Bits64) ~mode_crossing:true ~nullability:Non_null;
+      { jkind =
+          mk_jkind (Base Bits64) ~mode_crossing:true ~nullability:Non_null
+            ~separability:Non_float;
         name = "bits64 mod everything"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let vec128 =
       { jkind =
-          mk_jkind (Base Vec128) ~mode_crossing:false ~nullability:Non_null;
+          mk_jkind (Base Vec128) ~mode_crossing:false ~nullability:Non_null
+            ~separability:Non_float;
         name = "vec128"
       }
 
-    (* CR layouts v3: change to [Maybe_null] when separability is implemented. *)
+    (* CR layouts v3: change to [Maybe_null] when or_null arrays are implemented. *)
     let kind_of_unboxed_128bit_vectors =
-      { jkind = mk_jkind (Base Vec128) ~mode_crossing:true ~nullability:Non_null;
+      { jkind =
+          mk_jkind (Base Vec128) ~mode_crossing:true ~nullability:Non_null
+            ~separability:Non_float;
         name = "vec128 mod everything"
       }
 
@@ -1491,6 +1593,8 @@ module Const = struct
         value_or_null;
         value_or_null_mod_everything;
         value;
+        non_float_value;
+        immutable_separable_value;
         immutable_data;
         sync_data;
         mutable_data;
@@ -1682,8 +1786,9 @@ module Const = struct
                 { jkind =
                     { layout = jkind.layout;
                       mod_bounds =
-                        Mod_bounds.set_nullability Nullability.Non_null
-                          Mod_bounds.max;
+                        Mod_bounds.set_separability Separability.Separable
+                          (Mod_bounds.set_nullability Nullability.Non_null
+                             Mod_bounds.max);
                       with_bounds = No_with_bounds
                     };
                   name = Layout.Const.to_string jkind.layout
@@ -1693,7 +1798,7 @@ module Const = struct
           match out_jkind_verbose with
           | Some out_jkind -> out_jkind
           | None ->
-            (* If we fail, try again with nullable jkinds. *)
+            (* If we fail, try again with nullable/non-separable jkinds. *)
             let out_jkind_verbose =
               convert_with_base
                 ~base:
@@ -1762,6 +1867,8 @@ module Const = struct
       | "any_non_null" -> Builtin.any_non_null.jkind
       | "value_or_null" -> Builtin.value_or_null.jkind
       | "value" -> Builtin.value.jkind
+      | "non_float_value" -> Builtin.non_float_value.jkind
+      | "immutable_separable_value" -> Builtin.immutable_separable_value.jkind
       | "void" -> Builtin.void.jkind
       | "immediate64" -> Builtin.immediate64.jkind
       | "immediate" -> Builtin.immediate.jkind
@@ -1802,7 +1909,8 @@ module Const = struct
           mod_bounds = base.mod_bounds;
           with_bounds =
             With_bounds.add_modality ~modality
-              ~relevant_for_nullability:`Irrelevant ~type_expr:type_
+              ~relevant_for_nullability:`Irrelevant
+              ~relevant_for_separability:`Irrelevant ~type_expr:type_
               base.with_bounds
         })
     | Default | Kind_of _ -> raise ~loc:jkind.pjkind_loc Unimplemented_syntax
@@ -1869,15 +1977,11 @@ end
 module Jkind_desc = struct
   let of_const t = Layout_and_axes.map Layout.of_const t
 
-  let add_nullability_crossing t =
-    { t with
-      mod_bounds = Mod_bounds.set_nullability Nullability.min t.mod_bounds
-    }
-
   let unsafely_set_bounds t ~from =
     { t with mod_bounds = from.mod_bounds; with_bounds = from.with_bounds }
 
-  let add_with_bounds ~relevant_for_nullability ~type_expr ~modality t =
+  let add_with_bounds ~relevant_for_nullability ~relevant_for_separability
+      ~type_expr ~modality t =
     match Types.get_desc type_expr with
     | Tarrow (_, _, _, _) ->
       (* Optimization: all arrow types have the same (with-bound-free) jkind, so
@@ -1888,13 +1992,14 @@ module Jkind_desc = struct
           Mod_bounds.join t.mod_bounds
             (Mod_bounds.set_min_in_set Mod_bounds.for_arrow
                (Axis_set.complement
-                  (relevant_axes_of_modality ~modality ~relevant_for_nullability)))
+                  (relevant_axes_of_modality ~modality ~relevant_for_nullability
+                     ~relevant_for_separability)))
       }
     | _ ->
       { t with
         with_bounds =
-          With_bounds.add_modality ~relevant_for_nullability ~type_expr
-            ~modality t.with_bounds
+          With_bounds.add_modality ~relevant_for_nullability
+            ~relevant_for_separability ~type_expr ~modality t.with_bounds
       }
 
   let max = of_const Const.max
@@ -1935,11 +2040,12 @@ module Jkind_desc = struct
 
   let map_type_expr f t = Layout_and_axes.map_type_expr f t
 
-  let of_new_sort_var nullability_upper_bound =
+  let of_new_sort_var nullability_upper_bound separability_upper_bound =
     let layout, sort = Layout.of_new_sort_var () in
     ( { layout;
         mod_bounds =
-          Mod_bounds.set_nullability nullability_upper_bound Mod_bounds.max;
+          Mod_bounds.set_nullability nullability_upper_bound Mod_bounds.max
+          |> Mod_bounds.set_separability separability_upper_bound;
         with_bounds = No_with_bounds
       },
       sort )
@@ -1947,9 +2053,16 @@ module Jkind_desc = struct
   module Builtin = struct
     let any = max
 
+    let any_non_null = of_const Const.Builtin.any_non_null.jkind
+
     let value_or_null = of_const Const.Builtin.value_or_null.jkind
 
     let value = of_const Const.Builtin.value.jkind
+
+    let non_float_value = of_const Const.Builtin.non_float_value.jkind
+
+    let immutable_separable_value =
+      of_const Const.Builtin.immutable_separable_value.jkind
 
     let immutable_data = of_const Const.Builtin.immutable_data.jkind
 
@@ -1971,7 +2084,7 @@ module Jkind_desc = struct
       List.fold_right
         (fun (type_expr, modality) bounds ->
           With_bounds.add_modality ~relevant_for_nullability:`Relevant
-            ~type_expr ~modality bounds)
+            ~relevant_for_separability:`Irrelevant ~type_expr ~modality bounds)
         tys_modalities No_with_bounds
     in
     { layout; mod_bounds; with_bounds }
@@ -2021,6 +2134,10 @@ module Builtin = struct
       fresh_jkind Jkind_desc.Builtin.any ~annotation:(mk_annot "any")
         ~why:(Any_creation why)
 
+  let any_non_null ~why =
+    fresh_jkind Jkind_desc.Builtin.any_non_null
+      ~annotation:(mk_annot "any_non_null") ~why:(Any_creation why)
+
   let value_v1_safety_check =
     { jkind = Jkind_desc.Builtin.value_or_null;
       annotation = mk_annot "value";
@@ -2044,6 +2161,16 @@ module Builtin = struct
 
   let value ~(why : History.value_creation_reason) =
     fresh_jkind Jkind_desc.Builtin.value ~annotation:(mk_annot "value")
+      ~why:(Value_creation why)
+
+  let immutable_separable_value ~(why : History.value_creation_reason) =
+    fresh_jkind Jkind_desc.Builtin.immutable_separable_value
+      ~annotation:(mk_annot "immutable_separable_value")
+      ~why:(Value_creation why)
+
+  let non_float_value ~(why : History.value_creation_reason) =
+    fresh_jkind Jkind_desc.Builtin.non_float_value
+      ~annotation:(mk_annot "non_float_value")
       ~why:(Value_creation why)
 
   let immutable_data ~(why : History.value_creation_reason) =
@@ -2092,9 +2219,6 @@ module Builtin = struct
      want [Best] jkinds there. *)
 end
 
-let add_nullability_crossing t =
-  { t with jkind = Jkind_desc.add_nullability_crossing t.jkind }
-
 let unsafely_set_bounds (type l r) ~(from : (l * r) jkind) t =
   { t with jkind = Jkind_desc.unsafely_set_bounds t.jkind ~from:from.jkind }
 
@@ -2104,7 +2228,8 @@ let add_with_bounds ~modality ~type_expr t =
       Jkind_desc.add_with_bounds
       (* We only care about types in fields of unboxed products for the
          nullability of the overall kind *)
-        ~relevant_for_nullability:`Irrelevant ~type_expr ~modality t.jkind
+        ~relevant_for_nullability:`Irrelevant
+        ~relevant_for_separability:`Irrelevant ~type_expr ~modality t.jkind
   }
 
 let has_with_bounds (type r) (t : (_ * r) jkind) =
@@ -2116,13 +2241,13 @@ let has_with_bounds (type r) (t : (_ * r) jkind) =
 (* construction *)
 
 let of_new_sort_var ~why =
-  let jkind, sort = Jkind_desc.of_new_sort_var Maybe_null in
+  let jkind, sort = Jkind_desc.of_new_sort_var Maybe_null Non_separable in
   fresh_jkind jkind ~annotation:None ~why:(Concrete_creation why), sort
 
 let of_new_sort ~why = fst (of_new_sort_var ~why)
 
 let of_new_legacy_sort_var ~why =
-  let jkind, sort = Jkind_desc.of_new_sort_var Non_null in
+  let jkind, sort = Jkind_desc.of_new_sort_var Non_null Separable in
   fresh_jkind jkind ~annotation:None ~why:(Concrete_legacy_creation why), sort
 
 let of_new_legacy_sort ~why = fst (of_new_legacy_sort_var ~why)
@@ -2265,7 +2390,7 @@ let for_boxed_variant cstrs =
        (* CR layouts v2.8: This is sad, but I don't know how to account for
           existentials in the with_bounds. See doc named "Existential
           with_bounds". *)
-    then Builtin.value ~why:Boxed_variant
+    then Builtin.non_float_value ~why:Boxed_variant
     else
       let base =
         (if is_mutable then Builtin.mutable_data else Builtin.immutable_data)
@@ -2315,7 +2440,8 @@ let for_object =
       mod_bounds =
         Mod_bounds.create ~linearity ~locality ~uniqueness ~portability
           ~contention ~yielding ~statefulness ~visibility
-          ~externality:Externality.max ~nullability:Non_null;
+          ~externality:Externality.max ~nullability:Non_null
+          ~separability:Separability.Separable;
       with_bounds = No_with_bounds
     }
     ~annotation:None ~why:(Value_creation Object)
@@ -2457,6 +2583,7 @@ let set_layout jk layout = { jk with jkind = { jk.jkind with layout } }
 let apply_modality_l modality jk =
   let relevant_axes =
     relevant_axes_of_modality ~modality ~relevant_for_nullability:`Relevant
+      ~relevant_for_separability:`Relevant
   in
   let mod_bounds =
     Mod_bounds.set_min_in_set jk.jkind.mod_bounds
@@ -2474,6 +2601,7 @@ let apply_modality_l modality jk =
 let apply_modality_r modality jk =
   let relevant_axes =
     relevant_axes_of_modality ~modality ~relevant_for_nullability:`Relevant
+      ~relevant_for_separability:`Relevant
   in
   let mod_bounds =
     Mod_bounds.set_max_in_set jk.jkind.mod_bounds
@@ -3384,7 +3512,9 @@ let is_value_for_printing ~ignore_null { jkind; _ } =
       then
         { value with
           mod_bounds =
-            Mod_bounds.set_nullability Nullability.Maybe_null value.mod_bounds
+            Mod_bounds.set_separability Separability.Non_separable
+              (Mod_bounds.set_nullability Nullability.Maybe_null
+                 value.mod_bounds)
         }
         :: values
       else values

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2066,8 +2066,11 @@ module Jkind_desc = struct
     let with_bounds =
       List.fold_right
         (fun (type_expr, modality) bounds ->
-          With_bounds.add_modality ~relevant_for_nullability:`Relevant
-            ~relevant_for_separability:`Irrelevant ~type_expr ~modality bounds)
+          With_bounds.add_modality
+            ~relevant_for_nullability:`Relevant
+              (* CR layouts v3.4: this should be relevant for 1-element unboxed
+                 records, but irrelevant for everything else. *)
+            ~relevant_for_separability:`Relevant ~type_expr ~modality bounds)
         tys_modalities No_with_bounds
     in
     { layout; mod_bounds; with_bounds }

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -276,9 +276,6 @@ module Const : sig
     (** Values that are not floats. *)
     val non_float_value : t
 
-    (** Immutable separable values that don't contain functions. *)
-    val immutable_separable_value : t
-
     (** Immutable values that don't contain functions and are not floats. *)
     val immutable_data : t
 
@@ -360,9 +357,6 @@ module Builtin : sig
   val value : why:History.value_creation_reason -> 'd Types.jkind
 
   val non_float_value : why:History.value_creation_reason -> 'd Types.jkind
-
-  val immutable_separable_value :
-    why:History.value_creation_reason -> 'd Types.jkind
 
   (** This is suitable for records or variants without mutable fields. *)
   val immutable_data : why:History.value_creation_reason -> 'd Types.jkind
@@ -519,6 +513,9 @@ val for_arrow : Types.jkind_l
 
 (** The jkind of an object type.  *)
 val for_object : Types.jkind_l
+
+(** The jkind of a float. *)
+val for_float : Ident.t -> Types.jkind_l
 
 (******************************)
 (* elimination and defaulting *)

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -273,9 +273,6 @@ module Const : sig
     (** This is the jkind of normal ocaml values *)
     val value : t
 
-    (** Values that are not floats. *)
-    val non_float_value : t
-
     (** Immutable values that don't contain functions and are not floats. *)
     val immutable_data : t
 
@@ -355,8 +352,6 @@ module Builtin : sig
 
   (** This is the jkind of normal ocaml values *)
   val value : why:History.value_creation_reason -> 'd Types.jkind
-
-  val non_float_value : why:History.value_creation_reason -> 'd Types.jkind
 
   (** This is suitable for records or variants without mutable fields. *)
   val immutable_data : why:History.value_creation_reason -> 'd Types.jkind
@@ -516,6 +511,9 @@ val for_object : Types.jkind_l
 
 (** The jkind of a float. *)
 val for_float : Ident.t -> Types.jkind_l
+
+(** The jkind for values that are not floats. *)
+val for_non_float : why:History.value_creation_reason -> 'd Types.jkind
 
 (******************************)
 (* elimination and defaulting *)

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -273,13 +273,19 @@ module Const : sig
     (** This is the jkind of normal ocaml values *)
     val value : t
 
-    (** Immutable values that don't contain functions. *)
+    (** Values that are not floats. *)
+    val non_float_value : t
+
+    (** Immutable separable values that don't contain functions. *)
+    val immutable_separable_value : t
+
+    (** Immutable values that don't contain functions and are not floats. *)
     val immutable_data : t
 
-    (** Atomically mutable values that don't contain functions. *)
+    (** Atomically mutable values that don't contain functions and are not floats. *)
     val sync_data : t
 
-    (** Mutable values that don't contain functions. *)
+    (** Mutable values that don't contain functions and are not floats. *)
     val mutable_data : t
 
     (** Values of types of this jkind are immediate on 64-bit platforms; on other
@@ -339,6 +345,11 @@ module Builtin : sig
     [any]. *)
   val any : why:History.any_creation_reason -> 'd Types.jkind
 
+  (* CR layouts v3: change to [any_separable]. *)
+
+  (** Jkind of array elements. *)
+  val any_non_null : why:History.any_creation_reason -> 'd Types.jkind
+
   (** Value of types of this jkind are not retained at all at runtime *)
   val void : why:History.void_creation_reason -> ('l * disallowed) Types.jkind
 
@@ -347,6 +358,11 @@ module Builtin : sig
 
   (** This is the jkind of normal ocaml values *)
   val value : why:History.value_creation_reason -> 'd Types.jkind
+
+  val non_float_value : why:History.value_creation_reason -> 'd Types.jkind
+
+  val immutable_separable_value :
+    why:History.value_creation_reason -> 'd Types.jkind
 
   (** This is suitable for records or variants without mutable fields. *)
   val immutable_data : why:History.value_creation_reason -> 'd Types.jkind
@@ -387,9 +403,6 @@ module Builtin : sig
   val product_of_sorts :
     why:History.product_creation_reason -> int -> Types.jkind_l
 end
-
-(** Take an existing [t] and add an ability to cross across the nullability axis. *)
-val add_nullability_crossing : 'd Types.jkind -> 'd Types.jkind
 
 (** Forcibly change the mod- and with-bounds of a [t] based on the mod- and with-bounds of [from]. *)
 val unsafely_set_bounds :

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -273,13 +273,13 @@ module Const : sig
     (** This is the jkind of normal ocaml values *)
     val value : t
 
-    (** Immutable values that don't contain functions and are not floats. *)
+    (** Immutable non-float values that don't contain functions. *)
     val immutable_data : t
 
-    (** Atomically mutable values that don't contain functions and are not floats. *)
+    (** Atomically mutable non-float values that don't contain functions. *)
     val sync_data : t
 
-    (** Mutable values that don't contain functions and are not floats. *)
+    (** Mutable non-float values that don't contain functions. *)
     val mutable_data : t
 
     (** Values of types of this jkind are immediate on 64-bit platforms; on other

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -220,19 +220,6 @@ module Axis = struct
     | Nonmodal Externality -> "externality"
     | Nonmodal Nullability -> "nullability"
     | Nonmodal Separability -> "separability"
-
-  let is_modal (type a) : a t -> bool = function
-    | Modal (Comonadic Areality) -> true
-    | Modal (Comonadic Linearity) -> true
-    | Modal (Monadic Uniqueness) -> true
-    | Modal (Comonadic Portability) -> true
-    | Modal (Monadic Contention) -> true
-    | Modal (Comonadic Yielding) -> true
-    | Modal (Comonadic Statefulness) -> true
-    | Modal (Monadic Visibility) -> true
-    | Nonmodal Externality -> true
-    | Nonmodal Nullability -> false
-    | Nonmodal Separability -> false
 end
 
 module Axis_set = struct

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -40,11 +40,21 @@ module Nullability : sig
   include Axis_ops with type t := t
 end
 
+module Separability : sig
+  type t =
+    | Non_float
+    | Separable
+    | Non_separable
+
+  include Axis_ops with type t := t
+end
+
 module Axis : sig
   module Nonmodal : sig
     type 'a t =
       | Externality : Externality.t t
       | Nullability : Nullability.t t
+      | Separability : Separability.t t
   end
 
   (** Represents an axis of a jkind *)

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -72,10 +72,6 @@ module Axis : sig
   val all : packed list
 
   val name : _ t -> string
-
-  (** Is this a modal axis? Includes externality, because that will one
-      day be modal (it is a deep property). *)
-  val is_modal : _ t -> bool
 end
 
 module Axis_set : sig

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -410,7 +410,7 @@ let build_initial_env add_type add_extension empty_env =
   |> add_type ident_char ~jkind:Jkind.Const.Builtin.immediate
   |> add_type ident_exn ~kind:Type_open ~jkind:Jkind.Const.Builtin.non_float_value
   |> add_type ident_extension_constructor ~jkind:Jkind.Const.Builtin.immutable_data
-  |> add_type ident_float ~jkind:Jkind.Const.Builtin.immutable_separable_value
+  |> add_type_with_jkind ident_float ~jkind:(Jkind.for_float ident_float)
       ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_float
   |> add_type ident_floatarray ~jkind:Jkind.Const.Builtin.mutable_data
   |> add_type ident_int ~jkind:Jkind.Const.Builtin.immediate

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -389,8 +389,7 @@ let build_initial_env add_type add_extension empty_env =
   |> add_type1 ident_array
        ~variance:Variance.full
        ~separability:Separability.Ind
-       ~param_jkind:(Jkind.add_nullability_crossing
-                      (Jkind.Builtin.any ~why:Array_type_argument))
+       ~param_jkind:(Jkind.Builtin.any_non_null ~why:Array_type_argument)
        ~jkind:(fun param ->
          Jkind.Builtin.mutable_data ~why:(Primitive ident_array) |>
          Jkind.add_with_bounds
@@ -399,8 +398,7 @@ let build_initial_env add_type add_extension empty_env =
   |> add_type1 ident_iarray
        ~variance:Variance.covariant
        ~separability:Separability.Ind
-       ~param_jkind:(Jkind.add_nullability_crossing
-                      (Jkind.Builtin.any ~why:Array_type_argument))
+       ~param_jkind:(Jkind.Builtin.any_non_null ~why:Array_type_argument)
        ~jkind:(fun param ->
          Jkind.Builtin.immutable_data ~why:(Primitive ident_iarray) |>
          Jkind.add_with_bounds
@@ -410,9 +408,9 @@ let build_initial_env add_type add_extension empty_env =
        ~kind:(variant [ cstr ident_false []; cstr ident_true []])
        ~jkind:Jkind.Const.Builtin.immediate
   |> add_type ident_char ~jkind:Jkind.Const.Builtin.immediate
-  |> add_type ident_exn ~kind:Type_open ~jkind:Jkind.Const.Builtin.value
+  |> add_type ident_exn ~kind:Type_open ~jkind:Jkind.Const.Builtin.non_float_value
   |> add_type ident_extension_constructor ~jkind:Jkind.Const.Builtin.immutable_data
-  |> add_type ident_float ~jkind:Jkind.Const.Builtin.immutable_data
+  |> add_type ident_float ~jkind:Jkind.Const.Builtin.immutable_separable_value
       ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_float
   |> add_type ident_floatarray ~jkind:Jkind.Const.Builtin.mutable_data
   |> add_type ident_int ~jkind:Jkind.Const.Builtin.immediate
@@ -428,7 +426,7 @@ let build_initial_env add_type add_extension empty_env =
           It might also cross portability, linearity, uniqueness subject to its
           parameter. But I'm also fine not doing that for now (and wait until
           users complains).  *)
-       ~jkind:(fun _ -> Jkind.Builtin.value ~why:(Primitive ident_lazy_t))
+       ~jkind:(fun _ -> Jkind.Builtin.non_float_value ~why:(Primitive ident_lazy_t))
   |> add_type1 ident_list
        ~variance:Variance.covariant
        ~separability:Separability.Ind

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -408,7 +408,8 @@ let build_initial_env add_type add_extension empty_env =
        ~kind:(variant [ cstr ident_false []; cstr ident_true []])
        ~jkind:Jkind.Const.Builtin.immediate
   |> add_type ident_char ~jkind:Jkind.Const.Builtin.immediate
-  |> add_type ident_exn ~kind:Type_open ~jkind:Jkind.Const.Builtin.non_float_value
+  |> add_type_with_jkind ident_exn ~kind:Type_open
+    ~jkind:(Jkind.for_non_float ~why:(Primitive ident_exn))
   |> add_type ident_extension_constructor ~jkind:Jkind.Const.Builtin.immutable_data
   |> add_type_with_jkind ident_float ~jkind:(Jkind.for_float ident_float)
       ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_float
@@ -426,7 +427,7 @@ let build_initial_env add_type add_extension empty_env =
           It might also cross portability, linearity, uniqueness subject to its
           parameter. But I'm also fine not doing that for now (and wait until
           users complains).  *)
-       ~jkind:(fun _ -> Jkind.Builtin.non_float_value ~why:(Primitive ident_lazy_t))
+       ~jkind:(fun _ -> Jkind.for_non_float ~why:(Primitive ident_lazy_t))
   |> add_type1 ident_list
        ~variance:Variance.covariant
        ~separability:Separability.Ind

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6920,7 +6920,8 @@ and type_expect_
       in
       let cell_type =
         (* CR uniqueness: this could be the jkind of exp2 *)
-        mk_expected (newvar (Jkind.Builtin.value ~why:Boxed_record))
+        (* CR layouts: should this be (im)mutable_data with ...? *)
+        mk_expected (newvar (Jkind.Builtin.non_float_value ~why:Boxed_record))
       in
       let exp1 = type_expect ~recarg env (mode_default cell_mode) exp1 cell_type in
       let new_fields_mode =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6920,7 +6920,7 @@ and type_expect_
       in
       let cell_type =
         (* CR uniqueness: this could be the jkind of exp2 *)
-        mk_expected (newvar (Jkind.Builtin.non_float_value ~why:Boxed_record))
+        mk_expected (newvar (Jkind.for_non_float ~why:Boxed_record))
       in
       let exp1 = type_expect ~recarg env (mode_default cell_mode) exp1 cell_type in
       let new_fields_mode =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6920,7 +6920,6 @@ and type_expect_
       in
       let cell_type =
         (* CR uniqueness: this could be the jkind of exp2 *)
-        (* CR layouts: should this be (im)mutable_data with ...? *)
         mk_expected (newvar (Jkind.Builtin.non_float_value ~why:Boxed_record))
       in
       let exp1 = type_expect ~recarg env (mode_default cell_mode) exp1 cell_type in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -955,7 +955,8 @@ let transl_declaration env sdecl (id, uid) =
                    Constructor_uniform_value, sorts)
                 (Array.of_list cstrs)
             ),
-            Jkind.Builtin.value ~why:Boxed_variant
+          (* CR layouts: should this be (im)mutable_data with ...? *)
+          Jkind.Builtin.non_float_value ~why:Boxed_variant
         in
           Ttype_variant tcstrs, Type_variant (cstrs, rep, None), jkind
       | Ptype_record lbls ->
@@ -973,7 +974,8 @@ let transl_declaration env sdecl (id, uid) =
                [Record_mixed].  Those cases are fixed up after we can get
                accurate sorts for the fields, in [update_decl_jkind]. *)
               Record_boxed (Array.make (List.length lbls) Jkind.Sort.Const.void),
-              Jkind.Builtin.value ~why:Boxed_record
+              (* CR layouts: should this be (im)mutable_data with ...? *)
+              Jkind.Builtin.non_float_value ~why:Boxed_record
           in
           Ttype_record lbls, Type_record(lbls', rep, None), jkind
       | Ptype_record_unboxed_product lbls ->
@@ -994,7 +996,7 @@ let transl_declaration env sdecl (id, uid) =
           Type_record_unboxed_product(lbls', Record_unboxed_product, None), jkind
       | Ptype_open ->
         Ttype_open, Type_open,
-        Jkind.Builtin.value ~why:Extensible_variant
+        Jkind.Builtin.non_float_value ~why:Extensible_variant
       in
     let jkind =
     (* - If there's an annotation, we use that. It's checked against
@@ -1978,7 +1980,9 @@ let rec update_decl_jkind env dpath decl =
       decl
     | Type_open ->
       let type_jkind =
-        Jkind.Builtin.value ~why:Extensible_variant
+        Jkind.Builtin.non_float_value ~why:Extensible_variant
+        (* CR layouts: below is no longer true, and will be even less true
+           when exceptions start crossing portable/contended. Rethink? *)
         (* It's unlikely we'll ever be able to give better kinds than [value] to
            extensible variants, so we're not worried about backwards compatibility if we
            mark them as best here, and we want to be able to normalize them away *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -955,7 +955,6 @@ let transl_declaration env sdecl (id, uid) =
                    Constructor_uniform_value, sorts)
                 (Array.of_list cstrs)
             ),
-          (* CR layouts: should this be (im)mutable_data with ...? *)
           Jkind.Builtin.non_float_value ~why:Boxed_variant
         in
           Ttype_variant tcstrs, Type_variant (cstrs, rep, None), jkind
@@ -974,7 +973,6 @@ let transl_declaration env sdecl (id, uid) =
                [Record_mixed].  Those cases are fixed up after we can get
                accurate sorts for the fields, in [update_decl_jkind]. *)
               Record_boxed (Array.make (List.length lbls) Jkind.Sort.Const.void),
-              (* CR layouts: should this be (im)mutable_data with ...? *)
               Jkind.Builtin.non_float_value ~why:Boxed_record
           in
           Ttype_record lbls, Type_record(lbls', rep, None), jkind
@@ -1981,8 +1979,6 @@ let rec update_decl_jkind env dpath decl =
     | Type_open ->
       let type_jkind =
         Jkind.Builtin.non_float_value ~why:Extensible_variant
-        (* CR layouts: below is no longer true, and will be even less true
-           when exceptions start crossing portable/contended. Rethink? *)
         (* It's unlikely we'll ever be able to give better kinds than [value] to
            extensible variants, so we're not worried about backwards compatibility if we
            mark them as best here, and we want to be able to normalize them away *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -955,7 +955,7 @@ let transl_declaration env sdecl (id, uid) =
                    Constructor_uniform_value, sorts)
                 (Array.of_list cstrs)
             ),
-          Jkind.Builtin.non_float_value ~why:Boxed_variant
+          Jkind.for_non_float ~why:Boxed_variant
         in
           Ttype_variant tcstrs, Type_variant (cstrs, rep, None), jkind
       | Ptype_record lbls ->
@@ -973,7 +973,7 @@ let transl_declaration env sdecl (id, uid) =
                [Record_mixed].  Those cases are fixed up after we can get
                accurate sorts for the fields, in [update_decl_jkind]. *)
               Record_boxed (Array.make (List.length lbls) Jkind.Sort.Const.void),
-              Jkind.Builtin.non_float_value ~why:Boxed_record
+              Jkind.for_non_float ~why:Boxed_record
           in
           Ttype_record lbls, Type_record(lbls', rep, None), jkind
       | Ptype_record_unboxed_product lbls ->
@@ -994,7 +994,7 @@ let transl_declaration env sdecl (id, uid) =
           Type_record_unboxed_product(lbls', Record_unboxed_product, None), jkind
       | Ptype_open ->
         Ttype_open, Type_open,
-        Jkind.Builtin.non_float_value ~why:Extensible_variant
+        Jkind.for_non_float ~why:Extensible_variant
       in
     let jkind =
     (* - If there's an annotation, we use that. It's checked against
@@ -1978,7 +1978,7 @@ let rec update_decl_jkind env dpath decl =
       decl
     | Type_open ->
       let type_jkind =
-        Jkind.Builtin.non_float_value ~why:Extensible_variant
+        Jkind.for_non_float ~why:Extensible_variant
         (* It's unlikely we'll ever be able to give better kinds than [value] to
            extensible variants, so we're not worried about backwards compatibility if we
            mark them as best here, and we want to be able to normalize them away *)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -39,6 +39,7 @@ module Jkind_mod_bounds = struct
   module Visibility = Mode.Visibility.Const_op
   module Externality = Jkind_axis.Externality
   module Nullability = Jkind_axis.Nullability
+  module Separability = Jkind_axis.Separability
 
   type t = {
     locality: Locality.t;
@@ -51,6 +52,7 @@ module Jkind_mod_bounds = struct
     visibility: Visibility.t;
     externality: Externality.t;
     nullability: Nullability.t;
+    separability: Separability.t;
   }
 
   let[@inline] locality t = t.locality
@@ -63,6 +65,7 @@ module Jkind_mod_bounds = struct
   let[@inline] visibility t = t.visibility
   let[@inline] externality t = t.externality
   let[@inline] nullability t = t.nullability
+  let[@inline] separability t = t.separability
 
   let[@inline] create
       ~locality
@@ -74,7 +77,8 @@ module Jkind_mod_bounds = struct
       ~statefulness
       ~visibility
       ~externality
-      ~nullability =
+      ~nullability
+      ~separability =
     {
       locality;
       linearity;
@@ -86,6 +90,7 @@ module Jkind_mod_bounds = struct
       visibility;
       externality;
       nullability;
+      separability;
     }
 
   let[@inline] set_locality locality t = { t with locality }
@@ -98,6 +103,7 @@ module Jkind_mod_bounds = struct
   let[@inline] set_visibility visibility t = { t with visibility }
   let[@inline] set_externality externality t = { t with externality }
   let[@inline] set_nullability nullability t = { t with nullability }
+  let[@inline] set_separability separability t = { t with separability }
 
   let[@inline] set_max_in_set t max_axes =
     let open Jkind_axis.Axis_set in
@@ -153,6 +159,11 @@ module Jkind_mod_bounds = struct
       then Nullability.max
       else t.nullability
     in
+    let separability =
+      if mem max_axes (Nonmodal Separability)
+      then Separability.max
+      else t.separability
+    in
     {
       locality;
       linearity;
@@ -164,6 +175,7 @@ module Jkind_mod_bounds = struct
       visibility;
       externality;
       nullability;
+      separability;
     }
 
   let[@inline] set_min_in_set t min_axes =
@@ -220,6 +232,11 @@ module Jkind_mod_bounds = struct
       then Nullability.min
       else t.nullability
     in
+    let separability =
+      if mem min_axes (Nonmodal Separability)
+      then Separability.min
+      else t.separability
+    in
     {
       locality;
       linearity;
@@ -231,6 +248,7 @@ module Jkind_mod_bounds = struct
       yielding;
       externality;
       nullability;
+      separability;
     }
 
   let[@inline] is_max_within_set t axes =
@@ -254,7 +272,9 @@ module Jkind_mod_bounds = struct
     (not (mem axes (Nonmodal Externality)) ||
      Externality.(le max (externality t))) &&
     (not (mem axes (Nonmodal Nullability)) ||
-     Nullability.(le max (nullability t)))
+     Nullability.(le max (nullability t))) &&
+    (not (mem axes (Nonmodal Separability)) ||
+     Separability.(le max (separability t)))
 
   let[@inline] is_max = function
     | { locality = Local;
@@ -266,7 +286,8 @@ module Jkind_mod_bounds = struct
         statefulness = Stateful;
         visibility = Read_write;
         externality = External;
-        nullability = Maybe_null } -> true
+        nullability = Maybe_null;
+        separability = Non_separable } -> true
     | _ -> false
 
   let debug_print ppf
@@ -279,10 +300,11 @@ module Jkind_mod_bounds = struct
           statefulness;
           visibility;
           externality;
-          nullability } =
+          nullability;
+          separability } =
     Format.fprintf ppf "@[{ locality = %a;@ linearity = %a;@ uniqueness = %a;@ \
       portability = %a;@ contention = %a;@ yielding = %a;@ statefulness = %a;@ \
-      visibility = %a;@ externality = %a;@ nullability = %a }@]"
+      visibility = %a;@ externality = %a;@ nullability = %a;@ separability = %a }@]"
       Locality.print locality
       Linearity.print linearity
       Uniqueness.print uniqueness
@@ -293,6 +315,7 @@ module Jkind_mod_bounds = struct
       Visibility.print visibility
       Externality.print externality
       Nullability.print nullability
+      Separability.print separability
 end
 
 

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -304,7 +304,8 @@ module Jkind_mod_bounds = struct
           separability } =
     Format.fprintf ppf "@[{ locality = %a;@ linearity = %a;@ uniqueness = %a;@ \
       portability = %a;@ contention = %a;@ yielding = %a;@ statefulness = %a;@ \
-      visibility = %a;@ externality = %a;@ nullability = %a;@ separability = %a }@]"
+      visibility = %a;@ externality = %a;@ \
+      nullability = %a;@ separability = %a }@]"
       Locality.print locality
       Linearity.print linearity
       Uniqueness.print uniqueness

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -80,6 +80,7 @@ module Jkind_mod_bounds : sig
   module Visibility = Mode.Visibility.Const_op
   module Externality = Jkind_axis.Externality
   module Nullability = Jkind_axis.Nullability
+  module Separability = Jkind_axis.Separability
 
   type t
 
@@ -94,6 +95,7 @@ module Jkind_mod_bounds : sig
     visibility:Visibility.t ->
     externality:Externality.t ->
     nullability:Nullability.t ->
+    separability:Separability.t ->
     t
 
   val locality : t -> Locality.t
@@ -106,6 +108,7 @@ module Jkind_mod_bounds : sig
   val visibility : t -> Visibility.t
   val externality : t -> Externality.t
   val nullability : t -> Nullability.t
+  val separability : t -> Separability.t
 
   val set_locality : Locality.t -> t -> t
   val set_linearity : Linearity.t -> t -> t
@@ -117,6 +120,7 @@ module Jkind_mod_bounds : sig
   val set_visibility : Visibility.t -> t -> t
   val set_externality : Externality.t -> t -> t
   val set_nullability : Nullability.t -> t -> t
+  val set_separability : Separability.t -> t -> t
 
   (** [set_max_in_set bounds axes] sets all the axes in [axes] to their [max] within
       [bounds] *)


### PR DESCRIPTION
Add the separability jkind axis. Separability is a shallow, non-modal axis going `non_float < separable < non_separable`, with `non_float` denoting types whose values are not pointers to `Double_tag` blocks, `separable` denoting types with either all values being pointers to `Double_tag` blocks or none, and `non_separable` denoting all types.

Add jkinds `non_float_value`, for non-float values, and `immutable_separable_value`, for floats. I'm not sold on the second jkind and will likely drop it from the final version of this PR.

Change other jkinds to `non_float` or `separable` where appropriate. In particular, default `immutable_data` to `non_float`. This will exclude floats from `immutable_data`, but will mark records, variants and other `immutable_data` types as `non_float`. Since `immutable_data` almost always appears in a covariant positions, this seems like the best choice.

Separability is a shallow axis, so it should not affect with-bounds. Semantics of separability for product layouts are to be determined, but it seems like all products should be non-float?

`('a : non_float_value) or_null` will be made `non_float` in a future PR.

`t : non_separable_value` will provide an escape hatch from existing OCaml separability checks (e.g. for existential) in a future PR. Those checks will also themselves take into account separability annotations.

`any_non_null` will be changed to `any_separable`, with arrays accepting `any_separable` elements, in a future PR. 