### PR TITLE
Refactor amd64 simd

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -7,6 +7,7 @@ amd64/simd*.ml
 amd64/stack_check.ml
 amd64/stack_class.ml
 amd64/vectorize_specific.ml
+amd64/regalloc_stack_operands.ml
 arm64/cfg_selection.ml
 arm64/emit.ml
 arm64/selection.ml

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1505,25 +1505,22 @@ let emit_simd (op : Simd.operation) instr =
       then I.xorpd (res instr 0) (res instr 0);
       (* Instruction *)
       emit_simd_instr seq.instr imm instr
-    | Pcmpestra | Pcmpistra ->
+    | Pcompare_string p ->
+      let cond : X86_ast.condition =
+        match p with
+        | Pcmpestra -> A
+        | Pcmpestrc -> B
+        | Pcmpestro -> O
+        | Pcmpestrs -> S
+        | Pcmpestrz -> E
+        | Pcmpistra -> A
+        | Pcmpistrc -> B
+        | Pcmpistro -> O
+        | Pcmpistrs -> S
+        | Pcmpistrz -> E
+      in
       emit_simd_instr seq.instr imm instr;
-      I.set A (res8 instr 0);
-      I.movzx (res8 instr 0) (res instr 0)
-    | Pcmpestrc | Pcmpistrc ->
-      emit_simd_instr seq.instr imm instr;
-      I.set B (res8 instr 0);
-      I.movzx (res8 instr 0) (res instr 0)
-    | Pcmpestro | Pcmpistro ->
-      emit_simd_instr seq.instr imm instr;
-      I.set O (res8 instr 0);
-      I.movzx (res8 instr 0) (res instr 0)
-    | Pcmpestrs | Pcmpistrs ->
-      emit_simd_instr seq.instr imm instr;
-      I.set S (res8 instr 0);
-      I.movzx (res8 instr 0) (res instr 0)
-    | Pcmpestrz | Pcmpistrz ->
-      emit_simd_instr seq.instr imm instr;
-      I.set E (res8 instr 0);
+      I.set cond (res8 instr 0);
       I.movzx (res8 instr 0) (res instr 0))
 
 let emit_simd_instr_with_memory_arg (simd : Simd.Mem.operation) i addr =

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -529,9 +529,7 @@ let destroyed_by_simd_op (op : Simd.operation) =
     destroyed_by_simd_instr seq.instr
     |> Array.append
       (match seq.id with
-      | Sqrtss | Sqrtsd | Roundss | Roundsd
-      | Pcmpestra | Pcmpestrc | Pcmpestro | Pcmpestrs | Pcmpestrz
-      | Pcmpistra | Pcmpistrc | Pcmpistro | Pcmpistrs | Pcmpistrz -> [||])
+       | Sqrtss | Sqrtsd | Roundss | Roundsd | Pcompare_string _ -> [||])
 
 let destroyed_by_simd_mem_op (instr : Simd.Mem.operation) =
   match instr with

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -523,9 +523,9 @@ let destroyed_by_simd_instr (instr : Simd.instr) =
     | None -> [||]
 
 let destroyed_by_simd_op (op : Simd.operation) =
-  match op with
-  | Instruction { instr; _ } -> destroyed_by_simd_instr instr
-  | Sequence { seq; _ } ->
+  match op.instr with
+  | Instruction instr -> destroyed_by_simd_instr instr
+  | Sequence seq ->
     destroyed_by_simd_instr seq.instr
     |> Array.append
       (match seq.id with

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -5,61 +5,60 @@ open! Int_replace_polymorphic_compare
 
 let debug = false
 
-let may_use_stack_operand_for_second_argument
-  : type a . num_args:int -> res_is_fst:bool ->
-             spilled_map -> a Cfg.instruction -> stack_operands_rewrite
-  = fun ~num_args ~res_is_fst map instr ->
-  if debug then begin
+let may_use_stack_operand_for_second_argument :
+    type a.
+    num_args:int ->
+    res_is_fst:bool ->
+    spilled_map ->
+    a Cfg.instruction ->
+    stack_operands_rewrite =
+ fun ~num_args ~res_is_fst map instr ->
+  if debug
+  then (
     check_lengths instr ~of_arg:num_args ~of_res:1;
-    if res_is_fst then begin
-      check_same "res(0)" instr.res.(0) "arg(0)" instr.arg.(0);
-    end;
-  end;
-  begin match is_spilled map instr.arg.(1) with
+    if res_is_fst then check_same "res(0)" instr.res.(0) "arg(0)" instr.arg.(0));
+  (match is_spilled map instr.arg.(1) with
   | false -> ()
-  | true ->
-    use_stack_operand map instr.arg 1;
-  end;
+  | true -> use_stack_operand map instr.arg 1);
   May_still_have_spilled_registers
 
-let may_use_stack_operand_for_only_argument
-  : type a . has_result:bool -> spilled_map -> a Cfg.instruction -> stack_operands_rewrite
-  = fun ~has_result map instr ->
-  if debug then check_lengths instr ~of_arg:1 ~of_res:(if has_result then 1 else 0);
-  begin match is_spilled map instr.arg.(0) with
+let may_use_stack_operand_for_only_argument :
+    type a.
+    has_result:bool ->
+    spilled_map ->
+    a Cfg.instruction ->
+    stack_operands_rewrite =
+ fun ~has_result map instr ->
+  if debug
+  then check_lengths instr ~of_arg:1 ~of_res:(if has_result then 1 else 0);
+  (match is_spilled map instr.arg.(0) with
   | false -> ()
-  | true ->
-    use_stack_operand map instr.arg 0
-  end;
-  if has_result then
-    May_still_have_spilled_registers
-  else
-    All_spilled_registers_rewritten
+  | true -> use_stack_operand map instr.arg 0);
+  if has_result
+  then May_still_have_spilled_registers
+  else All_spilled_registers_rewritten
 
-let may_use_stack_operand_for_only_result
-  : type a . spilled_map -> a Cfg.instruction -> stack_operands_rewrite
-  = fun map instr ->
+let may_use_stack_operand_for_only_result :
+    type a. spilled_map -> a Cfg.instruction -> stack_operands_rewrite =
+ fun map instr ->
   if debug then check_lengths instr ~of_arg:0 ~of_res:1;
-  begin match is_spilled map instr.res.(0) with
-  | false ->
-    All_spilled_registers_rewritten
+  match is_spilled map instr.res.(0) with
+  | false -> All_spilled_registers_rewritten
   | true ->
     use_stack_operand map instr.res 0;
     All_spilled_registers_rewritten
-  end
 
-let may_use_stack_operand_for_result
-  : type a . num_args:int -> spilled_map -> a Cfg.instruction -> stack_operands_rewrite
-  = fun ~num_args map instr ->
+let may_use_stack_operand_for_result :
+    type a.
+    num_args:int -> spilled_map -> a Cfg.instruction -> stack_operands_rewrite =
+ fun ~num_args map instr ->
   if debug then check_lengths instr ~of_arg:num_args ~of_res:1;
-  begin match is_spilled map instr.res.(0) with
+  (match is_spilled map instr.res.(0) with
   | false -> ()
   | true ->
-    if Reg.same instr.arg.(0) instr.res.(0) then begin
-      use_stack_operand map instr.arg 0;
-    end;
-    use_stack_operand map instr.res 0;
-  end;
+    if Reg.same instr.arg.(0) instr.res.(0)
+    then use_stack_operand map instr.arg 0;
+    use_stack_operand map instr.res 0);
   May_still_have_spilled_registers
 
 type result =
@@ -67,66 +66,60 @@ type result =
   | Result_cannot_be_on_stack
 
 let is_stack_operand : Reg.t -> bool =
-  fun reg ->
-    match reg.loc with
-    | Stack _ -> true
-    | Unknown | Reg _ -> false
+ fun reg -> match reg.loc with Stack _ -> true | Unknown | Reg _ -> false
 
-let binary_operation
-  : type a . spilled_map -> a Cfg.instruction -> result -> stack_operands_rewrite
-  = fun map instr result ->
-  if debug then begin
+let binary_operation :
+    type a. spilled_map -> a Cfg.instruction -> result -> stack_operands_rewrite
+    =
+ fun map instr result ->
+  (if debug
+  then
     match result with
     | Result_can_be_on_stack ->
       check_lengths instr ~of_arg:2 ~of_res:1;
       check_same "res(0)" instr.res.(0) "arg(0)" instr.arg.(0)
-    | Result_cannot_be_on_stack ->
-      check_lengths instr ~of_arg:2 ~of_res:1
-  end;
+    | Result_cannot_be_on_stack -> check_lengths instr ~of_arg:2 ~of_res:1);
   let already_has_memory_operand =
     is_stack_operand instr.arg.(0)
     || is_stack_operand instr.arg.(1)
-    || (match result with
-      | Result_cannot_be_on_stack ->
-        assert (not (is_stack_operand instr.res.(0)));
-        false
-      | Result_can_be_on_stack ->
-        (* note: actually unreachable since instr.res.(0) and
-           instr.arg.(0) are the same. *)
-        is_stack_operand instr.res.(0))
+    ||
+    match result with
+    | Result_cannot_be_on_stack ->
+      assert (not (is_stack_operand instr.res.(0)));
+      false
+    | Result_can_be_on_stack ->
+      (* note: actually unreachable since instr.res.(0) and instr.arg.(0) are
+         the same. *)
+      is_stack_operand instr.res.(0)
   in
-  if already_has_memory_operand then
-    May_still_have_spilled_registers
-  else begin
+  if already_has_memory_operand
+  then May_still_have_spilled_registers
+  else
     match is_spilled map instr.arg.(0), is_spilled map instr.arg.(1) with
-    | false, false ->
-      begin match result with
-      | Result_can_be_on_stack ->
-        All_spilled_registers_rewritten
-      | Result_cannot_be_on_stack ->
-        May_still_have_spilled_registers
-      end
-    | false, true ->
+    | false, false -> (
+      match result with
+      | Result_can_be_on_stack -> All_spilled_registers_rewritten
+      | Result_cannot_be_on_stack -> May_still_have_spilled_registers)
+    | false, true -> (
       use_stack_operand map instr.arg 1;
-      begin match result with
+      match result with
       | Result_can_be_on_stack | Result_cannot_be_on_stack ->
-        May_still_have_spilled_registers
-      end
-    | true, false ->
-      (* note: slightly different from the case above, because arg.(0) and res.(0) are the same. *)
-      begin match result with
+        May_still_have_spilled_registers)
+    | true, false -> (
+      (* note: slightly different from the case above, because arg.(0) and
+         res.(0) are the same. *)
+      match result with
       | Result_can_be_on_stack ->
         use_stack_operand map instr.res 0;
         use_stack_operand map instr.arg 0;
         All_spilled_registers_rewritten
       | Result_cannot_be_on_stack ->
         use_stack_operand map instr.arg 0;
-        May_still_have_spilled_registers
-      end;
-    | true, true ->
-      if Reg.same instr.arg.(0) instr.arg.(1) then
-        May_still_have_spilled_registers
-      else begin
+        May_still_have_spilled_registers)
+    | true, true -> (
+      if Reg.same instr.arg.(0) instr.arg.(1)
+      then May_still_have_spilled_registers
+      else
         match result with
         | Result_can_be_on_stack ->
           use_stack_operand map instr.arg 0;
@@ -134,64 +127,82 @@ let binary_operation
           May_still_have_spilled_registers
         | Result_cannot_be_on_stack ->
           use_stack_operand map instr.arg 0;
-          May_still_have_spilled_registers
-      end
-  end
+          May_still_have_spilled_registers)
 
-let unary_operation_argument_or_result_on_stack
-  : type a . spilled_map -> a Cfg.instruction -> stack_operands_rewrite
-  = fun map instr ->
+let unary_operation_argument_or_result_on_stack :
+    type a. spilled_map -> a Cfg.instruction -> stack_operands_rewrite =
+ fun map instr ->
   if debug then check_lengths instr ~of_arg:1 ~of_res:1;
   if is_stack_operand instr.arg.(0) || is_stack_operand instr.res.(0)
   then May_still_have_spilled_registers
-  else match is_spilled map instr.arg.(0), is_spilled map instr.res.(0) with
-  | false, false -> All_spilled_registers_rewritten
-  | false, true ->
-    use_stack_operand map instr.res 0;
-    All_spilled_registers_rewritten
-  | true, false ->
-    use_stack_operand map instr.arg 0;
-    All_spilled_registers_rewritten
-  | true, true ->
-    if Reg.same instr.arg.(0) instr.res.(0)
-    then May_still_have_spilled_registers
-    else begin
+  else
+    match is_spilled map instr.arg.(0), is_spilled map instr.res.(0) with
+    | false, false -> All_spilled_registers_rewritten
+    | false, true ->
+      use_stack_operand map instr.res 0;
+      All_spilled_registers_rewritten
+    | true, false ->
       use_stack_operand map instr.arg 0;
-      May_still_have_spilled_registers
-    end
+      All_spilled_registers_rewritten
+    | true, true ->
+      if Reg.same instr.arg.(0) instr.res.(0)
+      then May_still_have_spilled_registers
+      else (
+        use_stack_operand map instr.arg 0;
+        May_still_have_spilled_registers)
 
 let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
-  begin match instr.desc with
+  match instr.desc with
   | Op (Floatop (_, (Iaddf | Isubf | Imulf | Idivf))) ->
-    may_use_stack_operand_for_second_argument map instr ~num_args:2 ~res_is_fst:true
+    may_use_stack_operand_for_second_argument map instr ~num_args:2
+      ~res_is_fst:true
   | Op (Specific Ipackf32) -> May_still_have_spilled_registers
-  | Op (Specific (Isimd (Instruction { instr = simd; _ })))
-  | Op (Specific (Isimd (Sequence { seq = { instr = simd; id =
-          Sqrtss | Sqrtsd | Roundss | Roundsd |
-          Pcmpestra | Pcmpestrc | Pcmpestro | Pcmpestrs | Pcmpestrz |
-          Pcmpistra | Pcmpistrc | Pcmpistro | Pcmpistrs | Pcmpistrz }; _ }))) ->
-    (match Array.length simd.args, simd.res with
+  | Op (Specific (Isimd op)) -> (
+    let simd =
+      match op.instr with
+      | Instruction instr -> instr
+      | Sequence seq -> seq.instr
+    in
+    match Array.length simd.args, simd.res with
     | 1, First_arg -> May_still_have_spilled_registers
     | 1, Res { loc = res_loc; _ } ->
       let arg_mem = Simd.loc_allows_mem simd.args.(0).loc in
       let res_mem = Simd.loc_allows_mem res_loc in
       assert (not (arg_mem && res_mem));
-      if arg_mem then may_use_stack_operand_for_only_argument map instr ~has_result:true
-      else if res_mem then may_use_stack_operand_for_result map instr ~num_args:1
+      if arg_mem
+      then may_use_stack_operand_for_only_argument map instr ~has_result:true
+      else if res_mem
+      then may_use_stack_operand_for_result map instr ~num_args:1
       else May_still_have_spilled_registers
     | num_args, First_arg ->
       if Simd.loc_allows_mem simd.args.(1).loc
-      then may_use_stack_operand_for_second_argument map instr ~num_args ~res_is_fst:true
+      then
+        may_use_stack_operand_for_second_argument map instr ~num_args
+          ~res_is_fst:true
       else May_still_have_spilled_registers
     | num_args, Res { loc = res_loc; _ } ->
       let arg_mem = Simd.loc_allows_mem simd.args.(1).loc in
       let res_mem = Simd.loc_allows_mem res_loc in
       assert (not (arg_mem && res_mem));
-      if arg_mem then may_use_stack_operand_for_second_argument map instr ~num_args ~res_is_fst:false
-      else if res_mem then may_use_stack_operand_for_result map instr ~num_args
+      if arg_mem
+      then
+        may_use_stack_operand_for_second_argument map instr ~num_args
+          ~res_is_fst:false
+      else if res_mem
+      then may_use_stack_operand_for_result map instr ~num_args
       else May_still_have_spilled_registers)
-  | Op (Specific (Isimd_mem ((SSE2 Add_f64 | SSE2 Sub_f64 | SSE2 Mul_f64 | SSE2 Div_f64 |
-                              SSE Add_f32 | SSE Sub_f32 | SSE Mul_f32 | SSE Div_f32), _))) ->
+  | Op
+      (Specific
+        (Isimd_mem
+          ( ( SSE2 Add_f64
+            | SSE2 Sub_f64
+            | SSE2 Mul_f64
+            | SSE2 Div_f64
+            | SSE Add_f32
+            | SSE Sub_f32
+            | SSE Mul_f32
+            | SSE Div_f32 ),
+            _ ))) ->
     May_still_have_spilled_registers
   | Op (Reinterpret_cast (Float_of_float32 | Float32_of_float | V128_of_v128))
   | Op (Static_cast (V128_of_scalar Float64x2 | Scalar_of_v128 Float64x2))
@@ -206,89 +217,81 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
   | Op (Static_cast (Scalar_of_v128 (Int16x8 | Int8x16))) ->
     (* CR mslater: (SIMD) replace once we have unboxed int16/int8 *)
     May_still_have_spilled_registers
-  | Op (Static_cast (Float_of_int (Float32 | Float64) |
-                     Int_of_float (Float32 | Float64) |
-                     Float_of_float32 | Float32_of_float)) ->
+  | Op
+      (Static_cast
+        ( Float_of_int (Float32 | Float64)
+        | Int_of_float (Float32 | Float64)
+        | Float_of_float32 | Float32_of_float )) ->
     may_use_stack_operand_for_only_argument map instr ~has_result:true
   | Op (Const_symbol _) ->
-    if !Clflags.pic_code || !Clflags.dlcode || Arch.win64 then
-      May_still_have_spilled_registers
-    else
-      may_use_stack_operand_for_only_result map instr
+    if !Clflags.pic_code || !Clflags.dlcode || Arch.win64
+    then May_still_have_spilled_registers
+    else may_use_stack_operand_for_only_result map instr
   | Op (Const_int n) ->
-    if (Nativeint.compare n 0x7FFFFFFFn) <= 0 && (Nativeint.compare n (-0x80000000n)) >= 0 then begin
-      may_use_stack_operand_for_only_result map instr
-    end else begin
-      May_still_have_spilled_registers
-    end
+    if Nativeint.compare n 0x7FFFFFFFn <= 0
+       && Nativeint.compare n (-0x80000000n) >= 0
+    then may_use_stack_operand_for_only_result map instr
+    else May_still_have_spilled_registers
   | Op (Intop (Iadd | Isub | Iand | Ior | Ixor)) ->
     binary_operation map instr Result_can_be_on_stack
-  | Op (Intop (Icomp _)) ->
-    binary_operation map instr Result_cannot_be_on_stack
+  | Op (Intop (Icomp _)) -> binary_operation map instr Result_cannot_be_on_stack
   | Op (Intop_imm (Icomp _, _)) ->
     may_use_stack_operand_for_only_argument map instr ~has_result:true
   | Op (Intop_imm (Iadd, _)) ->
-    (* Conservatively assume it will be turned into a `lea` instruction,
-       and ask for everything to be in registers. *)
+    (* Conservatively assume it will be turned into a `lea` instruction, and ask
+       for everything to be in registers. *)
     May_still_have_spilled_registers
-  | Op (Intop(Ilsl | Ilsr | Iasr)) ->
+  | Op (Intop (Ilsl | Ilsr | Iasr)) ->
     may_use_stack_operand_for_result map instr ~num_args:2
-  | Op(Intop_imm((Isub | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr), _)) ->
+  | Op (Intop_imm ((Isub | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr), _)) ->
     may_use_stack_operand_for_result map instr ~num_args:1
   | Op (Csel _) (* CR gyorsh: optimize *)
   | Op (Specific (Ilfence | Isfence | Imfence))
-  | Op (Intop(Imulh _ | Imul | Idiv | Imod))
+  | Op (Intop (Imulh _ | Imul | Idiv | Imod))
   | Op (Intop_imm ((Imulh _ | Imul | Idiv | Imod), _))
   | Op (Specific (Irdtsc | Irdpmc))
-  | Op (Intop (Ipopcnt | Iclz _| Ictz _))
+  | Op (Intop (Ipopcnt | Iclz _ | Ictz _))
   | Op (Intop_atomic _)
-  | Op (Move | Spill | Reload | Floatop (_, (Inegf | Iabsf | Icompf _))
-       | Const_float _ | Const_float32 _  | Const_vec128 _
-       | Stackoffset _ | Load _ | Store _ | Name_for_debugger _ | Probe_is_enabled _
-       | Opaque | Begin_region | End_region | Dls_get | Poll | Alloc _)
+  | Op
+      ( Move | Spill | Reload
+      | Floatop (_, (Inegf | Iabsf | Icompf _))
+      | Const_float _ | Const_float32 _ | Const_vec128 _ | Stackoffset _
+      | Load _ | Store _ | Name_for_debugger _ | Probe_is_enabled _ | Opaque
+      | Begin_region | End_region | Dls_get | Poll | Alloc _ )
   | Op (Reinterpret_cast (Int_of_value | Value_of_int))
-  | Op (Specific (Isextend32 | Izextend32 | Ilea _
-                 | Istore_int (_, _, _)
-                 | Ioffset_loc (_, _) | Ifloatarithmem (_, _, _)
-                 | Ipause
-                 | Icldemote _
-                 | Iprefetch _
-                 | Ibswap _))
-  | Reloadretaddr
-  | Pushtrap _
-  | Poptrap _
-  | Prologue ->
+  | Op
+      (Specific
+        ( Isextend32 | Izextend32 | Ilea _
+        | Istore_int (_, _, _)
+        | Ioffset_loc (_, _)
+        | Ifloatarithmem (_, _, _)
+        | Ipause | Icldemote _ | Iprefetch _ | Ibswap _ ))
+  | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue ->
     (* no rewrite *)
     May_still_have_spilled_registers
-  | Op (Intop_imm ((Ipopcnt | Iclz _ | Ictz _ ), _)) | Stack_check _ ->
+  | Op (Intop_imm ((Ipopcnt | Iclz _ | Ictz _), _)) | Stack_check _ ->
     (* should not happen *)
     fatal "unexpected instruction"
-  end
 
 let terminator (map : spilled_map) (term : Cfg.terminator Cfg.instruction) =
   ignore map;
   match (term : Cfg.terminator Cfg.instruction).desc with
   | Never -> fatal "unexpected terminator"
-  | Int_test { lt = _; eq = _; gt =_; is_signed = _; imm = None; }
-  | Int_test { lt = _; eq = _; gt =_; is_signed = _; imm = Some _; }
-  | Parity_test { ifso = _; ifnot = _; }
-  | Truth_test { ifso = _; ifnot = _; }
+  | Int_test { lt = _; eq = _; gt = _; is_signed = _; imm = None }
+  | Int_test { lt = _; eq = _; gt = _; is_signed = _; imm = Some _ }
+  | Parity_test { ifso = _; ifnot = _ }
+  | Truth_test { ifso = _; ifnot = _ }
   | Float_test _ ->
-    (* CR-someday xclerc for xclerc: this could be optimized, but the representation
-       makes it more difficult than the cases above, because (i) multiple
-       branching instructions may be emitted and (ii) the operand constraints
-       depend on the exact kind of branch (because we sometimes swap the
-       operands). *)
+    (* CR-someday xclerc for xclerc: this could be optimized, but the
+       representation makes it more difficult than the cases above, because (i)
+       multiple branching instructions may be emitted and (ii) the operand
+       constraints depend on the exact kind of branch (because we sometimes swap
+       the operands). *)
     May_still_have_spilled_registers
-  | Always _
-  | Return
-  | Raise _
-  | Switch _
-  | Tailcall_self _
-  | Tailcall_func _
+  | Always _ | Return | Raise _ | Switch _ | Tailcall_self _ | Tailcall_func _
   | Call_no_return _
-  | Prim {op = External _; _ } | Call {op = Indirect | Direct _; _} ->
+  | Prim { op = External _; _ }
+  | Call { op = Indirect | Direct _; _ } ->
     (* no rewrite *)
     May_still_have_spilled_registers
-  | Prim {op = Probe _; _} ->
-    may_use_stack_operands_everywhere map term
+  | Prim { op = Probe _; _ } -> may_use_stack_operands_everywhere map term

--- a/backend/amd64/simd.ml
+++ b/backend/amd64/simd.ml
@@ -60,8 +60,6 @@ module Seq = struct
     | Pcmpistrz -> "pcmpistrz"
 
   let equal { id = id0; instr = instr0 } { id = id1; instr = instr1 } =
-    Stdlib.( == ) instr0 instr1
-    &&
     match id0, id1 with
     | Sqrtss, Sqrtss
     | Sqrtsd, Sqrtsd
@@ -77,6 +75,7 @@ module Seq = struct
     | Pcmpistro, Pcmpistro
     | Pcmpistrs, Pcmpistrs
     | Pcmpistrz, Pcmpistrz ->
+      assert (Stdlib.( == ) instr0 instr1);
       true
     | ( ( Sqrtss | Sqrtsd | Roundss | Roundsd | Pcmpestra | Pcmpestrc
         | Pcmpestro | Pcmpestrs | Pcmpestrz | Pcmpistra | Pcmpistrc | Pcmpistro

--- a/backend/amd64/simd.ml
+++ b/backend/amd64/simd.ml
@@ -12,9 +12,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-42-66"]
+[@@@ocaml.warning "+a-42"]
 
-open! Int_replace_polymorphic_compare
+open! Int_replace_polymorphic_compare [@@warning "-66"]
 open Format
 include Amd64_simd_defs
 

--- a/backend/amd64/simd.ml
+++ b/backend/amd64/simd.ml
@@ -37,12 +37,40 @@ module Seq = struct
     | Pcmpistrs
     | Pcmpistrz
 
-  type nonrec instr =
+  type nonrec t =
     { id : id;
-      instr : instr
+      instr : Amd64_simd_instrs.instr
     }
 
-  let mnemonic ({ id; _ } : instr) =
+  let sqrtss = { id = Sqrtss; instr = Amd64_simd_instrs.sqrtss }
+
+  let sqrtsd = { id = Sqrtsd; instr = Amd64_simd_instrs.sqrtsd }
+
+  let roundss = { id = Roundss; instr = Amd64_simd_instrs.roundss }
+
+  let roundsd = { id = Roundsd; instr = Amd64_simd_instrs.roundsd }
+
+  let pcmpestra = { id = Pcmpestra; instr = Amd64_simd_instrs.pcmpestri }
+
+  let pcmpestrc = { id = Pcmpestrc; instr = Amd64_simd_instrs.pcmpestri }
+
+  let pcmpestro = { id = Pcmpestro; instr = Amd64_simd_instrs.pcmpestri }
+
+  let pcmpestrs = { id = Pcmpestrs; instr = Amd64_simd_instrs.pcmpestri }
+
+  let pcmpestrz = { id = Pcmpestrz; instr = Amd64_simd_instrs.pcmpestri }
+
+  let pcmpistra = { id = Pcmpistra; instr = Amd64_simd_instrs.pcmpistri }
+
+  let pcmpistrc = { id = Pcmpistrc; instr = Amd64_simd_instrs.pcmpistri }
+
+  let pcmpistro = { id = Pcmpistro; instr = Amd64_simd_instrs.pcmpistri }
+
+  let pcmpistrs = { id = Pcmpistrs; instr = Amd64_simd_instrs.pcmpistri }
+
+  let pcmpistrz = { id = Pcmpistrz; instr = Amd64_simd_instrs.pcmpistri }
+
+  let mnemonic ({ id; _ } : t) =
     match id with
     | Sqrtss -> "sqrtss"
     | Sqrtsd -> "sqrtsd"
@@ -86,11 +114,11 @@ end
 
 type operation =
   | Instruction of
-      { instr : instr;
+      { instr : Amd64_simd_instrs.instr;
         imm : int option
       }
   | Sequence of
-      { seq : Seq.instr;
+      { seq : Seq.t;
         imm : int option
       }
 

--- a/backend/amd64/simd.ml
+++ b/backend/amd64/simd.ml
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-[@@@ocaml.warning "+a-42"]
+[@@@ocaml.warning "+a-40-42"]
 
 open! Int_replace_polymorphic_compare [@@warning "-66"]
 open Format
@@ -26,12 +26,8 @@ end
 
 type instr = Amd64_simd_instrs.instr
 
-module Seq = struct
-  type id =
-    | Sqrtss
-    | Sqrtsd
-    | Roundss
-    | Roundsd
+module Pcompare_string = struct
+  type t =
     | Pcmpestra
     | Pcmpestrc
     | Pcmpestro
@@ -42,6 +38,46 @@ module Seq = struct
     | Pcmpistro
     | Pcmpistrs
     | Pcmpistrz
+
+  let equal t1 t2 =
+    match t1, t2 with
+    | Pcmpestra, Pcmpestra
+    | Pcmpestrc, Pcmpestrc
+    | Pcmpestro, Pcmpestro
+    | Pcmpestrs, Pcmpestrs
+    | Pcmpestrz, Pcmpestrz
+    | Pcmpistra, Pcmpistra
+    | Pcmpistrc, Pcmpistrc
+    | Pcmpistro, Pcmpistro
+    | Pcmpistrs, Pcmpistrs
+    | Pcmpistrz, Pcmpistrz ->
+      true
+    | ( ( Pcmpestra | Pcmpestrc | Pcmpestro | Pcmpestrs | Pcmpestrz | Pcmpistra
+        | Pcmpistrc | Pcmpistro | Pcmpistrs | Pcmpistrz ),
+        _ ) ->
+      false
+
+  let mnemonic t =
+    match t with
+    | Pcmpestra -> "pcmpestra"
+    | Pcmpestrc -> "pcmpestrc"
+    | Pcmpestro -> "pcmpestro"
+    | Pcmpestrs -> "pcmpestrs"
+    | Pcmpestrz -> "pcmpestrz"
+    | Pcmpistra -> "pcmpistra"
+    | Pcmpistrc -> "pcmpistrc"
+    | Pcmpistro -> "pcmpistro"
+    | Pcmpistrs -> "pcmpistrs"
+    | Pcmpistrz -> "pcmpistrz"
+end
+
+module Seq = struct
+  type id =
+    | Sqrtss
+    | Sqrtsd
+    | Roundss
+    | Roundsd
+    | Pcompare_string of Pcompare_string.t
 
   type nonrec t =
     { id : id;
@@ -56,25 +92,35 @@ module Seq = struct
 
   let roundsd = { id = Roundsd; instr = Amd64_simd_instrs.roundsd }
 
-  let pcmpestra = { id = Pcmpestra; instr = Amd64_simd_instrs.pcmpestri }
+  let pcmpestra =
+    { id = Pcompare_string Pcmpestra; instr = Amd64_simd_instrs.pcmpestri }
 
-  let pcmpestrc = { id = Pcmpestrc; instr = Amd64_simd_instrs.pcmpestri }
+  let pcmpestrc =
+    { id = Pcompare_string Pcmpestrc; instr = Amd64_simd_instrs.pcmpestri }
 
-  let pcmpestro = { id = Pcmpestro; instr = Amd64_simd_instrs.pcmpestri }
+  let pcmpestro =
+    { id = Pcompare_string Pcmpestro; instr = Amd64_simd_instrs.pcmpestri }
 
-  let pcmpestrs = { id = Pcmpestrs; instr = Amd64_simd_instrs.pcmpestri }
+  let pcmpestrs =
+    { id = Pcompare_string Pcmpestrs; instr = Amd64_simd_instrs.pcmpestri }
 
-  let pcmpestrz = { id = Pcmpestrz; instr = Amd64_simd_instrs.pcmpestri }
+  let pcmpestrz =
+    { id = Pcompare_string Pcmpestrz; instr = Amd64_simd_instrs.pcmpestri }
 
-  let pcmpistra = { id = Pcmpistra; instr = Amd64_simd_instrs.pcmpistri }
+  let pcmpistra =
+    { id = Pcompare_string Pcmpistra; instr = Amd64_simd_instrs.pcmpistri }
 
-  let pcmpistrc = { id = Pcmpistrc; instr = Amd64_simd_instrs.pcmpistri }
+  let pcmpistrc =
+    { id = Pcompare_string Pcmpistrc; instr = Amd64_simd_instrs.pcmpistri }
 
-  let pcmpistro = { id = Pcmpistro; instr = Amd64_simd_instrs.pcmpistri }
+  let pcmpistro =
+    { id = Pcompare_string Pcmpistro; instr = Amd64_simd_instrs.pcmpistri }
 
-  let pcmpistrs = { id = Pcmpistrs; instr = Amd64_simd_instrs.pcmpistri }
+  let pcmpistrs =
+    { id = Pcompare_string Pcmpistrs; instr = Amd64_simd_instrs.pcmpistri }
 
-  let pcmpistrz = { id = Pcmpistrz; instr = Amd64_simd_instrs.pcmpistri }
+  let pcmpistrz =
+    { id = Pcompare_string Pcmpistrz; instr = Amd64_simd_instrs.pcmpistri }
 
   let mnemonic ({ id; _ } : t) =
     match id with
@@ -82,40 +128,19 @@ module Seq = struct
     | Sqrtsd -> "sqrtsd"
     | Roundss -> "roundss"
     | Roundsd -> "roundsd"
-    | Pcmpestra -> "pcmpestra"
-    | Pcmpestrc -> "pcmpestrc"
-    | Pcmpestro -> "pcmpestro"
-    | Pcmpestrs -> "pcmpestrs"
-    | Pcmpestrz -> "pcmpestrz"
-    | Pcmpistra -> "pcmpistra"
-    | Pcmpistrc -> "pcmpistrc"
-    | Pcmpistro -> "pcmpistro"
-    | Pcmpistrs -> "pcmpistrs"
-    | Pcmpistrz -> "pcmpistrz"
+    | Pcompare_string p -> Pcompare_string.mnemonic p
 
   let equal { id = id0; instr = instr0 } { id = id1; instr = instr1 } =
-    match id0, id1 with
-    | Sqrtss, Sqrtss
-    | Sqrtsd, Sqrtsd
-    | Roundss, Roundss
-    | Roundsd, Roundsd
-    | Pcmpestra, Pcmpestra
-    | Pcmpestrc, Pcmpestrc
-    | Pcmpestro, Pcmpestro
-    | Pcmpestrs, Pcmpestrs
-    | Pcmpestrz, Pcmpestrz
-    | Pcmpistra, Pcmpistra
-    | Pcmpistrc, Pcmpistrc
-    | Pcmpistro, Pcmpistro
-    | Pcmpistrs, Pcmpistrs
-    | Pcmpistrz, Pcmpistrz ->
+    let return_true () =
       assert (Amd64_simd_instrs.equal instr0 instr1);
       true
-    | ( ( Sqrtss | Sqrtsd | Roundss | Roundsd | Pcmpestra | Pcmpestrc
-        | Pcmpestro | Pcmpestrs | Pcmpestrz | Pcmpistra | Pcmpistrc | Pcmpistro
-        | Pcmpistrs | Pcmpistrz ),
-        _ ) ->
-      false
+    in
+    match id0, id1 with
+    | Sqrtss, Sqrtss | Sqrtsd, Sqrtsd | Roundss, Roundss | Roundsd, Roundsd ->
+      return_true ()
+    | Pcompare_string p1, Pcompare_string p2 ->
+      if Pcompare_string.equal p1 p2 then return_true () else false
+    | (Sqrtss | Sqrtsd | Roundss | Roundsd | Pcompare_string _), _ -> false
 end
 
 module Pseudo_instr = struct

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -25,37 +25,7 @@ type error = Bad_immediate of string
 
 exception Error of error
 
-module Seq = struct
-  open! Simd.Seq
-
-  let sqrtss = { id = Sqrtss; instr = sqrtss }
-
-  let sqrtsd = { id = Sqrtsd; instr = sqrtsd }
-
-  let roundss = { id = Roundss; instr = roundss }
-
-  let roundsd = { id = Roundsd; instr = roundsd }
-
-  let pcmpestra = { id = Pcmpestra; instr = pcmpestri }
-
-  let pcmpestrc = { id = Pcmpestrc; instr = pcmpestri }
-
-  let pcmpestro = { id = Pcmpestro; instr = pcmpestri }
-
-  let pcmpestrs = { id = Pcmpestrs; instr = pcmpestri }
-
-  let pcmpestrz = { id = Pcmpestrz; instr = pcmpestri }
-
-  let pcmpistra = { id = Pcmpistra; instr = pcmpistri }
-
-  let pcmpistrc = { id = Pcmpistrc; instr = pcmpistri }
-
-  let pcmpistro = { id = Pcmpistro; instr = pcmpistri }
-
-  let pcmpistrs = { id = Pcmpistrs; instr = pcmpistri }
-
-  let pcmpistrz = { id = Pcmpistrz; instr = pcmpistri }
-end
+module Seq = Simd.Seq
 
 let instr instr ?i args = Some (Simd.Instruction { instr; imm = i }, args)
 

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -502,14 +502,12 @@ let pseudoregs_for_instr (simd : Simd.instr) arg_regs res_regs =
 let pseudoregs_for_operation (simd : Simd.operation) arg res =
   let arg_regs = Array.copy arg in
   let res_regs = Array.copy res in
-  match simd.instr with
-  | Instruction instr -> pseudoregs_for_instr instr arg_regs res_regs
-  | Sequence seq -> (
-    match seq.id with
-    | Sqrtss | Sqrtsd | Roundss | Roundsd | Pcmpestra | Pcmpestrc | Pcmpestro
-    | Pcmpestrs | Pcmpestrz | Pcmpistra | Pcmpistrc | Pcmpistro | Pcmpistrs
-    | Pcmpistrz ->
-      pseudoregs_for_instr seq.instr arg_regs res_regs)
+  let instr =
+    match simd.instr with
+    | Instruction instr -> instr
+    | Sequence seq -> seq.instr
+  in
+  pseudoregs_for_instr instr arg_regs res_regs
 
 (* Error report *)
 

--- a/tools/simdgen/amd64_simd_defs.ml
+++ b/tools/simdgen/amd64_simd_defs.ml
@@ -101,6 +101,8 @@ type enc =
     opcode : int
   }
 
+(* CR-someday gyorsh: restructure to avoid 'id and make the backend independent
+   of simdgen, backend should only depend on the result of simdgen. *)
 type 'id instr =
   { id : 'id;
     args : arg array;


### PR DESCRIPTION
Follow-up to #3853 refactoring. I think it will make the code easier to read and maintain:
- move simdgen to `backend/`
- remove simd_proc from amd64
- refactor `Simd.operation` and `Simd.Seq` to make selection and emit clearer.
- format another file
- enable more warnings