### PR TITLE
Support for phantom bindings

### DIFF
--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -216,13 +216,16 @@ let prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
   let exported_offsets =
     exported_offsets
     |> Exported_offsets.reexport_function_slots
-         (Name_occurrences.all_function_slots free_names_of_all_code)
+         (Name_occurrences.all_function_slots_at_normal_mode
+            free_names_of_all_code)
     |> Exported_offsets.reexport_value_slots
-         (Name_occurrences.all_value_slots free_names_of_all_code)
+         (Name_occurrences.all_value_slots_at_normal_mode free_names_of_all_code)
     |> Exported_offsets.reexport_function_slots
-         (Name_occurrences.all_function_slots slots_used_in_typing_env)
+         (Name_occurrences.all_function_slots_at_normal_mode
+            slots_used_in_typing_env)
     |> Exported_offsets.reexport_value_slots
-         (Name_occurrences.all_value_slots slots_used_in_typing_env)
+         (Name_occurrences.all_value_slots_at_normal_mode
+            slots_used_in_typing_env)
   in
   let cmx =
     Flambda_cmx_format.create ~final_typing_env ~all_code ~exported_offsets

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -99,8 +99,8 @@ let build_run_result unit ~free_names ~final_typing_env ~all_code slot_offsets :
   let value_slots_in_normal_projections =
     NO.value_slots_in_normal_projections free_names
   in
-  let all_function_slots = NO.all_function_slots free_names in
-  let all_value_slots = NO.all_value_slots free_names in
+  let all_function_slots = NO.all_function_slots_at_normal_mode free_names in
+  let all_value_slots = NO.all_value_slots_at_normal_mode free_names in
   let ({ used_value_slots; exported_offsets } : Slot_offsets.result) =
     let used_slots : Slot_offsets.used_slots =
       { function_slots_in_normal_projections;

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -3669,10 +3669,12 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode) ~big_endian
         Slot_offsets.
           { function_slots_in_normal_projections =
               Name_occurrences.function_slots_in_normal_projections free_names;
-            all_function_slots = Name_occurrences.all_function_slots free_names;
+            all_function_slots =
+              Name_occurrences.all_function_slots_at_normal_mode free_names;
             value_slots_in_normal_projections =
               Name_occurrences.value_slots_in_normal_projections free_names;
-            all_value_slots = Name_occurrences.all_value_slots free_names
+            all_value_slots =
+              Name_occurrences.all_value_slots_at_normal_mode free_names
           }
       in
       Slot_offsets.finalize_offsets (Acc.slot_offsets acc) ~get_code_metadata

--- a/middle_end/flambda2/nominal/name_mode.ml
+++ b/middle_end/flambda2/nominal/name_mode.ml
@@ -23,10 +23,13 @@ type name_mode = t
 
 (* Semilattice:
  *
- *         Normal
- *       /      \
- *      /        \
- *  In_types   Phantom
+ *   Normal
+ *      |
+ *      |
+ *   Phantom
+ *      |
+ *      |
+ *   In_types
  *)
 
 let join_in_terms t1 t2 =
@@ -56,7 +59,8 @@ let compare_partial_order t1 t2 =
   | Normal, Normal | Phantom, Phantom | In_types, In_types -> Some 0
   | Normal, (Phantom | In_types) -> Some 1
   | (Phantom | In_types), Normal -> Some (-1)
-  | Phantom, In_types | In_types, Phantom -> None
+  | Phantom, In_types -> Some 1
+  | In_types, Phantom -> Some (-1)
 
 include Container_types.Make (struct
   type nonrec t = t
@@ -76,8 +80,8 @@ include Container_types.Make (struct
     | Normal, Normal | Phantom, Phantom | In_types, In_types -> 0
     | Normal, (Phantom | In_types) -> 1
     | (Phantom | In_types), Normal -> -1
-    | Phantom, In_types -> -1
-    | In_types, Phantom -> 1
+    | Phantom, In_types -> 1
+    | In_types, Phantom -> -1
 
   let equal t1 t2 = compare t1 t2 = 0
 end)

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -774,10 +774,19 @@ let function_slots_in_normal_projections t =
       then Function_slot.Set.add function_slot acc
       else acc)
 
-let all_function_slots t =
-  Function_slot.Set.union
-    (For_function_slots.keys t.function_slots_in_projections)
-    (For_function_slots.keys t.function_slots_in_declarations)
+let all_function_slots_at_normal_mode t =
+  let from_projections =
+    For_function_slots.fold_with_mode t.function_slots_in_projections
+      ~init:Function_slot.Set.empty ~f:(fun acc function_slot name_mode ->
+        if Name_mode.is_normal name_mode
+        then Function_slot.Set.add function_slot acc
+        else acc)
+  in
+  For_function_slots.fold_with_mode t.function_slots_in_declarations
+    ~init:from_projections ~f:(fun acc function_slot name_mode ->
+      if Name_mode.is_normal name_mode
+      then Function_slot.Set.add function_slot acc
+      else acc)
 
 let value_slots_in_normal_projections t =
   For_value_slots.fold_with_mode t.value_slots_in_projections
@@ -786,10 +795,19 @@ let value_slots_in_normal_projections t =
       then Value_slot.Set.add value_slot acc
       else acc)
 
-let all_value_slots t =
-  Value_slot.Set.union
-    (For_value_slots.keys t.value_slots_in_projections)
-    (For_value_slots.keys t.value_slots_in_declarations)
+let all_value_slots_at_normal_mode t =
+  let from_projections =
+    For_value_slots.fold_with_mode t.value_slots_in_projections
+      ~init:Value_slot.Set.empty ~f:(fun acc value_slot name_mode ->
+        if Name_mode.is_normal name_mode
+        then Value_slot.Set.add value_slot acc
+        else acc)
+  in
+  For_value_slots.fold_with_mode t.value_slots_in_declarations
+    ~init:from_projections ~f:(fun acc value_slot name_mode ->
+      if Name_mode.is_normal name_mode
+      then Value_slot.Set.add value_slot acc
+      else acc)
 
 let variables t = For_names.keys t.names |> Name.set_to_var_set
 

--- a/middle_end/flambda2/nominal/name_occurrences.mli
+++ b/middle_end/flambda2/nominal/name_occurrences.mli
@@ -128,11 +128,11 @@ val continuations_including_in_trap_actions : t -> Continuation.Set.t
 
 val function_slots_in_normal_projections : t -> Function_slot.Set.t
 
-val all_function_slots : t -> Function_slot.Set.t
+val all_function_slots_at_normal_mode : t -> Function_slot.Set.t
 
 val value_slots_in_normal_projections : t -> Value_slot.Set.t
 
-val all_value_slots : t -> Value_slot.Set.t
+val all_value_slots_at_normal_mode : t -> Value_slot.Set.t
 
 val symbols : t -> Symbol.Set.t
 

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -451,19 +451,23 @@ let cse t = t.cse
 
 let comparison_results t = t.comparison_results
 
-let add_cse t prim ~bound_to =
-  let scope = get_continuation_scope t in
-  let cse = CSE.add t.cse prim ~bound_to scope in
-  let comparison_results =
-    let prim = Flambda_primitive.Eligible_for_cse.to_primitive prim in
-    match
-      ( Comparison_result.create ~prim ~comparison_results:t.comparison_results,
-        Simple.must_be_var bound_to )
-    with
-    | None, _ | _, None -> t.comparison_results
-    | Some comp, Some (var, _) -> Variable.Map.add var comp t.comparison_results
-  in
-  { t with cse; comparison_results }
+let add_cse t prim ~bound_to ~name_mode =
+  if not (Name_mode.is_normal name_mode)
+  then t
+  else
+    let scope = get_continuation_scope t in
+    let cse = CSE.add t.cse prim ~bound_to scope in
+    let comparison_results =
+      let prim = Flambda_primitive.Eligible_for_cse.to_primitive prim in
+      match
+        ( Comparison_result.create ~prim ~comparison_results:t.comparison_results,
+          Simple.must_be_var bound_to )
+      with
+      | None, _ | _, None -> t.comparison_results
+      | Some comp, Some (var, _) ->
+        Variable.Map.add var comp t.comparison_results
+    in
+    { t with cse; comparison_results }
 
 let find_cse t prim = CSE.find t.cse prim
 

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -149,7 +149,11 @@ val set_inlining_state : t -> Inlining_state.t -> t
 val get_inlining_state : t -> Inlining_state.t
 
 val add_cse :
-  t -> Flambda_primitive.Eligible_for_cse.t -> bound_to:Simple.t -> t
+  t ->
+  Flambda_primitive.Eligible_for_cse.t ->
+  bound_to:Simple.t ->
+  name_mode:Name_mode.t ->
+  t
 
 val find_cse : t -> Flambda_primitive.Eligible_for_cse.t -> Simple.t option
 

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -25,21 +25,13 @@ module UE = Upwards_env
 module DA = Downwards_acc
 module VB = Bound_var
 
-type let_creation_result =
-  | Defining_expr_deleted_at_compile_time
-  | Defining_expr_deleted_at_runtime
-  | Nothing_deleted_at_runtime
-
-let equal_let_creation_results r1 r2 =
-  match r1, r2 with
-  | Defining_expr_deleted_at_compile_time, Defining_expr_deleted_at_compile_time
-  | Defining_expr_deleted_at_runtime, Defining_expr_deleted_at_runtime
-  | Nothing_deleted_at_runtime, Nothing_deleted_at_runtime ->
-    true
-  | ( ( Defining_expr_deleted_at_compile_time | Defining_expr_deleted_at_runtime
-      | Nothing_deleted_at_runtime ),
-      _ ) ->
-    false
+type binding_to_place =
+  | Keep_binding of
+      { let_bound : Bound_pattern.t;
+        simplified_defining_expr : Simplified_named.t;
+        original_defining_expr : Named.t option
+      }
+  | Delete_binding of { original_defining_expr : Named.t option }
 
 let add_set_of_closures_offsets ~is_phantom named uacc =
   let add_offsets_from_set uacc set_of_closures =
@@ -73,167 +65,47 @@ let add_set_of_closures_offsets ~is_phantom named uacc =
   Named.fold_code_and_sets_of_closures named ~init:uacc
     ~f_code:add_offsets_from_code ~f_set:add_offsets_from_set
 
-type keep_binding_decision =
-  | Delete_binding
-  | Keep_binding of Name_mode.t
-
 let create_let uacc (bound_vars : Bound_pattern.t) (defining_expr : Named.t)
     ~free_names_of_defining_expr ~body ~cost_metrics_of_defining_expr =
   (* The name occurrences component of [uacc] is expected to be in the state
      described in the comment at the top of [Simplify_let.rebuild_let]. *)
-  let generate_phantom_lets = UA.generate_phantom_lets uacc in
+  let name_mode = Bound_pattern.name_mode bound_vars in
+  let is_phantom = Name_mode.is_phantom name_mode in
   let free_names_of_body = UA.name_occurrences uacc in
-  let bound_vars, keep_binding, let_creation_result =
-    let greatest_name_mode =
-      match bound_vars with
-      | Singleton bound_var ->
-        (* We avoid the closure allocation (below) in this case. *)
-        Name_occurrences.greatest_name_mode_var free_names_of_body
-          (VB.var bound_var)
-      | Set_of_closures _ ->
-        Bound_pattern.fold_all_bound_vars bound_vars
-          ~init:Name_mode.Or_absent.absent
-          ~f:(fun greatest_name_mode bound_var ->
-            Name_occurrences.greatest_name_mode_var free_names_of_body
-              (VB.var bound_var)
-            |> Name_mode.Or_absent.join_in_terms greatest_name_mode)
-      | Static _ -> assert false
-      (* see below *)
-    in
-    let declared_name_mode = Bound_pattern.name_mode bound_vars in
-    let mismatched_modes =
-      match
-        Name_mode.Or_absent.compare_partial_order greatest_name_mode
-          (Name_mode.Or_absent.present declared_name_mode)
-      with
-      | None -> true
-      | Some c -> c > 0
-    in
-    if mismatched_modes
-    then
-      Misc.fatal_errorf
-        "[Let]-binding declares variable(s) %a (mode %a) to be bound to@ %a,@ \
-         but there exist occurrences for such variable(s) at incompatible \
-         mode(s)@ (compared to %a)@ in the body (free names %a):@ %a"
-        Bound_pattern.print bound_vars Name_mode.print declared_name_mode
-        Named.print defining_expr Name_mode.Or_absent.print greatest_name_mode
-        Name_occurrences.print free_names_of_body
-        (RE.print (UA.are_rebuilding_terms uacc))
-        body;
-    let is_end_region =
-      match defining_expr with
-      | Prim (prim, _) -> P.is_end_region prim
-      | Simple _ | Set_of_closures _ | Static_consts _ | Rec_info _ -> None
-    in
-    let is_end_region_for_unused_region, is_end_region_for_used_region =
-      match is_end_region with
-      | None -> false, false
-      | Some region ->
-        let is_used = Name.Set.mem (Name.var region) (UA.required_names uacc) in
-        not is_used, is_used
-    in
-    if is_end_region_for_used_region
-       || (not is_end_region_for_unused_region)
-          && not (Named.at_most_generative_effects defining_expr)
-    then (
-      if not (Name_mode.is_normal declared_name_mode)
-      then
-        Misc.fatal_errorf
-          "Cannot [Let]-bind non-normal variable(s) to a [Named] that has more \
-           than generative effects:@ %a@ =@ %a"
-          Bound_pattern.print bound_vars Named.print defining_expr;
-      bound_vars, Keep_binding Name_mode.normal, Nothing_deleted_at_runtime)
+  let free_names_of_defining_expr =
+    if not is_phantom
+    then free_names_of_defining_expr
     else
-      let is_depth =
-        match defining_expr with
-        | Rec_info _ -> true
-        | Simple _ | Prim _ | Set_of_closures _ | Static_consts _ -> false
-      in
-      let has_uses = Name_mode.Or_absent.is_present greatest_name_mode in
-      let can_phantomise =
-        (not is_depth)
-        && Bound_pattern.exists_all_bound_vars bound_vars ~f:(fun bound_var ->
-               Variable.user_visible (VB.var bound_var))
-      in
-      let will_delete_binding =
-        if is_end_region_for_unused_region
-        then true
-        else
-          (* CR-someday mshinwell: This should detect whether there is any
-             provenance info associated with the variable. If there isn't, the
-             [Let] can be deleted even if debugging information is being
-             generated. *)
-          not (has_uses || (generate_phantom_lets && can_phantomise))
-      in
-      if will_delete_binding
-      then bound_vars, Delete_binding, Defining_expr_deleted_at_compile_time
-      else
-        let name_mode =
-          match greatest_name_mode with
-          | Absent -> Name_mode.phantom
-          | Present name_mode -> name_mode
-        in
-        assert (Name_mode.can_be_in_terms name_mode);
-        let bound_vars = Bound_pattern.with_name_mode bound_vars name_mode in
-        if Name_mode.is_normal name_mode
-        then bound_vars, Keep_binding name_mode, Nothing_deleted_at_runtime
-        else
-          (* CR lmaurer for poechsel: This seems to suggest (and the code toward
-             the end of [make_new_let_bindings] seems to assume) that we're
-             phantomising the binding right now, but in fact it may have been
-             phantom already if there has already been a simplifier pass.
-             Presumably this will cause double-counting of deleted code, which
-             is to say, the second pass will get as much credit for phantomising
-             as the first one did. *)
-          bound_vars, Keep_binding name_mode, Defining_expr_deleted_at_runtime
+      Name_occurrences.downgrade_occurrences_at_strictly_greater_name_mode
+        free_names_of_defining_expr name_mode
   in
-  (* CR-someday mshinwell: When leaving behind phantom lets, maybe we should
-     turn the defining expressions into simpler ones by using the type, if
-     possible. For example an Unbox_naked_int64 or something could potentially
-     turn into a variable. This defining expression usually never exists as the
-     types propagate the information forward. mshinwell: this might be done now
-     in Simplify_named, check. *)
-  match keep_binding with
-  | Delete_binding -> body, uacc, let_creation_result
-  | Keep_binding name_mode ->
-    let is_phantom = Name_mode.is_phantom name_mode in
-    let free_names_of_body = UA.name_occurrences uacc in
-    let free_names_of_defining_expr =
-      if not is_phantom
-      then free_names_of_defining_expr
-      else
-        Name_occurrences.downgrade_occurrences_at_strictly_greater_name_mode
-          free_names_of_defining_expr name_mode
+  let free_names_of_let =
+    let without_bound_vars =
+      Bound_pattern.fold_all_bound_vars bound_vars ~init:free_names_of_body
+        ~f:(fun free_names bound_var ->
+          Name_occurrences.remove_var free_names ~var:(VB.var bound_var))
     in
-    let free_names_of_let =
-      let without_bound_vars =
-        Bound_pattern.fold_all_bound_vars bound_vars ~init:free_names_of_body
-          ~f:(fun free_names bound_var ->
-            Name_occurrences.remove_var free_names ~var:(VB.var bound_var))
-      in
-      Name_occurrences.union without_bound_vars free_names_of_defining_expr
-    in
-    let uacc =
-      UA.add_cost_metrics_and_with_name_occurrences uacc
-        (Cost_metrics.increase_due_to_let_expr ~is_phantom
-           ~cost_metrics_of_defining_expr)
-        free_names_of_let
-    in
-    let uacc =
-      if Are_rebuilding_terms.do_not_rebuild_terms
-           (UA.are_rebuilding_terms uacc)
-      then uacc
-      else add_set_of_closures_offsets ~is_phantom defining_expr uacc
-    in
-    ( RE.create_let
-        (UA.are_rebuilding_terms uacc)
-        bound_vars defining_expr ~body ~free_names_of_body,
-      uacc,
-      let_creation_result )
+    Name_occurrences.union without_bound_vars free_names_of_defining_expr
+  in
+  let uacc =
+    UA.add_cost_metrics_and_with_name_occurrences uacc
+      (Cost_metrics.increase_due_to_let_expr ~is_phantom
+         ~cost_metrics_of_defining_expr)
+      free_names_of_let
+  in
+  let uacc =
+    if Are_rebuilding_terms.do_not_rebuild_terms (UA.are_rebuilding_terms uacc)
+    then uacc
+    else add_set_of_closures_offsets ~is_phantom defining_expr uacc
+  in
+  ( RE.create_let
+      (UA.are_rebuilding_terms uacc)
+      bound_vars defining_expr ~body ~free_names_of_body,
+    uacc )
 
 let create_let_binding uacc bound_vars defining_expr
     ~free_names_of_defining_expr ~body ~cost_metrics_of_defining_expr =
-  let re, uacc, _ =
+  let re, uacc =
     create_let uacc bound_vars defining_expr ~free_names_of_defining_expr ~body
       ~cost_metrics_of_defining_expr
   in
@@ -259,13 +131,13 @@ let create_coerced_singleton_let uacc var defining_expr
         (Bound_pattern.singleton var)
         defining_expr ~free_names_of_defining_expr ~body
         ~cost_metrics_of_defining_expr
-    | Prim _ | Set_of_closures _ | Static_consts _ | Rec_info _ -> (
+    | Prim _ | Set_of_closures _ | Static_consts _ | Rec_info _ ->
       let uncoerced_var =
         let name = "uncoerced_" ^ Variable.unique_name (VB.var var) in
         Variable.create name
       in
       (* Generate [let var = uncoerced_var @ <coercion>] *)
-      let ((body, uacc, inner_result) as inner) =
+      let body, uacc =
         let defining_simple =
           Simple.with_coercion (Simple.var uncoerced_var)
             coercion_from_defining_expr_to_var
@@ -282,71 +154,56 @@ let create_coerced_singleton_let uacc var defining_expr
       in
       let generate_outer_binding name_mode =
         (* Generate [let uncoerced_var = <defining_expr>] *)
-        let ((_body, _uacc, outer_result) as outer) =
+        let ((_body, _uacc) as outer) =
           let bound =
             Bound_pattern.singleton (VB.create uncoerced_var name_mode)
           in
           create_let uacc bound defining_expr ~free_names_of_defining_expr ~body
             ~cost_metrics_of_defining_expr
         in
-        (* Can't somehow end up with one but not the other *)
-        assert (equal_let_creation_results inner_result outer_result);
         outer
       in
-      match inner_result with
-      | Defining_expr_deleted_at_compile_time ->
-        (* No need to wrap what's not there after all *)
-        inner
-      | Defining_expr_deleted_at_runtime ->
-        generate_outer_binding Name_mode.phantom
-      | Nothing_deleted_at_runtime -> generate_outer_binding Name_mode.normal)
-
-type binding_to_place =
-  { let_bound : Bound_pattern.t;
-    simplified_defining_expr : Simplified_named.t;
-    original_defining_expr : Named.t option
-  }
+      generate_outer_binding (Bound_var.name_mode var)
 
 let make_new_let_bindings uacc ~bindings_outermost_first ~body =
   (* The name occurrences component of [uacc] is expected to be in the state
      described in the comment at the top of [Simplify_let.rebuild_let]. *)
+  let delete_binding uacc ~original_defining_expr =
+    match (original_defining_expr : Named.t option) with
+    | Some (Prim (prim, _dbg)) ->
+      UA.notify_removed ~operation:(Removed_operations.prim prim) uacc
+    | Some (Set_of_closures _) ->
+      UA.notify_removed ~operation:Removed_operations.alloc uacc
+    | Some (Simple _ | Static_consts _ | Rec_info _) | None -> uacc
+  in
   ListLabels.fold_left (List.rev bindings_outermost_first) ~init:(body, uacc)
-    ~f:(fun
-         (expr, uacc)
-         { let_bound; simplified_defining_expr; original_defining_expr }
-       ->
-      let { Simplified_named.named = defining_expr;
-            free_names = free_names_of_defining_expr;
-            cost_metrics = cost_metrics_of_defining_expr
-          } =
-        simplified_defining_expr
-      in
-      let defining_expr = Simplified_named.to_named defining_expr in
-      let expr, uacc, creation_result =
-        match (let_bound : Bound_pattern.t) with
-        | Singleton _ | Set_of_closures _ ->
-          create_let uacc let_bound defining_expr ~free_names_of_defining_expr
-            ~body:expr ~cost_metrics_of_defining_expr
-        | Static _ ->
-          (* Since [Simplified_named] doesn't permit the [Static_consts] case,
-             this must be a malformed binding. *)
-          Misc.fatal_errorf
-            "Mismatch between bound name(s) and defining expression:@ %a@ =@ %a"
-            Bound_pattern.print let_bound Named.print defining_expr
-      in
-      let uacc =
-        match creation_result with
-        | Nothing_deleted_at_runtime -> uacc
-        | Defining_expr_deleted_at_compile_time
-        | Defining_expr_deleted_at_runtime -> (
-          match original_defining_expr with
-          | Some (Prim (prim, _dbg)) ->
-            UA.notify_removed ~operation:(Removed_operations.prim prim) uacc
-          | Some (Set_of_closures _) ->
-            UA.notify_removed ~operation:Removed_operations.alloc uacc
-          | Some (Simple _ | Static_consts _ | Rec_info _) | None -> uacc)
-      in
-      expr, uacc)
+    ~f:(fun (expr, uacc) binding ->
+      match (binding : binding_to_place) with
+      | Delete_binding { original_defining_expr } ->
+        expr, delete_binding uacc ~original_defining_expr
+      | Keep_binding
+          { let_bound; simplified_defining_expr; original_defining_expr = _ } ->
+        let { Simplified_named.named = defining_expr;
+              free_names = free_names_of_defining_expr;
+              cost_metrics = cost_metrics_of_defining_expr
+            } =
+          simplified_defining_expr
+        in
+        let defining_expr = Simplified_named.to_named defining_expr in
+        let expr, uacc =
+          match (let_bound : Bound_pattern.t) with
+          | Singleton _ | Set_of_closures _ ->
+            create_let uacc let_bound defining_expr ~free_names_of_defining_expr
+              ~body:expr ~cost_metrics_of_defining_expr
+          | Static _ ->
+            (* Since [Simplified_named] doesn't permit the [Static_consts] case,
+               this must be a malformed binding. *)
+            Misc.fatal_errorf
+              "Mismatch between bound name(s) and defining expression:@ %a@ =@ \
+               %a"
+              Bound_pattern.print let_bound Named.print defining_expr
+        in
+        expr, uacc)
 
 let create_raw_let_symbol uacc bound_static static_consts ~body =
   (* Upon entry to this function, [UA.name_occurrences uacc] must precisely
@@ -566,7 +423,7 @@ let create_let_symbols uacc lifted_constant ~body =
         Cost_metrics.from_size code_size_of_defining_expr
       in
       let free_names_of_defining_expr = Named.free_names defining_expr in
-      let expr, uacc, _ =
+      let expr, uacc =
         create_coerced_singleton_let uacc
           (VB.create var Name_mode.normal)
           defining_expr ~coercion_from_defining_expr_to_var

--- a/middle_end/flambda2/simplify/expr_builder.mli
+++ b/middle_end/flambda2/simplify/expr_builder.mli
@@ -35,18 +35,20 @@ val create_let_binding :
   Rebuilt_expr.t * Upwards_acc.t
 
 type binding_to_place =
-  { let_bound : Bound_pattern.t;
-    simplified_defining_expr : Simplified_named.t;
-    original_defining_expr : Named.t option
-  }
-
-(** Create [Let] binding(s) around a given body. (The type of this function
+  | Keep_binding of
+      { let_bound : Bound_pattern.t;
+        simplified_defining_expr : Simplified_named.t;
+        original_defining_expr : Named.t option
+      }
+  | Delete_binding of { original_defining_expr : Named.t option }
+      (** Create [Let] binding(s) around a given body. (The type of this function
     prevents it from being used to create "let symbol" bindings; use the other
     functions in this module instead.) Bindings will be elided if they are
     unused.
 
     The [name_occurrences] in the provided [uacc] must contain exactly the free
     names of the [body]. *)
+
 val make_new_let_bindings :
   Upwards_acc.t ->
   bindings_outermost_first:binding_to_place list ->

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -47,10 +47,11 @@ let inline_linearly_used_continuation uacc ~create_apply_cont ~params:params'
             |> Bound_pattern.singleton
           in
           let named = Named.create_simple arg in
-          { Expr_builder.let_bound;
-            simplified_defining_expr = Simplified_named.create named;
-            original_defining_expr = Some named
-          })
+          Expr_builder.Keep_binding
+            { let_bound;
+              simplified_defining_expr = Simplified_named.create named;
+              original_defining_expr = Some named
+            })
     in
     let expr, uacc =
       let uacc =

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -545,10 +545,11 @@ let add_phantom_params_bindings uacc handler new_phantom_params =
         let prim = Flambda_primitive.(Nullary (Optimised_out kind)) in
         let named = Named.create_prim prim Debuginfo.none in
         let simplified_defining_expr = Simplified_named.create named in
-        { Expr_builder.let_bound;
-          simplified_defining_expr;
-          original_defining_expr = Some named
-        })
+        Expr_builder.Keep_binding
+          { let_bound;
+            simplified_defining_expr;
+            original_defining_expr = Some named
+          })
       (Bound_parameters.to_list new_phantom_params)
   in
   EB.make_new_let_bindings uacc ~body:handler

--- a/middle_end/flambda2/simplify/simplify_named_result.ml
+++ b/middle_end/flambda2/simplify/simplify_named_result.ml
@@ -34,12 +34,14 @@ let create_have_lifted_set_of_closures dacc bound_vars_to_symbols
     bindings_to_place =
       List.mapi
         (fun i (var, sym) ->
-          { Expr_builder.let_bound = Bound_pattern.singleton var;
-            simplified_defining_expr =
-              Simplified_named.create (Named.create_simple (Simple.symbol sym));
-            original_defining_expr =
-              (if i = 0 then Some original_defining_expr else None)
-          })
+          Expr_builder.Keep_binding
+            { let_bound = Bound_pattern.singleton var;
+              simplified_defining_expr =
+                Simplified_named.create
+                  (Named.create_simple (Simple.symbol sym));
+              original_defining_expr =
+                (if i = 0 then Some original_defining_expr else None)
+            })
         bound_vars_to_symbols;
     was_lifted_set_of_closures = true
   }

--- a/middle_end/flambda2/simplify/simplify_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive.ml
@@ -73,7 +73,7 @@ let try_cse dacc dbg ~original_prim ~min_name_mode ~result_var : cse_result =
           let bound_to = Simple.var result_var' in
           let dacc =
             DA.map_denv dacc ~f:(fun denv ->
-                DE.add_cse denv eligible_prim ~bound_to)
+                DE.add_cse denv eligible_prim ~bound_to ~name_mode:min_name_mode)
           in
           DA.merge_debuginfo_rewrite dacc ~bound_to dbg
       in

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -777,8 +777,49 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
     C.closure_bound_names_inside_functions_exactly_one_set context
   in
   let { set_of_closures; dacc } =
-    simplify_set_of_closures0 dacc context set_of_closures ~closure_bound_names
-      ~closure_bound_names_inside ~value_slots ~value_slot_types
+    if Name_mode.is_normal (Bound_pattern.name_mode bound_vars)
+    then
+      simplify_set_of_closures0 dacc context set_of_closures
+        ~closure_bound_names ~closure_bound_names_inside ~value_slots
+        ~value_slot_types
+    else
+      let dacc =
+        DA.map_denv dacc ~f:(fun denv ->
+            Bound_pattern.fold_all_bound_vars bound_vars ~init:denv
+              ~f:(fun denv var -> DE.define_variable denv var K.value))
+      in
+      let set_of_closures =
+        let value_slots =
+          Value_slot.Map.map
+            (fun simple ->
+              snd
+                (Simplify_simple.simplify_simple dacc simple
+                   ~min_name_mode:(Bound_pattern.name_mode bound_vars)))
+            (Set_of_closures.value_slots set_of_closures)
+        in
+        let function_decls =
+          Function_slot.Lmap.map
+            (fun (func : Function_declarations.code_id_in_function_declaration) ->
+              match func with
+              | Deleted _ -> func
+              | Code_id code_id ->
+                let code_metadata =
+                  DE.find_code_exn (DA.denv dacc) code_id
+                  |> Code_or_metadata.code_metadata
+                in
+                Function_declarations.Deleted
+                  { function_slot_size =
+                      Code_metadata.function_slot_size code_metadata;
+                    dbg = Code_metadata.dbg code_metadata
+                  })
+            (Function_declarations.funs_in_order
+               (Set_of_closures.function_decls set_of_closures))
+        in
+        Set_of_closures.create ~value_slots
+          (Set_of_closures.alloc_mode set_of_closures)
+          (Function_declarations.create function_decls)
+      in
+      { set_of_closures; dacc }
   in
   let defining_expr =
     let named = Named.create_set_of_closures set_of_closures in
@@ -798,11 +839,12 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
       ~free_names:(Named.free_names named)
   in
   Simplify_named_result.create dacc
-    [ { Expr_builder.let_bound = bound_vars;
-        simplified_defining_expr = defining_expr;
-        original_defining_expr =
-          Some (Named.create_set_of_closures set_of_closures)
-      } ]
+    [ Expr_builder.Keep_binding
+        { let_bound = bound_vars;
+          simplified_defining_expr = defining_expr;
+          original_defining_expr =
+            Some (Named.create_set_of_closures set_of_closures)
+        } ]
 
 type lifting_decision_result =
   { can_lift : bool;

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -145,7 +145,8 @@ let simplify_unbox_number (boxable_number_kind : K.Boxable_number.t) dacc
                   ( Box_number
                       (boxable_number_kind, Alloc_mode.For_allocations.heap),
                     Simple.var result_var' )))
-            ~bound_to:arg)
+            ~bound_to:arg
+            ~name_mode:(Bound_var.name_mode result_var))
   in
   SPR.with_dacc result dacc
 
@@ -164,7 +165,8 @@ let simplify_untag_immediate dacc ~original_term ~arg ~arg_ty:boxed_number_ty
         DE.add_cse denv
           (P.Eligible_for_cse.create_exn
              (Unary (Tag_immediate, Simple.var result_var')))
-          ~bound_to:arg)
+          ~bound_to:arg
+          ~name_mode:(Bound_var.name_mode result_var))
   in
   SPR.with_dacc result dacc
 
@@ -720,11 +722,13 @@ let simplify_obj_dup dbg dacc ~original_term ~arg ~arg_ty ~result_var =
           Named.create_prim (Unary (Unbox_number boxable_number, arg)) dbg
         in
         let bind_contents =
-          { Expr_builder.let_bound =
-              Bound_pattern.singleton (Bound_var.create contents_var NM.normal);
-            simplified_defining_expr = Simplified_named.create contents_expr;
-            original_defining_expr = None
-          }
+          Expr_builder.Keep_binding
+            { let_bound =
+                Bound_pattern.singleton
+                  (Bound_var.create contents_var NM.normal);
+              simplified_defining_expr = Simplified_named.create contents_expr;
+              original_defining_expr = None
+            }
         in
         let contents_simple = Simple.var contents_var in
         let dacc =
@@ -875,7 +879,8 @@ let[@inline always] simplify_immutable_block_load0
           | Some prim ->
             let dacc =
               DA.map_denv dacc ~f:(fun denv ->
-                  DE.add_cse denv prim ~bound_to:block)
+                  DE.add_cse denv prim ~bound_to:block
+                    ~name_mode:(Bound_var.name_mode result_var))
             in
             SPR.with_dacc result dacc))))
 

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
@@ -74,7 +74,8 @@ let simplify_make_block ~original_prim ~(block_kind : P.Block_kind.t)
         | Some prim ->
           DA.map_denv dacc ~f:(fun denv ->
               DE.add_cse denv prim
-                ~bound_to:(Simple.var (Bound_var.var result_var))))
+                ~bound_to:(Simple.var (Bound_var.var result_var))
+                ~name_mode:(Bound_var.name_mode result_var)))
     in
     SPR.create original_term ~try_reify:true dacc
 

--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -91,7 +91,10 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
     let get_tag_prim =
       P.Eligible_for_cse.create_get_tag ~block:(Name.var param_var)
     in
-    let denv = DE.add_cse denv get_tag_prim ~bound_to:(Simple.var tag.param) in
+    let denv =
+      DE.add_cse denv get_tag_prim ~bound_to:(Simple.var tag.param)
+        ~name_mode:Name_mode.normal
+    in
     (* Same thing for is_int *)
     let denv =
       match const_ctors with
@@ -110,6 +113,7 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
         in
         let denv =
           DE.add_cse denv is_int_prim ~bound_to:(Simple.var is_int.param)
+            ~name_mode:Name_mode.normal
         in
         denv
     in


### PR DESCRIPTION
This PR restores support for generating phantom bindings.

I wrote it by enabling phantom lets, and fixing errors as I find them. Given the number of bugs I had to fix, it is likely that some remain in some less-tested corner cases.

Here is a summary of the changes:
- The Name_mode lattice is now a straight line. The typing env requires all the variables in it to have a name mode at least `In_types`, so I made `Phantom` greater than `In_types` instead of not comparable. It would also be possible to prevent the typing env from handling variables in `Phantom` mode, and that should make the environments smaller, but I think it should be a separate PR.
- The logic in `Expr_builder` to decide whether to keep a binding, delete it or phantomise it has been moved to `Simplify_let_expr.rebuild_let`. This makes decisions more consistent (now even bindings removed by mutable unboxing get phantomised if needed)
- Slot offset computations now ignore slots not in normal mode, not only in projections. Phantom closures also get `Deleted` code IDs to avoid keeping old code around.
- No CSE equations are created for phantom bindings

It is possible that this PR still contains changes that were made redundant by a more general fix. Do not hesitate to point these out during review.