### PR TITLE
Remove direct assignment of the form x = e

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -80,8 +80,8 @@ let to_x86_directive (dir : ND.Directive.t) : X86_ast.asm_line list =
   | Const { constant; comment } ->
     comment_lines comment @ [to_x86_constant_with_width constant]
   | Direct_assignment (s, c) ->
-    (* We use [.set s c] for direct assignments, since it evaluates [c] directly.
-       The alternative, [s = c], is sensitive to relocations. *)
+    (* We use [.set s c] for direct assignments, since it evaluates [c]
+       directly. The alternative, [s = c], is sensitive to relocations. *)
     [X86_ast.Set (s, to_x86_constant c)]
   | File { file_num = None; _ } ->
     Misc.fatal_error "file directive must always carry a number on x86"

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -80,7 +80,9 @@ let to_x86_directive (dir : ND.Directive.t) : X86_ast.asm_line list =
   | Const { constant; comment } ->
     comment_lines comment @ [to_x86_constant_with_width constant]
   | Direct_assignment (s, c) ->
-    [X86_ast.Direct_assignment (s, to_x86_constant c)]
+    (* We use [.set s c] for direct assignments, since it evaluates [c] directly.
+       The alternative, [s = c], is sensitive to relocations. *)
+    [X86_ast.Set (s, to_x86_constant c)]
   | File { file_num = None; _ } ->
     Misc.fatal_error "file directive must always carry a number on x86"
   | File { file_num = Some file_num; filename } ->

--- a/backend/x86_ast.mli
+++ b/backend/x86_ast.mli
@@ -259,7 +259,5 @@ type asm_line =
   | Type of string * string
   | Reloc of reloc
 
-  (* MacOS only *)
-  | Direct_assignment of string * constant
 
 type asm_program = asm_line list

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1731,7 +1731,7 @@ let assemble_line b loc ins =
               offset = ConstSub (ConstThis, Const 4L);
             }  when String.Tbl.mem local_labels wrap_label ->
       record_local_reloc b ~offset:(-4) (RelocCall wrap_label)
-    | Reloc _ | Sleb128 _ | Uleb128 _ | Direct_assignment _ ->
+    | Reloc _ | Sleb128 _ | Uleb128 _ ->
       X86_gas.generate_asm Out_channel.stderr [ins];
       Misc.fatal_errorf "x86_binary_emitter: unsupported instruction"
   with e ->

--- a/backend/x86_dsl.ml
+++ b/backend/x86_dsl.ml
@@ -121,8 +121,6 @@ module D = struct
 
   let data () = section [".data"] None []
 
-  let direct_assignment var const = directive (Direct_assignment (var, const))
-
   let extrn s ptr = directive (External (s, ptr))
 
   let file ~file_num ~file_name = directive (File (file_num, file_name))

--- a/backend/x86_dsl.mli
+++ b/backend/x86_dsl.mli
@@ -121,8 +121,6 @@ module D : sig
 
   val data : unit -> unit
 
-  val direct_assignment : string -> constant -> unit
-
   val extrn : string -> data_type -> unit
 
   val file : file_num:int -> file_name:string -> unit

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -345,7 +345,6 @@ let print_line b = function
   (* masm only *)
   | External _ | Mode386 | Model _ -> assert false
 
-
 let generate_asm oc lines =
   let b = Buffer.create 10000 in
   output_string oc "\t.file \"\"\n";

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -344,10 +344,7 @@ let print_line b = function
       cst expr
   (* masm only *)
   | External _ | Mode386 | Model _ -> assert false
-  (* MacOS only *)
-  | Direct_assignment (var, c) ->
-    assert (List.mem Config.system ["macosx"; "darwin"]);
-    bprintf b "\t%s = %a" var cst c
+
 
 let generate_asm oc lines =
   let b = Buffer.create 10000 in

--- a/backend/x86_masm.ml
+++ b/backend/x86_masm.ml
@@ -270,7 +270,7 @@ let print_line b = function
   | Cfi_def_cfa_register _ | Cfi_def_cfa_offset _ | Cfi_offset _
   | Cfi_remember_state | Cfi_restore_state | File _ | Indirect_symbol _ | Loc _
   | Private_extern _ | Set _ | Size _ | Type _ | Hidden _ | Weak _ | Reloc _
-  | Direct_assignment _ | Protected _ ->
+  | Protected _ ->
     assert false
 
 let generate_asm oc lines =


### PR DESCRIPTION
This PR removes the direct assignments of the form `x = e` on macOS from the backend. The directive `.set x e` should be used instead, since it evaluates the expression `e` immediately instead of taking subsequent relocations into account. 