### PR TITLE
Cfg invariant allow Stack_check

### DIFF
--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -244,11 +244,8 @@ let check_stack_offset t label (block : Cfg.basic_block) =
             | Csel _ | Static_cast _ | Reinterpret_cast _ | Probe_is_enabled _
             | Opaque | Begin_region | End_region | Specific _
             | Name_for_debugger _ | Dls_get | Poll | Alloc _ )
-        | Reloadretaddr | Prologue ->
-          cur_stack_offset
-        | Stack_check _ ->
-          Misc.fatal_error
-            "Cfg_invariant.check_stack_offset: unexpected stack check")
+        | Reloadretaddr | Prologue | Stack_check _ ->
+          cur_stack_offset)
   in
   if not (Int.equal stack_offset_after_body terminator_stack_offset)
   then


### PR DESCRIPTION
Cfg invariant check after stack check insertion currently fails. This PR fixes it - we don't need to do anything special for Stack checks when checking stack offsets in Cfg_invariants, because stack offsets and stack checks do not affect each other (despite the name).

We haven't noticed the failure in the github CI because both cfg invariant checking and stack check insertion are disabled by default and we don't have a github action than enables them both. (Stack check insertion is on by default on arm64. I will propose a separate PR for stack check testing on amd64).