### PR TITLE
Emit fixed-size directives instead of instruction set specific ones

### DIFF
--- a/backend/x86_ast.mli
+++ b/backend/x86_ast.mli
@@ -417,20 +417,24 @@ type asm_line =
   | Align of bool * int
   | Byte of constant
   | Bytes of string
+  (** directive for an 8-bit constant *)
   | Comment of string
   | Global of string
   | Protected of string
   | Hidden of string
   | Weak of string
   | Long of constant
+  (** directive for a 32-bit constant *)
   | NewLabel of string * data_type
   | NewLine
   | Quad of constant
+  (** directive for a 64-bit constant *)
   | Section of string list * string option * string list * bool
   | Sleb128 of constant
   | Space of int
   | Uleb128 of constant
   | Word of constant
+  (** directive for a 16-bit constant *)
 
   (* masm only (the gas emitter will fail on them) *)
   | External of string * data_type

--- a/backend/x86_dsl.mli
+++ b/backend/x86_dsl.mli
@@ -96,6 +96,7 @@ module D : sig
      used *)
   val align : data:bool -> int -> unit
 
+  (** directive for an 8-bit constant *)
   val byte : constant -> unit
 
   val bytes : string -> unit
@@ -137,6 +138,7 @@ module D : sig
   val loc :
     file_num:int -> line:int -> col:int -> ?discriminator:int -> unit -> unit
 
+  (** directive for a 32-bit constant *)
   val long : constant -> unit
 
   val mode386 : unit -> unit
@@ -147,6 +149,7 @@ module D : sig
 
   val private_extern : string -> unit
 
+  (** directive for a 64-bit constant *)
   val qword : constant -> unit
 
   val reloc : offset:constant -> name:reloc_type -> expr:constant -> unit
@@ -170,6 +173,7 @@ module D : sig
 
   val weak : string -> unit
 
+  (** directive for a 16-bit constant *)
   val word : constant -> unit
 end
 

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -456,10 +456,10 @@ let print_line b = function
   | Protected s -> bprintf b "\t.protected\t%s" s
   | Hidden s -> bprintf b "\t.hidden\t%s" s
   | Weak s -> bprintf b "\t.weak\t%s" s
-  | Long n -> bprintf b "\t.long\t%a" cst n
+  | Long n -> bprintf b "\t.4byte\t%a" cst n
   | NewLabel (s, _) -> bprintf b "%s:" s
   | NewLine -> ()
-  | Quad n -> bprintf b "\t.quad\t%a" cst n
+  | Quad n -> bprintf b "\t.8byte\t%a" cst n
   | Section ([".data"], _, _, _) -> bprintf b "\t.data"
   | Section ([".text"], _, _, _) -> bprintf b "\t.text"
   | Section (name, flags, args, _delayed) -> (
@@ -473,7 +473,7 @@ let print_line b = function
   | Word n -> (
     match system with
     | S_solaris -> bprintf b "\t.value\t%a" cst n
-    | _ -> bprintf b "\t.word\t%a" cst n)
+    | _ -> bprintf b "\t.2byte\t%a" cst n)
   | Uleb128 n -> bprintf b "\t.uleb128\t%a" cst n
   | Sleb128 n -> bprintf b "\t.sleb128\t%a" cst n
   (* gas only *)


### PR DESCRIPTION
This PR replaces the existing directives for emitting integers (`.word`, `.long`, `.short`, and `.quad`) with fixed size versions that do not differ between Arm and x86. This is in preparation of sharing the code between x86 and Arm to generate these. 

Currently, on **x86** the directives have the following semantics:
- `.word` = 2 bytes
- `.long` = `.int` = 4 bytes
- `.short` = 2 bytes  (I believe this is the case on all architectures.) 
- `.quad` = 8 bytes  (I believe this is the case on all architectures.)

Currently, on **Arm 32-bit** and **Arm 64-bit**  the directives have the following semantics:
- `.word` = **4 bytes**
- `.long` = `.int` = 4 bytes
- `.short` = 2 bytes  (I believe this is the case on all architectures.) 
- `.quad` = 8 bytes  (I believe this is the case on all architectures.)


