### PR TITLE
Cleanup of the new asm directives

### DIFF
--- a/backend/asm_targets/asm_directives_new.ml
+++ b/backend/asm_targets/asm_directives_new.ml
@@ -355,7 +355,7 @@ module Directive = struct
       bprintf buf "\t.uleb128 %a%s" Constant.print constant comment
     | Direct_assignment (var, const) -> (
       match TS.assembler () with
-      | MacOS -> bprintf buf "%s = %a" var Constant.print const
+      | MacOS -> bprintf buf "\t.set %s, %a" var Constant.print const
       | _ ->
         Misc.fatal_error
           "Cannot emit [Direct_assignment] except on macOS-like assemblers")

--- a/backend/asm_targets/asm_directives_new.ml
+++ b/backend/asm_targets/asm_directives_new.ml
@@ -341,7 +341,7 @@ module Directive = struct
     | Size (s, c) -> bprintf buf "\t.size %s,%a" s Constant.print c
     | Sleb128 { constant; comment } ->
       let comment = gas_comment_opt comment in
-      bprintf buf "\t.sleb128 %a%s" Constant.print constant comment
+      bprintf buf "\t.sleb128\t%a%s" Constant.print constant comment
     | Type (s, typ) ->
       (* We use the "STT" forms when they are supported as they are unambiguous
          across platforms (cf. https://sourceware.org/binutils/docs/as/Type.html
@@ -352,7 +352,7 @@ module Directive = struct
       bprintf buf "\t.type %s %s" s typ
     | Uleb128 { constant; comment } ->
       let comment = gas_comment_opt comment in
-      bprintf buf "\t.uleb128 %a%s" Constant.print constant comment
+      bprintf buf "\t.uleb128\t%a%s" Constant.print constant comment
     | Direct_assignment (var, const) -> (
       match TS.assembler () with
       | MacOS -> bprintf buf "\t.set %s, %a" var Constant.print const

--- a/backend/asm_targets/asm_directives_new.ml
+++ b/backend/asm_targets/asm_directives_new.ml
@@ -50,6 +50,10 @@ let big_endian () =
   | None -> not_initialized ()
   | Some big_endian -> big_endian
 
+type symbol_type =
+  | Function
+  | Object
+
 let bprintf = Printf.bprintf
 
 module Directive = struct
@@ -189,7 +193,8 @@ module Directive = struct
     | Loc of
         { file_num : int;
           line : int;
-          col : int
+          col : int;
+          discriminator : int option
         }
     | New_label of string * thing_after_label
     | New_line
@@ -205,11 +210,12 @@ module Directive = struct
           comment : string option
         }
     | Space of { bytes : int }
-    | Type of string * string
+    | Type of string * symbol_type
     | Uleb128 of
         { constant : Constant.t;
           comment : string option
         }
+    | Protected of string
 
   let bprintf = Printf.bprintf
 
@@ -249,6 +255,25 @@ module Directive = struct
       incr pos;
       if !pos >= 16 then pos := 0
     done
+
+  (* CR sspies: This code is based on [emit_string_directive] in [emitaux.ml].
+     We break up the string into smaller chunks. *)
+  let print_ascii_string_gas buf s =
+    let l = String.length s in
+    if l = 0
+    then ()
+    else
+      (* We first print the string 80 characters at a time. *)
+      let i = ref 0 in
+      while l - !i > 80 do
+        bprintf buf "\t.ascii\t\"%s\"\n"
+          (string_of_string_literal (String.sub s !i 80));
+        i := !i + 80
+      done;
+      (* Then we print the remainder. We do not append a new line, because every
+         directive ends with a new line. *)
+      bprintf buf "\t.ascii\t\"%s\""
+        (string_of_string_literal (String.sub s !i (l - !i)))
 
   let print_gas buf t =
     let gas_comment_opt comment_opt =
@@ -291,7 +316,7 @@ module Directive = struct
     | Bytes { str; comment } ->
       (match TS.system (), TS.architecture () with
       | Solaris, _ | _, POWER -> buf_bytes_directive buf ~directive:".byte" str
-      | _ -> bprintf buf "\t.ascii\t\"%s\"" (string_of_string_literal str));
+      | _ -> print_ascii_string_gas buf str);
       bprintf buf "%s" (gas_comment_opt comment)
     | Comment s -> bprintf buf "\t\t\t/* %s */" s
     | Global s -> bprintf buf "\t.globl\t%s" s
@@ -321,11 +346,19 @@ module Directive = struct
       bprintf buf "\t.file\t%d\t\"%s\"" file_num
         (string_of_string_literal filename)
     | Indirect_symbol s -> bprintf buf "\t.indirect_symbol %s" s
-    | Loc { file_num; line; col } ->
-      (* PR#7726: Location.none uses column -1, breaks LLVM assembler *)
-      if col >= 0
-      then bprintf buf "\t.loc\t%d\t%d\t%d" file_num line col
-      else bprintf buf "\t.loc\t%d\t%d" file_num line
+    | Loc { file_num; line; col; discriminator } ->
+      (* If we don't set the optional column field, debug_line program gets the
+         column value from the previous .loc directive. *)
+      let print_col buf col =
+        if col >= 0 then bprintf buf "\t%d" col else bprintf buf "\t0"
+      in
+      let print_discriminator buf dis =
+        match dis with
+        | None -> ()
+        | Some dis -> bprintf buf "\tdiscriminator %d" dis
+      in
+      bprintf buf "\t.loc\t%d\t%d%a%a" file_num line print_col col
+        print_discriminator discriminator
     | Private_extern s -> bprintf buf "\t.private_extern %s" s
     | Size (s, c) -> bprintf buf "\t.size %s,%a" s Constant.print c
     | Sleb128 { constant; comment } ->
@@ -335,6 +368,9 @@ module Directive = struct
       (* We use the "STT" forms when they are supported as they are unambiguous
          across platforms (cf. https://sourceware.org/binutils/docs/as/Type.html
          ). *)
+      let typ =
+        match typ with Function -> "STT_FUNC" | Object -> "STT_OBJECT"
+      in
       bprintf buf "\t.type %s %s" s typ
     | Uleb128 { constant; comment } ->
       let comment = gas_comment_opt comment in
@@ -345,6 +381,7 @@ module Directive = struct
       | _ ->
         Misc.fatal_error
           "Cannot emit [Direct_assignment] except on macOS-like assemblers")
+    | Protected s -> bprintf buf "\t.protected\t%s" s
 
   let print_masm buf t =
     let unsupported name =
@@ -401,6 +438,7 @@ module Directive = struct
     | Type _ -> unsupported "Type"
     | Uleb128 _ -> unsupported "Uleb128"
     | Direct_assignment _ -> unsupported "Direct_assignment"
+    | Protected _ -> unsupported "Protected"
 
   let print b t =
     match TS.assembler () with
@@ -479,7 +517,8 @@ let cfi_startproc () = if should_generate_cfi () then emit Cfi_startproc
 
 let comment text = if !Clflags.keep_asm_file then emit (Comment text)
 
-let loc ~file_num ~line ~col = emit_non_masm (Loc { file_num; line; col })
+let loc ~file_num ~line ~col ?discriminator () =
+  emit_non_masm (Loc { file_num; line; col; discriminator })
 
 let space ~bytes = emit (Space { bytes })
 
@@ -493,13 +532,15 @@ let private_extern symbol = emit (Private_extern (Asm_symbol.encode symbol))
 
 let size symbol cst = emit (Size (Asm_symbol.encode symbol, lower_expr cst))
 
-let type_ symbol ~type_ = emit (Type (Asm_symbol.encode symbol, type_))
+let type_ symbol ~type_ = emit (Type (symbol, type_))
 
 let sleb128 ?comment i =
   emit (Sleb128 { constant = Directive.Constant.Signed_int i; comment })
 
 let uleb128 ?comment i =
   emit (Uleb128 { constant = Directive.Constant.Unsigned_int i; comment })
+
+let protected symbol = emit (Protected (Asm_symbol.encode symbol))
 
 let direct_assignment var cst = emit (Direct_assignment (var, lower_expr cst))
 
@@ -519,7 +560,7 @@ let float32 f =
     if !Clflags.keep_asm_file then Some (Printf.sprintf "%.12f" f) else None
   in
   let f_int32 = Int64.of_int32 (Int32.bits_of_float f) in
-  const ?comment (Signed_int f_int32) Sixty_four
+  const ?comment (Signed_int f_int32) Thirty_two
 
 let float64_core f f_int64 =
   match TS.machine_width () with
@@ -564,6 +605,11 @@ let size ?size_of symbol =
 
 let label ?comment label = const_machine_width ?comment (Label label)
 
+let label_plus_offset ?comment lab ~offset_in_bytes =
+  let offset_in_bytes = Targetint.to_int64 offset_in_bytes in
+  let lab = const_label lab in
+  const_machine_width ?comment (const_add lab (const_int64 offset_in_bytes))
+
 let define_label label =
   let lbl_section = Asm_label.section label in
   let this_section =
@@ -586,6 +632,7 @@ let new_line () = if !Clflags.keep_asm_file then emit New_line
 
 let sections_seen = ref []
 
+(* CR sspies: update this section switching code *)
 let switch_to_section section =
   let first_occurrence =
     if List.mem section !sections_seen
@@ -657,9 +704,10 @@ let temp_var_counter = ref 0
 let reset () =
   cached_strings := Cached_string.Map.empty;
   sections_seen := [];
+  current_section_ref := None;
   temp_var_counter := 0
 
-let file ?file_num ~file_name () =
+let file ~file_num ~file_name () =
   (* gas can silently emit corrupted line tables if a .file directive contains a
      number but an empty filename. *)
   let file_name =
@@ -670,6 +718,7 @@ let file ?file_num ~file_name () =
   in
   emit_non_masm (File { file_num; filename = file_name })
 
+(* CR sspies: fix this up using the new code *)
 let initialize ~big_endian ~(emit : Directive.t -> unit) =
   big_endian_ref := Some big_endian;
   emit_ref := Some emit;
@@ -700,9 +749,9 @@ let initialize ~big_endian ~(emit : Directive.t -> unit) =
   (* Stop dsymutil complaining about empty __debug_line sections (produces bogus
      error "line table parameters mismatch") by making sure such sections are
      never empty. *)
-  file ~file_num:1 ~file_name:"none" ();
+  file ~file_num:(Some 1) ~file_name:"none" ();
   (* also PR#7037 *)
-  loc ~file_num:1 ~line:1 ~col:1;
+  loc ~file_num:1 ~line:1 ~col:1 ();
   switch_to_section Asm_section.Text
 
 let file ~file_num ~file_name = file ~file_num ~file_name ()
@@ -712,7 +761,7 @@ let define_data_symbol symbol =
   (* check_symbol_for_definition_in_current_section symbol; *)
   emit (New_label (Asm_symbol.encode symbol, Machine_width_data));
   match TS.assembler (), TS.windows () with
-  | GAS_like, false -> type_ symbol ~type_:"STT_OBJECT"
+  | GAS_like, false -> type_ (Asm_symbol.encode symbol) ~type_:Object
   | GAS_like, true | MacOS, _ | MASM, _ -> ()
 
 (* CR mshinwell: Rename to [define_text_symbol]? *)
@@ -722,7 +771,17 @@ let define_function_symbol symbol =
   (* CR mshinwell: This shouldn't be called "New_label" *)
   emit (New_label (Asm_symbol.encode symbol, Code));
   match TS.assembler (), TS.windows () with
-  | GAS_like, false -> type_ symbol ~type_:"STT_FUNC"
+  | GAS_like, false -> type_ (Asm_symbol.encode symbol) ~type_:Function
+  | GAS_like, true | MacOS, _ | MASM, _ -> ()
+
+let type_symbol symbol ~ty =
+  match TS.assembler (), TS.windows () with
+  | GAS_like, false -> type_ (Asm_symbol.encode symbol) ~type_:ty
+  | GAS_like, true | MacOS, _ | MASM, _ -> ()
+
+let type_label label ~ty =
+  match TS.assembler (), TS.windows () with
+  | GAS_like, false -> type_ (Asm_label.encode label) ~type_:ty
   | GAS_like, true | MacOS, _ | MASM, _ -> ()
 
 let symbol ?comment sym = const_machine_width ?comment (Symbol sym)
@@ -837,6 +896,21 @@ let between_labels_64_bit_with_offsets ?comment:_comment ~upper ~upper_offset
       (const_add (const_label lower) (const_int64 lower_offset))
   in
   const_machine_width (force_assembly_time_constant expr)
+
+let between_this_and_label_offset_32bit_expr ~upper ~offset_upper =
+  let upper_section = Asm_label.section upper in
+  (match !current_section_ref with
+  | None -> not_initialized ()
+  | Some this_section ->
+    if not (Asm_section.equal upper_section this_section)
+    then
+      Misc.fatal_errorf
+        "Label %a in section %a is not in the current section %a"
+        Asm_label.print upper Asm_section.print upper_section Asm_section.print
+        this_section);
+  let offset_upper = Targetint.to_int64 offset_upper in
+  let expr = Sub (Add (Label upper, Signed_int offset_upper), This) in
+  const expr Thirty_two
 
 let between_symbol_in_current_unit_and_label_offset ?comment:_comment ~upper
     ~lower ~offset_upper () =

--- a/backend/asm_targets/asm_directives_new.ml
+++ b/backend/asm_targets/asm_directives_new.ml
@@ -25,8 +25,6 @@ module Int8 = Numbers.Int8
 module Int16 = Numbers.Int16
 module Uint64 = Numbers.Uint64
 module TS = Target_system
-
-(* CR sspies: replace polymorphic compare *)
 open! Int_replace_polymorphic_compare
 
 (* CR sspies: Removed [dwarf_supported] *)

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -410,7 +410,7 @@ end
     Calling the functions in this module will cause directives to be passed
     to the given [emit] function (a typical implementation of which will just
     call [Directive.print] on its parameter).
-    This function _does not_ swich sections.
+    This function _does not_ switch sections.
     If Dwarf debug information is supposed to be produced,
     additionally [debug_header] should be called, which
     will switch to the text section after emitting some debug section labels.  *)

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -28,7 +28,7 @@
     DWARF) to places that are currently at the start of these sections
     get relocated correctly when those places become not at the start
     (e.g. during linking). *)
-val switch_to_section : Asm_section.t -> unit
+val switch_to_section : ?emit_label_on_first_occurrence:bool -> Asm_section.t -> unit
 
 (** Emit subsequent directives to the given section, where the section must
     not be one of those in type [section] (see above).  The section is
@@ -409,8 +409,13 @@ end
     Calling the functions in this module will cause directives to be passed
     to the given [emit] function (a typical implementation of which will just
     call [Directive.print] on its parameter).
-    This function switches to the text section. *)
+    This function _does not_ swich sections.
+    If Dwarf debug information is supposed to be produced,
+    additionally [debug_header] should be called, which
+    will switch to the text section after emitting some debug section labels.  *)
 val initialize : big_endian:bool -> emit:(Directive.t -> unit) -> unit
+
+val debug_header : get_file_num: (string -> int) -> unit
 
 (** Reinitialize the emitter before compiling a different source file. *)
 val reset : unit -> unit

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -28,7 +28,8 @@
     DWARF) to places that are currently at the start of these sections
     get relocated correctly when those places become not at the start
     (e.g. during linking). *)
-val switch_to_section : ?emit_label_on_first_occurrence:bool -> Asm_section.t -> unit
+val switch_to_section :
+  ?emit_label_on_first_occurrence:bool -> Asm_section.t -> unit
 
 (** Emit subsequent directives to the given section, where the section must
     not be one of those in type [section] (see above).  The section is
@@ -415,7 +416,7 @@ end
     will switch to the text section after emitting some debug section labels.  *)
 val initialize : big_endian:bool -> emit:(Directive.t -> unit) -> unit
 
-val debug_header : get_file_num: (string -> int) -> unit
+val debug_header : get_file_num:(string -> int) -> unit
 
 (** Reinitialize the emitter before compiling a different source file. *)
 val reset : unit -> unit

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -115,10 +115,11 @@ val emit_cached_strings : unit -> unit
 val comment : string -> unit
 
 (** Assign a file number to a filename. *)
-val file : file_num:int -> file_name:string -> unit
+val file : file_num:int option -> file_name:string -> unit
 
 (** Mark the source location of the current assembly position. *)
-val loc : file_num:int -> line:int -> col:int -> unit
+val loc :
+  file_num:int -> line:int -> col:int -> ?discriminator:int -> unit -> unit
 
 (** Emit a blank line. *)
 val new_line : unit -> unit
@@ -176,6 +177,9 @@ val global : Asm_symbol.t -> unit
 (** Emit a machine-width reference to the given symbol. *)
 val symbol : ?comment:string -> Asm_symbol.t -> unit
 
+(** Emit a protected directive for the given symbol. *)
+val protected : Asm_symbol.t -> unit
+
 (** Mark a symbol as "private extern" (see assembler documentation for
     details). *)
 val private_extern : Asm_symbol.t -> unit
@@ -191,6 +195,20 @@ val define_label : Asm_label.t -> unit
 
 (** Emit a machine-width reference to the given label. *)
 val label : ?comment:string -> Asm_label.t -> unit
+
+(** Emit a machine-width reference to the given label with an offset. *)
+val label_plus_offset :
+  ?comment:string -> Asm_label.t -> offset_in_bytes:Targetint.t -> unit
+
+(** The type of the symbol. There are various other types, but we
+    currently only use and support the following. *)
+type symbol_type =
+  | Function
+  | Object
+
+val type_symbol : Asm_symbol.t -> ty:symbol_type -> unit
+
+val type_label : Asm_label.t -> ty:symbol_type -> unit
 
 (** Emit a machine-width reference to the address formed by adding the
     given byte offset to the address of the given symbol.  The symbol may be
@@ -232,6 +250,13 @@ val between_labels_64_bit_with_offsets :
   unit ->
   unit
 
+(** Emit a 32-bit-wide label expression giving the displacement obtained
+    by subtracting the current assembly location from the sum of the address
+    of the given label plus the given offset.  The label must be in the
+    same section as the assembler is currently emitting into. *)
+val between_this_and_label_offset_32bit_expr :
+  upper:Asm_label.t -> offset_upper:Targetint.t -> unit
+
 (** Emit a machine-width reference giving the displacement between the
     [lower] symbol and the sum of the address of the [upper] label plus
     [offset_upper].  The [lower] symbol must be in the current compilation
@@ -267,7 +292,9 @@ val offset_into_dwarf_section_symbol :
 
 module Directive : sig
   module Constant : sig
-    type t = private
+    (* CR sspies: make this private again once the first-class module has been
+       removed *)
+    type t =
       | Signed_int of Int64.t
       | Unsigned_int of Numbers.Uint64.t
       | This
@@ -288,27 +315,38 @@ module Directive : sig
 
     val constant : t -> Constant.t
 
-    type width_in_bytes = private
+    (* CR sspies: make this private again once the first-class module has been
+       removed *)
+    type width_in_bytes =
       | Eight
       | Sixteen
       | Thirty_two
       | Sixty_four
 
     val width_in_bytes : t -> width_in_bytes
+
+    val create : Constant.t -> width_in_bytes -> t
   end
 
-  type thing_after_label = private
+  (* CR sspies: make this private again once the first-class module has been
+     removed *)
+  type thing_after_label =
     | Code
     | Machine_width_data
 
-  type comment = private string
+  (* CR sspies: make this private again once the first-class module has been
+     removed *)
+  type comment = string
+
+  (* CR sspies: make this private again once the first-class module has been
+     removed *)
 
   (** Internal representation of directives.  Only needed if writing a custom
       assembler or printer instead of using [print], below.
       Symbols that occur in values of type [t] are encoded as [string]s and
       have had all necessary prefixing, mangling, escaping and suffixing
       applied. *)
-  type t = private
+  type t =
     | Align of { bytes : int }
     | Bytes of
         { str : string;
@@ -337,7 +375,8 @@ module Directive : sig
     | Loc of
         { file_num : int;
           line : int;
-          col : int
+          col : int;
+          discriminator : int option
         }
     | New_label of string * thing_after_label
     | New_line
@@ -353,11 +392,12 @@ module Directive : sig
           comment : string option
         }
     | Space of { bytes : int }
-    | Type of string * string
+    | Type of string * symbol_type
     | Uleb128 of
         { constant : Constant.t;
           comment : string option
         }
+    | Protected of string
 
   (** Translate the given directive to textual form.  This produces output
       suitable for either gas or MASM as appropriate. *)

--- a/utils/target_system.ml
+++ b/utils/target_system.ml
@@ -176,3 +176,8 @@ let is_macos () =
   match assembler () with
   | MASM | GAS_like -> false
   | MacOS -> true
+
+  let is_gas () =
+    match assembler () with
+    | MASM | MacOS -> false
+    | GAS_like -> true

--- a/utils/target_system.mli
+++ b/utils/target_system.mli
@@ -74,3 +74,5 @@ val system: unit -> system
 val windows : unit -> bool
 
 val is_macos : unit -> bool
+
+val is_gas : unit -> bool


### PR DESCRIPTION
This PR cleans up the new implementation of asm directives a bit and adds functionality needed to use the directives more widely in the emission code. There are two important changes:

1. The first one is that this PR splits up the function `initialize` into `initialize` and `debug_header`. The reason is that subsequent PRs will use the new and old asm directives together until the old asm directives are completely removed. Both must be initialized, and it should not be the case that we duplicate the assembly directives that they emit. 
2. The second one is that this PR tweaks the logic for switching sections. The code for this is stateful, and the asm directives track internally in which section we currently are. This tracking implicitly assumed that the new asm directives are the only ones used to switch sections. But when we use this code in conjunction with manual section switching, this assumption is no longer correct.

