### PR TITLE
flambda2: Do not expose relations as types 

### DIFF
--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -282,11 +282,9 @@ let join_one_cse_equation ~cse_at_each_use prim bound_to_map
            anyway. *)
         match[@ocaml.warning "-fragile-match"] EP.to_primitive prim with
         | Unary (Is_int { variant_only = true }, scrutinee) ->
-          TEE.add_or_replace_equation env_extension (Name.var var)
-            (T.is_int_for_scrutinee ~scrutinee)
+          TEE.add_is_int_relation env_extension (Name.var var) ~scrutinee
         | Unary (Get_tag, block) ->
-          TEE.add_or_replace_equation env_extension (Name.var var)
-            (T.get_tag_for_block ~block)
+          TEE.add_get_tag_relation env_extension (Name.var var) ~scrutinee:block
         | _ -> env_extension
       in
       let allowed =

--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -84,8 +84,9 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
     let tag_v = VB.create tag.param Name_mode.normal in
     let denv = DE.define_variable denv tag_v K.naked_immediate in
     let denv =
-      DE.add_equation_on_variable denv tag.param
-        (T.get_tag_for_block ~block:(Simple.var param_var))
+      DE.map_typing_env denv ~f:(fun tenv ->
+          TE.add_get_tag_relation tenv (Name.var tag.param)
+            ~scrutinee:(Simple.var param_var))
     in
     let get_tag_prim =
       P.Eligible_for_cse.create_get_tag ~block:(Name.var param_var)
@@ -99,8 +100,9 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
         let is_int_v = VB.create is_int.param Name_mode.normal in
         let denv = DE.define_variable denv is_int_v K.naked_immediate in
         let denv =
-          DE.add_equation_on_variable denv is_int.param
-            (T.is_int_for_scrutinee ~scrutinee:(Simple.var param_var))
+          DE.map_typing_env denv ~f:(fun tenv ->
+              TE.add_is_int_relation tenv (Name.var is_int.param)
+                ~scrutinee:(Simple.var param_var))
         in
         let is_int_prim =
           P.Eligible_for_cse.create_is_int ~variant_only:true

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -20,6 +20,15 @@ module Typing_env = struct
   let add_equation t name ty =
     add_equation t name ty ~meet_type:(Meet.meet_type ())
 
+  let add_is_null_relation t name ~scrutinee =
+    add_equation t name (Type_grammar.is_null ~scrutinee)
+
+  let add_is_int_relation t name ~scrutinee =
+    add_equation t name (Type_grammar.is_int_for_scrutinee ~scrutinee)
+
+  let add_get_tag_relation t name ~scrutinee =
+    add_equation t name (Type_grammar.get_tag_for_block ~block:scrutinee)
+
   let add_equations_on_params t ~params ~param_types =
     add_equations_on_params t ~params ~param_types
       ~meet_type:(Meet.meet_type ())
@@ -34,7 +43,20 @@ module Typing_env = struct
   module Alias_set = Aliases.Alias_set
 end
 
-module Typing_env_extension = Typing_env_extension
+module Typing_env_extension = struct
+  include Typing_env_extension
+
+  let add_is_null_relation t name ~scrutinee =
+    add_or_replace_equation t name (Type_grammar.is_null ~scrutinee)
+
+  let add_is_int_relation t name ~scrutinee =
+    add_or_replace_equation t name
+      (Type_grammar.is_int_for_scrutinee ~scrutinee)
+
+  let add_get_tag_relation t name ~scrutinee =
+    add_or_replace_equation t name
+      (Type_grammar.get_tag_for_block ~block:scrutinee)
+end
 
 type typing_env = Typing_env.t
 

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -77,6 +77,12 @@ module Typing_env_extension : sig
 
   val add_or_replace_equation : t -> Name.t -> flambda_type -> t
 
+  val add_is_null_relation : t -> Name.t -> scrutinee:Simple.t -> t
+
+  val add_is_int_relation : t -> Name.t -> scrutinee:Simple.t -> t
+
+  val add_get_tag_relation : t -> Name.t -> scrutinee:Simple.t -> t
+
   val disjoint_union : t -> t -> t
 
   module With_extra_variables : sig
@@ -180,6 +186,12 @@ module Typing_env : sig
 
   val add_equations_on_params :
     t -> params:Bound_parameters.t -> param_types:flambda_type list -> t
+
+  val add_is_null_relation : t -> Name.t -> scrutinee:Simple.t -> t
+
+  val add_is_int_relation : t -> Name.t -> scrutinee:Simple.t -> t
+
+  val add_get_tag_relation : t -> Name.t -> scrutinee:Simple.t -> t
 
   val mem : ?min_name_mode:Name_mode.t -> t -> Name.t -> bool
 
@@ -441,12 +453,6 @@ val box_vec128 : t -> Alloc_mode.For_types.t -> t
 val tagged_immediate_alias_to : naked_immediate:Variable.t -> t
 
 val tag_immediate : t -> t
-
-val is_int_for_scrutinee : scrutinee:Simple.t -> t
-
-val get_tag_for_block : block:Simple.t -> t
-
-val is_null : scrutinee:Simple.t -> t
 
 val any_block : t
 
@@ -795,7 +801,7 @@ val never_holds_locally_allocated_values :
 val remove_outermost_alias : Typing_env.t -> t -> t
 
 module Equal_types_for_debug : sig
-  val equal_type : Typing_env.t -> Type_grammar.t -> Type_grammar.t -> bool
+  val equal_type : Typing_env.t -> t -> t -> bool
 
   val equal_env_extension :
     Typing_env.t -> Typing_env_extension.t -> Typing_env_extension.t -> bool


### PR DESCRIPTION
Add dedicated functions for recording relational primitives (Is_int, Get_tag, Is_null) instead. This makes it easier to change the internal representation of relations in the typing env.

(This is groundwork for the match-in-match heuristic and improved relations)