### PR TITLE
Use [Are_rebuilding_terms.t] in DE instead of bool + other small changes to `ART` API

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -287,7 +287,7 @@ module Inlining = struct
   (* CR keryan: we need to emit warnings *)
   let inlinable env apply callee_approx =
     let tracker = Env.inlining_history_tracker env in
-    let are_rebuilding_terms = Are_rebuilding_terms.of_bool true in
+    let are_rebuilding_terms = Are_rebuilding_terms.are_rebuilding in
     let compilation_unit =
       Env.inlining_history_tracker env
       |> Inlining_history.Tracker.absolute
@@ -2178,7 +2178,7 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
       Inlining_report.record_decision_at_function_definition ~absolute_history
         ~code_metadata:(Code_or_metadata.code_metadata meta)
         ~pass:After_closure_conversion
-        ~are_rebuilding_terms:(Are_rebuilding_terms.of_bool true)
+        ~are_rebuilding_terms:Are_rebuilding_terms.are_rebuilding
         inlining_decision;
       if Function_decl_inlining_decision_type.must_be_inlined inlining_decision
       then code
@@ -2585,7 +2585,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
       Inlining_report.record_decision_at_function_definition ~absolute_history
         ~code_metadata:(Code_or_metadata.code_metadata meta)
         ~pass:After_closure_conversion
-        ~are_rebuilding_terms:(Are_rebuilding_terms.of_bool true)
+        ~are_rebuilding_terms:Are_rebuilding_terms.are_rebuilding
         inlining_decision;
       if Function_decl_inlining_decision_type.must_be_inlined inlining_decision
       then code

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -41,7 +41,7 @@ type t =
     variables_defined_at_toplevel : Variable.Set.t;
     cse : CSE.t;
     comparison_results : Comparison_result.t Variable.Map.t;
-    do_not_rebuild_terms : bool;
+    are_rebuilding_terms : Are_rebuilding_terms.t;
     closure_info : Closure_info.t;
     get_imported_code : unit -> Exported_code.t;
     all_code : Code.t Code_id.Map.t;
@@ -71,7 +71,7 @@ let [@ocamlformat "disable"] print ppf { round; typing_env;
                 inlining_state; propagating_float_consts;
                 at_unit_toplevel; unit_toplevel_exn_continuation;
                 variables_defined_at_toplevel; cse; comparison_results;
-                do_not_rebuild_terms; closure_info;
+                are_rebuilding_terms; closure_info;
                 unit_toplevel_return_continuation; all_code;
                 get_imported_code = _; inlining_history_tracker = _;
                 loopify_state; defined_variables_by_scope;
@@ -90,7 +90,7 @@ let [@ocamlformat "disable"] print ppf { round; typing_env;
       @[<hov 1>(variables_defined_at_toplevel@ %a)@]@ \
       @[<hov 1>(cse@ @[<hov 1>%a@])@]@ \
       @[<hov 1>(comparison_results@ @[<hov 1>%a@])@]@ \
-      @[<hov 1>(do_not_rebuild_terms@ %b)@]@ \
+      @[<hov 1>(are_rebuilding_terms@ %a)@]@ \
       @[<hov 1>(closure_info@ %a)@]@ \
       @[<hov 1>(all_code@ %a)@]@ \
       @[<hov 1>(loopify_state@ %a)@]@ \
@@ -109,7 +109,7 @@ let [@ocamlformat "disable"] print ppf { round; typing_env;
     Variable.Set.print variables_defined_at_toplevel
     CSE.print cse
     (Variable.Map.print Comparison_result.print) comparison_results
-    do_not_rebuild_terms
+    Are_rebuilding_terms.print are_rebuilding_terms
     Closure_info.print closure_info
     (Code_id.Map.print Code.print) all_code
     Loopify_state.print loopify_state
@@ -165,7 +165,7 @@ let create ~round ~(resolver : resolver)
       variables_defined_at_toplevel = Variable.Set.empty;
       cse = CSE.empty;
       comparison_results = Variable.Map.empty;
-      do_not_rebuild_terms = false;
+      are_rebuilding_terms = Are_rebuilding_terms.are_rebuilding;
       closure_info = Closure_info.not_in_a_closure;
       all_code = Code_id.Map.empty;
       get_imported_code;
@@ -242,7 +242,7 @@ let enter_set_of_closures
       variables_defined_at_toplevel;
       cse = _;
       comparison_results = _;
-      do_not_rebuild_terms;
+      are_rebuilding_terms;
       closure_info = _;
       get_imported_code;
       all_code;
@@ -264,7 +264,7 @@ let enter_set_of_closures
     variables_defined_at_toplevel;
     cse = CSE.empty;
     comparison_results = Variable.Map.empty;
-    do_not_rebuild_terms;
+    are_rebuilding_terms;
     closure_info = Closure_info.in_a_set_of_closures;
     get_imported_code;
     all_code;
@@ -473,14 +473,17 @@ let find_comparison_result t var =
 let with_cse t cse = { t with cse }
 
 let set_do_not_rebuild_terms_and_disable_inlining t =
-  { t with do_not_rebuild_terms = true; can_inline = false }
+  { t with
+    are_rebuilding_terms = Are_rebuilding_terms.are_not_rebuilding;
+    can_inline = false
+  }
 
 let disable_inlining t = { t with can_inline = false }
 
-let set_rebuild_terms t = { t with do_not_rebuild_terms = false }
+let set_rebuild_terms t =
+  { t with are_rebuilding_terms = Are_rebuilding_terms.are_rebuilding }
 
-let are_rebuilding_terms t =
-  Are_rebuilding_terms.of_bool (not t.do_not_rebuild_terms)
+let are_rebuilding_terms t = t.are_rebuilding_terms
 
 let enter_closure code_id ~return_continuation ~exn_continuation ~my_closure t =
   { t with
@@ -558,7 +561,7 @@ let generate_phantom_lets t =
   && Flambda_features.Expert.phantom_lets ()
   (* It would be a waste of time generating phantom lets when not rebuilding
      terms, since they have no effect on cost metrics. *)
-  && Are_rebuilding_terms.are_rebuilding (are_rebuilding_terms t)
+  && Are_rebuilding_terms.do_rebuild_terms (are_rebuilding_terms t)
 
 let loopify_state t = t.loopify_state
 
@@ -630,7 +633,7 @@ let denv_for_lifted_continuation ~denv_for_join ~denv =
     propagating_float_consts = denv.propagating_float_consts;
     unit_toplevel_return_continuation = denv.unit_toplevel_return_continuation;
     unit_toplevel_exn_continuation = denv.unit_toplevel_exn_continuation;
-    do_not_rebuild_terms = denv.do_not_rebuild_terms;
+    are_rebuilding_terms = denv.are_rebuilding_terms;
     closure_info = denv.closure_info;
     get_imported_code = denv.get_imported_code;
     loopify_state = denv.loopify_state

--- a/middle_end/flambda2/simplify/env/upwards_env.ml
+++ b/middle_end/flambda2/simplify/env/upwards_env.ml
@@ -18,6 +18,7 @@ type t =
   { continuations : Continuation_in_env.t Continuation.Map.t;
     continuation_aliases : Continuation.t Continuation.Map.t;
     apply_cont_rewrites : Apply_cont_rewrite.t Continuation.Map.t;
+    (* this [are_rebuilding_terms] is **only** used for printing *)
     are_rebuilding_terms : Are_rebuilding_terms.t
   }
 

--- a/middle_end/flambda2/simplify/env/upwards_env.mli
+++ b/middle_end/flambda2/simplify/env/upwards_env.mli
@@ -18,6 +18,9 @@
 
 type t
 
+(** Create an upwards environment.
+
+    The [are_rebuilding_terms] provided is only used for printing. *)
 val create : Are_rebuilding_terms.t -> t
 
 val print : Format.formatter -> t -> unit

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -220,8 +220,7 @@ let create_let uacc (bound_vars : Bound_pattern.t) (defining_expr : Named.t)
         free_names_of_let
     in
     let uacc =
-      if Are_rebuilding_terms.do_not_rebuild_terms
-           (UA.are_rebuilding_terms uacc)
+      if Are_rebuilding_terms.do_not_rebuild_terms (UA.are_rebuilding_terms uacc)
       then uacc
       else add_set_of_closures_offsets ~is_phantom defining_expr uacc
     in

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -50,7 +50,7 @@ let record_free_names_of_apply_as_used dacc ~use_id ~exn_cont_use_id apply =
 
 let loopify_decision_for_call dacc apply =
   let denv = DA.denv dacc in
-  if not (Are_rebuilding_terms.are_rebuilding (DE.are_rebuilding_terms denv))
+  if Are_rebuilding_terms.do_not_rebuild_terms (DE.are_rebuilding_terms denv)
   then
     (* During speculative inlining, we are only rebuilding the inlined body, and
        in particular we run the Flow Analysis on just the inlined body. The Flow
@@ -226,7 +226,7 @@ let simplify_direct_full_application ~simplify_expr dacc apply function_type
         Simplify_rec_info_expr.known_remaining_unrolling_depth dacc
           (Call_site_inlining_decision.get_rec_info dacc ~function_type)
       in
-      if Are_rebuilding_terms.are_rebuilding
+      if Are_rebuilding_terms.do_rebuild_terms
            (DE.are_rebuilding_terms (DA.denv dacc))
       then
         Inlining_report.record_decision_at_call_site_for_known_function
@@ -917,7 +917,7 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
     (call : Call_kind.Function_call.t) ~apply_alloc_mode ~down_to_up =
   fail_if_probe apply;
   let denv = DA.denv dacc in
-  if Are_rebuilding_terms.are_rebuilding (DE.are_rebuilding_terms denv)
+  if Are_rebuilding_terms.do_rebuild_terms (DE.are_rebuilding_terms denv)
   then
     Inlining_report.record_decision_at_call_site_for_unknown_function
       ~pass:Inlining_report.Pass.Before_simplify

--- a/middle_end/flambda2/simplify_shared/are_rebuilding_terms.ml
+++ b/middle_end/flambda2/simplify_shared/are_rebuilding_terms.ml
@@ -15,14 +15,14 @@
 (**************************************************************************)
 
 type t = bool
+(* [true] if rebuilding, [false] if not rebuilding *)
 
-let of_bool t = t
+let are_rebuilding = true
+let are_not_rebuilding = false
 
-let to_bool t = t
+let print ppf t =
+  Format.fprintf ppf "%b" t
 
-let do_not_rebuild_terms t = not (to_bool t)
+let do_rebuild_terms t = t
+let do_not_rebuild_terms t = not t
 
-let [@ocamlformat "disable"] print ppf t =
-  Format.fprintf ppf "%b" (to_bool t)
-
-let are_rebuilding t = t

--- a/middle_end/flambda2/simplify_shared/are_rebuilding_terms.mli
+++ b/middle_end/flambda2/simplify_shared/are_rebuilding_terms.mli
@@ -19,10 +19,12 @@
 
 type t
 
-val of_bool : bool -> t
-
-val do_not_rebuild_terms : t -> bool
-
-val are_rebuilding : t -> bool
-
 val print : Format.formatter -> t -> unit
+
+(* CR gbury: the terms/names used for creating values and for inspecting them
+    would make more sens if they were swapped. *)
+val are_rebuilding : t
+val are_not_rebuilding : t
+
+val do_rebuild_terms : t -> bool
+val do_not_rebuild_terms : t -> bool


### PR DESCRIPTION
Also, remove the `of_bool` function in favour of dedicated constructors for values of type [ART.t], since they were only called with constant literals for now, and introduce a non-negated function to know whether we are rebuilding terms.

As a comment/CR states, now that we have functions./values to both create and inspect values of type `ART.t`, it could make more sens to have the `{do|do_not}_rebuild_terms` names used to create new values, and the `{are|are_not}_rebuilding_terms` names used to inspect the value to know what is the status of term rebuilding, but I did not change it as that would have make the diff bigger. That being said, if people agree that swapping the names makes sense, I'd be glad to do it.

Not a necessary patch, but seems cleaner (for the curious, this patch originally comes from the time when we considered a partial rebuilding upwards pass for match-in-match, which required `ART.t` to become a proper enum with 3 cases; that attempt was eventually abandoned in favor of the current approach, but some changes/patches to `ART` seemed interesting to keep).
