### PR TITLE
Capsule tests should only run on runtime5

### DIFF
--- a/testsuite/tests/capsule-api/basics.ml
+++ b/testsuite/tests/capsule-api/basics.ml
@@ -1,6 +1,7 @@
 (* TEST
  include stdlib_alpha;
  flags = "-extension-universe alpha";
+ runtime5;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/capsule-api/data.ml
+++ b/testsuite/tests/capsule-api/data.ml
@@ -1,6 +1,7 @@
 (* TEST
  include stdlib_alpha;
  flags = "-extension-universe alpha";
+ runtime5;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/capsule-api/key.ml
+++ b/testsuite/tests/capsule-api/key.ml
@@ -1,6 +1,7 @@
 (* TEST
  include stdlib_alpha;
  flags = "-extension-universe alpha";
+ runtime5;
  { bytecode; }
  { native; }
 *)
@@ -161,7 +162,7 @@ let () =
 let () =
   let exception F of int in
   let (P k) = Capsule.create () in
-  (* Encapsulated exceptions from inside [with_password_shared_local] are unwrapped. *) 
+  (* Encapsulated exceptions from inside [with_password_shared_local] are unwrapped. *)
   try
     Capsule.Key.with_password_shared_local k
       (fun (type k) (p : k Capsule.Password.Shared.t) ->

--- a/testsuite/tests/capsule-api/poisoning.ml
+++ b/testsuite/tests/capsule-api/poisoning.ml
@@ -1,13 +1,14 @@
 (* TEST
  include stdlib_alpha;
  flags = "-extension-universe alpha";
+ runtime5;
  { bytecode; }
  { native; }
 *)
 
 module Capsule = Stdlib_alpha.Capsule
 
-let m = 
+let m =
   let (P k) = Capsule.create () in
   Capsule.Mutex.P (Capsule.Mutex.create k)
 ;;


### PR DESCRIPTION
a minor change in testsuite. Do we expect these tests to pass on runtime4 too?