### PR TITLE
Enable warnings in amd64/emit

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -19,7 +19,7 @@
    [Flambda_backend_flags] and shared variables. For details, see
    [asmgen.mli]. *)
 
-[@@@ocaml.warning "+a-45-9-4-40-41-42"]
+[@@@ocaml.warning "+a-45-4-40-41-42"]
 
 open! Int_replace_polymorphic_compare
 open Arch
@@ -357,17 +357,17 @@ let record_frame_label live dbg =
   let live_offset = ref [] in
   Reg.Set.iter
     (function
-      | { typ = Val; loc = Reg r } as reg ->
+      | { typ = Val; loc = Reg r; _ } as reg ->
         assert (Proc.gc_regs_offset reg = r);
         live_offset := ((r lsl 1) + 1) :: !live_offset
-      | { typ = Val; loc = Stack s } as reg ->
+      | { typ = Val; loc = Stack s; _ } as reg ->
         live_offset
           := slot_offset s (Stack_class.of_machtype reg.typ) :: !live_offset
-      | { typ = Valx2; loc = Reg _ } as reg ->
+      | { typ = Valx2; loc = Reg _; _ } as reg ->
         let n = Proc.gc_regs_offset reg in
         let encode n = (n lsl 1) + 1 in
         live_offset := encode n :: encode (n + 1) :: !live_offset
-      | { typ = Valx2; loc = Stack s } as reg ->
+      | { typ = Valx2; loc = Stack s; _ } as reg ->
         let n = slot_offset s (Stack_class.of_machtype reg.typ) in
         live_offset := n :: (n + Arch.size_addr) :: !live_offset
       | { typ = Addr; _ } as r -> Misc.fatal_error ("bad GC root " ^ Reg.name r)
@@ -1657,7 +1657,7 @@ let emit_instr ~first ~fallthrough i =
       output_epilogue (fun () ->
           add_used_symbol func.sym_name;
           emit_jump func)
-  | Lcall_op (Lextcall { func; alloc; stack_ofs }) ->
+  | Lcall_op (Lextcall { func; alloc; stack_ofs; _ }) ->
     add_used_symbol func;
     if Config.runtime5 && stack_ofs > 0
     then (

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -34,7 +34,6 @@ open X86_ast_utils
 open X86_proc
 open X86_dsl
 module String = Misc.Stdlib.String
-module Int = Numbers.Int
 
 (* [Branch_relaxation] is not used in this file, but is required by emit.ml
    files for certain other targets; the reference here ensures that when
@@ -2215,7 +2214,7 @@ let fundecl fundecl =
   then
     let n = frame_size () - 8 - if fp then 8 else 0 in
     if n <> 0 then cfi_adjust_cfa_offset (-n));
-  Option.iter def_label fun_end_label;
+  (match fun_end_label with Some l -> def_label l | None -> ());
   cfi_endproc ();
   emit_function_type_and_size fundecl.fun_name
 

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1189,13 +1189,13 @@ let emit_atomic instr op (size : Cmm.atomic_bitwidth) addr =
     | Exchange -> 1
     | Compare_exchange -> 2
   in
-  let dst = addressing addr DWORD instr first_memory_arg_index in
   let src_index = first_memory_arg_index - 1 in
   let typ, src =
     match size with
     | Thirtytwo -> DWORD, arg32 instr src_index
     | Sixtyfour | Word -> QWORD, arg instr src_index
   in
+  let dst = addressing addr typ instr first_memory_arg_index in
   Address_sanitizer.emit_sanitize ~dependencies:[| src |] ~address:dst
     Thirtytwo_unsigned Store_modify;
   match op with


### PR DESCRIPTION
- Removed some `open` because they caused shadowing of `Cmm.label` and `Reg.typ`. 
- `open Int` was not used.
- The rest was straightfoward warning 4 and 9.