### PR TITLE
Introduce a new flavor of type, `Tof_kind`, for representing existentials that end up in with-bounds

### DIFF
--- a/extract_externals/traverse_typed_tree.ml
+++ b/extract_externals/traverse_typed_tree.ml
@@ -121,7 +121,7 @@ let classify env ty : classification =
              Maybe we should emit a warning. *)
           Any)
     | Tarrow _ | Ttuple _ | Tpackage _ | Tobject _ | Tnil | Tvariant _ -> Addr
-    | Tlink _ | Tsubst _ | Tpoly _ | Tfield _ | Tunboxed_tuple _ -> assert false
+    | Tlink _ | Tsubst _ | Tpoly _ | Tfield _ | Tunboxed_tuple _ | Tof_kind _ -> assert false
 
 type can_be_float_array =
   | YesFloatArray
@@ -236,7 +236,7 @@ let rec value_kind env (subst : value_shape Subst.t) ~visited ~depth ty :
     else
       match lookup_subst (get_id ty) subst with None -> Value | Some sh -> sh)
   | Tpoly _ -> assert false (* handled by [scrape_ty] currently *)
-  | Tfield _ | Tnil | Tlink _ | Tsubst _ -> assert false
+  | Tfield _ | Tnil | Tlink _ | Tsubst _ | Tof_kind _ -> assert false
   (* NOTE: we should never encounter those in an external declaration *)
   | Tunboxed_tuple _ -> assert false (* not of layout value *)
   | Tpackage _ -> Block None

--- a/extract_externals/traverse_typed_tree.ml
+++ b/extract_externals/traverse_typed_tree.ml
@@ -121,7 +121,8 @@ let classify env ty : classification =
              Maybe we should emit a warning. *)
           Any)
     | Tarrow _ | Ttuple _ | Tpackage _ | Tobject _ | Tnil | Tvariant _ -> Addr
-    | Tlink _ | Tsubst _ | Tpoly _ | Tfield _ | Tunboxed_tuple _ | Tof_kind _ -> assert false
+    | Tlink _ | Tsubst _ | Tpoly _ | Tfield _ | Tunboxed_tuple _ | Tof_kind _ ->
+      assert false
 
 type can_be_float_array =
   | YesFloatArray

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -267,7 +267,8 @@ let iter_on_occurrences
           f ~namespace:Module ctyp_env path lid
       | Ttyp_var _ | Ttyp_arrow _ | Ttyp_tuple _ | Ttyp_object _
       | Ttyp_unboxed_tuple _
-      | Ttyp_alias _ | Ttyp_variant _ | Ttyp_poly _ | Ttyp_call_pos -> ());
+      | Ttyp_alias _ | Ttyp_variant _ | Ttyp_poly _ | Ttyp_of_kind _
+      | Ttyp_call_pos -> ());
       default_iterator.typ sub ct);
 
   pat =

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -506,7 +506,8 @@ let remove_option typ =
     | Tfield _
     | Tnil
     | Tvariant _
-    | Tpackage _ -> t
+    | Tpackage _
+    | Tof_kind _ -> t
     | Tlink t2 -> trim (get_desc t2)
     | Tsubst _ -> assert false
   in

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -43,7 +43,8 @@ let rec is_arrow_type t =
   | Types.Tunboxed_tuple _
   | Types.Tconstr _
   | Types.Tvar _ | Types.Tunivar _ | Types.Tobject _ | Types.Tpoly _
-  | Types.Tfield _ | Types.Tnil | Types.Tvariant _ | Types.Tpackage _ -> false
+  | Types.Tfield _ | Types.Tnil | Types.Tvariant _ | Types.Tpackage _
+  | Types.Tof_kind _ -> false
   | Types.Tsubst _ -> assert false
 
 
@@ -53,7 +54,8 @@ let rec need_parent t =
   | Types.Tlink t2 -> need_parent t2
   | Types.Tconstr _
   | Types.Tvar _ | Types.Tunivar _ | Types.Tobject _ | Types.Tpoly _
-  | Types.Tfield _ | Types.Tnil | Types.Tvariant _ | Types.Tpackage _ -> false
+  | Types.Tfield _ | Types.Tnil | Types.Tvariant _ | Types.Tpackage _
+  | Types.Tof_kind _ -> false
   | Types.Tsubst _ -> assert false
 
 let print_type_scheme ppf t =

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -76,7 +76,8 @@ let parameter_list_from_arrows typ =
     | Types.Tnil
     | Types.Tunivar _
     | Types.Tpackage _
-    | Types.Tvariant _ ->
+    | Types.Tvariant _
+    | Types.Tof_kind _ ->
         []
     | Types.Tsubst _ ->
         assert false

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -74,6 +74,7 @@ module Typ = struct
   let package ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_package (a, b))
   let extension ?loc ?attrs a = mk ?loc ?attrs (Ptyp_extension a)
   let open_ ?loc ?attrs mod_ident t = mk ?loc ?attrs (Ptyp_open (mod_ident, t))
+  let of_kind ?loc ?attrs a = mk ?loc ?attrs (Ptyp_of_kind a)
 
   let force_poly t =
     match t.ptyp_desc with
@@ -132,6 +133,8 @@ module Typ = struct
             Ptyp_package(longident,List.map (fun (n,typ) -> (n,loop typ) ) lst)
         | Ptyp_open (mod_ident, core_type) ->
             Ptyp_open (mod_ident, loop core_type)
+        | Ptyp_of_kind jkind ->
+            Ptyp_of_kind (loop_jkind jkind)
         | Ptyp_extension (s, arg) ->
             Ptyp_extension (s, arg)
       in

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -90,6 +90,7 @@ module Typ :
     val package: ?loc:loc -> ?attrs:attrs -> lid -> (lid * core_type) list
                  -> core_type
     val open_ : ?loc:loc -> ?attrs:attrs -> lid -> core_type -> core_type
+    val of_kind : ?loc:loc -> ?attrs:attrs -> jkind_annotation -> core_type
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> core_type
 
     val force_poly: core_type -> core_type

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -155,6 +155,8 @@ module T = struct
     | Ptyp_open (mod_ident, t) ->
         iter_loc sub mod_ident;
         sub.typ sub t
+    | Ptyp_of_kind jkind ->
+        sub.jkind_annotation sub jkind
     | Ptyp_extension x -> sub.extension sub x
 
   let iter_type_declaration sub

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -192,6 +192,8 @@ module T = struct
           (List.map (map_tuple (map_loc sub) (sub.typ sub)) l)
     | Ptyp_open (mod_ident, t) ->
         open_ ~loc ~attrs (map_loc sub mod_ident) (sub.typ sub t)
+    | Ptyp_of_kind jkind ->
+        of_kind ~loc ~attrs (sub.jkind_annotation sub jkind)
     | Ptyp_extension x -> extension ~loc ~attrs (sub.extension sub x)
 
   let map_type_declaration sub

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -123,6 +123,7 @@ let rec add_type bv ty =
   | Ptyp_open (mod_ident, t) ->
     let bv = open_module bv mod_ident.txt in
     add_type bv t
+  | Ptyp_of_kind jkind -> add_jkind bv jkind
   | Ptyp_extension e -> handle_extension e
 
 and add_type_labeled_tuple bv tl =

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4724,6 +4724,8 @@ atomic_type:
       { mktyp ~loc:$sloc (Ptyp_var (name, Some jkind)) }
   | LPAREN UNDERSCORE COLON jkind=jkind_annotation RPAREN
       { mktyp ~loc:$sloc (Ptyp_any (Some jkind)) }
+  | LPAREN TYPE COLON jkind=jkind_annotation RPAREN
+      { mktyp ~loc:$loc (Ptyp_of_kind jkind) }
 
 
 (* This is the syntax of the actual type parameters in an application of

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -202,6 +202,7 @@ and core_type_desc =
          *)
   | Ptyp_package of package_type  (** [(module S)]. *)
   | Ptyp_open of Longident.t loc * core_type (** [M.(T)] *)
+  | Ptyp_of_kind of jkind_annotation (** [(type : k)] *)
   | Ptyp_extension of extension  (** [[%id]]. *)
 
 and arg_label = Asttypes.arg_label =

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -525,7 +525,7 @@ and core_type ctxt f x =
                           l)
           sl (core_type ctxt) ct
     | Ptyp_of_kind jkind ->
-      pp f "(type : %a)" (jkind_annotation reset_ctxt) jkind
+      pp f "@[(type@ :@ %a)@]" (jkind_annotation reset_ctxt) jkind
     | _ -> pp f "@[<2>%a@]" (core_type1 ctxt) x
 
 and core_type1 ctxt f x =

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -524,6 +524,8 @@ and core_type ctxt f x =
                           (tyvar_loc_jkind tyvar) ~sep:"@;")
                           l)
           sl (core_type ctxt) ct
+    | Ptyp_of_kind jkind ->
+      pp f "(type : %a)" (jkind_annotation reset_ctxt) jkind
     | _ -> pp f "@[<2>%a@]" (core_type1 ctxt) x
 
 and core_type1 ctxt f x =
@@ -608,7 +610,7 @@ and core_type1 ctxt f x =
     | Ptyp_open(li, ct) ->
        pp f "@[<hov2>%a.(%a)@]" longident_loc li (core_type ctxt) ct
     | Ptyp_extension e -> extension ctxt f e
-    | (Ptyp_arrow _ | Ptyp_alias _ | Ptyp_poly _) ->
+    | (Ptyp_arrow _ | Ptyp_alias _ | Ptyp_poly _ | Ptyp_of_kind _) ->
        paren true (core_type ctxt) f x
 
 and core_type2 ctxt f x =

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -220,6 +220,8 @@ let rec core_type i ppf x =
   | Ptyp_open (mod_ident, t) ->
       line i ppf "Ptyp_open \"%a\"\n" fmt_longident_loc mod_ident;
       core_type i ppf t
+  | Ptyp_of_kind jkind ->
+    line i ppf "Ptyp_of_kind %a\n" (jkind_annotation (i + 1)) jkind
   | Ptyp_extension (s, arg) ->
       line i ppf "Ptyp_extension \"%s\"\n" s.txt;
       payload i ppf arg

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -240,6 +240,8 @@ let rec core_type i ppf x =
   | Ptyp_open (mod_ident, t) ->
       line i ppf "Ptyp_open \"%a\"\n" fmt_longident_loc mod_ident;
       core_type i ppf t
+  | Ptyp_of_kind jkind ->
+      line i ppf "Ptyp_of_kind %a\n" (jkind_annotation (i+1)) jkind
   | Ptyp_extension (s, arg) ->
       line i ppf "Ptyp_extension \"%s\"\n" s.txt;
       payload i ppf arg

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1252,6 +1252,22 @@ type 'a contended : immutable_data with 'a @@ contended
 type 'a contended_with_int : immutable_data with 'a @@ contended
 |}]
 
+(* Parsing implemented, but kind-checking not yet implemented *)
+type 'a abstract
+type existential_abstract : immutable_data with (type : value mod portable) abstract =
+  | Mk : ('a : value mod portable) abstract -> existential_abstract
+[%%expect{|
+type 'a abstract
+Lines 2-3, characters 0-67:
+2 | type existential_abstract : immutable_data with (type : value mod portable) abstract =
+3 |   | Mk : ('a : value mod portable) abstract -> existential_abstract
+Error: The kind of type "existential_abstract" is value
+         because it's a boxed variant type.
+       But the kind of type "existential_abstract" must be a subkind of
+         immutable_data with (type : value mod portable) abstract
+         because of the annotation on the declaration of the type existential_abstract.
+|}]
+
 (* not yet supported *)
 module _ : sig
   type 'a gel : kind_of_ 'a mod global

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1268,6 +1268,13 @@ Error: The kind of type "existential_abstract" is value
          because of the annotation on the declaration of the type existential_abstract.
 |}]
 
+type test_printing = (type : value) * (type : value) * (x:(type : value) -> int) -> (type : value)
+[%%expect{|
+type test_printing =
+    (type : value) * (type : value) * (x:(type : value) -> int) -> (type :
+    value)
+|}]
+
 (* not yet supported *)
 module _ : sig
   type 'a gel : kind_of_ 'a mod global

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -589,6 +589,8 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
               tree_of_val (depth - 1) obj ty
           | Tpackage _ ->
               Oval_stuff "<module>"
+          | Tof_kind _jkind ->
+              Oval_stuff "of_kind_ <kind>"
         end
 
       and tree_of_record_fields depth env path type_params ty_list

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -583,14 +583,12 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 find (row_fields row)
           | Tobject (_, _) ->
               Oval_stuff "<obj>"
-          | Tsubst _ | Tfield(_, _, _, _) | Tnil | Tlink _ ->
+          | Tsubst _ | Tfield(_, _, _, _) | Tnil | Tlink _ | Tof_kind _  ->
               fatal_error "Printval.outval_of_value"
           | Tpoly (ty, _) ->
               tree_of_val (depth - 1) obj ty
           | Tpackage _ ->
               Oval_stuff "<module>"
-          | Tof_kind _jkind ->
-              Oval_stuff "of_kind_ <kind>"
         end
 
       and tree_of_record_fields depth env path type_params ty_list

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -260,7 +260,10 @@ let fold_row f init row =
       (row_fields row)
   in
   match get_desc (row_more row) with
-  | Tvar _ | Tunivar _ | Tsubst _ | Tconstr _ | Tnil | Tof_kind _ ->
+  | Tvar _ | Tunivar _ | Tsubst _ | Tconstr _ | Tnil
+    (* Tof_kind can appear in [row_more] in case the row's row variable was existentially
+       quantified in a GADT *)
+  | Tof_kind _ ->
     begin match
       Option.map (fun (_,l) -> List.fold_left f result l) (row_name row)
     with

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -260,7 +260,7 @@ let fold_row f init row =
       (row_fields row)
   in
   match get_desc (row_more row) with
-  | Tvar _ | Tunivar _ | Tsubst _ | Tconstr _ | Tnil ->
+  | Tvar _ | Tunivar _ | Tsubst _ | Tconstr _ | Tnil | Tof_kind _ ->
     begin match
       Option.map (fun (_,l) -> List.fold_left f result l) (row_name row)
     with
@@ -300,6 +300,7 @@ let fold_type_expr f init ty =
     List.fold_left f result tyl
   | Tpackage (_, fl)  ->
     List.fold_left (fun result (_n, ty) -> f result ty) init fl
+  | Tof_kind _ -> init
 
 let iter_type_expr f ty =
   fold_type_expr (fun () v -> f v) () ty
@@ -481,6 +482,7 @@ let rec copy_type_desc ?(keep_names=false) f = function
       let tyl = List.map f tyl in
       Tpoly (f ty, tyl)
   | Tpackage (p, fl)  -> Tpackage (p, List.map (fun (n, ty) -> (n, f ty)) fl)
+  | Tof_kind jk -> Tof_kind jk
 
 (* Utilities for copying *)
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5545,6 +5545,9 @@ let rec eqtype rename type_pairs subst env ~do_jkind_check t1 t2 =
         eqtype_subst type_pairs subst t1 k1 t2 k2 ~do_jkind_check
     | (Tconstr (p1, [], _), Tconstr (p2, [], _)) when Path.same p1 p2 ->
         ()
+    | (Tof_kind k1, Tof_kind k2) ->
+      if not (Jkind.equal k1 k2)
+      then raise_for Equality (Unequal_tof_kind_jkinds (k1, k2))
     | _ ->
         let t1' = expand_head_rigid env t1 in
         let t2' = expand_head_rigid env t2 in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1297,7 +1297,7 @@ let rec copy ?partial ?keep_names copy_scope ty =
                   Tsubst (ty, None) -> ty
                   (* TODO: is this case possible?
                      possibly an interaction with (copy more) below? *)
-                | Tconstr _ | Tnil ->
+                | Tconstr _ | Tnil | Tof_kind _ ->
                     copy more
                 | Tvar _ | Tunivar _ ->
                     if keep then more else newty mored
@@ -2103,7 +2103,7 @@ let rec extract_concrete_typedecl env ty =
       end
   | Tpoly(ty, _) -> extract_concrete_typedecl env ty
   | Tarrow _ | Ttuple _ | Tunboxed_tuple _ | Tobject _ | Tfield _ | Tnil
-  | Tvariant _ | Tpackage _ -> Has_no_typedecl
+  | Tvariant _ | Tpackage _ | Tof_kind _ -> Has_no_typedecl
   | Tvar _ | Tunivar _ -> May_have_typedecl
   | Tlink _ | Tsubst _ -> assert false
 
@@ -2217,7 +2217,7 @@ let contained_without_boxing env ty =
     List.map snd labeled_tys
   | Tpoly (ty, _) -> [ty]
   | Tvar _ | Tarrow _ | Ttuple _ | Tobject _ | Tfield _ | Tnil | Tlink _
-  | Tsubst _ | Tvariant _ | Tunivar _ | Tpackage _ -> []
+  | Tsubst _ | Tvariant _ | Tunivar _ | Tpackage _ | Tof_kind _ -> []
 
 (* We use ty_prev to track the last type for which we found a definition,
    allowing us to return a type for which a definition was found even if
@@ -2271,7 +2271,7 @@ let type_jkind_purely_if_principal' =
    don't. *)
 let rec estimate_type_jkind ~expand_component env ty =
   match get_desc ty with
-  | Tvar { jkind } -> Jkind.disallow_right jkind
+  | Tvar { jkind } | Tof_kind jkind -> Jkind.disallow_right jkind
   | Tarrow _ -> Jkind.for_arrow
   | Ttuple elts -> Jkind.for_boxed_tuple elts
   | Tunboxed_tuple ltys ->
@@ -6319,6 +6319,9 @@ let rec build_subtype env (visited : transient_expr list)
       else (t, Unchanged)
   | Tunivar _ | Tpackage _ ->
       (t, Unchanged)
+  | Tof_kind _ ->
+    (* CR aspsmith: Do we need to do something here? *)
+    (t, Unchanged)
 
 and build_subtype_tuple env visited loops posi level t labeled_tlist
       constructor =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2271,7 +2271,7 @@ let type_jkind_purely_if_principal' =
    don't. *)
 let rec estimate_type_jkind ~expand_component env ty =
   match get_desc ty with
-  | Tvar { jkind } | Tof_kind jkind -> Jkind.disallow_right jkind
+  | Tvar { jkind } -> Jkind.disallow_right jkind
   | Tarrow _ -> Jkind.for_arrow
   | Ttuple elts -> Jkind.for_boxed_tuple elts
   | Tunboxed_tuple ltys ->
@@ -2334,6 +2334,7 @@ let rec estimate_type_jkind ~expand_component env ty =
        down a test case that cares. *)
     Jkind.round_up ~jkind_of_type |>
     Jkind.disallow_right
+  | Tof_kind jkind -> Jkind.disallow_right jkind
   | Tpackage _ -> Jkind.Builtin.value ~why:First_class_module
 
 and close_open_jkind ~expand_component ~is_open env jkind =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1297,7 +1297,7 @@ let rec copy ?partial ?keep_names copy_scope ty =
                   Tsubst (ty, None) -> ty
                   (* TODO: is this case possible?
                      possibly an interaction with (copy more) below? *)
-                | Tconstr _ | Tnil | Tof_kind _ ->
+                | Tconstr _ | Tnil ->
                     copy more
                 | Tvar _ | Tunivar _ ->
                     if keep then more else newty mored
@@ -6320,11 +6320,7 @@ let rec build_subtype env (visited : transient_expr list)
       let (t1', c) = build_subtype env visited loops posi level t1 in
       if c > Unchanged then (newty (Tpoly(t1', tl)), c)
       else (t, Unchanged)
-  | Tunivar _ | Tpackage _ ->
-      (t, Unchanged)
-  | Tof_kind _ ->
-    (* CR aspsmith: Do we need to do something here? *)
-    (t, Unchanged)
+  | Tunivar _ | Tpackage _ | Tof_kind _ -> (t, Unchanged)
 
 and build_subtype_tuple env visited loops posi level t labeled_tlist
       constructor =

--- a/typing/errortrace.ml
+++ b/typing/errortrace.ml
@@ -112,6 +112,7 @@ type ('a, 'variety) elt =
   | Bad_jkind_sort : type_expr * Jkind.Violation.t -> ('a, _) elt
   | Unequal_var_jkinds :
       type_expr * jkind_lr * type_expr * jkind_lr -> ('a, _) elt
+  | Unequal_tof_kind_jkinds : jkind_lr * jkind_lr -> ('a, _) elt
 
 type ('a, 'variety) t = ('a, 'variety) elt list
 
@@ -128,6 +129,7 @@ let map_elt (type variety) f : ('a, variety) elt -> ('b, variety) elt = function
   | Bad_jkind _ as x -> x
   | Bad_jkind_sort _ as x -> x
   | Unequal_var_jkinds _ as x -> x
+  | Unequal_tof_kind_jkinds _ as x -> x
 
 let map f t = List.map (map_elt f) t
 

--- a/typing/errortrace.mli
+++ b/typing/errortrace.mli
@@ -97,6 +97,7 @@ type ('a, 'variety) elt =
   | Bad_jkind_sort : type_expr * Jkind.Violation.t -> ('a, _) elt
   | Unequal_var_jkinds :
       type_expr * jkind_lr * type_expr * jkind_lr -> ('a, _) elt
+  | Unequal_tof_kind_jkinds : jkind_lr * jkind_lr -> ('a, _) elt
 
 type ('a, 'variety) t = ('a, 'variety) elt list
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -958,7 +958,7 @@ module Layout_and_axes = struct
                   { t with constr = Path.Map.add p (fuel - 1, args) constr }
               else Stop { t with fuel_status = Ran_out_of_fuel })
           | Tvar _ | Tarrow _ | Tunboxed_tuple _ | Tobject _ | Tfield _ | Tnil
-          | Tvariant _ | Tunivar _ | Tpackage _ ->
+          | Tvariant _ | Tunivar _ | Tpackage _ | Tof_kind _ ->
             (* these cases either cannot be infinitely recursive or their jkinds
                do not have with_bounds *)
             (* CR layouts v2.8: Some of these might get with-bounds someday. We

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2673,6 +2673,8 @@ module Format_history = struct
     | Type_variable name -> fprintf ppf "the type variable %s" name
     | Type_wildcard loc ->
       fprintf ppf "the wildcard _ at %a" Location.print_loc_in_lowercase loc
+    | Type_of_kind loc ->
+      fprintf ppf "the type at %a" Location.print_loc_in_lowercase loc
     | With_error_message (_message, context) ->
       (* message gets printed in [format_flattened_history] so we ignore it here *)
       format_annotation_context ppf context
@@ -3464,6 +3466,7 @@ module Debug_printers = struct
     | Type_variable name -> fprintf ppf "Type_variable %S" name
     | Type_wildcard loc ->
       fprintf ppf "Type_wildcard (%a)" Location.print_loc loc
+    | Type_of_kind loc -> fprintf ppf "Type_of_kind (%a)" Location.print_loc loc
     | With_error_message (message, context) ->
       fprintf ppf "With_error_message (%s, %a)" message annotation_context
         context

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1780,30 +1780,8 @@ module Const = struct
     | Mod (base, modifiers) ->
       let base = of_user_written_annotation_unchecked_level context base in
       (* for each mode, lower the corresponding modal bound to be that mode *)
-      let parsed_modifiers = Typemode.transl_modifier_annots modifiers in
       let mod_bounds =
-        let value_for_axis (type a) ~(axis : a Axis.t) : a =
-          let (module A) = Axis.get axis in
-          let parsed_modifier =
-            Typemode.Transled_modifiers.get ~axis parsed_modifiers
-          in
-          let base_bound = Mod_bounds.get ~axis base.mod_bounds in
-          match parsed_modifier, base_bound with
-          | None, base_modifier -> base_modifier
-          | Some parsed_modifier, base_modifier ->
-            A.meet base_modifier parsed_modifier.txt
-        in
-        Mod_bounds.create
-          ~locality:(value_for_axis ~axis:(Modal (Comonadic Areality)))
-          ~linearity:(value_for_axis ~axis:(Modal (Comonadic Linearity)))
-          ~uniqueness:(value_for_axis ~axis:(Modal (Monadic Uniqueness)))
-          ~portability:(value_for_axis ~axis:(Modal (Comonadic Portability)))
-          ~contention:(value_for_axis ~axis:(Modal (Monadic Contention)))
-          ~yielding:(value_for_axis ~axis:(Modal (Comonadic Yielding)))
-          ~statefulness:(value_for_axis ~axis:(Modal (Comonadic Statefulness)))
-          ~visibility:(value_for_axis ~axis:(Modal (Monadic Visibility)))
-          ~externality:(value_for_axis ~axis:(Nonmodal Externality))
-          ~nullability:(value_for_axis ~axis:(Nonmodal Nullability))
+        Mod_bounds.meet base.mod_bounds (Typemode.transl_mod_bounds modifiers)
       in
       { layout = base.layout; mod_bounds; with_bounds = No_with_bounds }
     | Product ts ->

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -235,6 +235,7 @@ module History = struct
     | Univar : string -> (allowed * allowed) annotation_context
     | Type_variable : string -> (allowed * allowed) annotation_context
     | Type_wildcard : Location.t -> (allowed * allowed) annotation_context
+    | Type_of_kind : Location.t -> (allowed * allowed) annotation_context
     | With_error_message :
         string * 'd annotation_context
         -> 'd annotation_context

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -559,10 +559,12 @@ and print_out_type_3 ppf =
   | Otyp_attribute (t, attr) ->
       fprintf ppf "@[<1>(%a [@@%s])@]"
         print_out_type_0 t attr.oattr_name
-  | Otyp_jkind_annot (t, lay) ->
+  | Otyp_jkind_annot (t, jk) ->
     fprintf ppf "@[<1>(%a@ :@ %a)@]"
       print_out_type_0 t
-      print_out_jkind lay
+      print_out_jkind jk
+  | Otyp_canonical jk ->
+    fprintf ppf "(type@ :@ %a)" print_out_jkind jk
 and print_out_type ppf typ =
   print_out_type_0 ppf typ
 and print_simple_out_type ppf typ =

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -563,7 +563,7 @@ and print_out_type_3 ppf =
     fprintf ppf "@[<1>(%a@ :@ %a)@]"
       print_out_type_0 t
       print_out_jkind jk
-  | Otyp_canonical jk ->
+  | Otyp_of_kind jk ->
     fprintf ppf "(type@ :@ %a)" print_out_jkind jk
 and print_out_type ppf typ =
   print_out_type_0 ppf typ

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -154,7 +154,7 @@ and out_type =
   | Otyp_jkind_annot of out_type * out_jkind
       (* Currently only introduced with very explicit code in [Printtyp] and not
          synthesized directly from the [Typedtree] *)
-  | Otyp_canonical of out_jkind
+  | Otyp_of_kind of out_jkind
 
 and out_constructor = {
   ocstr_name: string;

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -154,6 +154,7 @@ and out_type =
   | Otyp_jkind_annot of out_type * out_jkind
       (* Currently only introduced with very explicit code in [Printtyp] and not
          synthesized directly from the [Typedtree] *)
+  | Otyp_canonical of out_jkind
 
 and out_constructor = {
   ocstr_name: string;

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1601,7 +1601,7 @@ let rec tree_of_typexp mode alloc_mode ty =
             )) fl in
         Otyp_module (tree_of_path (Some Module_type) p, fl)
     | Tof_kind jkind ->
-      Otyp_canonical (out_jkind_of_desc (Jkind.get jkind))
+      Otyp_of_kind (out_jkind_of_desc (Jkind.get jkind))
   in
   if List.memq px !delayed then delayed := List.filter ((!=) px) !delayed;
   alias_nongen_row mode px ty;

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -721,6 +721,8 @@ and raw_type_desc ppf = function
   | Tpackage (p, fl) ->
       fprintf ppf "@[<hov1>Tpackage(@,%a,@,%a)@]" path p
         raw_lid_type_list fl
+  | Tof_kind jkind ->
+    fprintf ppf "(type@ :@ %a)" Jkind.format jkind
 and raw_row_fixed ppf = function
 | None -> fprintf ppf "None"
 | Some Types.Fixed_private -> fprintf ppf "Some Fixed_private"
@@ -1598,6 +1600,8 @@ let rec tree_of_typexp mode alloc_mode ty =
               tree_of_typexp mode Alloc.Const.legacy ty
             )) fl in
         Otyp_module (tree_of_path (Some Module_type) p, fl)
+    | Tof_kind jkind ->
+      Otyp_canonical (out_jkind_of_desc (Jkind.get jkind))
   in
   if List.memq px !delayed then delayed := List.filter ((!=) px) !delayed;
   alias_nongen_row mode px ty;

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -308,6 +308,8 @@ let rec core_type i ppf x =
   | Ttyp_open (path, _mod_ident, t) ->
       line i ppf "Ttyp_open %a\n" fmt_path path;
       core_type i ppf t
+  | Ttyp_of_kind jkind ->
+      line i ppf "Ttyp_of_kind %a\n" (jkind_annotation i) jkind;
   | Ttyp_call_pos -> line i ppf "Ttyp_call_pos\n";
 
 and labeled_core_type i ppf (l, t) =

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -479,6 +479,9 @@ let rec typexp copy_scope s ty =
                     if should_duplicate_vars then newpersty mored
                     else if dup && is_Tvar more then newgenty mored
                     else more
+                | Tof_kind _ ->
+                  (* CR aspsmith: ?? *)
+                  typexp copy_scope s more
                 | _ -> assert false
               in
               (* Register new type first for recursion *)

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -479,9 +479,6 @@ let rec typexp copy_scope s ty =
                     if should_duplicate_vars then newpersty mored
                     else if dup && is_Tvar more then newgenty mored
                     else more
-                | Tof_kind _ ->
-                  (* CR aspsmith: ?? *)
-                  typexp copy_scope s more
                 | _ -> assert false
               in
               (* Register new type first for recursion *)

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -676,6 +676,7 @@ let typ sub {ctyp_loc; ctyp_desc; ctyp_env; ctyp_attributes; _} =
   | Ttyp_open (_, mod_ident, t) ->
       iter_loc sub mod_ident;
       sub.typ sub t
+  | Ttyp_of_kind jkind -> sub.jkind_annotation sub jkind
   | Ttyp_call_pos -> ()
 
 let class_structure sub {cstr_self; cstr_fields; _} =

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -936,6 +936,8 @@ let typ sub x =
         Ttyp_package (sub.package_type sub pack)
     | Ttyp_open (path, mod_ident, t) ->
         Ttyp_open (path, map_loc sub mod_ident, sub.typ sub t)
+    | Ttyp_of_kind jkind ->
+      Ttyp_of_kind (sub.jkind_annotation sub jkind)
   in
   let ctyp_attributes = sub.attributes sub x.ctyp_attributes in
   {x with ctyp_loc; ctyp_desc; ctyp_env; ctyp_attributes}

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4276,8 +4276,8 @@ let report_error ppf = function
       let get_jkind_error : _ Errortrace.elt -> _ = function
       | Bad_jkind (ty, violation) | Bad_jkind_sort (ty, violation) ->
         Some (ty, violation)
-      | Unequal_var_jkinds _ | Diff _ | Variant _ | Obj _
-      | Escape _ | Incompatible_fields _ | Rec_occur _ -> None
+      | Unequal_var_jkinds _ | Unequal_tof_kind_jkinds _ | Diff _ | Variant _
+      | Obj _ | Escape _ | Incompatible_fields _ | Rec_occur _ -> None
       in
       begin match List.find_map get_jkind_error err.trace with
       | Some (ty, violation) ->

--- a/typing/typedecl_separability.ml
+++ b/typing/typedecl_separability.ml
@@ -149,6 +149,7 @@ let rec immediate_subtypes : type_expr -> type_expr list = fun ty ->
       immediate_subtypes_object_row [] ty
   | Tlink _ | Tsubst _ -> assert false (* impossible due to Ctype.repr *)
   | Tvar _ | Tunivar _ -> []
+  | Tof_kind _ -> []
   | Tpoly (pty, _) -> [pty]
   | Tconstr (_path, tys, _) -> tys
 
@@ -407,7 +408,9 @@ let check_type
     | (Tvariant(_)        , Sep    )
     | (Tobject(_,_)       , Sep    )
     | ((Tnil | Tfield _)  , Sep    )
-    | (Tpackage(_,_)      , Sep    ) -> empty
+    | (Tpackage(_,_)      , Sep    )
+    (* CR aspsmith: ?? *)
+    | (Tof_kind(_)      , Sep    ) -> empty
     (* "Deeply separable" case for these same constructors. *)
     | (Tarrow _           , Deepsep)
     | (Ttuple _           , Deepsep)
@@ -443,6 +446,7 @@ let check_type
     | (Tpoly(pty,_)       , m      ) ->
         check_type hyps pty m
     | (Tunivar(_)         , _      ) -> empty
+    | (Tof_kind(_)         , _      ) -> empty
     (* Type constructor case. *)
     | (Tconstr(path,tys,_), m      ) ->
         let msig = (Env.find_type path env).type_separability in

--- a/typing/typedecl_separability.ml
+++ b/typing/typedecl_separability.ml
@@ -409,8 +409,7 @@ let check_type
     | (Tobject(_,_)       , Sep    )
     | ((Tnil | Tfield _)  , Sep    )
     | (Tpackage(_,_)      , Sep    )
-    (* CR aspsmith: ?? *)
-    | (Tof_kind(_)      , Sep    ) -> empty
+    | (Tof_kind(_)        , Sep    ) -> empty
     (* "Deeply separable" case for these same constructors. *)
     | (Tarrow _           , Deepsep)
     | (Ttuple _           , Deepsep)

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -104,7 +104,7 @@ let compute_variance env visited vari ty =
         compute_same (row_more row)
     | Tpoly (ty, _) ->
         compute_same ty
-    | Tvar _ | Tnil | Tlink _ | Tunivar _ -> ()
+    | Tvar _ | Tnil | Tlink _ | Tunivar _ | Tof_kind _ -> ()
     | Tpackage (_, fl) ->
         let v = Variance.(compose vari full) in
         List.iter (fun (_, ty) -> compute_variance_rec v ty) fl

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -715,6 +715,7 @@ and core_type_desc =
   | Ttyp_poly of (string * Parsetree.jkind_annotation option) list * core_type
   | Ttyp_package of package_type
   | Ttyp_open of Path.t * Longident.t loc * core_type
+  | Ttyp_of_kind of Parsetree.jkind_annotation
   | Ttyp_call_pos
 
 and package_type = {

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -985,6 +985,7 @@ and core_type_desc =
   | Ttyp_poly of (string * Parsetree.jkind_annotation option) list * core_type
   | Ttyp_package of package_type
   | Ttyp_open of Path.t * Longident.t loc * core_type
+  | Ttyp_of_kind of Parsetree.jkind_annotation
   | Ttyp_call_pos
       (** [Ttyp_call_pos] represents the type of the value of a Position
           argument ([lbl:[%call_pos] -> ...]). *)

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -29,27 +29,5 @@ val untransl_modalities :
   Mode.Modality.Value.Const.t ->
   Parsetree.modalities
 
-module Transled_modifiers : sig
-  type t =
-    { locality : Mode.Locality.Const.t Location.loc option;
-      linearity : Mode.Linearity.Const.t Location.loc option;
-      uniqueness : Mode.Uniqueness.Const.t Location.loc option;
-      portability : Mode.Portability.Const.t Location.loc option;
-      contention : Mode.Contention.Const.t Location.loc option;
-      yielding : Mode.Yielding.Const.t Location.loc option;
-      statefulness : Mode.Statefulness.Const.t Location.loc option;
-      visibility : Mode.Visibility.Const.t Location.loc option;
-      externality : Jkind_axis.Externality.t Location.loc option;
-      nullability : Jkind_axis.Nullability.t Location.loc option
-    }
-
-  val empty : t
-
-  val get : axis:'a Jkind_axis.Axis.t -> t -> 'a Location.loc option
-
-  val set : axis:'a Jkind_axis.Axis.t -> t -> 'a Location.loc option -> t
-end
-
-(** Interpret a list of modifiers.
-    A "modifier" is any keyword coming after a `mod` in a jkind *)
-val transl_modifier_annots : Parsetree.modes -> Transled_modifiers.t
+(** Interpret a mod-bounds. *)
+val transl_mod_bounds : Parsetree.modes -> Types.Jkind_mod_bounds.t

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -186,7 +186,7 @@ let classify ~classify_product env loc ty sort : _ classification =
       end
   | Tarrow _ | Ttuple _ | Tpackage _ | Tobject _ | Tnil | Tvariant _ ->
       Addr
-  | Tlink _ | Tsubst _ | Tpoly _ | Tfield _ | Tunboxed_tuple _ ->
+  | Tlink _ | Tsubst _ | Tpoly _ | Tfield _ | Tunboxed_tuple _ | Tof_kind _ ->
       assert false
   end
   | Base Float64 -> Unboxed_float Unboxed_float64

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -323,6 +323,7 @@ and type_desc =
   | Tunivar of { name : string option; jkind : jkind_lr }
   | Tpoly of type_expr * type_expr list
   | Tpackage of Path.t * (Longident.t * type_expr) list
+  | Tof_kind of jkind_lr
 
 and arg_label =
   | Nolabel
@@ -1307,6 +1308,7 @@ let best_effort_compare_type_expr te1 te2 =
         | Tunboxed_tuple _ -> 3
         | Tconstr (_, _, _) -> 5
         | Tpoly (_, _) -> 6
+        | Tof_kind _ -> 7
         (* Types we should never see *)
         | Tlink _ -> Misc.fatal_error "Tlink encountered in With_bounds_types"
       in

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -234,6 +234,15 @@ and type_desc =
   | Tpackage of Path.t * (Longident.t * type_expr) list
   (** Type of a first-class module (a.k.a package). *)
 
+  | Tof_kind of jkind_lr
+  (** [Tof_kind jkind] ==> [(type : jkind)]
+
+      The "canonical" type of a particular kind.
+
+      These types are uninhabited, and any appearing in translation will cause an error.
+      They are only used to represent the kinds of existentially-quantified types
+      mentioned in with-bounds. *)
+
 (** This is used in the Typedtree. It is distinct from
     {{!Asttypes.arg_label}[arg_label]} because Position argument labels are
     discovered through typechecking. *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -242,6 +242,7 @@ and type_desc =
       These types are uninhabited, and any appearing in translation will cause an error.
       They are only used to represent the kinds of existentially-quantified types
       mentioned in with-bounds. *)
+      (* CR reisenberg: add link to test once one exists *)
 
 (** This is used in the Typedtree. It is distinct from
     {{!Asttypes.arg_label}[arg_label]} because Position argument labels are

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1066,6 +1066,13 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       in
       let cty = transl_type new_env ~policy ~row_context mode t in
       ctyp (Ttyp_open (path, mod_ident, cty)) cty.ctyp_type
+  | Ptyp_of_kind jkind ->
+    let tjkind = jkind_of_annotation (Type_of_kind loc) styp.ptyp_attributes jkind in
+    let ty =
+      (* CR aspsmith: can we use [newgenty] here? *)
+      newty (Tof_kind tjkind)
+    in
+    ctyp (Ttyp_of_kind jkind) ty
   | Ptyp_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1068,7 +1068,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       ctyp (Ttyp_open (path, mod_ident, cty)) cty.ctyp_type
   | Ptyp_of_kind jkind ->
     let tjkind = jkind_of_annotation (Type_of_kind loc) styp.ptyp_attributes jkind in
-    let ty = Btype.newgenty (Tof_kind tjkind) in
+    let ty = newty (Tof_kind tjkind) in
     ctyp (Ttyp_of_kind jkind) ty
   | Ptyp_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1068,10 +1068,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       ctyp (Ttyp_open (path, mod_ident, cty)) cty.ctyp_type
   | Ptyp_of_kind jkind ->
     let tjkind = jkind_of_annotation (Type_of_kind loc) styp.ptyp_attributes jkind in
-    let ty =
-      (* CR aspsmith: can we use [newgenty] here? *)
-      newty (Tof_kind tjkind)
-    in
+    let ty = Btype.newgenty (Tof_kind tjkind) in
     ctyp (Ttyp_of_kind jkind) ty
   | Ptyp_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -1006,6 +1006,7 @@ let core_type sub ct =
         Ptyp_poly (bound_vars, sub.typ sub ct)
     | Ttyp_package pack -> Ptyp_package (sub.package_type sub pack)
     | Ttyp_open (_path, mod_ident, t) -> Ptyp_open (mod_ident, sub.typ sub t)
+    | Ttyp_of_kind jkind -> Ptyp_of_kind jkind
     | Ttyp_call_pos ->
         Ptyp_extension call_pos_extension
   in


### PR DESCRIPTION
Add a new flavor of type `Tof_kind`, which will (in a forthcoming PR) be used to stand-in for existential types that end up in with-bounds (eg because they're an argument to an abstract type constructor). The syntax looks like:
```ocaml
type 'a abstract
type existential_abstract : immutable_data with (type : value mod portable) abstract =
  | Mk : ('a : value mod portable). 'a abstract -> existential_abstract
```

These types are uninhabited, and can never be inferred as the type of an expression - their only purpose is to show up in with-bounds. Another way of doing this would be to put a TConstr of every possible combination of mod-bounds in the initial environment, but this felt moderately cleaner and didn't end up being much more work

Note that this is basically untested as of this PR, except for the parsing - a subsequent PR will actually use this in kind inference for GADTs, and there more testing is performed.

Review all in one go; the commits aren't useful.