### PR TITLE
Linear.has_fallthrough is not always true

### DIFF
--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -62,7 +62,7 @@ and call_operation =
 
 let has_fallthrough = function
   | Lreturn | Lbranch _ | Lswitch _ | Lraise _
-  | Lcall_op Ltailcall_ind | Lcall_op (Ltailcall_imm _)
+  | Lcall_op Ltailcall_ind | Lcall_op (Ltailcall_imm _) -> false
   | _ -> true
 
 type fundecl =


### PR DESCRIPTION
Fix a minor bug introduced in https://github.com/ocaml-flambda/flambda-backend/pull/3286. It's not miscompilation, possibly slightly worse codegen around labels.