### PR TITLE
Use new directives on x86

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2669,6 +2669,11 @@ let end_assembly () =
      now in the text section. The reason is that the additional padding will
      never be executed, so there is no need to pad it with nops in the X86
      binary emitter. *)
+  (* CR sspies: We should just determine the filling based on the current
+     section for the binary emitter and then remove the argument
+     [fill_x86_bin_emitter]. This is the only place, where it does not seem to
+     match the current section, and it seems it does not matter whether we pad
+     with zeros or nops here. *)
   ND.align ~fill_x86_bin_emitter:Zero ~bytes:8;
   (* PR#7591 *)
   emit_global_label ~section:Text "frametable";

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -298,6 +298,8 @@ let emit_cmm_symbol (s : Cmm.symbol) =
   (* This label is special in that it is not of the form "Lnumber". Instead, we
      take the symbol, encode it, and turn the resulting string into a label. The
      label will still be prefixed by ".L"/"L" when emitting. *)
+  (* CR sspies: Extend the new directives code to support local symbols properly (as
+    opposed to requiring chaining the label and symbol code).*)
   | Local -> `Label (L.create_string_unchecked Text (S.encode sym))
 
 let emit_cmm_symbol_str (s : Cmm.symbol) =
@@ -343,6 +345,7 @@ let emit_named_text_section ?(suffix = "") func_name =
          currently does not supported named text sections. In the rest of this
          file, we pretend the section is called Text rather than the function
          specific text section. *)
+      (* CR sspies: Add proper support for named text sections. *)
       ND.unsafe_set_internal_section_ref Text)
   else ND.text ()
 
@@ -868,6 +871,7 @@ let global_maybe_protected (sym : S.t) =
          inlining. *)
       ND.protected sym
 
+(* CR sspies: The naming of these functions is confusing. *)
 let emit_global_label_for_symbol ~section lbl =
   add_def_symbol lbl;
   let lbl = S.create lbl in
@@ -2129,6 +2133,8 @@ let fundecl fundecl =
   else global_maybe_protected fundecl_sym;
   (* Even if the function name is Local, still emit an actual linker symbol for
      it. This provides symbols for perf, gdb, and similar tools *)
+  (* CR sspies: The following two directives should be abstracted into a single function
+    in the directives module. *)
   ND.define_symbol_label ~section:Text fundecl_sym;
   ND.define_label (L.create_string_unchecked Text (S.encode fundecl_sym));
   emit_debug_info fundecl.fun_dbg;
@@ -2163,6 +2169,7 @@ let emit_item : Cmm.data_item -> unit = function
     | Global ->
       global_maybe_protected sym;
       add_def_symbol s.sym_name;
+      (* CR sspies: Figure out why we emit two labels for the function.*)
       ND.define_symbol_label ~section:Data sym;
       ND.define_label (L.create_string_unchecked Data (S.encode sym)))
   | Cint8 n -> ND.int8 (Numbers.Int8.of_int_exn n)
@@ -2230,6 +2237,7 @@ let begin_assembly unix =
   if is_win64 system
   then (
     (* These symbols are emitted without additional encoding.*)
+    (* CR sspies: Pre-define these symbols in [Asm_symbol]. *)
     ND.extrn (S.create ~already_encoded:true "caml_call_gc");
     ND.extrn (S.create ~already_encoded:true "caml_c_call");
     ND.extrn (S.create ~already_encoded:true "caml_allocN");
@@ -2604,6 +2612,8 @@ let emit_trap_notes () =
     ND.int64 0L
   in
   let emit_desc () =
+    (* CR sspies: This symbol could be pre-defined in [Asm_symbol].
+       We could then avoid exposing the `already_encoded` flag. *)
     ND.symbol (S.create ~already_encoded:true "_.stapsdt.base");
     emit_labels (L.Set.elements traps.enter_traps);
     emit_labels traps.push_traps;
@@ -2668,8 +2678,6 @@ let end_assembly () =
         (fun lbl ofs ->
           let lbl = label_to_asm_label ~section:Text lbl in
           let ofs = Targetint.of_int32 ofs in
-          (* CR sspies: On x86 macOS, this changes the name of the variables,
-             but should be semantically equivalent. *)
           ND.between_this_and_label_offset_32bit_expr ~upper:lbl
             ~offset_upper:ofs);
       efa_def_label =

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2173,10 +2173,10 @@ let emit_item : Cmm.data_item -> unit = function
     | Global ->
       global_maybe_protected sym;
       add_def_symbol s.sym_name;
-      (* Following the same convention as for function symbols above, we emit both a label
-         and a linker symbol for [sym]. *)
-      (* CR sspies: The following two directives should be abstracted into a single
-         function in the directives module. *)
+      (* Following the same convention as for function symbols above, we emit
+         both a label and a linker symbol for [sym]. *)
+      (* CR sspies: The following two directives should be abstracted into a
+         single function in the directives module. *)
       ND.define_symbol_label ~section:Data sym;
       ND.define_label (L.create_string_unchecked Data (S.encode sym)))
   | Cint8 n -> ND.int8 (Numbers.Int8.of_int_exn n)

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -151,12 +151,12 @@ let label_to_asm_label (l : label) ~(section : Asm_targets.Asm_section.t) : L.t
     =
   L.create_int section (Label.to_int l)
 
-(* X86 operands for jumping to the respective label. [emit_asm_label_arg] can be used with
-   [L.t] labels and [emit_label_arg] with Linear [label] arguments. *)
+(* X86 operands for jumping to the respective label. [emit_asm_label_arg] can be
+   used with [L.t] labels and [emit_label_arg] with Linear [label] arguments. *)
 let emit_asm_label_arg lbl = sym (L.encode lbl)
 
-let emit_label_arg ~section lbl_str = sym (L.encode (label_to_asm_label ~section lbl_str))
-
+let emit_label_arg ~section lbl_str =
+  sym (L.encode (label_to_asm_label ~section lbl_str))
 
 (* Override proc.ml *)
 
@@ -305,8 +305,8 @@ let emit_cmm_symbol (s : Cmm.symbol) =
   (* This label is special in that it is not of the form "Lnumber". Instead, we
      take the symbol, encode it, and turn the resulting string into a label. The
      label will still be prefixed by ".L"/"L" when emitting. *)
-  (* CR sspies: Extend the new directives code to support local symbols properly (as
-    opposed to requiring chaining the label and symbol code).*)
+  (* CR sspies: Extend the new directives code to support local symbols properly
+     (as opposed to requiring chaining the label and symbol code).*)
   | Local -> `Label (L.create_string_unchecked Text (S.encode sym))
 
 let emit_cmm_symbol_str (s : Cmm.symbol) =
@@ -2128,8 +2128,8 @@ let fundecl fundecl =
   else global_maybe_protected fundecl_sym;
   (* Even if the function name is Local, still emit an actual linker symbol for
      it. This provides symbols for perf, gdb, and similar tools *)
-  (* CR sspies: The following two directives should be abstracted into a single function
-    in the directives module. *)
+  (* CR sspies: The following two directives should be abstracted into a single
+     function in the directives module. *)
   ND.define_symbol_label ~section:Text fundecl_sym;
   ND.define_label (L.create_string_unchecked Text (S.encode fundecl_sym));
   emit_debug_info fundecl.fun_dbg;
@@ -2607,8 +2607,8 @@ let emit_trap_notes () =
     ND.int64 0L
   in
   let emit_desc () =
-    (* CR sspies: This symbol could be pre-defined in [Asm_symbol].
-       We could then avoid exposing the `already_encoded` flag. *)
+    (* CR sspies: This symbol could be pre-defined in [Asm_symbol]. We could
+       then avoid exposing the `already_encoded` flag. *)
     ND.symbol (S.create ~already_encoded:true "_.stapsdt.base");
     emit_labels (L.Set.elements traps.enter_traps);
     emit_labels traps.push_traps;

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -778,7 +778,7 @@ let emit_literals p align emit_literal =
       (* CR sspies: The following section is incorrect. We are in a data section
          here. Fix this when cleaning up the section mechanism. *)
       D.unsafe_set_internal_section_ref Text);
-    D.align ~bytes:align;
+    D.align ~data_section:false ~bytes:align;
     List.iter emit_literal !p;
     p := [])
 
@@ -2069,7 +2069,7 @@ let fundecl fundecl =
   contains_calls := fundecl.fun_contains_calls;
   emit_named_text_section !function_name;
   let fun_sym = S.create fundecl.fun_name in
-  D.align ~bytes:8;
+  D.align ~data_section:false ~bytes:8;
   D.global fun_sym;
   D.type_symbol ~ty:Function fun_sym;
   D.define_symbol_label ~section:Text fun_sym;
@@ -2130,11 +2130,11 @@ let emit_item (d : Cmm.data_item) =
     D.symbol_plus_offset ~offset_in_bytes:(Targetint.of_int o) sym
   | Cstring s -> D.string s
   | Cskip n -> D.space ~bytes:n
-  | Calign n -> D.align ~bytes:n
+  | Calign n -> D.align ~data_section:true ~bytes:n
 
 let data l =
   D.data ();
-  D.align ~bytes:8;
+  D.align ~data_section:true ~bytes:8;
   List.iter emit_item l
 
 let file_emitter ~file_num ~file_name =
@@ -2172,7 +2172,7 @@ let begin_assembly _unix =
   if macosx
   then (
     DSL.ins I.NOP [||];
-    D.align ~bytes:8);
+    D.align ~data_section:false ~bytes:8);
   let code_end = Cmm_helpers.make_symbol "code_end" in
   Emitaux.Dwarf_helpers.begin_dwarf ~code_begin ~code_end ~file_emitter
 
@@ -2190,7 +2190,7 @@ let end_assembly () =
   D.global data_end_sym;
   D.define_symbol_label ~section:Data data_end_sym;
   D.int64 0L;
-  D.align ~bytes:8;
+  D.align ~data_section:true ~bytes:8;
   (* #7887 *)
   let frametable = Cmm_helpers.make_symbol "frametable" in
   let frametable_sym = S.create frametable in
@@ -2213,7 +2213,7 @@ let end_assembly () =
       (* CR sspies: for some reason, we can get negative numbers here *)
       efa_32 = (fun n -> D.int32 n);
       efa_word = (fun n -> D.targetint (Targetint.of_int_exn n));
-      efa_align = (fun n -> D.align ~bytes:n);
+      efa_align = (fun n -> D.align ~data_section:true ~bytes:n);
       efa_label_rel =
         (fun lbl ofs ->
           let lbl = label_to_asm_label ~section:Data lbl in

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -778,7 +778,7 @@ let emit_literals p align emit_literal =
       (* CR sspies: The following section is incorrect. We are in a data section
          here. Fix this when cleaning up the section mechanism. *)
       D.unsafe_set_internal_section_ref Text);
-    D.align ~data_section:false ~bytes:align;
+    D.align ~fill_x86_bin_emitter:Nop ~bytes:align;
     List.iter emit_literal !p;
     p := [])
 
@@ -2069,7 +2069,7 @@ let fundecl fundecl =
   contains_calls := fundecl.fun_contains_calls;
   emit_named_text_section !function_name;
   let fun_sym = S.create fundecl.fun_name in
-  D.align ~data_section:false ~bytes:8;
+  D.align ~fill_x86_bin_emitter:Nop ~bytes:8;
   D.global fun_sym;
   D.type_symbol ~ty:Function fun_sym;
   D.define_symbol_label ~section:Text fun_sym;
@@ -2130,11 +2130,11 @@ let emit_item (d : Cmm.data_item) =
     D.symbol_plus_offset ~offset_in_bytes:(Targetint.of_int o) sym
   | Cstring s -> D.string s
   | Cskip n -> D.space ~bytes:n
-  | Calign n -> D.align ~data_section:true ~bytes:n
+  | Calign n -> D.align ~fill_x86_bin_emitter:Zero ~bytes:n
 
 let data l =
   D.data ();
-  D.align ~data_section:true ~bytes:8;
+  D.align ~fill_x86_bin_emitter:Zero ~bytes:8;
   List.iter emit_item l
 
 let file_emitter ~file_num ~file_name =
@@ -2172,7 +2172,7 @@ let begin_assembly _unix =
   if macosx
   then (
     DSL.ins I.NOP [||];
-    D.align ~data_section:false ~bytes:8);
+    D.align ~fill_x86_bin_emitter:Nop ~bytes:8);
   let code_end = Cmm_helpers.make_symbol "code_end" in
   Emitaux.Dwarf_helpers.begin_dwarf ~code_begin ~code_end ~file_emitter
 
@@ -2190,7 +2190,7 @@ let end_assembly () =
   D.global data_end_sym;
   D.define_symbol_label ~section:Data data_end_sym;
   D.int64 0L;
-  D.align ~data_section:true ~bytes:8;
+  D.align ~fill_x86_bin_emitter:Zero ~bytes:8;
   (* #7887 *)
   let frametable = Cmm_helpers.make_symbol "frametable" in
   let frametable_sym = S.create frametable in
@@ -2213,7 +2213,7 @@ let end_assembly () =
       (* CR sspies: for some reason, we can get negative numbers here *)
       efa_32 = (fun n -> D.int32 n);
       efa_word = (fun n -> D.targetint (Targetint.of_int_exn n));
-      efa_align = (fun n -> D.align ~data_section:true ~bytes:n);
+      efa_align = (fun n -> D.align ~fill_x86_bin_emitter:Zero ~bytes:n);
       efa_label_rel =
         (fun lbl ofs ->
           let lbl = label_to_asm_label ~section:Data lbl in

--- a/backend/asm_targets/asm_directives_new.ml
+++ b/backend/asm_targets/asm_directives_new.ml
@@ -934,11 +934,11 @@ let between_labels_16_bit ?comment:_ ~upper:_ ~lower:_ () =
 
 let between_labels_32_bit ?comment:_comment ~upper ~lower () =
   let expr = const_sub (const_label upper) (const_label lower) in
-  (* CR sspies: Unlike in most of the other distance computation functions in this file,
-     we do not force an assembly time constant in this function. This is to follow the
-     existing/previous implementation of the x86 backend. In the future, we should
-     investigate whether it would be more appropriate to force an assembly time constant.
-  *)
+  (* CR sspies: Unlike in most of the other distance computation functions in
+     this file, we do not force an assembly time constant in this function. This
+     is to follow the existing/previous implementation of the x86 backend. In
+     the future, we should investigate whether it would be more appropriate to
+     force an assembly time constant. *)
   const expr Thirty_two
 
 let between_labels_64_bit ?comment:_ ~upper:_ ~lower:_ () =

--- a/backend/asm_targets/asm_directives_new.ml
+++ b/backend/asm_targets/asm_directives_new.ml
@@ -467,7 +467,7 @@ module Directive = struct
     | Hidden _ -> unsupported "Hidden"
     | Weak _ -> unsupported "Weak"
     | External s -> bprintf buf "\tEXTRN\t%s: NEAR" s
-    (* The only supported "type" on EXTRN declarations i NEAR. *)
+    (* The only supported "type" on EXTRN declarations is NEAR. *)
     | Reloc _ -> unsupported "Reloc"
 
   let print b t =
@@ -517,7 +517,7 @@ let const_with_offset const (offset : int64) =
   if Int64.equal offset 0L
   then const
   else if Int64.compare offset 0L < 0
-  then Add (const, Signed_int (Int64.neg offset))
+  then Sub (const, Signed_int (Int64.neg offset))
   else Add (const, Signed_int offset)
 
 let emit_ref = ref None
@@ -934,8 +934,11 @@ let between_labels_16_bit ?comment:_ ~upper:_ ~lower:_ () =
 
 let between_labels_32_bit ?comment:_comment ~upper ~lower () =
   let expr = const_sub (const_label upper) (const_label lower) in
-  (* CR sspies: Following the x86 implementation, we *do not* force an assembly
-     time constant here. *)
+  (* CR sspies: Unlike in most of the other distance computation functions in this file,
+     we do not force an assembly time constant in this function. This is to follow the
+     existing/previous implementation of the x86 backend. In the future, we should
+     investigate whether it would be more appropriate to force an assembly time constant.
+  *)
   const expr Thirty_two
 
 let between_labels_64_bit ?comment:_ ~upper:_ ~lower:_ () =

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -159,7 +159,7 @@ val cfi_def_cfa_register : reg:string -> unit
 val mark_stack_non_executable : unit -> unit
 
 (** Leave as much space as is required to achieve the given alignment. *)
-val align : bytes:int -> unit
+val align : data_section:bool -> bytes:int -> unit
 
 (** Emit a directive giving the displacement between the given symbol and
     the current position.  This should only be used to state sizes of
@@ -167,6 +167,8 @@ val align : bytes:int -> unit
     [size_of] may be specified when the symbol used for measurement differs
     from that whose size is being stated (e.g. on POWER with ELF ABI v1). *)
 val size : ?size_of:Asm_symbol.t -> Asm_symbol.t -> unit
+
+val size_const : Asm_symbol.t -> int64 -> unit
 
 (** Leave a gap in the object file. *)
 val space : bytes:int -> unit
@@ -196,6 +198,15 @@ val protected : Asm_symbol.t -> unit
 (** Mark a symbol as "private extern" (see assembler documentation for
     details). *)
 val private_extern : Asm_symbol.t -> unit
+
+(** Mark an already encoded symbol as external. *)
+val extrn : Asm_symbol.t -> unit
+
+(** Mark an already encoded symbol or label as hidden. *)
+val hidden : Asm_symbol.t -> unit
+
+(** Mark an already encoded symbol or label as weak. *)
+val weak : Asm_symbol.t -> unit
 
 (** Marker inside the definition of a lazy symbol stub (see platform or
     assembler documentation for details). *)
@@ -306,6 +317,12 @@ val offset_into_dwarf_section_symbol :
   Asm_symbol.t ->
   unit
 
+val reloc_x86_64_plt32 :
+  offset_from_this:int64 ->
+  target_symbol:Asm_symbol.t ->
+  rel_offset_from_next:int64 ->
+  unit
+
 module Directive : sig
   module Constant : sig
     (* CR sspies: make this private again once the first-class module has been
@@ -354,6 +371,10 @@ module Directive : sig
      removed *)
   type comment = string
 
+  (* ELF specific *)
+  type reloc_type = R_X86_64_PLT32
+  (* X86 only *)
+
   (* CR sspies: make this private again once the first-class module has been
      removed *)
 
@@ -363,7 +384,14 @@ module Directive : sig
       have had all necessary prefixing, mangling, escaping and suffixing
       applied. *)
   type t =
-    | Align of { bytes : int }
+    | Align of
+        { bytes : int;
+              (** The number of bytes to align to. This will be taken log2 by the emitter on
+          Arm and macOS platforms.*)
+          data_section : bool
+              (** The data_section flag controls whether the binary emitter emits NOP instructions
+          or null bytes. *)
+        }
     | Bytes of
         { str : string;
           comment : string option
@@ -417,6 +445,14 @@ module Directive : sig
           comment : string option
         }
     | Protected of string
+    | Hidden of string
+    | Weak of string
+    | External of string
+    | Reloc of
+        { offset : Constant.t;
+          name : reloc_type;
+          expr : Constant.t
+        }
 
   (** Translate the given directive to textual form.  This produces output
       suitable for either gas or MASM as appropriate. *)

--- a/backend/asm_targets/asm_directives_new.mli
+++ b/backend/asm_targets/asm_directives_new.mli
@@ -158,8 +158,16 @@ val cfi_def_cfa_register : reg:string -> unit
     supported on all platforms. *)
 val mark_stack_non_executable : unit -> unit
 
-(** Leave as much space as is required to achieve the given alignment. *)
-val align : data_section:bool -> bytes:int -> unit
+type align_padding =
+  | Nop
+  | Zero
+
+(** Leave as much space as is required to achieve the given alignment. On x86 in the
+    binary emitter, it is important what the space is filled with: in the text section,
+    one would typically fill it with [nop] instructions and in the data section, one
+    would typically fill it with zeros. This is controlled by the parameter
+    [fill_x86_bin_emitter]. *)
+val align : fill_x86_bin_emitter:align_padding -> bytes:int -> unit
 
 (** Emit a directive giving the displacement between the given symbol and
     the current position.  This should only be used to state sizes of
@@ -388,9 +396,9 @@ module Directive : sig
         { bytes : int;
               (** The number of bytes to align to. This will be taken log2 by the emitter on
           Arm and macOS platforms.*)
-          data_section : bool
-              (** The data_section flag controls whether the binary emitter emits NOP instructions
-          or null bytes. *)
+          fill_x86_bin_emitter : align_padding
+              (** The [fill_x86_bin_emitter] flag controls whether the x86 binary emitter
+                  emits NOP instructions or null bytes. *)
         }
     | Bytes of
         { str : string;

--- a/backend/asm_targets/asm_label.ml
+++ b/backend/asm_targets/asm_label.ml
@@ -69,6 +69,8 @@ let create_string section label =
   assert (not (contains_escapable_char label));
   { section; label = String label }
 
+let create_string_unchecked section label = { section; label = String label }
+
 let label_prefix =
   match Target_system.assembler () with MacOS -> "L" | MASM | GAS_like -> ".L"
 
@@ -138,6 +140,7 @@ let for_dwarf_section (dwarf_section : Asm_section.dwarf_section) =
   | Debug_str -> Lazy.force debug_str_label
   | Debug_line -> Lazy.force debug_line_label
 
+(* CR sspies: Remove the other cases where we never emit a label upfront. *)
 let for_section (section : Asm_section.t) =
   match section with
   | DWARF dwarf_section -> for_dwarf_section dwarf_section
@@ -147,3 +150,7 @@ let for_section (section : Asm_section.t) =
   | Eight_byte_literals -> Lazy.force eight_byte_literals_label
   | Sixteen_byte_literals -> Lazy.force sixteen_byte_literals_label
   | Jump_tables -> Lazy.force jump_tables_label
+  | Stapsdt_base -> Misc.fatal_error "Stapsdt_base has no associated label"
+  | Stapsdt_note -> Misc.fatal_error "Stapsdt_note has no associated label"
+  | Probes -> Misc.fatal_error "Probes has no associated label"
+  | Note_ocaml_eh -> Misc.fatal_error "Note_ocaml_eh has no associated label"

--- a/backend/asm_targets/asm_label.mli
+++ b/backend/asm_targets/asm_label.mli
@@ -52,6 +52,9 @@ val create_int : Asm_section.t -> int -> t
 (** Create a textual label. The supplied name must not require escaping. *)
 val create_string : Asm_section.t -> string -> t
 
+(** Create a textual label. Argument string is not checked, so use with caution. *)
+val create_string_unchecked : Asm_section.t -> string -> t
+
 (** Convert a label to the corresponding textual form, suitable for direct
     emission into an assembly file. This may be useful e.g. when emitting an
     instruction referencing a label. *)

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -195,7 +195,7 @@ let details t ~first_occurrence =
     | Read_only_data, _, (MinGW_32 | Win32) -> data ()
     | Read_only_data, _, (MinGW_64 | Cygwin) -> [".rdata"], Some "dr", []
     | Read_only_data, _, _ -> rodata ()
-    | Stapsdt_base, _, (GNU | Solaris | Linux | Generic_BSD | BeOS) ->
+    | Stapsdt_base, _, Linux ->
       [".stapsdt.base"], Some "aG", ["\"progbits\""; ".stapsdt.base"; "comdat"]
     | Stapsdt_base, _, _ ->
       Misc.fatal_error "stapsdt not supported on platforms other than Linux."

--- a/backend/asm_targets/asm_section.ml
+++ b/backend/asm_targets/asm_section.ml
@@ -195,11 +195,13 @@ let details t ~first_occurrence =
     | Read_only_data, _, (MinGW_32 | Win32) -> data ()
     | Read_only_data, _, (MinGW_64 | Cygwin) -> [".rdata"], Some "dr", []
     | Read_only_data, _, _ -> rodata ()
-    (* CR sspies: Is this one really possible on all systems? *)
-    | Stapsdt_base, _, _ ->
+    | Stapsdt_base, _, (GNU | Solaris | Linux | Generic_BSD | BeOS) ->
       [".stapsdt.base"], Some "aG", ["\"progbits\""; ".stapsdt.base"; "comdat"]
+    | Stapsdt_base, _, _ ->
+      Misc.fatal_error "stapsdt not supported on platforms other than Linux."
     | Stapsdt_note, _, MacOS_like ->
       ["__DATA"; "__note_stapsdt"], None, ["regular"]
+      (* NOTE: This is section is currently not tested. *)
     | Stapsdt_note, _, (GNU | Solaris | Linux | Generic_BSD | BeOS) ->
       [".note.stapsdt"], Some "?", ["\"note\""]
     | Stapsdt_note, _, _ ->

--- a/backend/asm_targets/asm_section.mli
+++ b/backend/asm_targets/asm_section.mli
@@ -48,6 +48,10 @@ type t =
   | Sixteen_byte_literals
   | Jump_tables
   | Text
+  | Stapsdt_base
+  | Stapsdt_note
+  | Probes
+  | Note_ocaml_eh
 
 val to_string : t -> string
 

--- a/backend/asm_targets/asm_symbol.mli
+++ b/backend/asm_targets/asm_symbol.mli
@@ -29,10 +29,10 @@ val should_be_escaped : char -> bool
 
 include Identifiable.S
 
-(* If [without_prefix] is not provided [encode] will prefix the symbol using the
-   (architecture-dependent) prefix for symbols, for example "_" on macOS. In
-   contrast, [to_raw_string] will always return the non-prefixed version. *)
-val create : ?without_prefix:unit -> string -> t
+(** [create] creates a new symbol. By default, it is assumed that the symbol has not been
+    encoded. In some rare cases, the symbol is encoded elsewhere. In these cases, set the
+    flag [already_encoded] to [true].  *)
+val create : ?already_encoded:bool -> string -> t
 
 val encode : t -> string
 

--- a/utils/target_system.ml
+++ b/utils/target_system.ml
@@ -177,7 +177,7 @@ let is_macos () =
   | MASM | GAS_like -> false
   | MacOS -> true
 
-  let is_gas () =
-    match assembler () with
-    | MASM | MacOS -> false
-    | GAS_like -> true
+let is_gas () =
+  match assembler () with
+  | MASM | MacOS -> false
+  | GAS_like -> true


### PR DESCRIPTION
This PR replaces the existing code for emitting directives on x86 with the new directives. The changes that were observed in the emitted assembly code are summarized in this PR (#3932).