### PR TITLE
Revert "modalities zap to id for mli-less files"

### DIFF
--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -89,10 +89,10 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
-          value_mode meet(local,once,nonportable,yielding,stateful)(modevar#0[global,many,portable,unyielding,stateful .. global,many,nonportable,unyielding,stateful]);imply(unique,uncontended,read_write)(modevar#1[aliased,contended,immutable .. unique,uncontended,read_write])
+          value_mode global,many,portable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#1[aliased,contended,immutable .. unique,uncontended,read_write])
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
-          alloc_mode map_comonadic(regional_to_global)(modevar#6[global,many,portable,unyielding,stateful .. global,many,nonportable,unyielding,stateful]);id(modevar#7[aliased,contended,immutable .. unique,uncontended,read_write])
+          alloc_mode global,many,portable,unyielding,stateful;id(modevar#7[aliased,contended,immutable .. unique,uncontended,read_write])
           []
           Tfunction_cases (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           alloc_mode global,many,nonportable,unyielding,stateful;aliased,uncontended,read_write

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -89,10 +89,10 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern 
           Tpat_var "fib"
-          value_mode meet(local,once,nonportable,yielding,stateful)(modevar#0[global,many,portable,unyielding,stateful .. global,many,nonportable,unyielding,stateful]);imply(unique,uncontended,read_write)(modevar#1[aliased,contended,immutable .. unique,uncontended,read_write])
+          value_mode global,many,portable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#1[aliased,contended,immutable .. unique,uncontended,read_write])
         expression 
           Texp_function
-          alloc_mode map_comonadic(regional_to_global)(modevar#6[global,many,portable,unyielding,stateful .. global,many,nonportable,unyielding,stateful]);id(modevar#7[aliased,contended,immutable .. unique,uncontended,read_write])
+          alloc_mode global,many,portable,unyielding,stateful;id(modevar#7[aliased,contended,immutable .. unique,uncontended,read_write])
           []
           Tfunction_cases 
           alloc_mode global,many,nonportable,unyielding,stateful;aliased,uncontended,read_write

--- a/testsuite/tests/templates/basic/bad_arg_impl.reference
+++ b/testsuite/tests/templates/basic/bad_arg_impl.reference
@@ -2,7 +2,7 @@ File "bad_arg_impl.ml", line 1:
 Error: The argument module bad_arg_impl.ml
        does not match the parameter signature monoid.cmi: 
        Values do not match:
-         val append : unit -> unit -> [> `Banana ]
+         val append : unit -> unit -> [> `Banana ] @@ stateless
        is not included in
          val append : t -> t -> t
        The type "unit -> unit -> [> `Banana ]" is not compatible with the type

--- a/testsuite/tests/typing-modes/def_nonportable.ml
+++ b/testsuite/tests/typing-modes/def_nonportable.ml
@@ -1,0 +1,1 @@
+let (f @ nonportable) x = x

--- a/testsuite/tests/typing-modes/use_portable.bad.reference
+++ b/testsuite/tests/typing-modes/use_portable.bad.reference
@@ -1,4 +1,4 @@
 File "use_portable.ml", line 3, characters 22-38:
 3 | let () = portable_use Maybe_portable.f
                           ^^^^^^^^^^^^^^^^
-Error: This value is "nonportable" but expected to be "portable".
+Error: This value is nonportable but expected to be portable.

--- a/testsuite/tests/typing-modes/val_modalities_floor.ml
+++ b/testsuite/tests/typing-modes/val_modalities_floor.ml
@@ -1,8 +1,12 @@
+(* We test that cmi generated without mli has the modalities pushed to the
+strongest instead of legacy *)
+
 (* TEST
  readonly_files = "\
    def_portable.ml \
-   use_portable.ml use_portable.reference \
-  ";
+   def_nonportable.ml \
+   use_portable.ml use_portable.bad.reference \
+ ";
 {
    setup-ocamlopt.byte-build-env;
    flags = "-extension mode";
@@ -17,15 +21,27 @@
     ocamlopt.byte;
 
     module = "use_portable.ml";
-    compiler_output = "use_portable.output";
+
+    ocamlopt_byte_exit_status = "0";
+    ocamlopt.byte;
+   }
+
+   {
+    src = "def_nonportable.ml";
+    dst = "maybe_portable.ml";
+    copy;
+
+    module = "maybe_portable.ml";
+    ocamlopt_byte_exit_status = "0";
+    ocamlopt.byte;
+
+    module = "use_portable.ml";
+    compiler_output = "use_portable.bad.output";
     ocamlopt_byte_exit_status = "2";
     ocamlopt.byte;
 
-    compiler_reference = "use_portable.reference";
+    compiler_reference = "use_portable.bad.reference";
     check-ocamlopt.byte-output;
     }
 }
 *)
-
-(* We test that cmi generated without mli has the modalities pushed to the
-legacy instead of strongest *)

--- a/testsuite/tests/typing-zero-alloc/cmi_test.ml
+++ b/testsuite/tests/typing-zero-alloc/cmi_test.ml
@@ -20,7 +20,7 @@ Line 3, characters 6-18:
 Error: Signature mismatch:
        Modules do not match:
          sig
-           val f_unconstrained_variable : int -> int
+           val f_unconstrained_variable : int -> int @@ portable
            module M_constrained_variable =
              Cmi_test_lib.M_constrained_variable
            module M_no_variable = Cmi_test_lib.M_no_variable
@@ -28,7 +28,7 @@ Error: Signature mismatch:
        is not included in
          sig val f_unconstrained_variable : int -> int [@@zero_alloc] end
        Values do not match:
-         val f_unconstrained_variable : int -> int
+         val f_unconstrained_variable : int -> int @@ portable
        is not included in
          val f_unconstrained_variable : int -> int [@@zero_alloc]
        The former provides a weaker "zero_alloc" guarantee than the latter.
@@ -45,11 +45,11 @@ Line 3, characters 6-41:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : int -> int [@@zero_alloc] end
+         sig val f : int -> int @@ portable [@@zero_alloc] end
        is not included in
          sig val f : int -> int [@@zero_alloc strict] end
        Values do not match:
-         val f : int -> int [@@zero_alloc]
+         val f : int -> int @@ portable [@@zero_alloc]
        is not included in
          val f : int -> int [@@zero_alloc strict]
        The former provides a weaker "zero_alloc" guarantee than the latter.

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3901,10 +3901,10 @@ let type_implementation target modulename initial_env ast =
           in
           check_nongen_signature finalenv simple_sg;
           let simple_sg =
-            (* Generating [cmi] without [mli]. This [cmi] could be on either side of
-              inclusion check, so we zap to identity for legacy compatibility. *)
+            (* Generating [cmi] without [mli]. This [cmi] will only be on the
+               LHS of inclusion check, so we zap to floor (strongest). *)
             remove_modality_and_zero_alloc_variables_sg finalenv
-              ~zap_modality:Mode.Modality.Value.zap_to_id simple_sg
+              ~zap_modality:Mode.Modality.Value.zap_to_floor simple_sg
           in
           normalize_signature simple_sg;
           let argument_interface =


### PR DESCRIPTION
Reverts ocaml-flambda/flambda-backend#3865

This turned out to require too much changes in the tree.