### PR TITLE
Use Typing_env_extension for CSE join result

### DIFF
--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -25,6 +25,7 @@ module P = Flambda_primitive
 module RI = Apply_cont_rewrite_id
 module T = Flambda2_types
 module TE = Flambda2_types.Typing_env
+module TEE = Flambda2_types.Typing_env_extension
 module List = ListLabels
 
 module T0 : sig
@@ -121,7 +122,7 @@ end = struct
 end
 
 let cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params prev_cse
-    (extra_bindings : EPA.t) extra_equations =
+    (extra_bindings : EPA.t) env_extension =
   let params_set =
     List.map params ~f:Bound_parameter.name |> Name.Set.of_list
   in
@@ -163,7 +164,7 @@ let cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params prev_cse
                   (* If [param] has an extra equation associated to it, we
                      shouldn't propagate equations on it as it will mess with
                      the application of constraints later *)
-                  if Name.Map.mem (BP.name param) extra_equations
+                  if TEE.has_equation (BP.name param) env_extension
                   then None
                   else Some (BP.simple param)
                 | Already_in_scope _ | New_let_binding _
@@ -244,18 +245,18 @@ let cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params prev_cse
         cse eligible)
 
 let join_one_cse_equation ~cse_at_each_use prim bound_to_map
-    (cse, extra_bindings, extra_equations, allowed) =
+    (cse, extra_bindings, env_extension, allowed) =
   let has_value_on_all_paths =
     List.for_all cse_at_each_use ~f:(fun (_, id, _) ->
         RI.Map.mem id bound_to_map)
   in
   if not has_value_on_all_paths
-  then cse, extra_bindings, extra_equations, allowed
+  then cse, extra_bindings, env_extension, allowed
   else
     let bound_to_set = RI.Map.data bound_to_map |> Rhs_kind.Set.of_list in
     match Rhs_kind.Set.get_singleton bound_to_set with
     | Some (Rhs_kind.Rhs_in_scope { bound_to }) ->
-      EP.Map.add prim bound_to cse, extra_bindings, extra_equations, allowed
+      EP.Map.add prim bound_to cse, extra_bindings, env_extension, allowed
     | None | Some (Rhs_kind.Needs_extra_binding { bound_to = _ }) ->
       let prim_result_kind = P.result_kind' (EP.to_primitive prim) in
       let var = Variable.create "cse_param" in
@@ -271,7 +272,7 @@ let join_one_cse_equation ~cse_at_each_use prim bound_to_map
         EPA.add extra_bindings ~extra_param ~extra_args
           ~invalids:Apply_cont_rewrite_id.Set.empty
       in
-      let extra_equations =
+      let env_extension =
         (* For the primitives Is_int and Get_tag, they're strongly linked to
            their argument: additional information on the cse parameter should
            translate into additional information on the argument. This can be
@@ -281,19 +282,17 @@ let join_one_cse_equation ~cse_at_each_use prim bound_to_map
            anyway. *)
         match[@ocaml.warning "-fragile-match"] EP.to_primitive prim with
         | Unary (Is_int { variant_only = true }, scrutinee) ->
-          Name.Map.add (Name.var var)
+          TEE.add_or_replace_equation env_extension (Name.var var)
             (T.is_int_for_scrutinee ~scrutinee)
-            extra_equations
         | Unary (Get_tag, block) ->
-          Name.Map.add (Name.var var)
+          TEE.add_or_replace_equation env_extension (Name.var var)
             (T.get_tag_for_block ~block)
-            extra_equations
-        | _ -> extra_equations
+        | _ -> env_extension
       in
       let allowed =
         Name_occurrences.add_name allowed (Name.var var) NM.normal
       in
-      cse, extra_bindings, extra_equations, allowed
+      cse, extra_bindings, env_extension, allowed
 
 let cut_cse_environment ({ by_scope; _ } as t) ~scope_at_fork =
   (* This extracts those CSE equations that arose between the fork point and
@@ -322,9 +321,7 @@ module Join_result = struct
   type nonrec t =
     { cse_at_join_point : t;
       extra_params : EPA.t;
-      (* CR-someday mshinwell: Change [extra_equations] to
-         [Typing_env_extension.t]. *)
-      extra_equations : T.t Name.Map.t;
+      env_extension : TEE.t;
       extra_allowed_names : Name_occurrences.t
     }
 end
@@ -340,10 +337,10 @@ let join0 ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params
      defined at the fork point, having canonicalised such name, cannot be
      propagated. This step also canonicalises the right-hand sides of the CSE
      equations. *)
-  let compute_cse_one_round prev_cse extra_params extra_equations ~allowed =
+  let compute_cse_one_round prev_cse extra_params env_extension ~allowed =
     let new_cse =
       cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params
-        prev_cse extra_params extra_equations
+        prev_cse extra_params env_extension
     in
     (* To make use of a CSE equation at or after the join point, its right-hand
        side must have the same value, no matter which path is taken from the
@@ -351,11 +348,11 @@ let join0 ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params
        this. Sometimes we can force an equation to satisfy the property by
        explicitly passing the value of the right-hand side as an extra parameter
        to the continuation at the join point. *)
-    let cse', extra_params', extra_equations', allowed =
+    let cse', extra_params', env_extension', allowed =
       EP.Map.fold
         (join_one_cse_equation ~cse_at_each_use)
         new_cse
-        (EP.Map.empty, EPA.empty, Name.Map.empty, allowed)
+        (EP.Map.empty, EPA.empty, TEE.empty, allowed)
     in
     let need_other_round =
       (* If we introduce new parameters, then CSE equations involving the
@@ -367,28 +364,25 @@ let join0 ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params
     (* The order of cse arguments does not matter since only simples already in
        scope are used as extra arguments. *)
     let extra_params = EPA.concat ~outer:extra_params' ~inner:extra_params in
-    let extra_equations =
-      Name.Map.disjoint_union extra_equations extra_equations'
-    in
-    cse, extra_params, extra_equations, allowed, need_other_round
+    let env_extension = TEE.disjoint_union env_extension env_extension' in
+    cse, extra_params, env_extension, allowed, need_other_round
   in
-  let cse, extra_params, extra_equations, allowed =
-    let rec do_rounds current_round cse extra_params extra_equations allowed =
-      let cse, extra_params, extra_equations, allowed, need_other_round =
-        compute_cse_one_round cse extra_params extra_equations ~allowed
+  let cse, extra_params, env_extension, allowed =
+    let rec do_rounds current_round cse extra_params env_extension allowed =
+      let cse, extra_params, env_extension, allowed, need_other_round =
+        compute_cse_one_round cse extra_params env_extension ~allowed
       in
       if need_other_round && current_round < Flambda_features.cse_depth ()
-      then
-        do_rounds (succ current_round) cse extra_params extra_equations allowed
+      then do_rounds (succ current_round) cse extra_params env_extension allowed
       else
         ( (* Either a fixpoint has been reached or we've already explored far
              enough *)
           cse,
           extra_params,
-          extra_equations,
+          env_extension,
           allowed )
     in
-    do_rounds 1 EP.Map.empty EPA.empty Name.Map.empty Name_occurrences.empty
+    do_rounds 1 EP.Map.empty EPA.empty TEE.empty Name_occurrences.empty
   in
   let have_propagated_something = ref false in
   let cse_at_join_point =
@@ -416,7 +410,7 @@ let join0 ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params
     Some
       { Join_result.cse_at_join_point;
         extra_params;
-        extra_equations;
+        env_extension;
         extra_allowed_names = allowed
       }
 

--- a/middle_end/flambda2/simplify/common_subexpression_elimination.mli
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.mli
@@ -22,6 +22,7 @@ module P = Flambda_primitive
 module RI = Apply_cont_rewrite_id
 module T = Flambda2_types
 module TE = Flambda2_types.Typing_env
+module TEE = Flambda2_types.Typing_env_extension
 
 type t
 
@@ -41,7 +42,7 @@ module Join_result : sig
   type nonrec t = private
     { cse_at_join_point : t;
       extra_params : EPA.t;
-      extra_equations : T.t Name.Map.t;
+      env_extension : TEE.t;
       extra_allowed_names : Name_occurrences.t
     }
 end

--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -119,9 +119,7 @@ let join ?cut_after denv params ~consts_lifted_during_body ~use_envs_with_ids
     match cse_join_result with
     | None -> handler_env
     | Some cse_join_result ->
-      Name.Map.fold
-        (fun name ty handler_env -> TE.add_equation handler_env name ty)
-        cse_join_result.extra_equations handler_env
+      TE.add_env_extension handler_env cse_join_result.env_extension
   in
   let denv =
     let denv = DE.with_typing_env denv handler_env in

--- a/middle_end/flambda2/types/env/typing_env_extension.ml
+++ b/middle_end/flambda2/types/env/typing_env_extension.ml
@@ -36,6 +36,8 @@ let from_map equations =
 
 let to_map ({ equations } : t) = equations
 
+let has_equation name ({ equations } : t) = Name.Map.mem name equations
+
 let one_equation name ty =
   More_type_creators.check_equation name ty;
   TG.Env_extension.create ~equations:(Name.Map.singleton name ty)
@@ -55,6 +57,11 @@ let add_or_replace_equation ({ equations } : t) name ty =
 let replace_equation ({ equations } : t) name ty =
   TG.Env_extension.create
     ~equations:(Name.Map.add (* replace *) name ty equations)
+
+let disjoint_union ({ equations = equations1 } : t)
+    ({ equations = equations2 } : t) =
+  TG.Env_extension.create
+    ~equations:(Name.Map.disjoint_union equations1 equations2)
 
 let ids_for_export = TG.Env_extension.ids_for_export
 

--- a/middle_end/flambda2/types/env/typing_env_extension.mli
+++ b/middle_end/flambda2/types/env/typing_env_extension.mli
@@ -30,11 +30,15 @@ val from_map : Type_grammar.t Name.Map.t -> t
 
 val to_map : t -> Type_grammar.t Name.Map.t
 
+val has_equation : Name.t -> t -> bool
+
 val one_equation : Name.t -> Type_grammar.t -> t
 
 val add_or_replace_equation : t -> Name.t -> Type_grammar.t -> t
 
 val replace_equation : t -> Name.t -> Type_grammar.t -> t
+
+val disjoint_union : t -> t -> t
 
 include Contains_ids.S with type t := t
 

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -71,9 +71,13 @@ module Typing_env_extension : sig
 
   val empty : t
 
+  val has_equation : Name.t -> t -> bool
+
   val one_equation : Name.t -> flambda_type -> t
 
   val add_or_replace_equation : t -> Name.t -> flambda_type -> t
+
+  val disjoint_union : t -> t -> t
 
   module With_extra_variables : sig
     type t


### PR DESCRIPTION
This is a longstanding CR and reduces the exposure of types' internals to simplify.

(Groundwork for the match-in-match heuristic)