### PR TITLE
Critical edges (CFG)

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -580,7 +580,7 @@ let instr_id = InstructionId.make_sequence ()
 
 let reset_instr_id () = InstructionId.reset instr_id
 
-let next_instr_id () = InstructionId.get_next instr_id
+let next_instr_id () = InstructionId.get_and_incr instr_id
 
 let make_instr desc arg res dbg =
   { desc;

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -170,7 +170,7 @@ let rec combine : instr_id:InstructionId.sequence -> cell option -> unit =
             Cfg.Op (Intop_imm (Operation.Iadd, total_size_of_other_allocations));
           arg = [| first_allocation_res0 |];
           res = [| first_allocation_res0 |];
-          id = InstructionId.get_next instr_id
+          id = InstructionId.get_and_incr instr_id
         });
     combine ~instr_id compatible_allocs.next_cell
 

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -270,7 +270,7 @@ end = struct
     { instruction_id }
 
   let get_and_incr_instruction_id state =
-    InstructionId.get_next state.instruction_id
+    InstructionId.get_and_incr state.instruction_id
 end
 
 let insert_single_move :

--- a/backend/cfg/cfg_edge.ml
+++ b/backend/cfg/cfg_edge.ml
@@ -1,0 +1,22 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+
+module T = struct
+  type t =
+    { src : Label.t;
+      dst : Label.t
+    }
+
+  let compare { src = left_src; dst = left_dst }
+      { src = right_src; dst = right_dst } =
+    match Label.compare left_src right_src with
+    | 0 -> Label.compare left_dst right_dst
+    | c -> c
+end
+
+include T
+
+module Map : Map.S with type key = t = Map.Make (T)
+
+module Set : Set.S with type elt = t = Set.Make (T)

--- a/backend/cfg/cfg_edge.mli
+++ b/backend/cfg/cfg_edge.mli
@@ -1,0 +1,12 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+type t =
+  { src : Label.t;
+    dst : Label.t
+  }
+
+val compare : t -> t -> int
+
+module Map : Map.S with type key = t
+
+module Set : Set.S with type elt = t

--- a/backend/cfg/cfg_loop_infos.ml
+++ b/backend/cfg/cfg_loop_infos.ml
@@ -7,25 +7,9 @@ let fatal = Misc.fatal_errorf
 
 let debug = false
 
-module Edge = struct
-  type t =
-    { src : Label.t;
-      dst : Label.t
-    }
-
-  let compare { src = left_src; dst = left_dst }
-      { src = right_src; dst = right_dst } =
-    match Label.compare left_src right_src with
-    | 0 -> Label.compare left_dst right_dst
-    | c -> c
-end
-
-module EdgeMap : Map.S with type key = Edge.t = Map.Make (Edge)
-
-module EdgeSet : Set.S with type elt = Edge.t = Set.Make (Edge)
-
 let compute_back_edges cfg dominators =
-  Cfg.fold_blocks cfg ~init:EdgeSet.empty ~f:(fun src_label src_block acc ->
+  Cfg.fold_blocks cfg ~init:Cfg_edge.Set.empty
+    ~f:(fun src_label src_block acc ->
       let dst_labels =
         (* CR-soon xclerc for xclerc: probably safe to pass `~exn:false`. *)
         Cfg.successor_labels ~normal:true ~exn:true src_block
@@ -36,13 +20,14 @@ let compute_back_edges cfg dominators =
             Cfg_dominators.is_dominating dominators dst_label src_label
           in
           if is_back_edge
-          then EdgeSet.add { Edge.src = src_label; dst = dst_label } acc
+          then
+            Cfg_edge.Set.add { Cfg_edge.src = src_label; dst = dst_label } acc
           else acc)
         dst_labels acc)
 
 type loop = Label.Set.t
 
-let compute_loop_of_back_edge cfg { Edge.src; dst } =
+let compute_loop_of_back_edge cfg { Cfg_edge.src; dst } =
   let rec visit stack acc =
     match stack with
     | [] -> acc
@@ -60,12 +45,13 @@ let compute_loop_of_back_edge cfg { Edge.src; dst } =
   in
   visit [src] (Label.Set.add src (Label.Set.singleton dst))
 
-type loops = loop EdgeMap.t
+type loops = loop Cfg_edge.Map.t
 
 let compute_loops_of_back_edges cfg back_edges =
-  EdgeSet.fold
-    (fun edge acc -> EdgeMap.add edge (compute_loop_of_back_edge cfg edge) acc)
-    back_edges EdgeMap.empty
+  Cfg_edge.Set.fold
+    (fun edge acc ->
+      Cfg_edge.Map.add edge (compute_loop_of_back_edge cfg edge) acc)
+    back_edges Cfg_edge.Map.empty
 
 type header_map = loop list Label.Map.t
 
@@ -73,8 +59,8 @@ let compute_header_map loops =
   let compare_loop_by_cardinal left right =
     Int.compare (Label.Set.cardinal left) (Label.Set.cardinal right)
   in
-  EdgeMap.fold
-    (fun { Edge.src = _; dst = header } labels acc ->
+  Cfg_edge.Map.fold
+    (fun { Cfg_edge.src = _; dst = header } labels acc ->
       Label.Map.update header
         (function
           | None -> Some [labels]
@@ -120,7 +106,7 @@ let compute_loop_depths cfg header_map =
     init
 
 type t =
-  { back_edges : EdgeSet.t;
+  { back_edges : Cfg_edge.Set.t;
     loops : loops;
     header_map : header_map;
     loop_depths : loop_depths
@@ -136,12 +122,12 @@ let build : Cfg.t -> Cfg_dominators.t -> t =
   then (
     Format.eprintf "*** Cfg_loop_infos.build for %S\n" cfg.Cfg.fun_name;
     Format.eprintf "back edges:\n";
-    EdgeSet.iter
-      (fun { Edge.src; dst } ->
+    Cfg_edge.Set.iter
+      (fun { Cfg_edge.src; dst } ->
         Format.eprintf "- %a -> %a\n" Label.format src Label.format dst)
       back_edges;
-    EdgeMap.iter
-      (fun { Edge.src; dst } labels ->
+    Cfg_edge.Map.iter
+      (fun { Cfg_edge.src; dst } labels ->
         Format.eprintf "loop for back edge %a -> %a:\n" Label.format src
           Label.format dst;
         Label.Set.iter (Format.eprintf "- %a:\n" Label.format) labels)

--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -1,31 +1,18 @@
 [@@@ocaml.warning "+a-40-41-42"]
 
-module Edge : sig
-  type t =
-    { src : Label.t;
-      dst : Label.t
-    }
-
-  val compare : t -> t -> int
-end
-
-module EdgeMap : Map.S with type key = Edge.t
-
-module EdgeSet : Set.S with type elt = Edge.t
-
-val compute_back_edges : Cfg.t -> Cfg_dominators.t -> EdgeSet.t
+val compute_back_edges : Cfg.t -> Cfg_dominators.t -> Cfg_edge.Set.t
 
 type loop = Label.Set.t
 (* Blocks in a loop; if a node is part of several/nested loops, it will appear
    in several sets. *)
 
-val compute_loop_of_back_edge : Cfg.t -> Edge.t -> loop
+val compute_loop_of_back_edge : Cfg.t -> Cfg_edge.t -> loop
 (* Assumes the passed edge is a back edge. *)
 
-type loops = loop EdgeMap.t
+type loops = loop Cfg_edge.Map.t
 (* Map from back edge to loop. *)
 
-val compute_loops_of_back_edges : Cfg.t -> EdgeSet.t -> loops
+val compute_loops_of_back_edges : Cfg.t -> Cfg_edge.Set.t -> loops
 (* Assumes the passed edges are back edges. *)
 
 type header_map = loop list Label.Map.t
@@ -39,7 +26,7 @@ type loop_depths = int Label.Map.t
 val compute_loop_depths : Cfg.t -> header_map -> loop_depths
 
 type t = private
-  { back_edges : EdgeSet.t;
+  { back_edges : Cfg_edge.Set.t;
     loops : loops;
     header_map : header_map;
     loop_depths : loop_depths

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -309,7 +309,7 @@ let instr_cfg_with_layout :
        InstructionId.make_sequence ~last_used:(Cfg.max_instr_id cfg) ())
   in
   let next_instruction_id () =
-    InstructionId.get_next (Lazy.force instruction_id)
+    InstructionId.get_and_incr (Lazy.force instruction_id)
   in
   Cfg_edge.Set.fold
     (fun { Cfg_edge.src; dst } added_poll ->

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -299,7 +299,7 @@ let exists_unsafe_path :
 let instr_cfg_with_layout :
     Cfg_with_layout.t ->
     safe_map:bool Label.Tbl.t ->
-    back_edges:Cfg_loop_infos.EdgeSet.t ->
+    back_edges:Cfg_edge.Set.t ->
     bool =
  fun cfg_with_layout ~safe_map ~back_edges ->
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
@@ -311,8 +311,8 @@ let instr_cfg_with_layout :
   let next_instruction_id () =
     InstructionId.get_next (Lazy.force instruction_id)
   in
-  Cfg_loop_infos.EdgeSet.fold
-    (fun { Cfg_loop_infos.Edge.src; dst } added_poll ->
+  Cfg_edge.Set.fold
+    (fun { Cfg_edge.src; dst } added_poll ->
       let needs_poll =
         (not (Label.Tbl.find safe_map src))
         && exists_unsafe_path cfg ~safe_map ~from:dst ~to_:src

--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -184,7 +184,7 @@ let insert_instruction (cfg : Cfg.t) (label : Label.t) ~max_frame_size
        xclerc: (keeping the comment, and the explicit values below until all of
        that is implemented.) *)
     let seq = InstructionId.make_sequence ~last_used:max_instr_id () in
-    let id = InstructionId.get_next seq in
+    let id = InstructionId.get_and_incr seq in
     Cfg.make_instruction ()
       ~desc:(Cfg.Stack_check { max_frame_size_bytes = max_frame_size })
       ~stack_offset ~id ~available_before:None ~available_across:None

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -456,7 +456,7 @@ let insert_block :
       ( Debuginfo.none,
         Fdo_info.none,
         Reg.Set.empty,
-        predecessor_block.stack_offset,
+        predecessor_block.terminator.stack_offset,
         None,
         None )
     | Some

--- a/backend/cfg/instructionId.ml
+++ b/backend/cfg/instructionId.ml
@@ -23,7 +23,7 @@ let reset seq = seq.next <- 0
 
 let get seq = seq.next
 
-let get_next seq =
+let get_and_incr seq =
   let res = seq.next in
   seq.next <- succ seq.next;
   res

--- a/backend/cfg/instructionId.ml
+++ b/backend/cfg/instructionId.ml
@@ -21,6 +21,8 @@ let make_sequence ?(last_used = -1) () = { next = succ last_used }
 
 let reset seq = seq.next <- 0
 
+let get seq = seq.next
+
 let get_next seq =
   let res = seq.next in
   seq.next <- succ seq.next;

--- a/backend/cfg/instructionId.mli
+++ b/backend/cfg/instructionId.mli
@@ -24,6 +24,6 @@ val reset : sequence -> unit
 
 val get : sequence -> t
 
-val get_next : sequence -> t
+val get_and_incr : sequence -> t
 
 val to_int_unsafe : t -> int

--- a/backend/cfg/instructionId.mli
+++ b/backend/cfg/instructionId.mli
@@ -22,6 +22,8 @@ val make_sequence : ?last_used:t -> unit -> sequence
 
 val reset : sequence -> unit
 
+val get : sequence -> t
+
 val get_next : sequence -> t
 
 val to_int_unsafe : t -> int

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -42,7 +42,7 @@ end = struct
 
   let fun_dbg t = (Cfg_with_layout.cfg t.cfg_with_layout).fun_dbg
 
-  let next_available_instruction t = InstructionId.get_next t.instruction_id
+  let next_available_instruction t = InstructionId.get_and_incr t.instruction_id
 
   let create ppf_dump cl =
     (* CR-someday tip: the function may someday take a cfg_with_infos instead of

--- a/backend/regalloc/regalloc_gi_state.ml
+++ b/backend/regalloc/regalloc_gi_state.ml
@@ -52,4 +52,4 @@ let[@inline] initial_temporary_count state = state.initial_temporaries
 let[@inline] stack_slots state = state.stack_slots
 
 let[@inline] get_and_incr_instruction_id state =
-  InstructionId.get_next state.instruction_id
+  InstructionId.get_and_incr state.instruction_id

--- a/backend/regalloc/regalloc_irc_state.ml
+++ b/backend/regalloc/regalloc_irc_state.ml
@@ -550,7 +550,7 @@ let[@inline] add_alias state v u =
 let[@inline] stack_slots state = state.stack_slots
 
 let[@inline] get_and_incr_instruction_id state =
-  InstructionId.get_next state.instruction_id
+  InstructionId.get_and_incr state.instruction_id
 
 let[@inline] add_inst_temporaries_list state regs =
   state.inst_temporaries

--- a/backend/regalloc/regalloc_ls_state.ml
+++ b/backend/regalloc/regalloc_ls_state.ml
@@ -107,7 +107,7 @@ let[@inline] active_classes state = state.active
 let[@inline] stack_slots state = state.stack_slots
 
 let[@inline] get_and_incr_instruction_id state =
-  InstructionId.get_next state.instruction_id
+  InstructionId.get_and_incr state.instruction_id
 
 let rec check_ranges (prev : Range.t) (cell : Range.t DLL.cell option) : int =
   if prev.begin_ > prev.end_

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -296,6 +296,8 @@ let rewrite_gen :
           if not (DLL.is_empty new_instrs)
           then
             (* insert block *)
+            (* CR-soon xclerc for xclerc: now that we preprocess critical nodes,
+               no insertion should occur here. *)
             let (_ : Cfg.basic_block list) =
               Cfg_with_layout.insert_block
                 (Cfg_with_infos.cfg_with_layout cfg_with_infos)
@@ -325,6 +327,37 @@ let rewrite_gen :
    above. *)
 let threshold_split_live_ranges = 1024
 
+(* A critical edge is an edge such that the source has several successors and
+   the destination has several predecessors. Such edges are problematic because
+   if an instruction needs to be inserted between the source and the
+   destination, a block will need to be inserted. *)
+let compute_critical_edges : Cfg.t -> Cfg_edge.Set.t =
+ fun cfg ->
+  Cfg.fold_blocks cfg ~init:Cfg_edge.Set.empty
+    ~f:(fun label block critical_edges ->
+      match block.exn with
+      | Some _ -> critical_edges
+      | None -> (
+        let successor_labels =
+          Cfg.successor_labels ~normal:true ~exn:false block
+        in
+        match Label.Set.cardinal successor_labels with
+        | 0 | 1 -> critical_edges
+        | _ ->
+          Label.Set.fold
+            (fun successor_label critical_edges ->
+              let successor_block = Cfg.get_block_exn cfg successor_label in
+              if (not (Cfg.can_raise_terminator block.terminator.desc))
+                 && (not (Label.equal label successor_label))
+                 && Label.Set.cardinal successor_block.predecessors > 1
+              then (
+                assert (not successor_block.is_trap_handler);
+                Cfg_edge.Set.add
+                  { Cfg_edge.src = label; dst = successor_label }
+                  critical_edges)
+              else critical_edges)
+            successor_labels critical_edges))
+
 let prelude :
     (module Utils) ->
     on_fatal_callback:(unit -> unit) ->
@@ -341,6 +374,32 @@ let prelude :
     Utils.log "precondition";
     Regalloc_invariants.precondition cfg_with_layout);
   let cfg_infos = collect_cfg_infos cfg_with_layout in
+  let cfg = Cfg_with_layout.cfg cfg_with_layout in
+  (* We identify critical edges, and pre-emptively insert block so that the
+     register allocator will not have to change the shape of the CFG. *)
+  let critical_edges = compute_critical_edges cfg in
+  let cfg_infos =
+    if Cfg_edge.Set.is_empty critical_edges
+    then cfg_infos
+    else
+      let instruction_id =
+        InstructionId.make_sequence ~last_used:cfg_infos.max_instruction_id ()
+      in
+      Cfg_edge.Set.iter
+        (fun { Cfg_edge.src; dst } ->
+          let (_inserted_blocks : Cfg.basic_block list) =
+            Cfg_with_layout.insert_block cfg_with_layout (DLL.make_empty ())
+              ~after:(Cfg.get_block_exn cfg src)
+              ~before:(Some (Cfg.get_block_exn cfg dst))
+              ~next_instruction_id:(fun () ->
+                InstructionId.get_next instruction_id)
+          in
+          ())
+        critical_edges;
+      Cfg_with_infos.invalidate_liveness cfg_with_infos;
+      Cfg_with_infos.invalidate_dominators_and_loop_infos cfg_with_infos;
+      { cfg_infos with max_instruction_id = InstructionId.get instruction_id }
+  in
   let num_temporaries =
     (* note: this should probably be `Reg.Set.cardinal (Reg.Set.union
        cfg_infos.arg cfg_infos.res)` but the following experimentally produces

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -392,7 +392,7 @@ let prelude :
               ~after:(Cfg.get_block_exn cfg src)
               ~before:(Some (Cfg.get_block_exn cfg dst))
               ~next_instruction_id:(fun () ->
-                InstructionId.get_next instruction_id)
+                InstructionId.get_and_incr instruction_id)
           in
           ())
         critical_edges;

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -400,6 +400,8 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
             let instrs = DLL.make_empty () in
             add_phi_moves_to_instr_list state ~before:predecessor_block
               ~phi:block substs to_unify instrs;
+            (* CR-soon xclerc for xclerc: now that we preprocess critical nodes,
+               no insertion should occur here. *)
             let inserted_blocks =
               Cfg_with_layout.insert_block
                 (Cfg_with_infos.cfg_with_layout cfg_with_infos)

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -719,4 +719,4 @@ let phi_at_beginning state = state.phi_at_beginning
 let stack_slots state = state.stack_slots
 
 let get_and_incr_instruction_id state =
-  InstructionId.get_next state.instruction_id
+  InstructionId.get_and_incr state.instruction_id

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -321,7 +321,7 @@ end = struct
   (* CR-someday xclerc for xclerc: move to Cfg_loop_infos? *)
   let is_in_loop : Cfg_loop_infos.t -> Label.t -> bool =
    fun loops label ->
-    Cfg_loop_infos.EdgeMap.exists
+    Cfg_edge.Map.exists
       (fun _ (loop : Cfg_loop_infos.loop) -> Label.Set.mem label loop)
       loops.loops
 

--- a/dune
+++ b/dune
@@ -489,6 +489,7 @@
   ;; backend/cfg
   cfg
   cfg_available_regs
+  cfg_edge
   cfg_intf
   cfg_to_linear
   cfg_with_layout

--- a/flambda-backend/tests/backend/regalloc_validator/check_regalloc_validation.ml
+++ b/flambda-backend/tests/backend/regalloc_validator/check_regalloc_validation.ml
@@ -234,11 +234,11 @@ let float = Array.init 8 (fun _ -> Reg.create Float)
 let base_templ () : Cfg_desc.t * (unit -> InstructionId.t) =
   let make_id =
     let seq = InstructionId.make_sequence () in
-    let _zero : InstructionId.t = InstructionId.get_next seq in
-    let _one : InstructionId.t = InstructionId.get_next seq in
-    let _two : InstructionId.t = InstructionId.get_next seq in
+    let _zero : InstructionId.t = InstructionId.get_and_incr seq in
+    let _one : InstructionId.t = InstructionId.get_and_incr seq in
+    let _two : InstructionId.t = InstructionId.get_and_incr seq in
     fun () ->
-      InstructionId.get_next seq
+      InstructionId.get_and_incr seq
   in
   let make_locs regs f =
     let locs = f (Array.map (fun (r : Reg.t) -> r.typ) regs) in
@@ -830,11 +830,11 @@ let () =
 let make_loop ~loop_loc_first n =
   let make_id =
     let seq = InstructionId.make_sequence () in
-    let _zero : InstructionId.t = InstructionId.get_next seq in
-    let _one : InstructionId.t = InstructionId.get_next seq in
-    let _two : InstructionId.t = InstructionId.get_next seq in
+    let _zero : InstructionId.t = InstructionId.get_and_incr seq in
+    let _one : InstructionId.t = InstructionId.get_and_incr seq in
+    let _two : InstructionId.t = InstructionId.get_and_incr seq in
     fun () ->
-      InstructionId.get_next seq
+      InstructionId.get_and_incr seq
   in
   let make_locs regs f =
     let locs = f (Array.map (fun (r : Reg.t) -> r.typ) regs) in


### PR DESCRIPTION
This pull request identifies critical
edges in the CFG, and preemptively
inserts blocks so that there are no
critical edges left.

A critical edge is an edge such that
the source has several successors
and the destination several predecessors.
Such edges are problematic, because
if an instruction (typically a spill or a
reload) needs to be inserted between
the source and the destination, then
a block has to be inserted.

As a result, register allocation should
no longer insert blocks. I have tested
on the compiler distribution it is indeed
the case, but further testing is needed
before we can confidently simplify the
logic by removing the other insertions.
I have left CR-soons to do so.

This pul request also contains a
small fix to the existing insertion
logic on a code path that was not
exercised before - credits go to
@gretay-js.