### PR TITLE
Stable ordering for bound continuations

### DIFF
--- a/middle_end/flambda2/algorithms/lmap.ml
+++ b/middle_end/flambda2/algorithms/lmap.ml
@@ -61,6 +61,8 @@ module type S = sig
 
   val exists : (key -> 'a -> bool) -> 'a t -> bool
 
+  val choose : 'a t -> key * 'a
+
   val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t
 
   val of_seq : (key * 'a) Seq.t -> 'a t
@@ -107,6 +109,8 @@ module Make (T : Thing) : S with type key = T.t = struct
     | (k, v) :: m -> f k v fixed_arg && for_all_with_fixed_arg f m fixed_arg
 
   let exists f m = List.exists (fun (k, v) -> f k v) m
+
+  let choose = function [] -> raise Not_found | res :: _ -> res
 
   let keys m = List.map fst m
 

--- a/middle_end/flambda2/algorithms/lmap.mli
+++ b/middle_end/flambda2/algorithms/lmap.mli
@@ -105,6 +105,10 @@ module type S = sig
 
   val exists : (key -> 'a -> bool) -> 'a t -> bool
 
+  (** Returns an unspecified binding from the map
+      @raise Not_found if the map is empty *)
+  val choose : 'a t -> key * 'a
+
   (** Keys in the sequence must be distinct from each other and from keys
       already in the map; neither of these conditions is checked. *)
   val add_seq : (key * 'a) Seq.t -> 'a t -> 'a t

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -1300,7 +1300,7 @@ and let_cont_exprs env (let_cont1 : Let_cont.t) (let_cont2 : Let_cont.t) :
       ~f:(fun ~invariant_params ~body1 ~body2 cont_handlers1 cont_handlers2 ->
         pairs ~f1:exprs ~f2:compare_handler_maps
           ~subst2:(fun env map ->
-            Continuation.Lmap.map (subst_cont_handler env) map)
+            Continuation.Lmap.map_sharing (subst_cont_handler env) map)
           env
           (body1, cont_handlers1 |> Continuation_handlers.to_map)
           (body2, cont_handlers2 |> Continuation_handlers.to_map)

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -419,7 +419,7 @@ and subst_let_cont env (let_cont_expr : Let_cont_expr.t) =
       ~f:(fun ~invariant_params ~body handlers ->
         let body = subst_expr env body in
         let handlers =
-          Continuation.Map.map_sharing (subst_cont_handler env)
+          Continuation.Lmap.map_sharing (subst_cont_handler env)
             (handlers |> Continuation_handlers.to_map)
         in
         Let_cont_expr.create_recursive handlers ~invariant_params ~body)
@@ -1283,7 +1283,7 @@ and let_cont_exprs env (let_cont1 : Let_cont.t) (let_cont2 : Let_cont.t) :
                  ~free_names_of_body:Unknown))
   | Recursive handlers1, Recursive handlers2 ->
     let compare_handler_maps env map1 map2 :
-        Continuation_handler.t Continuation.Map.t Comparison.t =
+        Continuation_handler.t Continuation.Lmap.t Comparison.t =
       lists
         ~f:(fun env (cont, handler1) (_cont, handler2) ->
           cont_handlers env handler1 handler2
@@ -1292,15 +1292,15 @@ and let_cont_exprs env (let_cont1 : Let_cont.t) (let_cont2 : Let_cont.t) :
           |> Comparison.map ~f:(fun handler1' -> cont, handler1'))
         ~subst:(fun env (cont, handler) -> cont, subst_cont_handler env handler)
         ~subst_snd:false env
-        (map1 |> Continuation.Map.bindings)
-        (map2 |> Continuation.Map.bindings)
-      |> Comparison.map ~f:Continuation.Map.of_list
+        (map1 |> Continuation.Lmap.bindings)
+        (map2 |> Continuation.Lmap.bindings)
+      |> Comparison.map ~f:Continuation.Lmap.of_list
     in
     Recursive_let_cont_handlers.pattern_match_pair handlers1 handlers2
       ~f:(fun ~invariant_params ~body1 ~body2 cont_handlers1 cont_handlers2 ->
         pairs ~f1:exprs ~f2:compare_handler_maps
           ~subst2:(fun env map ->
-            Continuation.Map.map_sharing (subst_cont_handler env) map)
+            Continuation.Lmap.map (subst_cont_handler env) map)
           env
           (body1, cont_handlers1 |> Continuation_handlers.to_map)
           (body2, cont_handlers2 |> Continuation_handlers.to_map)

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -1146,7 +1146,7 @@ module Let_cont_with_acc = struct
     in
     let expr = Let_cont.create_recursive ~invariant_params handlers ~body in
     let acc =
-      Continuation.Map.fold
+      Continuation.Lmap.fold
         (fun cont _ acc -> Acc.remove_continuation_from_free_names cont acc)
         handlers acc
     in
@@ -1166,9 +1166,9 @@ module Let_cont_with_acc = struct
           ( Name_occurrences.union free_names handler_free_names,
             Cost_metrics.( + ) costs cost_metrics_of_handler,
             acc,
-            Continuation.Map.add cont handler handlers ))
+            Continuation.Lmap.add cont handler handlers ))
         handlers
-        (Name_occurrences.empty, Cost_metrics.zero, acc, Continuation.Map.empty)
+        (Name_occurrences.empty, Cost_metrics.zero, acc, Continuation.Lmap.empty)
     in
     let body_free_names, acc, body = Acc.eval_branch_free_names acc ~f:body in
     let acc =

--- a/middle_end/flambda2/identifiers/continuation.ml
+++ b/middle_end/flambda2/identifiers/continuation.ml
@@ -165,6 +165,7 @@ end
 module Tree = Patricia_tree.Make (T)
 module Set = Tree.Set
 module Map = Tree.Map
+module Lmap = Lmap.Make (T)
 
 let export t = find_data t
 

--- a/middle_end/flambda2/identifiers/continuation.mli
+++ b/middle_end/flambda2/identifiers/continuation.mli
@@ -22,6 +22,8 @@ type exported
 
 include Container_types.S with type t := t
 
+module Lmap : Lmap.S with type key := t
+
 module Sort : sig
   type t =
     | Normal_or_exn

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -696,7 +696,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
       Flambda.Let_cont.create_non_recursive name handler ~body
         ~free_names_of_body:Unknown
     | Recursive ->
-      let handlers = Continuation.Map.singleton name handler in
+      let handlers = Continuation.Lmap.singleton name handler in
       Flambda.Let_cont.create_recursive ~invariant_params:Bound_parameters.empty
         handlers ~body)
   | Let_cont _ -> failwith "TODO andwhere"

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -1015,7 +1015,7 @@ and let_cont_expr env (lc : Flambda.Let_cont_expr.t) =
       ~f:(fun ~invariant_params:_ ~body handlers ->
         (* TODO support them *)
         let env =
-          Continuation.Set.fold
+          List.fold_right
             (fun c env ->
               let _, env = Env.bind_named_continuation env c in
               env)
@@ -1033,7 +1033,7 @@ and let_cont_expr env (lc : Flambda.Let_cont_expr.t) =
               in
               cont_handler env c sort handler)
             (handlers |> Flambda.Continuation_handlers.to_map
-           |> Continuation.Map.bindings)
+           |> Continuation.Lmap.bindings)
         in
         let body = expr env body in
         Fexpr.Let_cont { recursive = Recursive; bindings; body })
@@ -1236,7 +1236,7 @@ module Iter = struct
 
   and let_cont_rec f_c f_s conts body =
     let map = Continuation_handlers.to_map conts in
-    Continuation.Map.iter (continuation_handler f_c f_s) map;
+    Continuation.Lmap.iter (continuation_handler f_c f_s) map;
     expr f_c f_s body
 
   and continuation_handler f_c f_s _ h =

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -512,7 +512,7 @@ and rebuild_holed (kinds : Flambda_kind.t Name.Map.t) (env : env)
            (Bound_parameters.to_list params))
     in
     let handlers =
-      Continuation.Map.mapi
+      Continuation.Lmap.mapi
         (fun cont handler ->
           let { bound_parameters; expr; is_exn_handler; is_cold } = handler in
           let bound_parameters = filter_params cont bound_parameters in
@@ -522,9 +522,7 @@ and rebuild_holed (kinds : Flambda_kind.t Name.Map.t) (env : env)
         handlers
     in
     let invariant_params =
-      filter_params
-        (fst (Continuation.Map.min_binding handlers))
-        invariant_params
+      filter_params (fst (Continuation.Lmap.choose handlers)) invariant_params
     in
     let let_cont_expr =
       RE.create_recursive_let_cont ~invariant_params handlers ~body:hole

--- a/middle_end/flambda2/reaper/rebuilt_expr.mli
+++ b/middle_end/flambda2/reaper/rebuilt_expr.mli
@@ -19,7 +19,7 @@ type continuation_handler =
   }
 
 type continuation_handlers =
-  { handlers : Flambda.Continuation_handler.t Continuation.Map.t;
+  { handlers : Flambda.Continuation_handler.t Continuation.Lmap.t;
     free_names : Name_occurrences.t
   }
 
@@ -38,14 +38,14 @@ val create_continuation_handler :
   continuation_handler
 
 val create_continuation_handlers :
-  continuation_handler Continuation.Map.t -> continuation_handlers
+  continuation_handler Continuation.Lmap.t -> continuation_handlers
 
 val create_non_recursive_let_cont :
   Continuation.t -> continuation_handler -> body:t -> t
 
 val create_recursive_let_cont :
   invariant_params:Bound_parameters.t ->
-  continuation_handler Continuation.Map.t ->
+  continuation_handler Continuation.Lmap.t ->
   body:t ->
   t
 

--- a/middle_end/flambda2/reaper/rev_expr.ml
+++ b/middle_end/flambda2/reaper/rev_expr.ml
@@ -33,7 +33,7 @@ type rev_expr_holed =
       }
   | Let_cont_rec of
       { invariant_params : Bound_parameters.t;
-        handlers : cont_handler Continuation.Map.t;
+        handlers : cont_handler Continuation.Lmap.t;
         parent : rev_expr_holed
       }
 

--- a/middle_end/flambda2/reaper/rev_expr.mli
+++ b/middle_end/flambda2/reaper/rev_expr.mli
@@ -33,7 +33,7 @@ type rev_expr_holed =
       }
   | Let_cont_rec of
       { invariant_params : Bound_parameters.t;
-        handlers : cont_handler Continuation.Map.t;
+        handlers : cont_handler Continuation.Lmap.t;
         parent : rev_expr_holed
       }
 

--- a/middle_end/flambda2/simplify/original_handlers.mli
+++ b/middle_end/flambda2/simplify/original_handlers.mli
@@ -17,18 +17,20 @@ type t = private
   | Recursive of
       { invariant_params : Bound_parameters.t;
         lifted_params : Lifted_cont_params.t;
-        continuation_handlers : One_recursive_handler.t Continuation.Map.t
+        continuation_handlers : One_recursive_handler.t Continuation.Lmap.t
       }
   | Non_recursive of Non_recursive_handler.t
 
 val create_recursive :
   invariant_params:Bound_parameters.t ->
   lifted_params:Lifted_cont_params.t ->
-  continuation_handlers:One_recursive_handler.t Continuation.Map.t ->
+  continuation_handlers:One_recursive_handler.t Continuation.Lmap.t ->
   t
 
 val create_non_recursive : Non_recursive_handler.t -> t
 
 val print : Format.formatter -> t -> unit
+
+val bound_continuations : t -> Continuation.t list
 
 val add_params_to_lift : t -> Lifted_cont_params.t -> t

--- a/middle_end/flambda2/simplify/rebuilt_expr.mli
+++ b/middle_end/flambda2/simplify/rebuilt_expr.mli
@@ -133,7 +133,7 @@ val create_non_recursive_let_cont_without_free_names :
 val create_recursive_let_cont :
   Are_rebuilding_terms.t ->
   invariant_params:Bound_parameters.t ->
-  Continuation_handler.t Continuation.Map.t ->
+  Continuation_handler.t Continuation.Lmap.t ->
   body:t ->
   t
 

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -138,7 +138,7 @@ and simplify_function_body dacc expr ~return_continuation ~return_arity
         (Apply_cont_expr.create cont ~args ~dbg:Debuginfo.none)
     in
     let handlers =
-      Continuation.Map.singleton cont
+      Continuation.Lmap.singleton cont
         (Continuation_handler.create params ~handler:expr
            ~free_names_of_handler:Unknown ~is_exn_handler:false ~is_cold:false)
     in

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.mli
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.mli
@@ -22,5 +22,5 @@ val simplify_let_cont :
 
 val simplify_as_recursive_let_cont :
   simplify_expr:Expr.t Simplify_common.expr_simplifier ->
-  (Expr.t * Continuation_handler.t Continuation.Map.t)
+  (Expr.t * Continuation_handler.t Continuation.Lmap.t)
   Simplify_common.expr_simplifier

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -340,10 +340,10 @@ module Continuation_handlers : sig
   type t
 
   (** Obtain the mapping from continuation to handler. *)
-  val to_map : t -> Continuation_handler.t Continuation.Map.t
+  val to_map : t -> Continuation_handler.t Continuation.Lmap.t
 
   (** The domain of [to_map t]. *)
-  val domain : t -> Continuation.Set.t
+  val domain : t -> Continuation.t list
 
   (** Whether any of the continuations are exception handlers. *)
   val contains_exn_handler : t -> bool
@@ -402,7 +402,7 @@ module Let_cont_expr : sig
   (** Create a definition of a set of possibly-recursive continuations. *)
   val create_recursive :
     invariant_params:Bound_parameters.t ->
-    Continuation_handler.t Continuation.Map.t ->
+    Continuation_handler.t Continuation.Lmap.t ->
     body:expr ->
     expr
 end

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -862,7 +862,7 @@ and let_cont_rec env res invariant_params conts body =
   (* Compute the environment for Ccatch ids *)
   let conts_to_handlers = Continuation_handlers.to_map conts in
   let env =
-    Continuation.Map.fold
+    Continuation.Lmap.fold
       (fun k handler acc ->
         let continuation_arg_tys =
           Continuation_handler.pattern_match' handler
@@ -880,7 +880,7 @@ and let_cont_rec env res invariant_params conts body =
   in
   (* Translate each continuation handler *)
   let conts_to_handlers, res =
-    Continuation.Map.fold
+    Continuation.Lmap.fold
       (fun k handler (conts_to_handlers, res) ->
         let vars, _arity, handler, free_vars_of_handler, res =
           continuation_handler env res handler


### PR DESCRIPTION
This PR changes the representation of bound continuations to use a list (`Lmap`) instead of a regular map. This is done so that we can ensure that an (arbitrary) order of the bound continuations is kept even through renaming and other transformations. This is a pre-requisite for the replay_history (which itself is a pre-requisite of match-in-match).