### PR TITLE
flambda2(types): Refactor `add_equation`

### DIFF
--- a/middle_end/flambda2/types/env/aliases.mli
+++ b/middle_end/flambda2/types/env/aliases.mli
@@ -60,14 +60,14 @@ val is_empty : t -> bool
 (** The result of calling [add] to state that two [Simple.t]s are now aliases. *)
 type add_result = private
   { t : t;  (** The new state of the alias tracker. *)
-    canonical_element : Simple.t;
-        (** The canonical element of the combined equivalence class. In the type
-            environment, this will be the name (if it is a name) that is
-            assigned a concrete type. *)
-    alias_of_demoted_element : Simple.t
+    demoted_name : Name.t;
         (** Whichever argument to [add] had its equivalence class consumed and
             its canonical element demoted to an alias. It is this name that
             needs its type to change to record the new canonical element. *)
+    canonical_element : Simple.t
+        (** The canonical element of the combined equivalence class. In the type
+            environment, this will be the name (if it is a name) that is
+            assigned a concrete type. *)
   }
 
 (** Add an alias relationship to the tracker. The two simple expressions must be

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -111,8 +111,6 @@ val increment_scope : t -> t
 
 val add_definition : t -> Bound_name.t -> Flambda_kind.t -> t
 
-(** The caller is to ensure that the supplied type is the most precise available
-    for the given name. *)
 val add_equation : t -> Name.t -> Type_grammar.t -> meet_type:meet_type -> t
 
 val add_equation_strict :

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -3616,7 +3616,7 @@ module Head_of_kind_naked_nativeint =
 module Head_of_kind_naked_vec128 =
   Make_head_of_kind_naked_number (Vector_types.Vec128.Bit_pattern)
 
-let rec recover_const_alias t : RWC.t option =
+let rec must_be_singleton t : RWC.t option =
   match t with
   | Value ty -> (
     match TD.descr ty with
@@ -3650,7 +3650,7 @@ let rec recover_const_alias t : RWC.t option =
           match immediates with
           | Unknown -> None
           | Known immediates -> (
-            match recover_const_alias immediates with
+            match must_be_singleton immediates with
             | None -> None
             | Some const -> (
               match RWC.descr const with

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -816,4 +816,4 @@ module Head_of_kind_naked_vec128 :
     with type n = Vector_types.Vec128.Bit_pattern.t
     with type n_set = Vector_types.Vec128.Bit_pattern.Set.t
 
-val recover_const_alias : t -> Reg_width_const.t option
+val must_be_singleton : t -> Reg_width_const.t option


### PR DESCRIPTION
Previously, the `add_equation` logic handled multiple concerns at the same time in a relatively convoluted way, in part due to the need to accomodate both basic and advanced meet algorithms in the same code. With the removal of the basic meet (#3726), we can considerably simplify the code.

This commit refactors `add_equation` by decomposing it into smaller, well-defined steps and recognizing that concrete types and aliases need to be handled differently.

This restructuring clarifies the process of adding an equation:

1. Compute the canonical of the LHS with `get_canonical_simple_ignoring_name_mode`

2. Check if the type is a concrete type or an alias, which is then resolved to its current canonical (`add_equation_on_canonical`).

3. If an alias, merge the two canonical simples using `merge_distinct_canonicals` (which updates the Aliases structure), then call `record_demotion` to update the typing env, transferring the existing concrete type from the demoted element to its new canonical element.

4. If a concrete type, perform the `meet` with the existing concrete type, then call `replace_concrete_equation` if a more precise concrete type is found.  `replace_concrete_equation` automatically demotes to a constant instead if the concrete type is a singleton (without going through `record_demotion`, since we have already computed the `meet`).

Additionally, `Type_grammar.recover_const_alias` is renamed to `must_be_singleton`, which better captures its behavior.

Overall, this should be easier to read and maintain. It also facilitates extensions; for instance, the improved relations tracking for the match-in-match heuristics will rely on `record_demotion` and `add_alias_between_canonicals`.