### PR TITLE
Store instruction id sequence in CFG

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -88,11 +88,11 @@ type t =
     (* CR-someday gyorsh: compute locally. *)
     fun_num_stack_slots : int Stack_class.Tbl.t;
     fun_poll : Lambda.poll_attribute;
-    instruction_id : InstructionId.sequence
+    next_instruction_id : InstructionId.sequence
   }
 
 let create ~fun_name ~fun_args ~fun_codegen_options ~fun_dbg ~fun_contains_calls
-    ~fun_num_stack_slots ~fun_poll ~instruction_id =
+    ~fun_num_stack_slots ~fun_poll ~next_instruction_id =
   { fun_name;
     fun_args;
     fun_codegen_options;
@@ -104,7 +104,7 @@ let create ~fun_name ~fun_args ~fun_codegen_options ~fun_dbg ~fun_contains_calls
     fun_contains_calls;
     fun_num_stack_slots;
     fun_poll;
-    instruction_id
+    next_instruction_id
   }
 
 let mem_block t label = Label.Tbl.mem t.blocks label
@@ -541,31 +541,7 @@ let make_instruction ~desc ?(arg = [||]) ?(res = [||]) ?(dbg = Debuginfo.none)
     available_across
   }
 
-(* CR-soon xclerc for xclerc: move this state to selection. *)
-let instr_id = InstructionId.make_sequence ()
-
-let reset_instr_id () = InstructionId.reset instr_id
-
-let next_instr_id () = InstructionId.get_and_incr instr_id
-
 let invalid_stack_offset = -1
-
-let make_instr desc arg res dbg =
-  { desc;
-    arg;
-    res;
-    dbg;
-    fdo = Fdo_info.none;
-    live = Reg.Set.empty;
-    stack_offset = invalid_stack_offset;
-    id = next_instr_id ();
-    irc_work_list = Unknown_list;
-    ls_order = 0;
-    (* CR mshinwell/xclerc: should this be [None]? *)
-    available_before =
-      Some (Reg_availability_set.Ok Reg_with_debug_info.Set.empty);
-    available_across = None
-  }
 
 let make_empty_block ?label terminator : basic_block =
   let start =

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -87,11 +87,12 @@ type t =
     fun_contains_calls : bool;
     (* CR-someday gyorsh: compute locally. *)
     fun_num_stack_slots : int Stack_class.Tbl.t;
-    fun_poll : Lambda.poll_attribute
+    fun_poll : Lambda.poll_attribute;
+    instruction_id : InstructionId.sequence
   }
 
 let create ~fun_name ~fun_args ~fun_codegen_options ~fun_dbg ~fun_contains_calls
-    ~fun_num_stack_slots ~fun_poll =
+    ~fun_num_stack_slots ~fun_poll ~instruction_id =
   { fun_name;
     fun_args;
     fun_codegen_options;
@@ -102,7 +103,8 @@ let create ~fun_name ~fun_args ~fun_codegen_options ~fun_dbg ~fun_contains_calls
     blocks = Label.Tbl.create 31;
     fun_contains_calls;
     fun_num_stack_slots;
-    fun_poll
+    fun_poll;
+    instruction_id
   }
 
 let mem_block t label = Label.Tbl.mem t.blocks label
@@ -539,6 +541,7 @@ let make_instruction ~desc ?(arg = [||]) ?(res = [||]) ?(dbg = Debuginfo.none)
     available_across
   }
 
+(* CR-soon xclerc for xclerc: move this state to selection. *)
 let instr_id = InstructionId.make_sequence ()
 
 let reset_instr_id () = InstructionId.reset instr_id
@@ -653,16 +656,6 @@ let basic_block_contains_calls block =
      | Prim { op = External _; _ } -> true
      | Prim { op = Probe _; _ } -> true)
   || DLL.exists block.body ~f:is_alloc_or_poll
-
-let max_instr_id t =
-  (* CR-someday xclerc for xclerc: factor out with similar function in
-     regalloc/. *)
-  fold_blocks t ~init:InstructionId.none ~f:(fun _label block max_id ->
-      let max_id =
-        DLL.fold_left block.body ~init:max_id ~f:(fun max_id instr ->
-            InstructionId.max max_id instr.id)
-      in
-      InstructionId.max max_id block.terminator.id)
 
 let equal_irc_work_list left right =
   match left, right with

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -100,7 +100,8 @@ type t =
         (** Precomputed during selection and poll insertion. *)
     fun_num_stack_slots : int Stack_class.Tbl.t;
         (** Precomputed at register allocation time *)
-    fun_poll : Lambda.poll_attribute (* Whether to insert polling points. *)
+    fun_poll : Lambda.poll_attribute; (* Whether to insert polling points. *)
+    instruction_id : InstructionId.sequence (* Next instruction id. *)
   }
 
 val create :
@@ -111,6 +112,7 @@ val create :
   fun_contains_calls:bool ->
   fun_num_stack_slots:int Stack_class.Tbl.t ->
   fun_poll:Lambda.poll_attribute ->
+  instruction_id:InstructionId.sequence ->
   t
 
 val fun_name : t -> string
@@ -234,6 +236,8 @@ val make_instr :
   'a -> Reg.t array -> Reg.t array -> Debuginfo.t -> 'a instruction
 
 (** These IDs are also used by [make_instr] *)
+val instr_id : InstructionId.sequence
+
 val next_instr_id : unit -> InstructionId.t
 
 val reset_instr_id : unit -> unit
@@ -242,9 +246,6 @@ val make_empty_block : ?label:Label.t -> terminator instruction -> basic_block
 
 (** "Contains calls" in the traditional sense as used in upstream [Selectgen]. *)
 val basic_block_contains_calls : basic_block -> bool
-
-(* [max_instr_id cfg] returns the maximum instruction identifier in [cfg]. *)
-val max_instr_id : t -> InstructionId.t
 
 val equal_irc_work_list : irc_work_list -> irc_work_list -> bool
 

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -83,6 +83,9 @@ type codegen_option =
 
 val of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list
 
+(* CR-someday xclerc: we should probably make `t` abstract and make each and
+   every modifiction through accessors; that would help enforce invariants. *)
+
 (** Control Flow Graph of a function. *)
 type t =
   { blocks : basic_block Label.Tbl.t;  (** Map from labels to blocks *)
@@ -101,7 +104,7 @@ type t =
     fun_num_stack_slots : int Stack_class.Tbl.t;
         (** Precomputed at register allocation time *)
     fun_poll : Lambda.poll_attribute; (* Whether to insert polling points. *)
-    instruction_id : InstructionId.sequence (* Next instruction id. *)
+    next_instruction_id : InstructionId.sequence (* Next instruction id. *)
   }
 
 val create :
@@ -112,7 +115,7 @@ val create :
   fun_contains_calls:bool ->
   fun_num_stack_slots:int Stack_class.Tbl.t ->
   fun_poll:Lambda.poll_attribute ->
-  instruction_id:InstructionId.sequence ->
+  next_instruction_id:InstructionId.sequence ->
   t
 
 val fun_name : t -> string
@@ -230,17 +233,6 @@ val make_instruction :
   ?available_across:Reg_availability_set.t option ->
   unit ->
   'a instruction
-
-(* CR mshinwell: consolidate with [make_instruction] and tidy up ID interface *)
-val make_instr :
-  'a -> Reg.t array -> Reg.t array -> Debuginfo.t -> 'a instruction
-
-(** These IDs are also used by [make_instr] *)
-val instr_id : InstructionId.sequence
-
-val next_instr_id : unit -> InstructionId.t
-
-val reset_instr_id : unit -> unit
 
 val make_empty_block : ?label:Label.t -> terminator instruction -> basic_block
 

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -177,7 +177,7 @@ let rec combine : instr_id:InstructionId.sequence -> cell option -> unit =
 let run : Cfg_with_layout.t -> Cfg_with_layout.t =
  fun cfg_with_layout ->
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  let instr_id = cfg.instruction_id in
+  let instr_id = cfg.next_instruction_id in
   Cfg.iter_blocks cfg ~f:(fun _label block ->
       combine ~instr_id (DLL.hd_cell block.body));
   cfg_with_layout

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -177,9 +177,7 @@ let rec combine : instr_id:InstructionId.sequence -> cell option -> unit =
 let run : Cfg_with_layout.t -> Cfg_with_layout.t =
  fun cfg_with_layout ->
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  let instr_id =
-    InstructionId.make_sequence ~last_used:(Cfg.max_instr_id cfg) ()
-  in
+  let instr_id = cfg.instruction_id in
   Cfg.iter_blocks cfg ~f:(fun _label block ->
       combine ~instr_id (DLL.hd_cell block.body));
   cfg_with_layout

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -258,16 +258,14 @@ let debug = false
 module State : sig
   type t
 
-  val make : last_used:InstructionId.t -> t
+  val make : InstructionId.sequence -> t
 
   val get_and_incr_instruction_id : t -> InstructionId.t
 end = struct
   (* CR-soon xclerc for xclerc: factor out with the state of GI, IRC, LS. *)
   type t = { instruction_id : InstructionId.sequence }
 
-  let make ~last_used =
-    let instruction_id = InstructionId.make_sequence ~last_used () in
-    { instruction_id }
+  let make instruction_id = { instruction_id }
 
   let get_and_incr_instruction_id state =
     InstructionId.get_and_incr state.instruction_id
@@ -521,8 +519,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     let cfg = Cfg_with_layout.cfg cfg_with_layout in
     (if not (List.mem ~set:cfg.fun_codegen_options Cfg.No_CSE)
     then
-      let cfg_infos = Regalloc_utils.collect_cfg_infos cfg_with_layout in
-      let state = State.make ~last_used:cfg_infos.max_instruction_id in
+      let state = State.make cfg.instruction_id in
       cse_blocks state cfg);
     cfg_with_layout
 end

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -519,7 +519,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     let cfg = Cfg_with_layout.cfg cfg_with_layout in
     (if not (List.mem ~set:cfg.fun_codegen_options Cfg.No_CSE)
     then
-      let state = State.make cfg.instruction_id in
+      let state = State.make cfg.next_instruction_id in
       cse_blocks state cfg);
     cfg_with_layout
 end

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -303,7 +303,9 @@ let instr_cfg_with_layout :
     bool =
  fun cfg_with_layout ~safe_map ~back_edges ->
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  let next_instruction_id () = InstructionId.get_and_incr cfg.instruction_id in
+  let next_instruction_id () =
+    InstructionId.get_and_incr cfg.next_instruction_id
+  in
   Cfg_edge.Set.fold
     (fun { Cfg_edge.src; dst } added_poll ->
       let needs_poll =

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -303,14 +303,7 @@ let instr_cfg_with_layout :
     bool =
  fun cfg_with_layout ~safe_map ~back_edges ->
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  let instruction_id =
-    lazy
-      (let cfg = Cfg_with_layout.cfg cfg_with_layout in
-       InstructionId.make_sequence ~last_used:(Cfg.max_instr_id cfg) ())
-  in
-  let next_instruction_id () =
-    InstructionId.get_and_incr (Lazy.force instruction_id)
-  in
+  let next_instruction_id () = InstructionId.get_and_incr cfg.instruction_id in
   Cfg_edge.Set.fold
     (fun { Cfg_edge.src; dst } added_poll ->
       let needs_poll =

--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -169,7 +169,7 @@ let insert_instruction (cfg : Cfg.t) (label : Label.t) ~max_frame_size =
 
        xclerc: (keeping the comment, and the explicit values below until all of
        that is implemented.) *)
-    let id = InstructionId.get_and_incr cfg.instruction_id in
+    let id = InstructionId.get_and_incr cfg.next_instruction_id in
     Cfg.make_instruction ()
       ~desc:(Cfg.Stack_check { max_frame_size_bytes = max_frame_size })
       ~stack_offset ~id ~available_before:None ~available_across:None

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -452,6 +452,7 @@ let print_assembly (blocks : Cfg.basic_block list) =
     Cfg.create ~fun_name ~fun_args:[||] ~fun_codegen_options:[]
       ~fun_dbg:Debuginfo.none ~fun_contains_calls:true
       ~fun_num_stack_slots:(Stack_class.Tbl.make 0) ~fun_poll:Default_poll
+      ~instruction_id:(InstructionId.make_sequence ())
   in
   List.iter
     (fun (block : Cfg.basic_block) ->

--- a/backend/cfg/cfg_to_linear.mli
+++ b/backend/cfg/cfg_to_linear.mli
@@ -28,5 +28,3 @@
 [@@@ocaml.warning "+a-40-41-42"]
 
 val run : Cfg_with_layout.t -> Linear.fundecl
-
-val print_assembly : Cfg.basic_block list -> unit

--- a/backend/cfg/sub_cfg.mli
+++ b/backend/cfg/sub_cfg.mli
@@ -22,6 +22,18 @@
 
 [@@@ocaml.warning "+a-40-41-42"]
 
+(** These IDs are also used by [make_instr] *)
+val instr_id : InstructionId.sequence
+
+val next_instr_id : unit -> InstructionId.t
+
+val reset_instr_id : unit -> unit
+
+(* CR mshinwell: consolidate with [Cfg.make_instruction] and tidy up ID
+   interface *)
+val make_instr :
+  'a -> Reg.t array -> Reg.t array -> Debuginfo.t -> 'a Cfg.instruction
+
 (** A "sub" CFG is the counterpart of an instruction list in the original Mach
     selection pass.
 

--- a/backend/cfg/sub_cfg.mli
+++ b/backend/cfg/sub_cfg.mli
@@ -25,8 +25,6 @@
 (** These IDs are also used by [make_instr] *)
 val instr_id : InstructionId.sequence
 
-val next_instr_id : unit -> InstructionId.t
-
 val reset_instr_id : unit -> unit
 
 (* CR mshinwell: consolidate with [Cfg.make_instruction] and tidy up ID

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -31,7 +31,6 @@ module State : sig
 end = struct
   type t =
     { ppf_dump : Format.formatter;
-      instruction_id : InstructionId.sequence;
       cfg_with_infos : Cfg_with_infos.t Lazy.t;
       cfg_with_layout : Cfg_with_layout.t
     }
@@ -42,15 +41,14 @@ end = struct
 
   let fun_dbg t = (Cfg_with_layout.cfg t.cfg_with_layout).fun_dbg
 
-  let next_available_instruction t = InstructionId.get_and_incr t.instruction_id
+  let next_available_instruction t =
+    InstructionId.get_and_incr
+      (Cfg_with_layout.cfg t.cfg_with_layout).instruction_id
 
   let create ppf_dump cl =
     (* CR-someday tip: the function may someday take a cfg_with_infos instead of
        creating a new one *)
-    let cfg = Cfg_with_layout.cfg cl in
     { ppf_dump;
-      instruction_id =
-        InstructionId.make_sequence ~last_used:(Cfg.max_instr_id cfg) ();
       cfg_with_layout = cl;
       cfg_with_infos = lazy (Cfg_with_infos.make cl)
     }

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -43,7 +43,7 @@ end = struct
 
   let next_available_instruction t =
     InstructionId.get_and_incr
-      (Cfg_with_layout.cfg t.cfg_with_layout).instruction_id
+      (Cfg_with_layout.cfg t.cfg_with_layout).next_instruction_id
 
   let create ppf_dump cl =
     (* CR-someday tip: the function may someday take a cfg_with_infos instead of

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1485,6 +1485,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           (Cfg.of_cmm_codegen_option f.Cmm.fun_codegen_options)
         ~fun_dbg:f.Cmm.fun_dbg ~fun_contains_calls:true
         ~fun_num_stack_slots:(Stack_class.Tbl.make 0) ~fun_poll:f.Cmm.fun_poll
+        ~instruction_id:Cfg.instr_id
     in
     let layout = DLL.make_empty () in
     let entry_block =

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1425,6 +1425,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     SU.current_function_is_check_enabled
       := Zero_alloc_checker.is_check_enabled f.Cmm.fun_codegen_options
            f.Cmm.fun_name.sym_name f.Cmm.fun_dbg;
+    Sub_cfg.reset_instr_id ();
     let num_regs_per_arg = Array.make (List.length f.Cmm.fun_args) 0 in
     let rargs =
       List.mapi

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -450,7 +450,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     Sub_cfg.add_instruction sub_cfg basic arg res dbg
 
   let insert_op_debug_returning_id _env sub_cfg op dbg arg res =
-    let instr = Cfg.make_instr (Cfg.Op op) arg res dbg in
+    let instr = Sub_cfg.make_instr (Cfg.Op op) arg res dbg in
     Sub_cfg.add_instruction' sub_cfg instr;
     instr.id
 
@@ -1485,20 +1485,20 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           (Cfg.of_cmm_codegen_option f.Cmm.fun_codegen_options)
         ~fun_dbg:f.Cmm.fun_dbg ~fun_contains_calls:true
         ~fun_num_stack_slots:(Stack_class.Tbl.make 0) ~fun_poll:f.Cmm.fun_poll
-        ~instruction_id:Cfg.instr_id
+        ~next_instruction_id:Sub_cfg.instr_id
     in
     let layout = DLL.make_empty () in
     let entry_block =
       Cfg.make_empty_block ~label:(Cfg.entry_label cfg)
-        (Cfg.make_instr (Cfg.Always tailrec_label) [||] [||] Debuginfo.none)
+        (Sub_cfg.make_instr (Cfg.Always tailrec_label) [||] [||] Debuginfo.none)
     in
     DLL.add_begin entry_block.body
-      (Cfg.make_instr Cfg.Prologue [||] [||] Debuginfo.none);
+      (Sub_cfg.make_instr Cfg.Prologue [||] [||] Debuginfo.none);
     Cfg.add_block_exn cfg entry_block;
     DLL.add_end layout entry_block.start;
     let tailrec_block =
       Cfg.make_empty_block ~label:tailrec_label
-        (Cfg.make_instr
+        (Sub_cfg.make_instr
            (Cfg.Always (Sub_cfg.start_label body))
            [||] [||] Debuginfo.none)
     in
@@ -1529,7 +1529,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           if Cfg.is_return_terminator block.terminator.desc
           then
             DLL.add_end block.body
-              (Cfg.make_instr Cfg.Reloadretaddr [||] [||] Debuginfo.none);
+              (Sub_cfg.make_instr Cfg.Reloadretaddr [||] [||] Debuginfo.none);
           Cfg.add_block_exn cfg block;
           DLL.add_end layout block.start)
         else assert (DLL.is_empty block.body));

--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -270,10 +270,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
   let all_temporaries = Reg.Set.union cfg_infos.arg cfg_infos.res in
   let initial_temporaries = Reg.Set.cardinal all_temporaries in
   if debug then log "#temporaries=%d" initial_temporaries;
-  let state =
-    State.make ~stack_slots ~initial_temporaries
-      ~last_used:cfg_infos.max_instruction_id
-  in
+  let state = State.make ~stack_slots ~initial_temporaries in
   let spilling_because_unused = Reg.Set.diff cfg_infos.res cfg_infos.arg in
   (match Reg.Set.elements spilling_because_unused with
   | [] -> ()

--- a/backend/regalloc/regalloc_gi_state.ml
+++ b/backend/regalloc/regalloc_gi_state.ml
@@ -8,20 +8,13 @@ type t =
   { mutable assignments : Hardware_register.location Reg.Map.t;
     mutable introduced_temporaries : Reg.Set.t;
     stack_slots : Regalloc_stack_slots.t;
-    instruction_id : InstructionId.sequence;
     initial_temporaries : int
   }
 
-let[@inline] make ~initial_temporaries ~stack_slots ~last_used =
+let[@inline] make ~initial_temporaries ~stack_slots =
   let assignments = Reg.Map.empty in
-  let instruction_id = InstructionId.make_sequence ~last_used () in
   let introduced_temporaries = Reg.Set.empty in
-  { assignments;
-    introduced_temporaries;
-    stack_slots;
-    instruction_id;
-    initial_temporaries
-  }
+  { assignments; introduced_temporaries; stack_slots; initial_temporaries }
 
 let[@inline] add_assignment state reg ~to_ =
   state.assignments <- Reg.Map.add reg to_ state.assignments
@@ -50,6 +43,3 @@ let[@inline] introduced_temporary_count state =
 let[@inline] initial_temporary_count state = state.initial_temporaries
 
 let[@inline] stack_slots state = state.stack_slots
-
-let[@inline] get_and_incr_instruction_id state =
-  InstructionId.get_and_incr state.instruction_id

--- a/backend/regalloc/regalloc_gi_state.mli
+++ b/backend/regalloc/regalloc_gi_state.mli
@@ -4,11 +4,7 @@ open! Regalloc_gi_utils
 
 type t
 
-val make :
-  initial_temporaries:int ->
-  stack_slots:Regalloc_stack_slots.t ->
-  last_used:InstructionId.t ->
-  t
+val make : initial_temporaries:int -> stack_slots:Regalloc_stack_slots.t -> t
 
 val add_assignment : t -> Reg.t -> to_:Hardware_register.location -> unit
 
@@ -29,5 +25,3 @@ val initial_temporary_count : t -> int
 val introduced_temporary_count : t -> int
 
 val stack_slots : t -> Regalloc_stack_slots.t
-
-val get_and_incr_instruction_id : t -> InstructionId.t

--- a/backend/regalloc/regalloc_irc.ml
+++ b/backend/regalloc/regalloc_irc.ml
@@ -520,9 +520,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
   let all_temporaries = Reg.Set.union cfg_infos.arg cfg_infos.res in
   if debug then log "#temporaries=%d" (Reg.Set.cardinal all_temporaries);
   let state =
-    State.make
-      ~initial:(Reg.Set.elements all_temporaries)
-      ~stack_slots ~last_used:cfg_infos.max_instruction_id ()
+    State.make ~initial:(Reg.Set.elements all_temporaries) ~stack_slots ()
   in
   let spilling_because_unused = Reg.Set.diff cfg_infos.res cfg_infos.arg in
   (match Reg.Set.elements spilling_because_unused with

--- a/backend/regalloc/regalloc_irc_state.mli
+++ b/backend/regalloc/regalloc_irc_state.mli
@@ -5,12 +5,7 @@ open Regalloc_irc_utils
 
 type t
 
-val make :
-  initial:Reg.t list ->
-  stack_slots:Regalloc_stack_slots.t ->
-  last_used:InstructionId.t ->
-  unit ->
-  t
+val make : initial:Reg.t list -> stack_slots:Regalloc_stack_slots.t -> unit -> t
 
 val add_initial_one : t -> Reg.t -> unit
 
@@ -141,8 +136,6 @@ val find_alias : t -> Reg.t -> Reg.t
 val add_alias : t -> Reg.t -> Reg.t -> unit
 
 val stack_slots : t -> Regalloc_stack_slots.t
-
-val get_and_incr_instruction_id : t -> InstructionId.t
 
 val add_inst_temporaries_list : t -> Reg.t list -> unit
 

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -279,7 +279,7 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
       cfg_with_infos
   in
   let spilling_because_unused = Reg.Set.diff cfg_infos.res cfg_infos.arg in
-  let state = State.make ~stack_slots ~last_used:cfg_infos.max_instruction_id in
+  let state = State.make ~stack_slots in
   (match Reg.Set.elements spilling_because_unused with
   | [] -> ()
   | _ :: _ as spilled_nodes ->

--- a/backend/regalloc/regalloc_ls_state.ml
+++ b/backend/regalloc/regalloc_ls_state.ml
@@ -8,21 +8,19 @@ module DLL = Flambda_backend_utils.Doubly_linked_list
 type t =
   { interval_dll : Interval.t DLL.t;
     active : ClassIntervals.t Reg_class.Tbl.t;
-    stack_slots : Regalloc_stack_slots.t;
-    instruction_id : InstructionId.sequence
+    stack_slots : Regalloc_stack_slots.t
   }
 
 let for_fatal t =
   ( DLL.map t.interval_dll ~f:Interval.copy,
     Reg_class.Tbl.map t.active ~f:ClassIntervals.copy )
 
-let[@inline] make ~stack_slots ~last_used =
+let[@inline] make ~stack_slots =
   let interval_dll = DLL.make_empty () in
   let active =
     Reg_class.Tbl.init ~f:(fun _reg_class -> ClassIntervals.make ())
   in
-  let instruction_id = InstructionId.make_sequence ~last_used () in
-  { interval_dll; active; stack_slots; instruction_id }
+  { interval_dll; active; stack_slots }
 
 (* CR-someday xclerc: consider using Dynarray *)
 type class_interval_array =
@@ -111,9 +109,6 @@ let[@inline] active state ~reg_class = Reg_class.Tbl.find state.active reg_class
 let[@inline] active_classes state = state.active
 
 let[@inline] stack_slots state = state.stack_slots
-
-let[@inline] get_and_incr_instruction_id state =
-  InstructionId.get_and_incr state.instruction_id
 
 let rec check_ranges (prev : Range.t) (cell : Range.t DLL.cell option) : int =
   if prev.begin_ > prev.end_

--- a/backend/regalloc/regalloc_ls_state.mli
+++ b/backend/regalloc/regalloc_ls_state.mli
@@ -7,7 +7,7 @@ type t
 
 val for_fatal : t -> Interval.t DLL.t * ClassIntervals.t Reg_class.Tbl.t
 
-val make : stack_slots:Regalloc_stack_slots.t -> last_used:InstructionId.t -> t
+val make : stack_slots:Regalloc_stack_slots.t -> t
 
 val update_intervals : t -> Interval.t Reg.Tbl.t -> unit
 
@@ -22,8 +22,6 @@ val active : t -> reg_class:Reg_class.t -> ClassIntervals.t
 val active_classes : t -> ClassIntervals.t Reg_class.Tbl.t
 
 val stack_slots : t -> Regalloc_stack_slots.t
-
-val get_and_incr_instruction_id : t -> InstructionId.t
 
 val invariant_intervals : t -> Cfg_with_infos.t -> unit
 

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -211,7 +211,7 @@ let rewrite_gen :
           in
           let id =
             InstructionId.get_and_incr
-              (Cfg_with_infos.cfg cfg_with_infos).instruction_id
+              (Cfg_with_infos.cfg cfg_with_infos).next_instruction_id
           in
           let new_instr = Move.make_instr move ~id ~copy:instr ~from ~to_ in
           match direction with
@@ -299,7 +299,7 @@ let rewrite_gen :
                 new_instrs ~after:block ~before:None
                 ~next_instruction_id:(fun () ->
                   InstructionId.get_and_incr
-                    (Cfg_with_infos.cfg cfg_with_infos).instruction_id)
+                    (Cfg_with_infos.cfg cfg_with_infos).next_instruction_id)
             in
             block_insertion := true);
       if !block_rewritten && should_coalesce_temp_spills_and_reloads
@@ -375,15 +375,17 @@ let prelude :
   let critical_edges = compute_critical_edges cfg in
   if not (Cfg_edge.Set.is_empty critical_edges)
   then (
-    let instruction_id = (Cfg_with_infos.cfg cfg_with_infos).instruction_id in
+    let next_instruction_id () =
+      InstructionId.get_and_incr
+        (Cfg_with_infos.cfg cfg_with_infos).next_instruction_id
+    in
     Cfg_edge.Set.iter
       (fun { Cfg_edge.src; dst } ->
         let (_inserted_blocks : Cfg.basic_block list) =
           Cfg_with_layout.insert_block cfg_with_layout (DLL.make_empty ())
             ~after:(Cfg.get_block_exn cfg src)
             ~before:(Some (Cfg.get_block_exn cfg dst))
-            ~next_instruction_id:(fun () ->
-              InstructionId.get_and_incr instruction_id)
+            ~next_instruction_id
         in
         ())
       critical_edges;

--- a/backend/regalloc/regalloc_rewrite.mli
+++ b/backend/regalloc/regalloc_rewrite.mli
@@ -6,8 +6,6 @@ module type State = sig
   type t
 
   val stack_slots : t -> Regalloc_stack_slots.t
-
-  val get_and_incr_instruction_id : t -> InstructionId.t
 end
 
 module type Utils = sig

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -274,7 +274,7 @@ let insert_spills :
     (fun label (_, live_at_destruction_point) ->
       if debug then log "block %a" Label.format label;
       let block = Cfg_with_infos.get_block_exn cfg_with_infos label in
-      let instr_id = (Cfg_with_infos.cfg cfg_with_infos).instruction_id in
+      let instr_id = (Cfg_with_infos.cfg cfg_with_infos).next_instruction_id in
       let block_subst = Substitution.for_label substs label in
       insert_spills_in_block state ~instr_id ~block_subst ~stack_subst block
         (DLL.last_cell block.body) live_at_destruction_point)
@@ -339,7 +339,7 @@ let insert_reloads :
     (fun label live_at_definition_point ->
       if debug then log "block %a" Label.format label;
       let block = Cfg_with_infos.get_block_exn cfg_with_infos label in
-      let instr_id = (Cfg_with_infos.cfg cfg_with_infos).instruction_id in
+      let instr_id = (Cfg_with_infos.cfg cfg_with_infos).next_instruction_id in
       let block_subst = Substitution.for_label substs label in
       insert_reloads_in_block state ~instr_id ~block_subst ~stack_subst block
         (DLL.hd_cell block.body) live_at_definition_point)
@@ -397,7 +397,9 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
           let predecessor_block =
             Cfg_with_infos.get_block_exn cfg_with_infos predecessor_label
           in
-          let instr_id = (Cfg_with_infos.cfg cfg_with_infos).instruction_id in
+          let instr_id =
+            (Cfg_with_infos.cfg cfg_with_infos).next_instruction_id
+          in
           match predecessor_block.terminator.desc with
           | Return | Raise _ | Tailcall_func _ | Call_no_return _ | Never ->
             assert false

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -134,6 +134,7 @@ let apply_substitutions : Cfg_with_infos.t -> Substitution.map -> unit =
 
 type 'a make_operation =
   State.t ->
+  instr_id:InstructionId.sequence ->
   stack_subst:Substitution.t ->
   old_reg:Reg.t ->
   new_reg:Reg.t ->
@@ -145,7 +146,7 @@ type 'a make_operation =
    information from `copy`, and populating `stack_subst` with a mapping from
    `old_reg` to its stack slot. *)
 let make_spill : type a. a make_operation =
- fun state ~stack_subst ~old_reg ~new_reg ~copy ->
+ fun state ~instr_id ~stack_subst ~old_reg ~new_reg ~copy ->
   let stack_reg =
     match Reg.Tbl.find_opt stack_subst old_reg with
     | Some stack_reg -> stack_reg
@@ -162,7 +163,7 @@ let make_spill : type a. a make_operation =
   in
   if debug then log "spill %a -> %a" Printreg.reg new_reg Printreg.reg stack_reg;
   Move.make_instr Move.Store
-    ~id:(State.get_and_incr_instruction_id state)
+    ~id:(InstructionId.get_and_incr instr_id)
     ~copy ~from:new_reg ~to_:stack_reg
 
 let dummy_instr_of_terminator : Cfg.terminator Cfg.instruction -> Instruction.t
@@ -177,6 +178,7 @@ let dummy_instr_of_terminator : Cfg.terminator Cfg.instruction -> Instruction.t
 
 let rec insert_spills_or_reloads_in_block :
     State.t ->
+    instr_id:InstructionId.sequence ->
     make_spill_or_reload:'a make_operation ->
     occur_check:(Instruction.t -> Reg.t -> bool) ->
     insert:(Instruction.t DLL.cell -> Instruction.t -> unit) ->
@@ -189,8 +191,9 @@ let rec insert_spills_or_reloads_in_block :
     Instruction.t DLL.cell option ->
     Reg.Set.t ->
     unit =
- fun state ~make_spill_or_reload ~occur_check ~insert ~copy_default ~add_default
-     ~move_cell ~block_subst ~stack_subst block cell live_at_interesting_point ->
+ fun state ~instr_id ~make_spill_or_reload ~occur_check ~insert ~copy_default
+     ~add_default ~move_cell ~block_subst ~stack_subst block cell
+     live_at_interesting_point ->
   match Reg.Set.is_empty live_at_interesting_point with
   | true -> ()
   | false -> (
@@ -200,7 +203,7 @@ let rec insert_spills_or_reloads_in_block :
         (fun old_reg ->
           let new_reg = Substitution.apply_reg block_subst old_reg in
           let spill_or_reload =
-            make_spill_or_reload state ~stack_subst ~old_reg ~new_reg
+            make_spill_or_reload state ~instr_id ~stack_subst ~old_reg ~new_reg
               ~copy:copy_default
           in
           add_default block.body spill_or_reload)
@@ -214,8 +217,8 @@ let rec insert_spills_or_reloads_in_block :
             if occur_check instr new_reg
             then (
               let spill_or_reload =
-                make_spill_or_reload state ~stack_subst ~old_reg ~new_reg
-                  ~copy:instr
+                make_spill_or_reload state ~instr_id ~stack_subst ~old_reg
+                  ~new_reg ~copy:instr
               in
               insert cell spill_or_reload;
               false)
@@ -223,22 +226,25 @@ let rec insert_spills_or_reloads_in_block :
           live_at_interesting_point
       in
       let cell = move_cell cell in
-      insert_spills_or_reloads_in_block state ~make_spill_or_reload ~occur_check
-        ~insert ~copy_default ~add_default ~move_cell ~block_subst ~stack_subst
-        block cell live_at_interesting_point)
+      insert_spills_or_reloads_in_block state ~instr_id ~make_spill_or_reload
+        ~occur_check ~insert ~copy_default ~add_default ~move_cell ~block_subst
+        ~stack_subst block cell live_at_interesting_point)
 
 (* Inserts the spills in a block, as early as possible (i.e. immediately after
    the register is last set), to reduce live ranges. *)
 let insert_spills_in_block :
     State.t ->
+    instr_id:InstructionId.sequence ->
     block_subst:Substitution.t ->
     stack_subst:Substitution.t ->
     Cfg.basic_block ->
     Instruction.t DLL.cell option ->
     Reg.Set.t ->
     unit =
- fun state ~block_subst ~stack_subst block cell live_at_destruction_point ->
-  insert_spills_or_reloads_in_block state ~make_spill_or_reload:make_spill
+ fun state ~instr_id ~block_subst ~stack_subst block cell
+     live_at_destruction_point ->
+  insert_spills_or_reloads_in_block state ~instr_id
+    ~make_spill_or_reload:make_spill
     ~occur_check:(fun instr reg ->
       (* We have reached the insertion point not only if the register is
          explicitly set, but also if it is destroyed by the instruction. *)
@@ -268,8 +274,9 @@ let insert_spills :
     (fun label (_, live_at_destruction_point) ->
       if debug then log "block %a" Label.format label;
       let block = Cfg_with_infos.get_block_exn cfg_with_infos label in
+      let instr_id = (Cfg_with_infos.cfg cfg_with_infos).instruction_id in
       let block_subst = Substitution.for_label substs label in
-      insert_spills_in_block state ~block_subst ~stack_subst block
+      insert_spills_in_block state ~instr_id ~block_subst ~stack_subst block
         (DLL.last_cell block.body) live_at_destruction_point)
     destructions_at_end;
   if debug then dedent ();
@@ -280,7 +287,7 @@ let insert_spills :
    information from `copy`, and getting the stack slot from `stack_subst` if
    `old_reg` is mapped. *)
 let make_reload : type a. a make_operation =
- fun state ~stack_subst ~old_reg ~new_reg ~copy ->
+ fun state ~instr_id ~stack_subst ~old_reg ~new_reg ~copy ->
   let stack_reg : Reg.t =
     match Reg.Tbl.find_opt stack_subst old_reg with
     | Some stack_reg -> stack_reg
@@ -296,21 +303,24 @@ let make_reload : type a. a make_operation =
   if debug
   then log "reload %a -> %a" Printreg.reg stack_reg Printreg.reg new_reg;
   Move.make_instr Move.Load
-    ~id:(State.get_and_incr_instruction_id state)
+    ~id:(InstructionId.get_and_incr instr_id)
     ~copy ~from:stack_reg ~to_:new_reg
 
 (* Inserts the relaods in a block, as late as possible (i.e. immediately before
    the register is first read), to reduce live ranges. *)
 let insert_reloads_in_block :
     State.t ->
+    instr_id:InstructionId.sequence ->
     block_subst:Substitution.t ->
     stack_subst:Substitution.t ->
     Cfg.basic_block ->
     Instruction.t DLL.cell option ->
     Reg.Set.t ->
     unit =
- fun state ~block_subst ~stack_subst block cell live_at_definition_point ->
-  insert_spills_or_reloads_in_block state ~make_spill_or_reload:make_reload
+ fun state ~instr_id ~block_subst ~stack_subst block cell
+     live_at_definition_point ->
+  insert_spills_or_reloads_in_block state ~instr_id
+    ~make_spill_or_reload:make_reload
     ~occur_check:(fun instr reg -> occurs_array instr.arg reg)
     ~insert:DLL.insert_before
     ~copy_default:(dummy_instr_of_terminator block.terminator)
@@ -329,21 +339,22 @@ let insert_reloads :
     (fun label live_at_definition_point ->
       if debug then log "block %a" Label.format label;
       let block = Cfg_with_infos.get_block_exn cfg_with_infos label in
+      let instr_id = (Cfg_with_infos.cfg cfg_with_infos).instruction_id in
       let block_subst = Substitution.for_label substs label in
-      insert_reloads_in_block state ~block_subst ~stack_subst block
+      insert_reloads_in_block state ~instr_id ~block_subst ~stack_subst block
         (DLL.hd_cell block.body) live_at_definition_point)
     (State.definitions_at_beginning state);
   if debug then dedent ()
 
 let add_phi_moves_to_instr_list :
-    State.t ->
+    instr_id:InstructionId.sequence ->
     before:Cfg.basic_block ->
     phi:Cfg.basic_block ->
     Substitution.map ->
     Reg.Set.t ->
     Cfg.basic_instruction_list ->
     unit =
- fun state ~before ~phi substs to_unify instrs ->
+ fun ~instr_id ~before ~phi substs to_unify instrs ->
   let before_subst = Substitution.for_label substs before.start in
   let phi_subst = Substitution.for_label substs phi.start in
   Reg.Set.iter
@@ -360,7 +371,7 @@ let add_phi_moves_to_instr_list :
         if debug then log "phi %a -> %a" Printreg.reg from Printreg.reg to_;
         let phi_move =
           Move.make_instr Move.Plain
-            ~id:(State.get_and_incr_instruction_id state)
+            ~id:(InstructionId.get_and_incr instr_id)
             ~copy:before.terminator ~from ~to_
         in
         DLL.add_end instrs phi_move)
@@ -386,17 +397,18 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
           let predecessor_block =
             Cfg_with_infos.get_block_exn cfg_with_infos predecessor_label
           in
+          let instr_id = (Cfg_with_infos.cfg cfg_with_infos).instruction_id in
           match predecessor_block.terminator.desc with
           | Return | Raise _ | Tailcall_func _ | Call_no_return _ | Never ->
             assert false
           | Tailcall_self _ -> ()
           | Always _ ->
-            add_phi_moves_to_instr_list state ~before:predecessor_block
+            add_phi_moves_to_instr_list ~instr_id ~before:predecessor_block
               ~phi:block substs to_unify predecessor_block.body
           | Switch _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
           | Call _ | Prim _ ->
             let instrs = DLL.make_empty () in
-            add_phi_moves_to_instr_list state ~before:predecessor_block
+            add_phi_moves_to_instr_list ~instr_id ~before:predecessor_block
               ~phi:block substs to_unify instrs;
             (* CR-soon xclerc for xclerc: now that we preprocess critical nodes,
                no insertion should occur here. *)
@@ -405,7 +417,7 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
                 (Cfg_with_infos.cfg_with_layout cfg_with_infos)
                 instrs ~after:predecessor_block ~before:(Some block)
                 ~next_instruction_id:(fun () ->
-                  State.get_and_incr_instruction_id state)
+                  InstructionId.get_and_incr instr_id)
             in
             block_inserted := true;
             if debug && Lazy.force invariants
@@ -432,8 +444,8 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
   !block_inserted
 
 let split_at_destruction_points :
-    Cfg_with_infos.t -> cfg_infos -> (Regalloc_stack_slots.t * bool) option =
- fun cfg_with_infos cfg_infos ->
+    Cfg_with_infos.t -> (Regalloc_stack_slots.t * bool) option =
+ fun cfg_with_infos ->
   if debug
   then (
     log "split_at_destruction_points";
@@ -441,8 +453,7 @@ let split_at_destruction_points :
     Regalloc_irc_utils.log_cfg_with_infos cfg_with_infos);
   let state =
     Profile.record ~accumulate:true "state"
-      (fun () ->
-        State.make cfg_with_infos ~last_used:cfg_infos.max_instruction_id)
+      (fun () -> State.make cfg_with_infos)
       ()
   in
   if debug
@@ -485,9 +496,8 @@ let split_at_destruction_points :
       dedent ());
     Some (State.stack_slots state, block_inserted)
 
-let split_live_ranges : Cfg_with_infos.t -> cfg_infos -> Regalloc_stack_slots.t
-    =
- fun cfg_with_infos cfg_infos ->
+let split_live_ranges : Cfg_with_infos.t -> Regalloc_stack_slots.t =
+ fun cfg_with_infos ->
   (* CR-soon xclerc for xclerc: support closure, flambda, and
      flambda2/classic *)
   (match Config.flambda, Config.flambda2 with
@@ -501,7 +511,7 @@ let split_live_ranges : Cfg_with_infos.t -> cfg_infos -> Regalloc_stack_slots.t
        "Regalloc_split: classic mode is currently not supported" *)
     ()
   | true, true -> assert false);
-  match split_at_destruction_points cfg_with_infos cfg_infos with
+  match split_at_destruction_points cfg_with_infos with
   | None -> Regalloc_stack_slots.make ()
   | Some (stack_slots, block_inserted) ->
     Cfg_with_infos.invalidate_liveness cfg_with_infos;

--- a/backend/regalloc/regalloc_split.mli
+++ b/backend/regalloc/regalloc_split.mli
@@ -1,7 +1,5 @@
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-open Regalloc_utils
-
 (** Splits the live ranges of registers by introducing new registers
     at destruction points. Destructions points are locations where
     all hardware registers are clobbered. This means that all registers
@@ -15,4 +13,4 @@ open Regalloc_utils
     The algorithm is an adaptation of the one rewriting a CFG to put it in
     SSA form: we simply consider that new names are introduced at destruction
     points. *)
-val split_live_ranges : Cfg_with_infos.t -> cfg_infos -> Regalloc_stack_slots.t
+val split_live_ranges : Cfg_with_infos.t -> Regalloc_stack_slots.t

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -15,8 +15,7 @@ type t =
   { destructions_at_end : destructions_at_end;
     definitions_at_beginning : definitions_at_beginning;
     phi_at_beginning : phi_at_beginning;
-    stack_slots : Regalloc_stack_slots.t;
-    instruction_id : InstructionId.sequence
+    stack_slots : Regalloc_stack_slots.t
   }
 
 let log_renaming_info : t -> unit =
@@ -677,7 +676,7 @@ let[@inline] remove_empty_sets (map : 'a Label.Map.t) ~(f : 'a -> Reg.Set.t) :
     'a Label.Map.t =
   Label.Map.filter (fun _ data -> not (Reg.Set.is_empty (f data))) map
 
-let make cfg_with_infos ~last_used =
+let make cfg_with_infos =
   let destructions_at_end = compute_destructions cfg_with_infos in
   let definitions_at_beginning =
     compute_definitions cfg_with_infos ~destructions_at_end
@@ -702,12 +701,10 @@ let make cfg_with_infos ~last_used =
     compute_phis cfg_with_infos ~destructions_at_end ~definitions_at_beginning
   in
   let stack_slots = Regalloc_stack_slots.make () in
-  let instruction_id = InstructionId.make_sequence ~last_used () in
   { destructions_at_end;
     definitions_at_beginning;
     phi_at_beginning;
-    stack_slots;
-    instruction_id
+    stack_slots
   }
 
 let destructions_at_end state = state.destructions_at_end
@@ -717,6 +714,3 @@ let definitions_at_beginning state = state.definitions_at_beginning
 let phi_at_beginning state = state.phi_at_beginning
 
 let stack_slots state = state.stack_slots
-
-let get_and_incr_instruction_id state =
-  InstructionId.get_and_incr state.instruction_id

--- a/backend/regalloc/regalloc_split_state.mli
+++ b/backend/regalloc/regalloc_split_state.mli
@@ -25,7 +25,7 @@ val log_renaming_info : t -> unit
      (this set contains the original name of the registers which need
       a phi, i.e. if we need to insert `x = phi(x', x'')` then the set
       contains `x`). *)
-val make : Cfg_with_infos.t -> last_used:InstructionId.t -> t
+val make : Cfg_with_infos.t -> t
 
 val destructions_at_end : t -> destructions_at_end
 
@@ -34,5 +34,3 @@ val definitions_at_beginning : t -> definitions_at_beginning
 val phi_at_beginning : t -> phi_at_beginning
 
 val stack_slots : t -> Regalloc_stack_slots.t
-
-val get_and_incr_instruction_id : t -> InstructionId.t

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -55,8 +55,7 @@ val first_instruction_id : Cfg.basic_block -> InstructionId.t
 
 type cfg_infos =
   { arg : Reg.Set.t;
-    res : Reg.Set.t;
-    max_instruction_id : InstructionId.t
+    res : Reg.Set.t
   }
 
 (* CR xclerc for xclerc: this function currently reset the worklist to

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -598,7 +598,7 @@ let insert_debug (_env : environment) sub_cfg basic dbg arg res =
   Sub_cfg.add_instruction sub_cfg basic arg res dbg
 
 let insert_op_debug_returning_id (_env : environment) sub_cfg op dbg arg res =
-  let instr = Cfg.make_instr (Cfg.Op op) arg res dbg in
+  let instr = Sub_cfg.make_instr (Cfg.Op op) arg res dbg in
   Sub_cfg.add_instruction' sub_cfg instr;
   instr.id
 

--- a/flambda-backend/tests/backend/regalloc_validator/check_regalloc_validation.ml
+++ b/flambda-backend/tests/backend/regalloc_validator/check_regalloc_validation.ml
@@ -94,7 +94,7 @@ module Cfg_desc = struct
         ~fun_codegen_options:[]
          ~fun_contains_calls
         ~fun_num_stack_slots:(Stack_class.Tbl.make 0)
-        ~fun_poll:Lambda.Default_poll ~instruction_id:(InstructionId.make_sequence ())
+        ~fun_poll:Lambda.Default_poll ~next_instruction_id:(InstructionId.make_sequence ())
     in
     List.iter
       (fun (block : Block.t) ->

--- a/flambda-backend/tests/backend/regalloc_validator/check_regalloc_validation.ml
+++ b/flambda-backend/tests/backend/regalloc_validator/check_regalloc_validation.ml
@@ -94,7 +94,7 @@ module Cfg_desc = struct
         ~fun_codegen_options:[]
          ~fun_contains_calls
         ~fun_num_stack_slots:(Stack_class.Tbl.make 0)
-        ~fun_poll:Lambda.Default_poll
+        ~fun_poll:Lambda.Default_poll ~instruction_id:(InstructionId.make_sequence ())
     in
     List.iter
       (fun (block : Block.t) ->


### PR DESCRIPTION
This pull request factors out various
parts of the code computing the max
instruction id, by storing the sequence
for id distribution in `Cfg.t`.

In addition to code factorization, it
avoids repeated traversals of the CFG
values.

~~(I have kept the `InstructionId.sequence`
in the CFG module so that the diff is
relatively small, but will address that
CR-soon in a follow-up.)~~