### PR TITLE
Reverse Poptrap instructions before Return

### DIFF
--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -508,7 +508,7 @@ module Stack_offset_and_exn = struct
           InstructionId.format instr.id
       | top_trap :: traps ->
         (* CR-soon gyorsh: investigate why this check sometimes fails. *)
-        if false && not (Label.equal lbl_handler top_trap)
+        if not (Label.equal lbl_handler top_trap)
         then
           Misc.fatal_errorf
             "Cfgize.Stack_offset_and_exn.process_basic: poptrap label %a does \

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -147,7 +147,7 @@ let pop_all_traps env =
     | Operation.Uncaught -> acc
     | Operation.Specific_trap (lbl, t) -> pop_all (Pop lbl :: acc) t
   in
-  pop_all [] env.trap_stack
+  pop_all [] env.trap_stack |> List.rev
 
 let env_create ~tailrec_label =
   { vars = V.Map.empty;


### PR DESCRIPTION
I think there is a minor bug in selection when popping all trap handlers before a `Return`. Currently the `Poptrap` instructions are generated in reverse order. This PR fixes it and re-enables an assertion about it during selection. Without the fix in this PR, the assertion fails on `testsuite/tests/capsule-api/data.ml`.

The bug doesn't affect code generation because the assembly sequence for `Poptrap` doesn't use the label of the handler. The order didn't matter until recently because `Poptrap` instructions in Cfg didn't have handler labels until recently. These labels were added in PR https://github.com/ocaml-flambda/flambda-backend/pull/3768 so that `Poptrap` instructions can be eliminated if the corresponding handler is dead.

@lthls can you please review this little PR? are there any other places that should be fixed?