### PR TITLE
Patches illustrating the changes of removing the FCM in the assembly emitters

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -653,9 +653,9 @@ let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) =
 
       let loc ~file_num ~line ~col ?discriminator () =
         ignore discriminator;
-        D.loc ~file_num ~line ~col ?discriminator ()
+        ND.loc ~file_num ~line ~col ?discriminator ()
 
-      let comment str = D.comment str
+      let comment str = ND.comment str
 
       let label ?data_type str =
         let _ = data_type in
@@ -667,9 +667,9 @@ let build_asm_directives () : (module Asm_targets.Asm_directives_intf.S) =
         | [".text"], _, _ -> ND.text ()
         | name, flags, args -> ND.switch_to_section_raw ~names:name ~flags ~args
 
-      let text () = D.text ()
+      let text () = ND.text ()
 
-      let new_line () = D.new_line ()
+      let new_line () = ND.new_line ()
 
       let emit_constant const size =
         emit_directive

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -129,16 +129,10 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
         sections_seen := section :: !sections_seen;
         true)
     in
-    match !current_dwarf_section_ref with
-    | Some section' when Asm_section.equal section section' ->
-      assert (not first_occurrence);
-      ()
-    | _ ->
       current_dwarf_section_ref := Some section;
       let ({ names; flags; args } : Asm_section.section_details) =
         Asm_section.details section ~first_occurrence
       in
-      if not first_occurrence then new_line ();
       D.section ~delayed:(Asm_section.is_delayed section) names flags args;
       if first_occurrence then define_label (Asm_label.for_section section)
 

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -129,12 +129,12 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
         sections_seen := section :: !sections_seen;
         true)
     in
-      current_dwarf_section_ref := Some section;
-      let ({ names; flags; args } : Asm_section.section_details) =
-        Asm_section.details section ~first_occurrence
-      in
-      D.section ~delayed:(Asm_section.is_delayed section) names flags args;
-      if first_occurrence then define_label (Asm_label.for_section section)
+    current_dwarf_section_ref := Some section;
+    let ({ names; flags; args } : Asm_section.section_details) =
+      Asm_section.details section ~first_occurrence
+    in
+    D.section ~delayed:(Asm_section.is_delayed section) names flags args;
+    if first_occurrence then define_label (Asm_label.for_section section)
 
   let initialize () =
     cached_strings := Cached_string.Map.empty;
@@ -301,8 +301,8 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     (* CR poechsel: use the arguments *)
     A.emit_line "between_labels_64_bit"
 
-  let between_labels_64_bit_with_offsets ?comment:comment' ~upper ~upper_offset ~lower
-      ~lower_offset () =
+  let between_labels_64_bit_with_offsets ?comment:comment' ~upper ~upper_offset
+      ~lower ~lower_offset () =
     Option.iter comment comment';
     let upper_offset = Targetint.to_int64 upper_offset in
     let lower_offset = Targetint.to_int64 lower_offset in
@@ -317,8 +317,8 @@ module Make (A : Asm_directives_intf.Arg) : Asm_directives_intf.S = struct
     in
     const_machine_width (force_assembly_time_constant expr)
 
-  let between_symbol_in_current_unit_and_label_offset ?comment:comment' ~upper ~lower
-      ~offset_upper () =
+  let between_symbol_in_current_unit_and_label_offset ?comment:comment' ~upper
+      ~lower ~offset_upper () =
     (* CR mshinwell: add checks, as above: check_symbol_in_current_unit lower;
        check_symbol_and_label_in_same_section lower upper; *)
     Option.iter comment comment';


### PR DESCRIPTION
This PR illustrates the changes that I could find in the resulting assembly output that result from replacing the current first class module for assembly directives with the new assembly directives. Merging it is optional, since the changes are all superseded by PR #3892.