### PR TITLE
DLS.access takes closure at unyielding

### DIFF
--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -195,7 +195,7 @@ module Safe : sig
         [Encapsulated] to avoid leaking access to data in the DLS. *)
 
     val access
-      :  (Access.t -> 'a @ portable contended) @ local portable
+      :  (Access.t -> 'a @ portable contended) @ local portable unyielding
       -> 'a @ portable contended
       @@ portable
     (** [access f] scopes the computation [f] to (conceptually) run it in the current


### PR DESCRIPTION
Necessary for safety.