### PR TITLE
Fix register allocator selection

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -288,15 +288,12 @@ type register_allocator =
   | IRC
   | LS
 
-let default_allocator = IRC
-
 let register_allocator fd : register_allocator =
   match String.lowercase_ascii !Flambda_backend_flags.regalloc with
-  | "cfg" -> if should_use_linscan fd.fun_codegen_options then LS else IRC
+  | "" | "cfg" -> if should_use_linscan fd.fun_codegen_options then LS else IRC
   | "gi" -> GI
   | "irc" -> IRC
   | "ls" -> LS
-  | "" -> default_allocator
   | other -> Misc.fatal_errorf "unknown register allocator (%S)" other
 
 let available_regs ~stack_slots ~f x =


### PR DESCRIPTION
After the deletion of the Mach pipeline,
the default register allocator should be
equivalent to `"cfg"` rather than `"irc"`.