### PR TITLE
`DLS.access` allows once

### DIFF
--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -456,7 +456,7 @@ module type S = sig
     type 'a key : value mod portable contended
 
     val access
-      :  (Access.t -> 'a @ portable contended) @ local portable once
+      :  (Access.t -> 'a @ portable contended) @ local portable unyielding once
       -> 'a @ portable contended
       @@ portable
 

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -456,7 +456,7 @@ module type S = sig
     type 'a key : value mod portable contended
 
     val access
-      :  (Access.t -> 'a @ portable contended) @ local portable
+      :  (Access.t -> 'a @ portable contended) @ local portable once
       -> 'a @ portable contended
       @@ portable
 

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -195,7 +195,7 @@ module Safe : sig
         [Encapsulated] to avoid leaking access to data in the DLS. *)
 
     val access
-      :  (Access.t -> 'a @ portable contended) @ local portable unyielding
+      :  (Access.t -> 'a @ portable contended) @ local portable unyielding once
       -> 'a @ portable contended
       @@ portable
     (** [access f] scopes the computation [f] to (conceptually) run it in the current


### PR DESCRIPTION
More expressive, clearly safe