### PR TITLE
No unboxed versions for mixed-float records

### DIFF
--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -146,7 +146,8 @@ val f : 'a rep -> int = <fun>
 (***********************************)
 (* Implicit unboxed records basics *)
 
-(* Boxed, including mixed-block, records get implicit unboxed records *)
+(* Boxed records, including non-float mixed-block records, get implicit unboxed
+   records *)
 type r = { i : int ; s : string }
 type u : immediate & value = r#
 [%%expect{|
@@ -160,11 +161,20 @@ type r = { s : string; f : float#; }
 type u = r#
 |}]
 
-(* But not float or [@@unboxed] records *)
+(* But not float, mixed float/float#, or [@@unboxed] records *)
 type r = { f : float ; f2 : float }
 type bad = r#
 [%%expect{|
 type r = { f : float; f2 : float; }
+Line 2, characters 11-13:
+2 | type bad = r#
+               ^^
+Error: The type "r" has no unboxed version.
+|}]
+type r = { f : float ; f2 : float# }
+type bad = r#
+[%%expect{|
+type r = { f : float; f2 : float#; }
 Line 2, characters 11-13:
 2 | type bad = r#
                ^^


### PR DESCRIPTION
As mixed-block records containing only `float` and`float#` store floats flatly, they shouldn't get implicit unboxed versions if we want to support layout-directed `%box` in the future. (For this reason, we already chose not to give float records unboxed versions.)