### PR TITLE
Ensure register location equality is correct

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -511,9 +511,8 @@ let is_pure_basic : basic -> bool = function
     false
 
 let same_location (r1 : Reg.t) (r2 : Reg.t) =
-  match r1.loc with
-  | Unknown -> Misc.fatal_errorf "Cfg got unknown register location."
-  | Reg _ | Stack _ -> Reg.same_loc r1 r2
+  Reg.same_loc_fatal_on_unknown
+    ~fatal_message:"Cfg got unknown register location." r1 r2
 
 let is_noop_move instr =
   match instr.desc with

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -511,18 +511,9 @@ let is_pure_basic : basic -> bool = function
     false
 
 let same_location (r1 : Reg.t) (r2 : Reg.t) =
-  Reg.same_loc r1 r2
-  &&
   match r1.loc with
   | Unknown -> Misc.fatal_errorf "Cfg got unknown register location."
-  | Reg _ ->
-    Reg_class.equal
-      (Reg_class.of_machtype r1.typ)
-      (Reg_class.of_machtype r2.typ)
-  | Stack _ ->
-    Stack_class.equal
-      (Stack_class.of_machtype r1.typ)
-      (Stack_class.of_machtype r2.typ)
+  | Reg _ | Stack _ -> Reg.same_loc r1 r2
 
 let is_noop_move instr =
   match instr.desc with

--- a/backend/debug/reg_with_debug_info.ml
+++ b/backend/debug/reg_with_debug_info.ml
@@ -112,22 +112,10 @@ let assigned_to_stack t =
   | Stack (Domainstate _) | Reg _ | Unknown -> false
 
 let regs_at_same_location (reg1 : Reg.t) (reg2 : Reg.t) =
-  (* We need to check the register classes too: two locations both saying "stack
-     offset N" might actually be different physical locations, for example if
-     one is of class "Int" and another "Float" on amd64. [register_class] will
-     be [Proc.register_class], but cannot be here, due to a circular
-     dependency. *)
   Reg.equal_location reg1.loc reg2.loc
   &&
   match reg1.loc with
-  | Reg _ ->
-    Reg_class.equal
-      (Reg_class.of_machtype reg1.typ)
-      (Reg_class.of_machtype reg2.typ)
-  | Stack _ ->
-    Stack_class.equal
-      (Stack_class.of_machtype reg1.typ)
-      (Stack_class.of_machtype reg2.typ)
+  | Reg _ | Stack _ -> true
   | Unknown -> Misc.fatal_errorf "regs_at_same_location got Unknown locations"
 
 let at_same_location t (reg : Reg.t) = regs_at_same_location t.reg reg

--- a/backend/debug/reg_with_debug_info.ml
+++ b/backend/debug/reg_with_debug_info.ml
@@ -112,11 +112,8 @@ let assigned_to_stack t =
   | Stack (Domainstate _) | Reg _ | Unknown -> false
 
 let regs_at_same_location (reg1 : Reg.t) (reg2 : Reg.t) =
-  Reg.equal_location reg1.loc reg2.loc
-  &&
-  match reg1.loc with
-  | Reg _ | Stack _ -> true
-  | Unknown -> Misc.fatal_errorf "regs_at_same_location got Unknown locations"
+  Reg.same_loc_fatal_on_unknown
+    ~fatal_message:"regs_at_same_location got Unknown locations" reg1 reg2
 
 let at_same_location t (reg : Reg.t) = regs_at_same_location t.reg reg
 

--- a/backend/reg.ml
+++ b/backend/reg.ml
@@ -233,7 +233,11 @@ let equal_location left right =
     false
 
 let same_loc left right =
-  (* CR-soon azewierzejew: This should also compare [reg_class] for [Stack
-     (Local _)]. That's complicated because [reg_class] is definied in [Proc]
-     which relies on [Reg]. *)
   equal_location left.loc right.loc
+  &&
+  match left.loc with
+  | Unknown -> true
+  | Reg _ ->
+    Reg_class.equal (Reg_class.of_machtype left.typ) (Reg_class.of_machtype right.typ)
+  | Stack _ ->
+    Stack_class.equal (Stack_class.of_machtype left.typ) (Stack_class.of_machtype right.typ)

--- a/backend/reg.ml
+++ b/backend/reg.ml
@@ -241,3 +241,8 @@ let same_loc left right =
     Reg_class.equal (Reg_class.of_machtype left.typ) (Reg_class.of_machtype right.typ)
   | Stack _ ->
     Stack_class.equal (Stack_class.of_machtype left.typ) (Stack_class.of_machtype right.typ)
+
+let same_loc_fatal_on_unknown ~fatal_message left right =
+  match left.loc with
+  | Unknown -> Misc.fatal_error fatal_message
+  | Reg _ | Stack _ -> same_loc left right

--- a/backend/reg.mli
+++ b/backend/reg.mli
@@ -112,3 +112,4 @@ val reinit_relocatable_regs: unit -> unit
 val same : t -> t -> bool
 val compare : t -> t -> int
 val same_loc : t -> t -> bool
+val same_loc_fatal_on_unknown : fatal_message:string -> t -> t -> bool


### PR DESCRIPTION
This pull request changes the `Reg.same_loc`
function so that it is no longer error-prone, by
comparing not only the location, but also the
stack and register classes.

I am not 100% sure it is exactly the right
implementation, but I think it is sound and
can potentially void mistakes.