### PR TITLE
Fix link to renamed stack documentation

### DIFF
--- a/jane/doc/extensions/modes/intro.md
+++ b/jane/doc/extensions/modes/intro.md
@@ -1,6 +1,6 @@
 # Introduction to the Mode System
 
-The locality mode used for [Stack allocation](../local/intro.md) has been
+The locality mode used for [Stack allocation](../stack/intro.md) has been
 extended to more axes, each tracking a property of values, in order to support
 features such as [Parallelism](../parallelism/intro.md) and
 [Uniqueness](../uniqueness/intro.md). This documentation gives a general


### PR DESCRIPTION
As discovered during deployment