### PR TITLE
Fix kind checks for partial/over applications

### DIFF
--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -863,7 +863,8 @@ let simplify_direct_function_call ~simplify_expr dacc apply
       else if provided_num_args > num_params
       then (
         (* See comment above. *)
-        if not (Flambda_arity.is_one_param_of_kind_value result_arity)
+        if Flambda_features.kind_checks ()
+           && not (Flambda_arity.is_one_param_of_kind_value result_arity)
         then
           Misc.fatal_errorf
             "Non-singleton-value return arity for overapplied OCaml function:@ \
@@ -875,9 +876,10 @@ let simplify_direct_function_call ~simplify_expr dacc apply
       else if provided_num_args > 0 && provided_num_args < num_params
       then (
         (* See comment above. *)
-        if not
-             (Flambda_arity.is_one_param_of_kind_value
-                result_arity_of_application)
+        if Flambda_features.kind_checks ()
+           && not
+                (Flambda_arity.is_one_param_of_kind_value
+                   result_arity_of_application)
         then
           Misc.fatal_errorf
             "Non-singleton-value return arity for partially-applied OCaml \

--- a/middle_end/flambda2/tests/mlexamples/over_app_kind_check.ml
+++ b/middle_end/flambda2/tests/mlexamples/over_app_kind_check.ml
@@ -1,0 +1,6 @@
+type (_,_) eq = Eq : ('a,'a) eq
+
+let test (u : (int -> int64#, int -> int -> int) eq) a b =
+  let[@inline always][@local never] cast : type a b. (a,b) eq -> a -> b = fun Eq x -> x in
+  let[@inline never][@local never] f _ = #0L in
+  (cast u f) 0 0

--- a/middle_end/flambda2/tests/mlexamples/partial_app_kind_check.ml
+++ b/middle_end/flambda2/tests/mlexamples/partial_app_kind_check.ml
@@ -1,0 +1,6 @@
+type (_,_) eq = Eq : ('a,'a) eq
+
+let test (u : (int -> int -> int, int -> int64#) eq) a b =
+  let[@inline always][@local never] cast : type a b. (a,b) eq -> a -> b = fun Eq x -> x in
+  let[@inline never][@local never] f _ _ = 0 in
+  (cast u f) 0


### PR DESCRIPTION
The check is moved behind `Flambda_features.kind_checks ()`, as the error can be triggered in valid code with GADTs (see test files). I had to change a bit more code in the over-application case, as it otherwise produced another fatal error if the check was removed. 