### PR TITLE
"module type of" zap modalities to floor

### DIFF
--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3562,11 +3562,9 @@ let type_module_type_of env smod =
   let mty = Mtype.scrape_for_type_of ~remove_aliases env tmty.mod_type in
   (* PR#5036: must not contain non-generalized type variables *)
   check_nongen_modtype env smod.pmod_loc mty;
-  (* for [module type of], we zap to identity modality for best legacy
-  compatibility *)
   let mty =
     remove_modality_and_zero_alloc_variables_mty env
-      ~zap_modality:Mode.Modality.Value.zap_to_id mty
+      ~zap_modality:Mode.Modality.Value.zap_to_floor mty
   in
   tmty, mty
 


### PR DESCRIPTION
`module type of M` should zap modalities in `M` to the strongest. This might cause type error where user uses `module type of M` to constrain another implementation that's weaker than `M`, which is just bad code. I did some quick check in our internal code base and found such bad code to be rare.