### PR TITLE
Propagate Debugging Identifiers through Lambda

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -74,7 +74,8 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
         nontail = is_nontail rc
       }
   | Lfunction f -> Pseudo_event (Function (comp_fun f), f.loc)
-  | Llet (_, _k, id, arg, body) | Lmutlet (_k, id, arg, body) ->
+  | Llet (_, _k, id, _duid, arg, body) | Lmutlet (_k, id, _duid, arg, body) ->
+    (* We are intentionally dropping the [debug_uid] identifiers here. *)
     Let { id; arg = comp_arg arg; body = comp_expr body }
   | Lletrec (decl, body) ->
     Letrec
@@ -87,12 +88,13 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     Staticcatch
       { body = comp_arg body;
         id = static_label;
-        args = List.map fst args;
+        args = List.map (fun (id, _, _) -> id) args;
         handler = comp_expr handler
       }
   | Lstaticraise (static_label, args) ->
     Staticraise (static_label, List.map comp_arg args)
-  | Ltrywith (body, param, handler, _kind) ->
+  | Ltrywith (body, param, _param_duid, handler, _kind) ->
+    (* We are intentionally dropping the [debug_uid] identifiers here. *)
     Trywith { body = comp_arg body; param; handler = comp_expr handler }
   | Lifthenelse (cond, ifso, ifnot, _kind) ->
     Ifthenelse

--- a/chamelon/compat.jst.ml
+++ b/chamelon/compat.jst.ml
@@ -146,6 +146,7 @@ let mkTexp_function ?(id = texp_function_defaults)
                 | Some default ->
                     Tparam_optional_default (pattern, default, id.param_sort));
               fp_param = param;
+              fp_param_debug_uid = Lambda.debug_uid_none;
               fp_partial = partial;
               fp_sort = id.param_sort;
               fp_mode = id.param_mode;
@@ -163,6 +164,7 @@ let mkTexp_function ?(id = texp_function_defaults)
               {
                 fc_cases = cases;
                 fc_param = param;
+                fc_param_debug_uid = Lambda.debug_uid_none;
                 fc_partial = partial;
                 fc_env = id.env;
                 fc_ret_type = id.ret_type;

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -802,6 +802,10 @@ type parameter_attribute = {
   unbox_param: bool;
 }
 
+(* CR rtjoa: have you considered making this a [Shape.Uid.t option] rather than
+   define [debug_uid_none]? (not necessarily a suggestion; this depends on
+   how your later work uses debug uids)
+*)
 type debug_uid = Shape.Uid.t
 let debug_uid_none = Shape.Uid.internal_not_actually_unique
 
@@ -1455,9 +1459,12 @@ let build_substs update_env ?(freshen_bound_variables = false) s =
      themselves when [freshen_bound_variables] is set. *)
   let bind id duid l =
     let id' = if not freshen_bound_variables then id else Ident.rename id in
-    (* CR sspies: If [freshen_bound_variables] is set, this code duplicates
+    (* XCR sspies: If [freshen_bound_variables] is set, this code duplicates
     the debug uids. [freshen_bound_variables] is currently only set by
-    [duplicate] below, which is called from [tmc.ml]. *)
+    [duplicate] below, which is called from [tmc.ml].
+
+       rtjoa: this seems fine - I suppose it can only go wrong if a free
+       variable is substituted for one of a different type? *)
     id', duid, Ident.Map.add id id' l
   in
   let bind_many ids l =
@@ -1721,7 +1728,7 @@ let map f =
 let bind_with_layout str (var, duid, layout) exp body =
   match exp with
     Lvar var' when Ident.same var var' -> body
-    (* CR sspies: This implicitly assumes that they have the same debug uid,
+    (* XCR sspies: This implicitly assumes that they have the same debug uid,
        which is probably correct.*)
   | _ -> Llet(str, layout, var, duid, exp, body)
 

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -802,10 +802,6 @@ type parameter_attribute = {
   unbox_param: bool;
 }
 
-(* CR rtjoa: have you considered making this a [Shape.Uid.t option] rather than
-   define [debug_uid_none]? (not necessarily a suggestion; this depends on
-   how your later work uses debug uids)
-*)
 type debug_uid = Shape.Uid.t
 let debug_uid_none = Shape.Uid.internal_not_actually_unique
 
@@ -1459,12 +1455,6 @@ let build_substs update_env ?(freshen_bound_variables = false) s =
      themselves when [freshen_bound_variables] is set. *)
   let bind id duid l =
     let id' = if not freshen_bound_variables then id else Ident.rename id in
-    (* XCR sspies: If [freshen_bound_variables] is set, this code duplicates
-    the debug uids. [freshen_bound_variables] is currently only set by
-    [duplicate] below, which is called from [tmc.ml].
-
-       rtjoa: this seems fine - I suppose it can only go wrong if a free
-       variable is substituted for one of a different type? *)
     id', duid, Ident.Map.add id id' l
   in
   let bind_many ids l =
@@ -1728,8 +1718,6 @@ let map f =
 let bind_with_layout str (var, duid, layout) exp body =
   match exp with
     Lvar var' when Ident.same var var' -> body
-    (* XCR sspies: This implicitly assumes that they have the same debug uid,
-       which is probably correct.*)
   | _ -> Llet(str, layout, var, duid, exp, body)
 
 let negate_integer_comparison = function

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1180,7 +1180,9 @@ let name_lambda_list args fn =
   | (arg, layout) :: rem ->
       let id = Ident.create_local "let" in
       let id_debug_uid = debug_uid_none in
-      Llet(Strict, layout, id, id_debug_uid, arg, name_list (Lvar id :: names) rem) in
+      Llet(Strict, layout, id, id_debug_uid, arg,
+           name_list (Lvar id :: names) rem)
+  in
   name_list [] args
 
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -744,13 +744,6 @@ type debug_uid = Shape.Uid.t
     at the level of Lambda or below can use the same [debug_uid]. *)
 (* CR sspies: This comment is currently not accurate, since we do not yet
   emit these ids into dwarf code. *)
-(* XCR sspies: The point of the name [debug_uid] is to preserve the connection
-   to the underlying [Shape.Uid.t]. It could lead to confusion around the fact
-   that these identifiers are not actually unique.
-
-   rtjoa: How about naming it something like [typedtree_uid], or even not
-   aliasing it at all and referring to [Typedtree.Uid.t] or [Shape.Uid.t] below?
-   This could also help indicate that typedtree is the source of truth. *)
 
 val debug_uid_none : debug_uid
 (** [debug_uid_none] should be used for those identifiers that are not
@@ -804,13 +797,6 @@ type lambda =
       lambda * (static_label * (Ident.t * debug_uid * layout) list) * lambda
       * pop_region * layout
   | Ltrywith of lambda * Ident.t * debug_uid * lambda * layout
-  (* XCR sspies: What is the identifier in a [Ltrywith]. Should it get a debug
-     id?
-
-     rtjoa: I think [Typecore.name_cases] gives it a meaningful identifier
-     if one of the cases is a variable or alias, and otherwise it calls
-     [Ident.create_local "exn"]. So it seems like we should store a uid
-     in the former case. *)
   (* Lifthenelse (e, t, f, layout) evaluates t if e evaluates to 0, and evaluates f if
    e evaluates to any other value; layout must be the layout of [t] and [f] *)
   | Lifthenelse of lambda * lambda * lambda * layout

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -744,9 +744,13 @@ type debug_uid = Shape.Uid.t
     at the level of Lambda or below can use the same [debug_uid]. *)
 (* CR sspies: This comment is currently not accurate, since we do not yet
   emit these ids into dwarf code. *)
-(* CR sspies: The point of the name [debug_uid] is to preserve the connection
+(* XCR sspies: The point of the name [debug_uid] is to preserve the connection
    to the underlying [Shape.Uid.t]. It could lead to confusion around the fact
-   that these identifiers are not actually unique. *)
+   that these identifiers are not actually unique.
+
+   rtjoa: How about naming it something like [typedtree_uid], or even not
+   aliasing it at all and referring to [Typedtree.Uid.t] or [Shape.Uid.t] below?
+   This could also help indicate that typedtree is the source of truth. *)
 
 val debug_uid_none : debug_uid
 (** [debug_uid_none] should be used for those identifiers that are not
@@ -800,9 +804,14 @@ type lambda =
       lambda * (static_label * (Ident.t * debug_uid * layout) list) * lambda
       * pop_region * layout
   | Ltrywith of lambda * Ident.t * debug_uid * lambda * layout
-  (* CR sspies: What is the identifier in a [Ltrywith]. Should it get a debug
-     id? *)
-(* Lifthenelse (e, t, f, layout) evaluates t if e evaluates to 0, and evaluates f if
+  (* XCR sspies: What is the identifier in a [Ltrywith]. Should it get a debug
+     id?
+
+     rtjoa: I think [Typecore.name_cases] gives it a meaningful identifier
+     if one of the cases is a variable or alias, and otherwise it calls
+     [Ident.create_local "exn"]. So it seems like we should store a uid
+     in the former case. *)
+  (* Lifthenelse (e, t, f, layout) evaluates t if e evaluates to 0, and evaluates f if
    e evaluates to any other value; layout must be the layout of [t] and [f] *)
   | Lifthenelse of lambda * lambda * lambda * layout
   | Lsequence of lambda * lambda

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -740,8 +740,8 @@ type debug_uid = Shape.Uid.t
 (** The [debug_uid] values track typed-tree level identifiers that are then
     passed down to the lower level IRs and eventually emitted into dwarf output.
     WARNING: Unlike the name sugggests, these identifiers are not always unique.
-    Instead, in many cases, we use [debug_uid_none] below, and multiple variables
-    at the level of Lambda or below can use the same [debug_uid]. *)
+    Instead, in many cases, we use [debug_uid_none] below, and multiple
+    variables at the level of Lambda or below can use the same [debug_uid]. *)
 (* CR sspies: This comment is currently not accurate, since we do not yet
   emit these ids into dwarf code. *)
 
@@ -797,7 +797,7 @@ type lambda =
       lambda * (static_label * (Ident.t * debug_uid * layout) list) * lambda
       * pop_region * layout
   | Ltrywith of lambda * Ident.t * debug_uid * lambda * layout
-  (* Lifthenelse (e, t, f, layout) evaluates t if e evaluates to 0, and evaluates f if
+(* Lifthenelse (e, t, f, layout) evaluates t if e evaluates to 0, and evaluates f if
    e evaluates to any other value; layout must be the layout of [t] and [f] *)
   | Lifthenelse of lambda * lambda * lambda * layout
   | Lsequence of lambda * lambda

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -87,6 +87,15 @@
 
 *)
 
+(* CR rtjoa: I'm not familiar enough with the pattern matching compiler, but
+   documenting this case we discussed. Only [y] appears in dlambda, and it has
+   an internal uid.
+
+  let f x = match x with
+    | x, (Some y) when y -> (x, y)
+    | x, None -> (1, false)
+*)
+
 open Misc
 open Asttypes
 open Types

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -87,14 +87,6 @@
 
 *)
 
-(* CR rtjoa: I'm not familiar enough with the pattern matching compiler, but
-   documenting this case we discussed. Only [y] appears in dlambda, and it has
-   an internal uid.
-
-  let f x = match x with
-    | x, (Some y) when y -> (x, y)
-    | x, None -> (1, false)
-*)
 
 open Misc
 open Asttypes
@@ -3735,6 +3727,7 @@ let rec comp_match_handlers layout comp_fun partial ctx first_match next_matches
 
 (* To find reasonable names for variables *)
 
+(* CR rtjoa: extract uid from var/alias *)
 let rec name_pattern default = function
   | ((pat, _), _) :: rem -> (
       match pat.pat_desc with

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -87,7 +87,6 @@
 
 *)
 
-
 open Misc
 open Asttypes
 open Types

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -1260,7 +1260,7 @@ let rec lam ppf = function
       lfunction ppf lfun
   | Llet _ | Lmutlet _ as expr ->
       let let_kind = begin function
-        | Llet(str,_,_,_,_) ->
+        | Llet(str,_,_,_,_,_) ->
            begin match str with
              Alias -> "a" | Strict -> "" | StrictOpt -> "o"
            end
@@ -1269,8 +1269,8 @@ let rec lam ppf = function
         end
       in
       let rec letbody ~sp = function
-        | Llet(_, k, id, arg, body)
-        | Lmutlet(k, id, arg, body) as l ->
+        | Llet(_, k, id, _duid, arg, body)
+        | Lmutlet(k, id, _duid, arg, body) as l ->
            if sp then fprintf ppf "@ ";
            fprintf ppf "@[<2>%a =%s%a@ %a@]"
              Ident.print id (let_kind l) layout k lam arg;
@@ -1283,7 +1283,7 @@ let rec lam ppf = function
       let bindings ppf id_arg_list =
         let spc = ref false in
         List.iter
-          (fun { id; def } ->
+          (fun { id; debug_uid=_; def } ->
             if !spc then fprintf ppf "@ " else spc := true;
             fprintf ppf "@[<2>%a@ %a@]" Ident.print id lfunction def)
           id_arg_list in
@@ -1346,12 +1346,12 @@ let rec lam ppf = function
         lam lbody i
         (fun ppf vars ->
            List.iter
-             (fun (x, k) -> fprintf ppf " %a%a" Ident.print x layout k)
+             (fun (x, _duid, k) -> fprintf ppf " %a%a" Ident.print x layout k)
              vars
         )
         vars
         excl lam lhandler
-  | Ltrywith(lbody, param, lhandler, _kind) ->
+  | Ltrywith(lbody, param, _duid, lhandler, _kind) ->
       fprintf ppf "@[<2>(try@ %a@;<1 -1>with %a@ %a)@]"
         lam lbody Ident.print param lam lhandler
   | Lifthenelse(lcond, lif, lelse, _kind) ->

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -40,10 +40,10 @@ let rec eliminate_ref id = function
   | Lfunction lfun as lam ->
       check_function_escape id lfun;
       lam
-  | Llet(str, kind, v, e1, e2) ->
-      Llet(str, kind, v, eliminate_ref id e1, eliminate_ref id e2)
-  | Lmutlet(kind, v, e1, e2) ->
-      Lmutlet(kind, v, eliminate_ref id e1, eliminate_ref id e2)
+  | Llet(str, kind, v, duid, e1, e2) ->
+      Llet(str, kind, v, duid, eliminate_ref id e1, eliminate_ref id e2)
+  | Lmutlet(kind, v, duid, e1, e2) ->
+      Lmutlet(kind, v, duid, eliminate_ref id e1, eliminate_ref id e2)
   | Lletrec(idel, e2) ->
       List.iter (fun rb -> check_function_escape id rb.def) idel;
       Lletrec(idel, eliminate_ref id e2)
@@ -76,8 +76,8 @@ let rec eliminate_ref id = function
       Lstaticraise (i,List.map (eliminate_ref id) args)
   | Lstaticcatch(e1, i, e2, r, kind) ->
       Lstaticcatch(eliminate_ref id e1, i, eliminate_ref id e2, r, kind)
-  | Ltrywith(e1, v, e2, kind) ->
-      Ltrywith(eliminate_ref id e1, v, eliminate_ref id e2, kind)
+  | Ltrywith(e1, v, duid, e2, kind) ->
+      Ltrywith(eliminate_ref id e1, v, duid, eliminate_ref id e2, kind)
   | Lifthenelse(e1, e2, e3, kind) ->
       Lifthenelse(eliminate_ref id e1,
                   eliminate_ref id e2,
@@ -137,8 +137,8 @@ let simplify_exits lam =
       count ~try_depth ap.ap_func;
       List.iter (count ~try_depth) ap.ap_args
   | Lfunction {body} -> count ~try_depth body
-  | Llet(_, _kind, _v, l1, l2)
-  | Lmutlet(_kind, _v, l1, l2) ->
+  | Llet(_, _kind, _v, _duid, l1, l2)
+  | Lmutlet(_kind, _v, _duid, l1, l2) ->
       count ~try_depth l2; count ~try_depth l1
   | Lletrec(bindings, body) ->
       List.iter (fun { def = { body } } -> count ~try_depth body) bindings;
@@ -180,7 +180,7 @@ let simplify_exits lam =
         in
         count ~try_depth l2
       end
-  | Ltrywith(l1, _v, l2, _kind) ->
+  | Ltrywith(l1, _v, _duid, l2, _kind) ->
       count ~try_depth:(try_depth+1) l1;
       count ~try_depth l2;
   | Lifthenelse(l1, l2, l3, _kind) ->
@@ -246,10 +246,10 @@ let simplify_exits lam =
                      ap_args = List.map (simplif ~layout:None ~try_depth) ap.ap_args}
   | Lfunction lfun ->
       Lfunction (map_lfunction (simplif ~layout:None ~try_depth) lfun)
-  | Llet(str, kind, v, l1, l2) ->
-      Llet(str, kind, v, simplif ~layout:None ~try_depth l1, simplif ~layout ~try_depth l2)
-  | Lmutlet(kind, v, l1, l2) ->
-      Lmutlet(kind, v, simplif ~layout:None ~try_depth l1, simplif ~layout ~try_depth l2)
+  | Llet(str, kind, v, duid, l1, l2) ->
+      Llet(str, kind, v, duid, simplif ~layout:None ~try_depth l1, simplif ~layout ~try_depth l2)
+  | Lmutlet(kind, v, duid, l1, l2) ->
+      Lmutlet(kind, v, duid, simplif ~layout:None ~try_depth l1, simplif ~layout ~try_depth l2)
   | Lletrec(bindings, body) ->
       let bindings =
         List.map (fun ({ def = {kind; params; return; body = l; attr; loc;
@@ -308,10 +308,10 @@ let simplify_exits lam =
       let ls = List.map (simplif ~layout:None ~try_depth) ls in
       begin try
         let xs,handler =  Hashtbl.find subst i in
-        let ys = List.map (fun (x, k) -> Ident.rename x, k) xs in
+        let ys = List.map (fun (x, duid, k) -> Ident.rename x, duid, k) xs in
         let env =
           List.fold_right2
-            (fun (x, _) (y, _) env -> Ident.Map.add x y env)
+            (fun (x, _, _) (y, _, _) env -> Ident.Map.add x y env)
             xs ys Ident.Map.empty
         in
         (* The evaluation order for Lstaticraise arguments is currently
@@ -321,7 +321,7 @@ let simplify_exits lam =
            so will be evaluated last).
         *)
         List.fold_left2
-          (fun r (y, kind) l -> Llet (Strict, kind, y, l, r))
+          (fun r (y, duid, kind) l -> Llet (Strict, kind, y, duid, l, r))
           (Lambda.rename env handler) ys ls
       with
       | Not_found -> Lstaticraise (i,ls)
@@ -353,9 +353,9 @@ let simplify_exits lam =
           simplif ~layout ~try_depth l2,
           r,
           result_layout kind)
-  | Ltrywith(l1, v, l2, kind) ->
+  | Ltrywith(l1, v, duid, l2, kind) ->
       let l1 = simplif ~layout ~try_depth:(try_depth + 1) l1 in
-      Ltrywith(l1, v, simplif ~layout ~try_depth l2, result_layout kind)
+      Ltrywith(l1, v, duid, simplif ~layout ~try_depth l2, result_layout kind)
   | Lifthenelse(l1, l2, l3, kind) ->
       Lifthenelse(
         simplif ~layout:None ~try_depth l1,
@@ -400,7 +400,8 @@ let exact_application {kind; params; _} args =
 
 let beta_reduce params body args =
   List.fold_left2
-    (fun l param arg -> Llet(Strict, param.layout, param.name, arg, l))
+    (fun l (param: lparam) arg ->
+      Llet(Strict, param.layout, param.name, param.debug_uid, arg, l))
     body params args
 
 (* Simplification of lets *)
@@ -467,16 +468,16 @@ let simplify_lets lam =
       end
   | Lfunction fn ->
       count_lfunction fn
-  | Llet(_str, _k, v, Lvar w, l2) when optimize ->
+  | Llet(_str, _k, v, _duid, Lvar w, l2) when optimize ->
       (* v will be replaced by w in l2, so each occurrence of v in l2
          increases w's refcount *)
       count (bind_var bv v) l2;
       use_var bv w (count_var v)
-  | Llet(str, _kind, v, l1, l2) ->
+  | Llet(str, _kind, v, _duid, l1, l2) ->
       count (bind_var bv v) l2;
       (* If v is unused, l1 will be removed, so don't count its variables *)
       if str = Strict || count_var v > 0 then count bv l1
-  | Lmutlet(_kind, _v, l1, l2) ->
+  | Lmutlet(_kind, _v, _duid, l1, l2) ->
      count bv l1;
      count bv l2
   | Lletrec(bindings, body) ->
@@ -501,7 +502,7 @@ let simplify_lets lam =
       end
   | Lstaticraise (_i,ls) -> List.iter (count bv) ls
   | Lstaticcatch(l1, _, l2, Same_region, _) -> count bv l1; count bv l2
-  | Ltrywith(l1, _v, l2, _kind) -> count bv l1; count bv l2
+  | Ltrywith(l1, _v, _duid, l2, _kind) -> count bv l1; count bv l2
   | Lifthenelse(l1, l2, l3, _kind) -> count bv l1; count bv l2; count bv l3
   | Lsequence(l1, l2) -> count bv l1; count bv l2
   | Lwhile {wh_cond; wh_body} ->
@@ -555,16 +556,16 @@ let simplify_lets lam =
 (* This (small)  optimisation is always legal, it may uncover some
    tail call later on. *)
 
-  let mklet str kind v e1 e2 =
+  let mklet str kind v duid e1 e2 =
     match e2 with
     | Lvar w when optimize && Ident.same v w -> e1
-    | _ -> Llet (str, kind,v,e1,e2)
+    | _ -> Llet (str, kind,v,duid,e1,e2)
   in
 
-  let mkmutlet kind v e1 e2 =
+  let mkmutlet kind v duid e1 e2 =
     match e2 with
     | Lmutvar w when optimize && Ident.same v w -> e1
-    | _ -> Lmutlet (kind,v,e1,e2)
+    | _ -> Lmutlet (kind,v,duid,e1,e2)
   in
 
   let rec simplif = function
@@ -609,10 +610,10 @@ let simplify_lets lam =
       | kind, ret_mode, body ->
           lfunction ~kind ~params ~return:outer_return ~body ~attr:attr1 ~loc ~mode ~ret_mode
       end
-  | Llet(_str, _k, v, Lvar w, l2) when optimize ->
+  | Llet(_str, _k, v, _duid, Lvar w, l2) when optimize ->
       Hashtbl.add subst v (simplif (Lvar w));
       simplif l2
-  | Llet(Strict, kind, v,
+  | Llet(Strict, kind, v, duid,
          Lprim(Pmakeblock(0, Mutable, kind_ref, _mode) as prim, [linit], loc),
          lbody)
     when optimize ->
@@ -626,23 +627,23 @@ let simplify_lets lam =
           | Some [field_kind] -> Pvalue field_kind
           | Some _ -> assert false
         in
-        mkmutlet kind v slinit (eliminate_ref v slbody)
+        mkmutlet kind v duid slinit (eliminate_ref v slbody)
       with Real_reference ->
-        mklet Strict kind v (Lprim(prim, [slinit], loc)) slbody
+        mklet Strict kind v duid (Lprim(prim, [slinit], loc)) slbody
       end
-  | Llet(Alias, kind, v, l1, l2) ->
+  | Llet(Alias, kind, v, duid, l1, l2) ->
       begin match count_var v with
         0 -> simplif l2
       | 1 when optimize -> Hashtbl.add subst v (simplif l1); simplif l2
-      | _ -> Llet(Alias, kind, v, simplif l1, simplif l2)
+      | _ -> Llet(Alias, kind, v, duid, simplif l1, simplif l2)
       end
-  | Llet(StrictOpt, kind, v, l1, l2) ->
+  | Llet(StrictOpt, kind, v, duid, l1, l2) ->
       begin match count_var v with
         0 -> simplif l2
-      | _ -> mklet StrictOpt kind v (simplif l1) (simplif l2)
+      | _ -> mklet StrictOpt kind v duid (simplif l1) (simplif l2)
       end
-  | Llet(str, kind, v, l1, l2) -> mklet str kind v (simplif l1) (simplif l2)
-  | Lmutlet(kind, v, l1, l2) -> mkmutlet kind v (simplif l1) (simplif l2)
+  | Llet(str, kind, v, duid, l1, l2) -> mklet str kind v duid (simplif l1) (simplif l2)
+  | Lmutlet(kind, v, duid, l1, l2) -> mkmutlet kind v duid (simplif l1) (simplif l2)
   | Lletrec(bindings, body) ->
       let bindings =
         List.map (fun rb ->
@@ -669,7 +670,7 @@ let simplify_lets lam =
       Lstaticraise (i, List.map simplif ls)
   | Lstaticcatch(l1, (i,args), l2, r, kind) ->
       Lstaticcatch (simplif l1, (i,args), simplif l2, r, kind)
-  | Ltrywith(l1, v, l2, kind) -> Ltrywith(simplif l1, v, simplif l2, kind)
+  | Ltrywith(l1, v, duid, l2, kind) -> Ltrywith(simplif l1, v, duid, simplif l2, kind)
   | Lifthenelse(l1, l2, l3, kind) -> Lifthenelse(simplif l1, simplif l2, simplif l3, kind)
   | Lsequence(Lifused(v, l1), l2) ->
       if count_var v > 0
@@ -721,8 +722,8 @@ let rec emit_tail_infos is_tail lambda =
       list_emit_tail_infos false ap.ap_args
   | Lfunction lfun ->
       emit_tail_infos_lfunction is_tail lfun
-  | Llet (_, _k, _, lam, body)
-  | Lmutlet (_k, _, lam, body) ->
+  | Llet (_, _k, _, _, lam, body)
+  | Lmutlet (_k, _, _, lam, body) ->
       emit_tail_infos false lam;
       emit_tail_infos is_tail body
   | Lletrec (bindings, body) ->
@@ -755,7 +756,7 @@ let rec emit_tail_infos is_tail lambda =
   | Lstaticcatch (body, _, handler, _, _kind) ->
       emit_tail_infos is_tail body;
       emit_tail_infos is_tail handler
-  | Ltrywith (body, _, handler, _k) ->
+  | Ltrywith (body, _, _, handler, _k) ->
       emit_tail_infos false body;
       emit_tail_infos is_tail handler
   | Lifthenelse (cond, ifso, ifno, _k) ->
@@ -803,7 +804,7 @@ and emit_tail_infos_lfunction _is_tail lfun =
    'Some' constructor, only to deconstruct it immediately in the
    function's body. *)
 
-let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
+let split_default_wrapper ~id:fun_id ~debug_uid:fun_duid ~kind ~params ~return ~body
       ~attr ~loc ~mode ~ret_mode =
   let rec aux map add_region = function
     (* When compiling [fun ?(x=expr) -> body], this is first translated
@@ -821,7 +822,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
        which is why we need a deep pattern matching on the expected result of
        the pattern-matching compiler for options.
     *)
-    | Llet(Strict, k, id,
+    | Llet(Strict, k, id, duid,
            (Lifthenelse(Lprim (Pisint _, [Lvar optparam], _), _, _, _) as def),
            rest) when
         String.starts_with (Ident.name optparam) ~prefix:"*opt*" &&
@@ -829,7 +830,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
           && not (List.mem_assoc optparam map)
       ->
         let wrapper_body, inner = aux ((optparam, id) :: map) add_region rest in
-        Llet(Strict, k, id, def, wrapper_body), inner
+        Llet(Strict, k, id, duid, def, wrapper_body), inner
     | Lregion (rest, ret) ->
         let wrapper_body, inner = aux map true rest in
         if may_allocate_in_region wrapper_body then
@@ -844,10 +845,14 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
         List.iter (fun (id, _) -> if Ident.Set.mem id fv then raise Exit) map;
 
         let inner_id = Ident.create_local (Ident.name fun_id ^ "_inner") in
+        let inner_id_duid = Lambda.debug_uid_none in
+        (* CR sspies: This variable is not user visible, right? I think passing
+           on [fun_duid] would lead to a duplication of [debug_uid]. *)
         let map_param (p : Lambda.lparam) =
           try
             {
               name = List.assoc p.name map;
+              debug_uid = p.debug_uid;
               layout = Lambda.layout_optional_arg;
               attributes = Lambda.default_param_attribute;
               mode = p.mode
@@ -887,6 +892,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
             ~return ~body ~attr ~loc ~mode ~ret_mode
         in
         (wrapper_body, { id = inner_id;
+                         debug_uid = inner_id_duid;
                          def = inner_fun })
   in
   try
@@ -900,11 +906,13 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
     let body, inner = aux [] false body in
     let attr = { default_stub_attribute with zero_alloc = attr.zero_alloc } in
     [{ id = fun_id;
+       debug_uid = fun_duid;
        def = lfunction' ~kind ~params ~return ~body ~attr ~loc
            ~mode ~ret_mode };
      inner]
   with Exit ->
     [{ id = fun_id;
+       debug_uid = fun_duid;
        def = lfunction' ~kind ~params ~return ~body ~attr ~loc
            ~mode ~ret_mode  }]
 
@@ -969,7 +977,7 @@ let simplify_local_functions lam =
     | Some sco -> sco == scope
   in
   let rec tail = function
-    | Llet (_str, _kind, id, Lfunction lf, cont) when enabled lf.attr ->
+    | Llet (_str, _kind, id, _duid, Lfunction lf, cont) when enabled lf.attr ->
         let r =
           { func = lf;
             function_scope = !current_function_scope;
@@ -1079,7 +1087,7 @@ let simplify_local_functions lam =
   let rec rewrite lam0 =
     let lam =
       match lam0 with
-      | Llet (_, _, id, _, cont) when Hashtbl.mem static_id id ->
+      | Llet (_, _, id, _duid, _, cont) when Hashtbl.mem static_id id ->
           rewrite cont
       | Lapply {ap_func = Lvar id; ap_args; _} when Hashtbl.mem static_id id ->
          let st = Hashtbl.find static_id id in
@@ -1094,7 +1102,7 @@ let simplify_local_functions lam =
     in
     let new_params lf =
       List.map
-        (fun p -> (p.name, p.layout)) lf.params
+        (fun (p: lparam) -> (p.name, p.debug_uid, p.layout)) lf.params
     in
     List.fold_right
       (fun (st, lf, exclave) lam ->

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -846,8 +846,10 @@ let split_default_wrapper ~id:fun_id ~debug_uid:fun_duid ~kind ~params ~return ~
 
         let inner_id = Ident.create_local (Ident.name fun_id ^ "_inner") in
         let inner_id_duid = Lambda.debug_uid_none in
-        (* CR sspies: This variable is not user visible, right? I think passing
-           on [fun_duid] would lead to a duplication of [debug_uid]. *)
+        (* XCR sspies: This variable is not user visible, right? I think passing
+           on [fun_duid] would lead to a duplication of [debug_uid].
+
+           rtjoa: LGTM *)
         let map_param (p : Lambda.lparam) =
           try
             {

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -846,10 +846,6 @@ let split_default_wrapper ~id:fun_id ~debug_uid:fun_duid ~kind ~params ~return ~
 
         let inner_id = Ident.create_local (Ident.name fun_id ^ "_inner") in
         let inner_id_duid = Lambda.debug_uid_none in
-        (* XCR sspies: This variable is not user visible, right? I think passing
-           on [fun_duid] would lead to a duplication of [debug_uid].
-
-           rtjoa: LGTM *)
         let map_param (p : Lambda.lparam) =
           try
             {

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -247,9 +247,11 @@ let simplify_exits lam =
   | Lfunction lfun ->
       Lfunction (map_lfunction (simplif ~layout:None ~try_depth) lfun)
   | Llet(str, kind, v, duid, l1, l2) ->
-      Llet(str, kind, v, duid, simplif ~layout:None ~try_depth l1, simplif ~layout ~try_depth l2)
+      Llet(str, kind, v, duid, simplif ~layout:None ~try_depth l1,
+           simplif ~layout ~try_depth l2)
   | Lmutlet(kind, v, duid, l1, l2) ->
-      Lmutlet(kind, v, duid, simplif ~layout:None ~try_depth l1, simplif ~layout ~try_depth l2)
+      Lmutlet(kind, v, duid, simplif ~layout:None ~try_depth l1,
+              simplif ~layout ~try_depth l2)
   | Lletrec(bindings, body) ->
       let bindings =
         List.map (fun ({ def = {kind; params; return; body = l; attr; loc;
@@ -642,8 +644,10 @@ let simplify_lets lam =
         0 -> simplif l2
       | _ -> mklet StrictOpt kind v duid (simplif l1) (simplif l2)
       end
-  | Llet(str, kind, v, duid, l1, l2) -> mklet str kind v duid (simplif l1) (simplif l2)
-  | Lmutlet(kind, v, duid, l1, l2) -> mkmutlet kind v duid (simplif l1) (simplif l2)
+  | Llet(str, kind, v, duid, l1, l2) ->
+    mklet str kind v duid (simplif l1) (simplif l2)
+  | Lmutlet(kind, v, duid, l1, l2) ->
+    mkmutlet kind v duid (simplif l1) (simplif l2)
   | Lletrec(bindings, body) ->
       let bindings =
         List.map (fun rb ->
@@ -670,7 +674,8 @@ let simplify_lets lam =
       Lstaticraise (i, List.map simplif ls)
   | Lstaticcatch(l1, (i,args), l2, r, kind) ->
       Lstaticcatch (simplif l1, (i,args), simplif l2, r, kind)
-  | Ltrywith(l1, v, duid, l2, kind) -> Ltrywith(simplif l1, v, duid, simplif l2, kind)
+  | Ltrywith(l1, v, duid, l2, kind) ->
+    Ltrywith(simplif l1, v, duid, simplif l2, kind)
   | Lifthenelse(l1, l2, l3, kind) -> Lifthenelse(simplif l1, simplif l2, simplif l3, kind)
   | Lsequence(Lifused(v, l1), l2) ->
       if count_var v > 0
@@ -804,8 +809,8 @@ and emit_tail_infos_lfunction _is_tail lfun =
    'Some' constructor, only to deconstruct it immediately in the
    function's body. *)
 
-let split_default_wrapper ~id:fun_id ~debug_uid:fun_duid ~kind ~params ~return ~body
-      ~attr ~loc ~mode ~ret_mode =
+let split_default_wrapper ~id:fun_id ~debug_uid:fun_duid ~kind ~params ~return
+      ~body ~attr ~loc ~mode ~ret_mode =
   let rec aux map add_region = function
     (* When compiling [fun ?(x=expr) -> body], this is first translated
        to:

--- a/lambda/simplif.mli
+++ b/lambda/simplif.mli
@@ -31,6 +31,7 @@ val simplify_lambda: lambda -> lambda
 
 val split_default_wrapper
    : id:Ident.t
+  -> debug_uid: debug_uid
   -> kind:function_kind
   -> params:Lambda.lparam list
   -> return:Lambda.layout

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -67,7 +67,6 @@ let add_dst_params ({var; offset} : Ident.t destination) params =
     (* The destination parameters are generated internally as part of the TMC
        optimization. As such, they are not user visible, and we do not associate
        them with a [debug_uid]. *)
-    (* CR sspies: Is this comment correct? *)
     attributes = Lambda.default_param_attribute ; mode = alloc_heap } ::
   { name = offset ; layout = Lambda.layout_int ;
     debug_uid= Lambda.debug_uid_none;
@@ -1092,9 +1091,6 @@ and make_dps_variant var var_duid inner_ctx outer_ctx (lfun : lfunction) =
   in
   let dps_var = special.dps_id in
   let dps_var_duid = Lambda.debug_uid_none in
-  (* The [dps_var] variable is generated internally in the TMC optimization.
-     Hence, we do not associate any [debug_uid] with it. *)
-  (* CR sspies: Is the comment above correct? *)
   [var, var_duid, direct;
    dps_var, dps_var_duid, dps]
 

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -63,8 +63,14 @@ let offset_code (Offset t) = t
 
 let add_dst_params ({var; offset} : Ident.t destination) params =
   { name = var ; layout = Lambda.layout_block ;
+    debug_uid= Lambda.debug_uid_none;
+    (* The destination parameters are generated internally as part of the TMC
+       optimization. As such, they are not user visible, and we do not associate
+       them with a [debug_uid]. *)
+    (* CR sspies: Is this comment correct? *)
     attributes = Lambda.default_param_attribute ; mode = alloc_heap } ::
   { name = offset ; layout = Lambda.layout_int ;
+    debug_uid= Lambda.debug_uid_none;
     attributes = Lambda.default_param_attribute ; mode = alloc_heap } ::
   params
 
@@ -138,7 +144,9 @@ end = struct
     let placeholder_pos = List.length constr.before in
     let placeholder_pos_lam = Lconst (Const_base (Const_int placeholder_pos)) in
     let block_var = Ident.create_local "block" in
-    Llet (Strict, Lambda.layout_block, block_var, k_with_placeholder,
+    let block_var_duid = Lambda.debug_uid_none in
+    Llet (Strict, Lambda.layout_block, block_var, block_var_duid,
+          k_with_placeholder,
           body {
             var = block_var;
             offset = Offset placeholder_pos_lam ;
@@ -162,14 +170,16 @@ end = struct
             else begin
               let v = Ident.create_local
                   (Printf.sprintf "block%d_arg%d" block_id (arg_offset + i)) in
-              (Some (v, lam), Lvar v)
+              let v_duid = Lambda.debug_uid_none in
+              (Some (v, v_duid, lam), Lvar v)
             end)
         |> List.split in
       let body = k args in
       List.fold_right (fun binding body ->
           match binding with
           | None -> body
-          | Some (v, lam) -> Llet(Strict, Lambda.layout_tmc_field, v, lam, body)
+          | Some (v, v_duid, lam) ->
+            Llet(Strict, Lambda.layout_tmc_field, v, v_duid, lam, body)
         ) bindings body in
     fun ~block_id constr body ->
     bind_list ~block_id ~arg_offset:0 constr.before @@ fun vbefore ->
@@ -557,8 +567,8 @@ and specialized = {
 }
 
 let llets lk vk bindings body =
-  List.fold_right (fun (var, def) body ->
-    Llet (lk, vk, var, def, body)
+  List.fold_right (fun (var, var_duid, def) body ->
+    Llet (lk, vk, var, var_duid, def, body)
   ) bindings body
 
 let find_candidate = function
@@ -611,13 +621,13 @@ let rec choice ctx t =
         let l1 = traverse ctx l1 in
         let+ (l2, l3) = choice_pair ctx ~tail (l2, l3) in
         Lifthenelse (l1, l2, l3, kind)
-    | Lmutlet (vk, var, def, body) ->
+    | Lmutlet (vk, var, var_duid, def, body) ->
         (* mutable bindings are not TMC-specialized *)
         let def = traverse ctx def in
         let+ body = choice ctx ~tail body in
-        Lmutlet (vk, var, def, body)
-    | Llet (lk, vk, var, def, body) ->
-        let ctx, bindings = traverse_let ctx var def in
+        Lmutlet (vk, var, var_duid, def, body)
+    | Llet (lk, vk, var, var_duid, def, body) ->
+        let ctx, bindings = traverse_let ctx var var_duid def in
         let+ body = choice ctx ~tail body in
         llets lk vk bindings body
     | Lletrec (bindings, body) ->
@@ -651,13 +661,13 @@ let rec choice ctx t =
     | Lstaticraise (id, ls) ->
         let ls = traverse_list ctx ls in
         Choice.lambda (Lstaticraise (id, ls))
-    | Ltrywith (l1, id, l2, kind) ->
+    | Ltrywith (l1, id, id_duid, l2, kind) ->
         (* in [try l1 with id -> l2], the term [l1] is
            not in tail-call position (after it returns
            we need to remove the exception handler) *)
         let+ l1 = choice ctx ~tail:false l1
         and+ l2 = choice ctx ~tail l2 in
-        Ltrywith (l1, id, l2, kind)
+        Ltrywith (l1, id, id_duid, l2, kind)
     | Lstaticcatch (l1, ids, l2, r, kind) ->
         (* In [static-catch l1 with ids -> l2],
            the term [l1] is in fact in tail-position *)
@@ -994,8 +1004,8 @@ let rec choice ctx t =
   in choice ctx t
 
 and traverse ctx = function
-  | Llet (lk, vk, var, def, body) ->
-      let ctx, bindings = traverse_let ctx var def in
+  | Llet (lk, vk, var, var_duid, def, body) ->
+      let ctx, bindings = traverse_let ctx var var_duid def in
       let body = traverse ctx body in
       llets lk vk bindings body
   | Lletrec (bindings, body) ->
@@ -1007,10 +1017,10 @@ and traverse ctx = function
 and traverse_lfunction ctx lfun =
   map_lfunction (traverse ctx) lfun
 
-and traverse_let outer_ctx var def =
+and traverse_let outer_ctx var var_duid def =
   let inner_ctx = declare_binding outer_ctx (var, def) in
   let bindings =
-    traverse_let_binding outer_ctx inner_ctx var def
+    traverse_let_binding outer_ctx inner_ctx var var_duid def
   in
   inner_ctx, bindings
 
@@ -1025,22 +1035,22 @@ and traverse_letrec ctx bindings =
   in
   ctx, bindings
 
-and traverse_let_binding outer_ctx inner_ctx var def =
+and traverse_let_binding outer_ctx inner_ctx var var_duid def =
   match find_candidate def with
-  | None -> [ var, traverse outer_ctx def ]
+  | None -> [ var, var_duid, traverse outer_ctx def ]
   | Some lfun ->
-      let functions = make_dps_variant var inner_ctx outer_ctx lfun in
-      List.map (fun (var, lfun) -> var, Lfunction lfun) functions
+      let functions = make_dps_variant var var_duid inner_ctx outer_ctx lfun in
+      List.map (fun (var, var_duid, lfun) -> var, var_duid, Lfunction lfun) functions
 
-and traverse_letrec_binding ctx { id; def } =
+and traverse_letrec_binding ctx { id; debug_uid; def } =
   if def.attr.tmc_candidate
   then
-    let functions = make_dps_variant id ctx ctx def in
-    List.map (fun (id, def) -> { id; def }) functions
+    let functions = make_dps_variant id debug_uid ctx ctx def in
+    List.map (fun (id, id_duid, def) -> { id; debug_uid = id_duid; def }) functions
   else
-    [ { id; def = traverse_lfunction ctx def } ]
+    [ { id; debug_uid = debug_uid; def = traverse_lfunction ctx def } ]
 
-and make_dps_variant var inner_ctx outer_ctx (lfun : lfunction) =
+and make_dps_variant var var_duid inner_ctx outer_ctx (lfun : lfunction) =
   let special = Ident.Map.find var inner_ctx.specialized in
   let fun_choice = choice outer_ctx ~tail:true lfun.body in
   if fun_choice.Choice.tmc_calls = [] then
@@ -1081,7 +1091,12 @@ and make_dps_variant var inner_ctx outer_ctx (lfun : lfunction) =
       ~ret_mode:lfun.ret_mode
   in
   let dps_var = special.dps_id in
-  [var, direct; dps_var, dps]
+  let dps_var_duid = Lambda.debug_uid_none in
+  (* The [dps_var] variable is generated internally in the TMC optimization.
+     Hence, we do not associate any [debug_uid] with it. *)
+  (* CR sspies: Is the comment above correct? *)
+  [var, var_duid, direct;
+   dps_var, dps_var_duid, dps]
 
 and traverse_list ctx terms =
   List.map (traverse ctx) terms

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -1039,7 +1039,8 @@ and traverse_let_binding outer_ctx inner_ctx var var_duid def =
   | None -> [ var, var_duid, traverse outer_ctx def ]
   | Some lfun ->
       let functions = make_dps_variant var var_duid inner_ctx outer_ctx lfun in
-      List.map (fun (var, var_duid, lfun) -> var, var_duid, Lfunction lfun) functions
+      List.map
+        (fun (var, var_duid, lfun) -> var, var_duid, Lfunction lfun) functions
 
 and traverse_letrec_binding ctx { id; debug_uid; def } =
   if def.attr.tmc_candidate

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -1046,7 +1046,9 @@ and traverse_letrec_binding ctx { id; debug_uid; def } =
   if def.attr.tmc_candidate
   then
     let functions = make_dps_variant id debug_uid ctx ctx def in
-    List.map (fun (id, id_duid, def) -> { id; debug_uid = id_duid; def }) functions
+    List.map
+      (fun (id, id_duid, def) -> { id; debug_uid = id_duid; def })
+      functions
   else
     [ { id; debug_uid = debug_uid; def = traverse_lfunction ctx def } ]
 

--- a/lambda/transl_comprehension_utils.ml
+++ b/lambda/transl_comprehension_utils.ml
@@ -16,13 +16,6 @@ module Let_binding = struct
       var : lambda
     }
 
-  (* CR sspies: The [debug_uid] is Lambda.debug_uid_none at all call sites.
-     It appears we only use this function for internal variables. (The
-     definition does not really currently suggest that.) As an alternative,
-     we could remove the debug_uid from the record [t] and always choose
-     [Lambda.debug_uid_none] in the [let_one] function. In that case, it might
-     be worth renaming the function to suggest that this is only used for
-     internal variables. *)
   let make (let_kind : Let_kind.t) layout name debug_uid init =
     let id = Ident.create_local name in
     let var =

--- a/lambda/transl_comprehension_utils.ml
+++ b/lambda/transl_comprehension_utils.ml
@@ -11,21 +11,29 @@ module Let_binding = struct
     { let_kind : Let_kind.t;
       layout : layout;
       id : Ident.t;
+      debug_uid : debug_uid;
       init : lambda;
       var : lambda
     }
 
-  let make (let_kind : Let_kind.t) layout name init =
+  (* CR sspies: The [debug_uid] is Lambda.debug_uid_none at all call sites.
+     It appears we only use this function for internal variables. (The
+     definition does not really currently suggest that.) As an alternative,
+     we could remove the debug_uid from the record [t] and always choose
+     [Lambda.debug_uid_none] in the [let_one] function. In that case, it might
+     be worth renaming the function to suggest that this is only used for
+     internal variables. *)
+  let make (let_kind : Let_kind.t) layout name debug_uid init =
     let id = Ident.create_local name in
     let var =
       match let_kind with Mutable -> Lmutvar id | Immutable _ -> Lvar id
     in
-    { let_kind; layout; id; init; var }
+    { let_kind; layout; id; debug_uid; init; var }
 
-  let let_one { let_kind; layout; id; init } body =
+  let let_one { let_kind; layout; id; debug_uid; init } body =
     match let_kind with
-    | Immutable let_kind -> Llet (let_kind, layout, id, init, body)
-    | Mutable -> Lmutlet (layout, id, init, body)
+    | Immutable let_kind -> Llet (let_kind, layout, id, debug_uid, init, body)
+    | Mutable -> Lmutlet (layout, id, debug_uid, init, body)
 
   let let_all = List.fold_right let_one
 end

--- a/lambda/transl_comprehension_utils.mli
+++ b/lambda/transl_comprehension_utils.mli
@@ -28,13 +28,14 @@ module Let_binding : sig
     { let_kind : Let_kind.t;
       layout : layout;
       id : Ident.t;
+      debug_uid : debug_uid;
       init : lambda; (* initial value *)
       var : lambda (* occurrence of this variable *)
     }
 
   (** Create a fresh local identifier (with name as given by the string
       argument) to bind to an initial value given by the lambda argument. *)
-  val make : Let_kind.t -> layout -> string -> lambda -> t
+  val make : Let_kind.t -> layout -> string -> debug_uid -> lambda -> t
 
   (** Create a Lambda let-binding (with [Llet]) from a first-class let
       binding, providing the body. *)

--- a/lambda/transl_list_comprehension.ml
+++ b/lambda/transl_list_comprehension.ml
@@ -193,7 +193,7 @@ let iterator ~transl_exp ~scopes = function
         (transl_exp ~scopes Jkind.Sort.Const.for_predef_value sequence)
     in
     (* Create a fresh variable to use as the function argument. The debug uid is
-       [ident_debug_uid], because the variable is not visible to users. *)
+       [.debug_uid_none], because the variable is not visible to users. *)
     let element = Ident.create_local "element" in
     let element_debug_uid = Lambda.debug_uid_none in
     { builder = rev_dlist_concat_map;

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -280,8 +280,7 @@ let rec build_object_init_0
 
 
 let bind_method tbl lab id cl_init =
-  (* CR sspies: We could probably do a better job with uids here. Not sure it
-     is worth it, though. *)
+  (* CR sspies: Can we get a better debugging uid here? *)
   Llet(Strict, layout_label, id, Lambda.debug_uid_none,
                 mkappl (oo_prim "get_method_label",
                            [Lvar tbl; transl_label lab], layout_label),
@@ -306,7 +305,7 @@ let bind_methods tbl meths vals cl_init =
                 transl_meth_list (List.map fst methl)] @ names,
               layout_label_array),
        List.fold_right
-         (* CR sspies: Could we do a better job with debug uids here? *)
+         (* CR sspies: Can we get a better debugging uid here? *)
          (fun (_lab, id) lam -> decr i; Llet(StrictOpt, layout_label, id,
                                            Lambda.debug_uid_none,
                                            lfield ids !i, lam))

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -568,7 +568,8 @@ let rec transl_class_rebind ~scopes obj_init cl vf =
   | Tcl_open (_, cl) ->
       transl_class_rebind ~scopes obj_init cl vf
 
-let rec transl_class_rebind_0 ~scopes (self:Ident.t) self_debug_uid obj_init cl vf =
+let rec transl_class_rebind_0 ~scopes (self:Ident.t) self_debug_uid obj_init
+  cl vf =
   match cl.cl_desc with
     Tcl_let (rec_flag, defs, _vals, cl) ->
       let path, path_lam, obj_init =
@@ -580,7 +581,8 @@ let rec transl_class_rebind_0 ~scopes (self:Ident.t) self_debug_uid obj_init cl 
   | _ ->
       let path, path_lam, obj_init =
         transl_class_rebind ~scopes obj_init cl vf in
-      (path, path_lam, lfunction layout_obj [lparam self self_debug_uid layout_obj] obj_init)
+      (path, path_lam,
+       lfunction layout_obj [lparam self self_debug_uid layout_obj] obj_init)
 
 let transl_class_rebind ~scopes cl vf =
   try
@@ -604,7 +606,9 @@ let transl_class_rebind ~scopes cl vf =
     in
     let _, path_lam, obj_init' =
       transl_class_rebind_0 ~scopes self self_debug_uid obj_init0 cl vf in
-    let id = (obj_init' = lfunction layout_obj [lparam self self_debug_uid layout_obj] obj_init0) in
+    let id = (obj_init' = lfunction layout_obj
+                            [lparam self self_debug_uid layout_obj] obj_init0)
+    in
     if id then path_lam else
 
     let cla = Ident.create_local "class"
@@ -627,7 +631,8 @@ let transl_class_rebind ~scopes cl vf =
            lfunction layout_function [lparam table table_duid layout_table]
              (Llet(Strict, layout_function, env_init, env_init_duid,
                    mkappl(lfield cla 1, [Lvar table], layout_function),
-                   lfunction layout_function [lparam envs envs_duid layout_block]
+                   lfunction layout_function
+                     [lparam envs envs_duid layout_block]
                      (mkappl(Lvar new_init,
                              [mkappl(Lvar env_init, [Lvar envs], layout_obj)], layout_function))));
            lfield cla 2;
@@ -925,7 +930,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
          Dynamic (* Placeholder, real kind is computed in [lbody] below *))
     in
     let lam, rkind = mk_lam_and_kind (free_variables cl_init) in
-    Llet(Strict, layout_function, class_init, class_init_duid, cl_init, lam), rkind
+    Llet(Strict, layout_function, class_init, class_init_duid, cl_init, lam),
+    rkind
   and lbody fv =
     if List.for_all (fun id -> not (Ident.Set.mem id fv)) ids then
       mkappl (oo_prim "make_class",[transl_meth_list pub_meths;
@@ -952,7 +958,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
                           ~return:layout_function
                           ~mode:alloc_heap
                           ~ret_mode:alloc_heap
-                          ~params:[lparam cla cla_duid layout_table] ~body:cl_init;
+                          ~params:[lparam cla cla_duid layout_table]
+                          ~body:cl_init;
            lambda_unit; lenvs],
          Loc_unknown),
     Static
@@ -1024,7 +1031,8 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   in
   let ldirect () =
     ltable cla
-      (Llet(Strict, layout_function, env_init, env_init_duid, def_ids cla cl_init,
+      (Llet(Strict, layout_function, env_init, env_init_duid,
+            def_ids cla cl_init,
             Lsequence(mkappl (oo_prim "init_class", [Lvar cla], layout_unit),
                       lset cached 0 (Lvar env_init))))
   and lclass_virt () =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -77,8 +77,8 @@ let transl_object =
 let probe_handlers = ref []
 let clear_probe_handlers () = probe_handlers := []
 let declare_probe_handlers lam =
-  List.fold_left (fun acc (funcid, func) ->
-      Llet(Strict, Lambda.layout_function, funcid, func, acc))
+  List.fold_left (fun acc (funcid, func_duid, func) ->
+      Llet(Strict, Lambda.layout_function, funcid, func_duid, func, acc))
     lam
     !probe_handlers
 
@@ -475,9 +475,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       transl_match ~scopes ~arg_sort ~return_sort:sort e arg pat_expr_list
         partial
   | Texp_try(body, pat_expr_list) ->
-      let id = Typecore.name_cases "exn" pat_expr_list in
+      let id, id_duid = Typecore.name_cases "exn" pat_expr_list in
       let return_layout = layout_exp sort e in
-      Ltrywith(transl_exp ~scopes sort body, id,
+      Ltrywith(transl_exp ~scopes sort body, id, id_duid,
                Matching.for_trywith ~scopes ~return_layout e.exp_loc (Lvar id)
                  (transl_cases_try ~scopes sort pat_expr_list),
                return_layout)
@@ -884,12 +884,14 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         wh_body = event_before ~scopes wh_body
                     (maybe_region_layout layout_unit body);
       }
-  | Texp_for {for_id; for_from; for_to; for_dir; for_body; for_body_sort} ->
+  | Texp_for {for_id; for_debug_uid; for_from; for_to; for_dir; for_body;
+              for_body_sort} ->
       let for_body_sort = Jkind.Sort.default_for_transl_and_get for_body_sort in
       sort_must_not_be_void for_body.exp_loc for_body.exp_type for_body_sort;
       let body = transl_exp ~scopes for_body_sort for_body in
       Lfor {
         for_id;
+        for_debug_uid;
         for_loc = of_location ~scopes e.exp_loc;
         for_from = transl_exp ~scopes Jkind.Sort.Const.for_predef_value for_from;
         for_to = transl_exp ~scopes Jkind.Sort.Const.for_predef_value for_to;
@@ -957,7 +959,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       let loc = of_location ~scopes e.exp_loc in
       let self = transl_value_path loc e.exp_env path_self in
       let cpy = Ident.create_local "copy" in
-      Llet(Strict, Lambda.layout_object, cpy,
+      let cpy_duid = Lambda.debug_uid_none in
+      Llet(Strict, Lambda.layout_object, cpy, cpy_duid,
            Lapply{
              ap_loc=Loc_unknown;
              ap_func=Translobj.oo_prim "copy";
@@ -985,13 +988,16 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         let mod_scopes = enter_module_definition ~scopes id in
         !transl_module ~scopes:mod_scopes Tcoerce_none None modl
       in
-      Llet(Strict, Lambda.layout_module, id, defining_expr,
-           transl_exp ~scopes sort body)
+      (* CR sspies: Consider adding a [debug_uid]. *)
+      Llet(Strict, Lambda.layout_module, id, Lambda.debug_uid_none,
+          defining_expr, transl_exp ~scopes sort body)
   | Texp_letmodule(_, _, Mp_absent, _, body) ->
       transl_exp ~scopes sort body
   | Texp_letexception(cd, body) ->
       Llet(Strict, Lambda.layout_block,
-           cd.ext_id, transl_extension_constructor ~scopes e.exp_env None cd,
+          (* CR sspies: Consider adding a [debug_uid]. *)
+           cd.ext_id,  Lambda.debug_uid_none,
+           transl_extension_constructor ~scopes e.exp_env None cd,
            transl_exp ~scopes sort body)
   | Texp_pack modl ->
       !transl_module ~scopes Tcoerce_none None modl
@@ -1041,6 +1047,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
          let scopes = enter_lazy ~scopes in
          let fn = lfunction ~kind:(Curried {nlocal=0})
                             ~params:[{ name = Ident.create_local "param";
+                                       debug_uid = Lambda.debug_uid_none;
                                        layout = Lambda.layout_unit;
                                        attributes = Lambda.default_param_attribute;
                                        mode = alloc_heap}]
@@ -1070,11 +1077,12 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           cl_env = e.exp_env;
           cl_attributes = [];
          }
-  | Texp_letop{let_; ands; param; param_sort; body; body_sort; partial} ->
+  | Texp_letop{let_; ands; param; param_debug_uid; param_sort; body; body_sort;
+               partial} ->
       let body_sort = Jkind.Sort.default_for_transl_and_get body_sort in
       event_after ~scopes e
         (transl_letop ~scopes e.exp_loc e.exp_env let_ ands
-           param param_sort body body_sort partial)
+           param param_debug_uid param_sort body body_sort partial)
   | Texp_unreachable ->
       raise (Error (e.exp_loc, Unreachable_reached))
   | Texp_open (od, e) ->
@@ -1087,19 +1095,21 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       | [] when pure = Alias -> transl_exp ~scopes sort e
       | _ ->
           let oid = Ident.create_local "open" in
+          let oid_duid = Lambda.debug_uid_none in
           let body, _ =
             (* CR layouts v5: Currently we only allow values at the top of a
                module.  When that changes, some adjustments may be needed
                here. *)
             List.fold_left (fun (body, pos) id ->
               Llet(Alias, Lambda.layout_module_field, id,
+                   Lambda.debug_uid_none,
                    Lprim(mod_field pos, [Lvar oid],
                          of_location ~scopes od.open_loc), body),
               pos + 1
             ) (transl_exp ~scopes sort e, 0)
               (bound_value_identifiers od.open_bound_items)
           in
-          Llet(pure, Lambda.layout_module, oid,
+          Llet(pure, Lambda.layout_module, oid, oid_duid,
                !transl_module ~scopes Tcoerce_none None od.open_expr, body)
       end
   | Texp_probe {name; handler=exp; enabled_at_init} ->
@@ -1157,6 +1167,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       ) arg_idents;
       let make_param name = {
         name;
+        debug_uid = Lambda.debug_uid_none;
+        (* For probes, we currently do not track [debug_uid] values. *)
         layout = layout_probe_arg;
         attributes = Lambda.default_param_attribute;
         mode = alloc_local }
@@ -1186,6 +1198,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           may_fuse_arity = false;
         } in
       let funcid = Ident.create_local ("probe_handler_" ^ name) in
+      let funcid_duid = Lambda.debug_uid_none in
       let return_layout = layout_unit (* Probe bodies have type unit. *) in
       let handler =
         let assume_zero_alloc = get_assume_zero_alloc ~scopes in
@@ -1221,14 +1234,15 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       in
       begin match Config.flambda || Config.flambda2 with
       | true ->
-          Llet(Strict, Lambda.layout_function, funcid, handler, Lapply app)
+          Llet(Strict, Lambda.layout_function, funcid, funcid_duid, handler,
+               Lapply app)
       | false ->
         (* Needs to be lifted to top level manually here,
            because functions that contain other function declarations
            are not inlined by Closure. For example, adding a probe into
            the body of function foo will prevent foo from being inlined
            into another function. *)
-        probe_handlers := (funcid, handler)::!probe_handlers;
+        probe_handlers := (funcid, funcid_duid, handler)::!probe_handlers;
         Lapply app
       end
     end else begin
@@ -1418,6 +1432,7 @@ and transl_apply ~scopes
             l
         in
         let id_arg = Ident.create_local "param" in
+        let id_arg_duid = Lambda.debug_uid_none in
         (* Process remaining arguments and build closure *)
         let body =
           let loc = map_scopes enter_partial_or_eta_wrapper loc in
@@ -1439,6 +1454,7 @@ and transl_apply ~scopes
           let layout_arg = layout_of_sort (to_location loc) sort_arg in
           let params = [{
               name = id_arg;
+              debug_uid = id_arg_duid;
               layout = layout_arg;
               attributes = Lambda.default_param_attribute;
               mode = arg_mode
@@ -1450,7 +1466,10 @@ and transl_apply ~scopes
         (* Wrap "protected" definitions, starting from the left,
            so that evaluation is right-to-left. *)
         List.fold_right
-          (fun (id, layout, lam) body -> Llet(Strict, layout, id, lam, body))
+          (fun (id, layout, lam) body ->
+          (* CR sspies: It appears all variables in [defs] are hidden from
+             the user. Is that correct? *)
+          Llet(Strict, layout, id, Lambda.debug_uid_none, lam, body))
           !defs body
     | Arg (arg, _) :: l ->
       build_apply lam (arg :: args) loc pos ap_mode result_layout l
@@ -1551,6 +1570,7 @@ and transl_tupled_function
         let tparams =
           List.map (fun kind -> {
                 name = Ident.create_local "param";
+                debug_uid = Lambda.debug_uid_none;
                 layout = kind;
                 attributes = Lambda.default_param_attribute;
                 mode = alloc_heap
@@ -1585,7 +1605,8 @@ and transl_curried_function ~scopes loc repr params body
     | Tfunction_body body ->
         None, event_before ~scopes body (transl_exp ~scopes return_sort body)
     | Tfunction_cases
-        { fc_cases; fc_partial; fc_param; fc_loc; fc_arg_sort; fc_arg_mode }
+        { fc_cases; fc_partial; fc_param; fc_param_debug_uid;
+          fc_loc; fc_arg_sort; fc_arg_mode }
       ->
         let fc_arg_sort = Jkind.Sort.default_for_transl_and_get fc_arg_sort in
         let arg_layout =
@@ -1606,6 +1627,7 @@ and transl_curried_function ~scopes loc repr params body
         in
         let param =
           { name = fc_param;
+            debug_uid = fc_param_debug_uid;
             layout = arg_layout;
             attributes;
             mode = arg_mode;
@@ -1621,7 +1643,8 @@ and transl_curried_function ~scopes loc repr params body
   let body, params =
     List.fold_right
       (fun fp (body, params) ->
-        let { fp_param; fp_kind; fp_mode; fp_sort; fp_partial; fp_loc } = fp in
+        let { fp_param; fp_param_debug_uid; fp_kind; fp_mode; fp_sort;
+              fp_partial; fp_loc } = fp in
         let arg_env, arg_type, attributes =
           match fp_kind with
           | Tparam_pat pat ->
@@ -1634,6 +1657,7 @@ and transl_curried_function ~scopes loc repr params body
         let arg_mode = transl_alloc_mode_l fp_mode in
         let param =
           { name = fp_param;
+            debug_uid = fp_param_debug_uid;
             layout = arg_layout;
             attributes;
             mode = arg_mode;
@@ -1863,12 +1887,13 @@ and transl_let ~scopes ~return_layout ?(add_regions=false) ?(in_structure=false)
       let idlist =
         List.map
           (fun {vb_pat=pat} -> match pat.pat_desc with
-              Tpat_var (id,_,_,_) -> id
+              Tpat_var (id,_,uid,_) -> id, uid
+              (* CR sspies:  ^^^ seems like a reasonable uid for debugging *)
             | _ -> assert false)
         pat_expr_list in
       let transl_case
             {vb_expr=expr; vb_sort; vb_attributes; vb_rec_kind = rkind;
-             vb_loc; vb_pat} id =
+             vb_loc; vb_pat} (id, id_duid) =
         let vb_sort = Jkind.Sort.default_for_transl_and_get vb_sort in
         let def =
           transl_bound_exp ~scopes ~in_structure vb_pat vb_sort expr vb_loc vb_attributes
@@ -1876,7 +1901,7 @@ and transl_let ~scopes ~return_layout ?(add_regions=false) ?(in_structure=false)
         let def =
           if add_regions then maybe_region_exp vb_sort expr def else def
         in
-        ( id, rkind, def ) in
+        ( id, id_duid, rkind, def ) in
       let lam_bds = List.map2 transl_case pat_expr_list idlist in
       fun body -> Value_rec_compiler.compile_letrec lam_bds body
 
@@ -1900,6 +1925,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     (* Take a shallow copy of the init record, then mutate the fields
        of the copy *)
     let copy_id = Ident.create_local "newrecord" in
+    let copy_id_duid = Lambda.debug_uid_none in
     let update_field cont (lbl, definition) =
       (* CR layouts v5: allow more unboxed types here. *)
       check_record_field_sort lbl.lbl_loc lbl.lbl_sort;
@@ -1958,7 +1984,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
       Jkind.Sort.default_for_transl_and_get init_expr_sort
     in
     assert (is_heap_mode (Option.get mode)); (* Pduprecord must be Alloc_heap and not unboxed *)
-    Llet(Strict, Lambda.layout_block, copy_id,
+    Llet(Strict, Lambda.layout_block, copy_id, copy_id_duid,
          Lprim(Pduprecord (repres, size),
                [transl_exp ~scopes init_expr_sort init_expr],
                of_location ~scopes loc),
@@ -1968,6 +1994,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
        taken from init_expr if any *)
     (* CR layouts v5: allow non-value fields beyond just float# *)
     let init_id = Ident.create_local "init" in
+    let init_id_duid = Lambda.debug_uid_none in
     let lv =
       Array.mapi
         (fun i (lbl, definition) ->
@@ -2133,7 +2160,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
         let init_expr_sort =
           Jkind.Sort.default_for_transl_and_get init_expr_sort
         in
-        Llet(Strict, Lambda.layout_block, init_id,
+        Llet(Strict, Lambda.layout_block, init_id, init_id_duid,
              transl_exp ~scopes init_expr_sort init_expr, lam)
     end
 
@@ -2141,6 +2168,7 @@ and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
   match repres with
   | Record_unboxed_product ->
     let init_id = Ident.create_local "init" in
+    let init_id_duid = Lambda.debug_uid_none in
     let shape =
       Array.map
         (fun (lbl, definition) ->
@@ -2174,7 +2202,7 @@ and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
       in
       let layout = layout_exp init_expr_sort init_expr in
       let exp = transl_exp ~scopes init_expr_sort init_expr in
-      Llet(Strict, layout, init_id, exp, lam)
+      Llet(Strict, layout, init_id, init_id_duid, exp, lam)
 
 and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
   let return_layout = layout_exp return_sort e in
@@ -2205,8 +2233,8 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
         let ids_full = Typedtree.pat_bound_idents_full arg_sort pv in
         let ids = List.map (fun (id, _, _, _, _) -> id) ids_full in
         let ids_kinds =
-          List.map (fun (id, {Location.loc; _}, ty, _, s) ->
-            id, Typeopt.layout pv.pat_env loc s ty)
+          List.map (fun (id, {Location.loc; _}, ty, duid, s) ->
+            id, duid, Typeopt.layout pv.pat_env loc s ty)
             ids_full
         in
         let vids = List.map Ident.rename ids in
@@ -2246,10 +2274,10 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
      value actions run outside the try..with exception handler.
   *)
   let static_catch scrutinees val_ids handler =
-    let id = Typecore.name_pattern "exn" (List.map fst exn_cases) in
+    let id, id_duid = Typecore.name_pattern "exn" (List.map fst exn_cases) in
     let static_exception_id = next_raise_count () in
     Lstaticcatch
-      (Ltrywith (Lstaticraise (static_exception_id, scrutinees), id,
+      (Ltrywith (Lstaticraise (static_exception_id, scrutinees), id, id_duid,
                  Matching.for_trywith ~scopes ~return_layout e.exp_loc (Lvar id)
                    exn_cases,
                  return_layout),
@@ -2280,8 +2308,8 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
           List.map
             (fun (arg,s) ->
                let layout = layout_exp s arg in
-               let id = Typecore.name_pattern "val" [] in
-               (id, layout), (Lvar id, s, layout))
+               let id, id_duid = Typecore.name_pattern "val" [] in
+               (id, id_duid, layout), (Lvar id, s, layout))
             argl
           |> List.split
         in
@@ -2295,9 +2323,11 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
       Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
         e.exp_loc None (transl_exp ~scopes arg_sort arg) val_cases partial
     | arg, _ :: _ ->
-        let val_id = Typecore.name_pattern "val" (List.map fst val_cases) in
+        let val_id, val_id_duid = Typecore.name_pattern "val" (List.map fst val_cases) in
         let arg_layout = layout_exp arg_sort arg in
-        static_catch [transl_exp ~scopes arg_sort arg] [val_id, arg_layout]
+        static_catch
+          [transl_exp ~scopes arg_sort arg]
+          [val_id, val_id_duid, arg_layout]
           (Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
              e.exp_loc None (Lvar val_id) val_cases partial)
   in
@@ -2307,13 +2337,15 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
        handler, Same_region, return_layout)
   ) classic static_handlers
 
-and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
+and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case case_sort
       partial =
   let rec loop prev_layout prev_lam = function
     | [] -> prev_lam
     | and_ :: rest ->
         let left_id = Ident.create_local "left" in
+        let left_id_duid = Lambda.debug_uid_none in
         let right_id = Ident.create_local "right" in
+        let right_id_duid = Lambda.debug_uid_none in
         let op =
           transl_ident (of_location ~scopes and_.bop_op_name.loc) env
             and_.bop_op_type and_.bop_op_path and_.bop_op_val Id_value
@@ -2331,7 +2363,7 @@ and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
             and_.bop_op_type
         in
         let lam =
-          bind_with_layout Strict (right_id, right_layout) exp
+          bind_with_layout Strict (right_id, right_id_duid, right_layout) exp
             (Lapply{
                ap_loc = of_location ~scopes and_.bop_loc;
                ap_func = op;
@@ -2345,7 +2377,7 @@ and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
                ap_probe=None;
              })
         in
-        bind_with_layout Strict (left_id, prev_layout) prev_lam (loop result_layout lam rest)
+        bind_with_layout Strict (left_id, left_id_duid, prev_layout) prev_lam (loop result_layout lam rest)
   in
   let op =
     transl_ident (of_location ~scopes let_.bop_op_name.loc) env
@@ -2372,7 +2404,8 @@ and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
              ~return_sort:case_sort ~mode:alloc_heap ~return_mode
              loc repr []
              (Tfunction_cases
-                { fc_cases = [case]; fc_param = param; fc_partial = partial;
+                { fc_cases = [case]; fc_param = param;
+                  fc_param_debug_uid = param_debug_uid; fc_partial = partial;
                   fc_loc = ghost_loc; fc_exp_extra = None; fc_attributes = [];
                   fc_arg_mode = Mode.Alloc.disallow_right Mode.Alloc.legacy;
                   fc_arg_sort = param_sort; fc_env = env;

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -995,7 +995,6 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       transl_exp ~scopes sort body
   | Texp_letexception(cd, body) ->
       Llet(Strict, Lambda.layout_block,
-          (* CR sspies: Consider adding a [debug_uid]. *)
            cd.ext_id,  Lambda.debug_uid_none,
            transl_extension_constructor ~scopes e.exp_env None cd,
            transl_exp ~scopes sort body)
@@ -1467,10 +1466,6 @@ and transl_apply ~scopes
            so that evaluation is right-to-left. *)
         List.fold_right
           (fun (id, layout, lam) body ->
-          (* XCR sspies: It appears all variables in [defs] are hidden from
-             the user. Is that correct?
-
-             rtjoa: LGTM *)
           Llet(Strict, layout, id, Lambda.debug_uid_none, lam, body))
           !defs body
     | Arg (arg, _) :: l ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1467,8 +1467,10 @@ and transl_apply ~scopes
            so that evaluation is right-to-left. *)
         List.fold_right
           (fun (id, layout, lam) body ->
-          (* CR sspies: It appears all variables in [defs] are hidden from
-             the user. Is that correct? *)
+          (* XCR sspies: It appears all variables in [defs] are hidden from
+             the user. Is that correct?
+
+             rtjoa: LGTM *)
           Llet(Strict, layout, id, Lambda.debug_uid_none, lam, body))
           !defs body
     | Arg (arg, _) :: l ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -988,7 +988,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         let mod_scopes = enter_module_definition ~scopes id in
         !transl_module ~scopes:mod_scopes Tcoerce_none None modl
       in
-      (* CR sspies: Consider adding a [debug_uid]. *)
+      (* CR sspies: Add a debug uid to [Texp_letmodule] for the binder. *)
       Llet(Strict, Lambda.layout_module, id, Lambda.debug_uid_none,
           defining_expr, transl_exp ~scopes sort body)
   | Texp_letmodule(_, _, Mp_absent, _, body) ->
@@ -1885,7 +1885,6 @@ and transl_let ~scopes ~return_layout ?(add_regions=false) ?(in_structure=false)
         List.map
           (fun {vb_pat=pat} -> match pat.pat_desc with
               Tpat_var (id,_,uid,_) -> id, uid
-              (* CR sspies:  ^^^ seems like a reasonable uid for debugging *)
             | _ -> assert false)
         pat_expr_list in
       let transl_case

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2375,7 +2375,8 @@ and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
                ap_probe=None;
              })
         in
-        bind_with_layout Strict (left_id, left_id_duid, prev_layout) prev_lam (loop result_layout lam rest)
+        bind_with_layout Strict (left_id, left_id_duid, prev_layout) prev_lam
+            (loop result_layout lam rest)
   in
   let op =
     transl_ident (of_location ~scopes let_.bop_op_name.loc) env

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2319,7 +2319,9 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
       Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
         e.exp_loc None (transl_exp ~scopes arg_sort arg) val_cases partial
     | arg, _ :: _ ->
-        let val_id, val_id_duid = Typecore.name_pattern "val" (List.map fst val_cases) in
+        let val_id, val_id_duid =
+          Typecore.name_pattern "val" (List.map fst val_cases)
+        in
         let arg_layout = layout_exp arg_sort arg in
         static_catch
           [transl_exp ~scopes arg_sort arg]
@@ -2333,8 +2335,8 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
        handler, Same_region, return_layout)
   ) classic static_handlers
 
-and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case case_sort
-      partial =
+and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
+      case_sort partial =
   let rec loop prev_layout prev_lam = function
     | [] -> prev_lam
     | and_ :: rest ->

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -100,7 +100,8 @@ let transl_type_extension ~scopes env rootpath tyext body =
         transl_extension_constructor ~scopes env
           (field_path rootpath ext.ext_id) ext
       in
-      Llet(Strict, Lambda.layout_block, ext.ext_id, lam, body))
+      (* CR sspies: Can we find a better [debug_uid] here? *)
+      Llet(Strict, Lambda.layout_block, ext.ext_id, Lambda.debug_uid_none, lam, body))
     tyext.tyext_constructors
     body
 
@@ -125,9 +126,10 @@ let rec apply_coercion loc strict restr arg =
         wrap_id_pos_list loc id_pos_list get_field lam)
   | Tcoerce_functor(cc_arg, cc_res) ->
       let param = Ident.create_local "funarg" in
+      let param_duid = Lambda.debug_uid_none in
       let carg = apply_coercion loc Alias cc_arg (Lvar param) in
       apply_coercion_result loc strict arg
-        [{name = param; layout = Lambda.layout_module;
+        [{name = param; debug_uid = param_duid; layout = Lambda.layout_module;
           attributes = Lambda.default_param_attribute; mode = alloc_heap}]
         [carg] cc_res
   | Tcoerce_primitive { pc_desc; pc_env; pc_type; pc_poly_mode; pc_poly_sort } ->
@@ -147,9 +149,11 @@ and apply_coercion_result loc strict funct params args cc_res =
   match cc_res with
   | Tcoerce_functor(cc_arg, cc_res) ->
     let param = Ident.create_local "funarg" in
+    let param_duid = Lambda.debug_uid_none in
     let arg = apply_coercion loc Alias cc_arg (Lvar param) in
     apply_coercion_result loc strict funct
       ({ name = param;
+         debug_uid = param_duid;
          layout = Lambda.layout_module;
          attributes = Lambda.default_param_attribute;
          mode = alloc_heap } :: params)
@@ -193,9 +197,11 @@ and wrap_id_pos_list loc id_pos_list get_field lam =
     List.fold_left (fun (lam, fv, s) (id',pos,c) ->
       if Ident.Set.mem id' fv then
         let id'' = Ident.create_local (Ident.name id') in
+        let id''_duid = Lambda.debug_uid_none in
+        (* CR sspies: What does this function do? It seems to duplicate code.*)
         let rhs = apply_coercion loc Alias c (get_field pos) in
         let fv_rhs = free_variables rhs in
-        (Llet(Alias, Lambda.layout_module_field, id'', rhs, lam),
+        (Llet(Alias, Lambda.layout_module_field, id'', id''_duid, rhs, lam),
          Ident.Set.union fv fv_rhs,
          Ident.Map.add id' id'' s)
       else (lam, fv, s))
@@ -423,6 +429,8 @@ let eval_rec_bindings bindings cont =
       bind_inits rem
   | (Id id, Some(loc, shape), _rhs) :: rem ->
       Llet(Strict, Lambda.layout_module, id,
+          Lambda.debug_uid_none,
+          (* CR sspies: Is there a sensible [debug_uid] here? *)
            Lapply{
              ap_loc=Loc_unknown;
              ap_func=mod_prim "init_mod";
@@ -442,7 +450,9 @@ let eval_rec_bindings bindings cont =
   | (Ignore_loc loc, None, rhs) :: rem ->
       Lsequence(Lprim(Pignore, [rhs], loc), bind_strict rem)
   | (Id id, None, rhs) :: rem ->
-      Llet(Strict, Lambda.layout_module, id, rhs, bind_strict rem)
+      Llet(Strict, Lambda.layout_module, id,
+           Lambda.debug_uid_none, rhs, bind_strict rem)
+      (* CR sspies: Is there a sensible [debug_uid] here? *)
   | (_id, Some _, _rhs) :: rem ->
       bind_strict rem
   and patch_forwards = function
@@ -493,7 +503,8 @@ let transl_class_bindings ~scopes cl_list =
    List.map
      (fun ({ci_id_class=id; ci_expr=cl; ci_virt=vf}, meths) ->
        let def, rkind = transl_class ~scopes ids id meths cl vf in
-       (id, rkind, def))
+       (* CR sspies: Should class_infos have debug identifiers?  *)
+       (id, Lambda.debug_uid_none, rkind, def))
      cl_list)
 
 (* Compile one or more functors, merging curried functors to produce
@@ -548,14 +559,21 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
   let params, body =
     List.fold_left (fun (params, body) (param, loc, arg_coercion) ->
         let param' = Ident.rename param in
+        let param'_duid = Lambda.debug_uid_none in
+        (* CR sspies: Is there a sensible [debug_uid] here? *)
         let arg = apply_coercion loc Alias arg_coercion (Lvar param') in
         let params = {
           name = param';
+          debug_uid = param'_duid;
           layout = Lambda.layout_module;
           attributes = Lambda.default_param_attribute;
           mode = alloc_heap
         } :: params in
-        let body = Llet (Alias, Lambda.layout_module, param, arg, body) in
+        let param_duid = Lambda.debug_uid_none in
+        (* CR sspies: Should param come with a [debug_uid]? *)
+        let body = Llet (Alias, Lambda.layout_module, param, param_duid, arg,
+                         body)
+        in
         params, body)
       ([], transl_module ~scopes res_coercion body_path body)
       functor_params_rev
@@ -722,11 +740,13 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
           transl_type_extension ~scopes item.str_env rootpath tyext body, size
       | Tstr_exception ext ->
           let id = ext.tyexn_constructor.ext_id in
+          let id_duid = Lambda.debug_uid_none in
+          (* CR sspies: Can we find a better [debug_uid] here? *)
           let path = field_path rootpath id in
           let body, size =
             transl_structure ~scopes loc (id::fields) cc rootpath final_env rem
           in
-          Llet(Strict, Lambda.layout_block, id,
+          Llet(Strict, Lambda.layout_block, id, id_duid,
                transl_extension_constructor ~scopes
                                             item.str_env
                                             path
@@ -757,7 +777,9 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                                of_location ~scopes mb.mb_name.loc), body),
               size
           | Some id ->
-              Llet(pure_module mb.mb_expr, Lambda.layout_module, id, module_body, body), size
+              Llet(pure_module mb.mb_expr, Lambda.layout_module, id,
+              Lambda.debug_uid_none, module_body, body), size
+              (* CR sspies: Can we find a better [debug_uid] here? *)
           end
       | Tstr_module ({mb_presence=Mp_absent}) ->
           transl_structure ~scopes loc fields cc rootpath final_env rem
@@ -791,6 +813,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
           let ids = bound_value_identifiers incl.incl_type in
           let modl = incl.incl_mod in
           let mid = Ident.create_local "include" in
+          let mid_duid = Lambda.debug_uid_none in
           let rec rebind_idents pos newfields = function
               [] ->
                 transl_structure ~scopes loc newfields cc rootpath final_env rem
@@ -798,7 +821,9 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                 let body, size =
                   rebind_idents (pos + 1) (id :: newfields) ids
                 in
-                Llet(Alias, Lambda.layout_module_field, id,
+                let id_duid = Lambda.debug_uid_none in
+                (* CR sspies: Can we find a better [debug_uid] here? *)
+                Llet(Alias, Lambda.layout_module_field, id, id_duid,
                      Lprim(mod_field pos, [Lvar mid],
                            of_location ~scopes incl.incl_loc), body),
                 size
@@ -816,7 +841,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                 Strict, transl_include_functor ~generative:true modl ccs
                           scopes loc
           in
-          Llet(let_kind, Lambda.layout_module, mid, modl, body),
+          Llet(let_kind, Lambda.layout_module, mid, mid_duid, modl, body),
           size
 
       | Tstr_open od ->
@@ -831,6 +856,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
           | _ ->
               let ids = bound_value_identifiers od.open_bound_items in
               let mid = Ident.create_local "open" in
+              let mid_duid = Lambda.debug_uid_none in
               let rec rebind_idents pos newfields = function
                   [] -> transl_structure
                           ~scopes loc newfields cc rootpath final_env rem
@@ -838,13 +864,15 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                   let body, size =
                     rebind_idents (pos + 1) (id :: newfields) ids
                   in
-                  Llet(Alias, Lambda.layout_module_field, id,
+                  let id_duid = Lambda.debug_uid_none in
+                  (* CR sspies: Can we find a better [debug_uid] here? *)
+                  Llet(Alias, Lambda.layout_module_field, id, id_duid,
                       Lprim(mod_field pos, [Lvar mid],
                             of_location ~scopes od.open_loc), body),
                   size
               in
               let body, size = rebind_idents 0 fields ids in
-              Llet(pure, Lambda.layout_module, mid,
+              Llet(pure, Lambda.layout_module, mid, mid_duid,
                    transl_module ~scopes Tcoerce_none None od.open_expr, body),
               size
           end
@@ -920,7 +948,9 @@ let required_globals ~flambda body =
 
 let add_arg_block_to_module_block primary_block_lam size restr =
   let primary_block_id = Ident.create_local "*primary-block*" in
+  let primary_block_id_duid = Lambda.debug_uid_none in
   let arg_block_id = Ident.create_local "*arg-block*" in
+  let arg_block_id_duid = Lambda.debug_uid_none in
   let arg_block_lam =
     apply_coercion Loc_unknown Strict restr (Lvar primary_block_id)
   in
@@ -928,8 +958,10 @@ let add_arg_block_to_module_block primary_block_lam size restr =
   let all_fields = List.init size get_field @ [Lvar arg_block_id] in
   let arg_block_field = size in
   let new_size = size + 1 in
-  Llet(Strict, layout_module, primary_block_id, primary_block_lam,
-       Llet(Strict, layout_module, arg_block_id, arg_block_lam,
+  Llet(Strict, layout_module, primary_block_id,
+       primary_block_id_duid, primary_block_lam,
+       Llet(Strict, layout_module, arg_block_id,
+            arg_block_id_duid, arg_block_lam,
             Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
                   all_fields,
                   Loc_unknown))),
@@ -941,6 +973,8 @@ let add_runtime_parameters lam params =
     List.map
       (fun name ->
         { name;
+          debug_uid = Lambda.debug_uid_none;
+          (* CR sspies: Can we find a better [debug_uid] here? *)
           layout = Pvalue Lambda.generic_value;
           attributes = Lambda.default_param_attribute;
           mode = Lambda.alloc_heap })
@@ -1256,6 +1290,8 @@ let transl_store_structure ~scopes glob map prims aliases str =
                         (add_idents false ids subst) cont rem)
         | Tstr_exception ext ->
             let id = ext.tyexn_constructor.ext_id in
+            let id_duid = Lambda.debug_uid_none in
+            (* CR sspies: Can we find a better [debug_uid] here? *)
             let path = field_path rootpath id in
             let loc = of_location ~scopes ext.tyexn_constructor.ext_loc in
             let lam =
@@ -1264,7 +1300,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                                            path
                                            ext.tyexn_constructor
             in
-            Lsequence(Llet(Strict, Lambda.layout_block, id,
+            Lsequence(Llet(Strict, Lambda.layout_block, id, id_duid,
                            Lambda.subst no_env_update subst lam,
                            store_ident loc id),
                       transl_store ~scopes rootpath
@@ -1284,6 +1320,8 @@ let transl_store_structure ~scopes glob map prims aliases str =
             )
         | Tstr_module{mb_id=Some id;mb_loc=loc;mb_presence=Mp_present;
                       mb_expr={mod_desc = Tmod_structure str}} ->
+            let id_duid = Lambda.debug_uid_none in
+            (* CR sspies: Can we find a better [debug_uid] here? *)
             let loc = of_location ~scopes loc in
             let lam =
               transl_store
@@ -1294,7 +1332,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             (* Careful: see next case *)
             let subst = !transl_store_subst in
             Lsequence(lam,
-                      Llet(Strict, Lambda.layout_module, id,
+                      Llet(Strict, Lambda.layout_module, id, id_duid,
                            Lambda.subst no_env_update subst
                              (Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
                                     List.map (fun id -> Lvar id)
@@ -1312,6 +1350,8 @@ let transl_store_structure ~scopes glob map prims aliases str =
           } ->
             (*    Format.printf "coerc id %s: %a@." (Ident.unique_name id)
                                 Includemod.print_coercion cc; *)
+            let id_duid = Lambda.debug_uid_none in
+            (* CR sspies: Can we find a better [debug_uid] here? *)
             let loc = of_location ~scopes loc in
             let lam =
               transl_store
@@ -1323,7 +1363,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             let subst = !transl_store_subst in
             let field = field_of_str loc str in
             Lsequence(lam,
-                      Llet(Strict, Lambda.layout_module, id,
+                      Llet(Strict, Lambda.layout_module, id, id_duid,
                            Lambda.subst no_env_update subst
                              (Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
                                     List.map field map, loc)),
@@ -1334,6 +1374,8 @@ let transl_store_structure ~scopes glob map prims aliases str =
         | Tstr_module
             {mb_id=Some id; mb_presence=Mp_present; mb_expr=modl;
              mb_loc=loc; mb_attributes} ->
+            let id_duid = Lambda.debug_uid_none in
+            (* CR sspies: Can we find a better [debug_uid] here? *)
             let lam =
               Translattribute.add_inline_attribute
                 (transl_module
@@ -1347,7 +1389,8 @@ let transl_store_structure ~scopes glob map prims aliases str =
                the compilation unit (add_ident true returns subst unchanged).
                If not, we can use the value from the global
                (add_ident true adds id -> Pgetglobal... to subst). *)
-            Llet(Strict, Lambda.layout_module, id, Lambda.subst no_env_update subst lam,
+            Llet(Strict, Lambda.layout_module, id, id_duid,
+                 Lambda.subst no_env_update subst lam,
                  Lsequence(store_ident (of_location ~scopes loc) id,
                            transl_store ~scopes rootpath
                              (add_ident true id subst)
@@ -1406,6 +1449,8 @@ let transl_store_structure ~scopes glob map prims aliases str =
                     cont rem
               | id :: ids, arg :: args ->
                   Llet(Alias, Lambda.layout_module_field, id,
+                       Lambda.debug_uid_none,
+                       (* CR sspies: Can we find a better [debug_uid] here? *)
                        Lambda.subst no_env_update subst (field arg),
                        Lsequence(store_ident (of_location ~scopes loc) id,
                                  loop ids args))
@@ -1426,12 +1471,16 @@ let transl_store_structure ~scopes glob map prims aliases str =
             let ids = bound_value_identifiers incl.incl_type in
             let modl = incl.incl_mod in
             let mid = Ident.create_local "include" in
+            let mid_duid = Lambda.debug_uid_none in
             let loc = of_location ~scopes incl.incl_loc in
             let rec store_idents pos = function
               | [] -> transl_store
                         ~scopes rootpath (add_idents true ids subst) cont rem
               | id :: idl ->
-                  Llet(Alias, Lambda.layout_module_field, id, Lprim(mod_field pos, [Lvar mid],
+                  let id_duid = Lambda.debug_uid_none in
+                  (* CR sspies: Can we find a better [debug_uid] here? *)
+                  Llet(Alias, Lambda.layout_module_field, id, id_duid,
+                      Lprim(mod_field pos, [Lvar mid],
                                                  loc),
                        Lsequence(store_ident loc id,
                                  store_idents (pos + 1) idl))
@@ -1444,7 +1493,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
               | Tincl_gen_functor ccs ->
                   transl_include_functor ~generative:true modl ccs scopes loc
             in
-            Llet(Strict, Lambda.layout_module, mid,
+            Llet(Strict, Lambda.layout_module, mid, mid_duid,
                  Lambda.subst no_env_update subst modl,
                  store_idents 0 ids)
         | Tstr_open od ->
@@ -1461,7 +1510,10 @@ let transl_store_structure ~scopes glob map prims aliases str =
                   | [] -> transl_store ~scopes rootpath
                             (add_idents true ids0 subst) cont rem
                   | id :: idl ->
-                      Llet(Alias, Lambda.layout_module_field, id, Lvar ids.(pos),
+                      let id_duid = Lambda.debug_uid_none in
+                      (* CR sspies: Can we find a better [debug_uid] here? *)
+                      Llet(Alias, Lambda.layout_module_field, id, id_duid,
+                           Lvar ids.(pos),
                            Lsequence(store_ident loc id,
                                      store_idents (pos + 1) idl))
                 in
@@ -1479,19 +1531,22 @@ let transl_store_structure ~scopes glob map prims aliases str =
                 | _ ->
                     let ids = bound_value_identifiers od.open_bound_items in
                     let mid = Ident.create_local "open" in
+                    let mid_duid = Lambda.debug_uid_none in
                     let loc = of_location ~scopes od.open_loc in
                     let rec store_idents pos = function
                         [] -> transl_store ~scopes rootpath
                                 (add_idents true ids subst) cont rem
                       | id :: idl ->
-                          Llet(Alias, Lambda.layout_module_field, id,
+                          let id_duid = Lambda.debug_uid_none in
+                          (* CR sspies: Can we find a better [debug_uid] here? *)
+                          Llet(Alias, Lambda.layout_module_field, id, id_duid,
                                Lprim(mod_field pos,
                                      [Lvar mid], loc),
                                Lsequence(store_ident loc id,
                                          store_idents (pos + 1) idl))
                     in
                     Llet(
-                      pure, Lambda.layout_module, mid,
+                      pure, Lambda.layout_module, mid, mid_duid,
                       Lambda.subst no_env_update subst
                         (transl_module ~scopes Tcoerce_none None od.open_expr),
                       store_idents 0 ids)
@@ -1606,6 +1661,7 @@ let store_arg_block_with_module_block
     module_name set_primary_fields restr size =
   let glob = Lprim(Pgetglobal module_name, [], Loc_unknown) in
   let primary_block_id = Ident.create_local "*primary-block*" in
+  let primary_block_id_duid = Lambda.debug_uid_none in
   let primary_block_lam =
     (* We could just access the global, but if [restr] is the trivial coercion,
        that would end up storing the global in itself as a circular reference,
@@ -1617,6 +1673,7 @@ let store_arg_block_with_module_block
     Lprim(Pmakeblock(0, Immutable, None, alloc_heap), fields, Loc_unknown)
   in
   let arg_block_id = Ident.create_local "*arg-block*" in
+  let arg_block_duid = Lambda.debug_uid_none in
   let arg_block_lam =
     apply_coercion Loc_unknown Strict restr (Lvar primary_block_id)
   in
@@ -1627,9 +1684,10 @@ let store_arg_block_with_module_block
   in
   let lam =
     Lsequence(set_primary_fields,
-              Llet(Strict, layout_module, primary_block_id, primary_block_lam,
-                   Llet(Strict, layout_module, arg_block_id, arg_block_lam,
-                        set_arg_block)))
+              Llet(Strict, layout_module, primary_block_id,
+                   primary_block_id_duid, primary_block_lam,
+                   Llet(Strict, layout_module, arg_block_id, arg_block_duid,
+                        arg_block_lam, set_arg_block)))
   in
   new_size, lam, Some arg_field
 
@@ -1769,6 +1827,8 @@ let toploop_setvalue_id id = toploop_setvalue id (Lvar id)
 
 let close_toplevel_term (lam, ()) =
   Ident.Set.fold (fun id l -> Llet(Strict, Lambda.layout_any_value, id,
+                                  Lambda.debug_uid_none,
+                                  (* CR sspies: Seems like this is an internal use. *)
                                   toploop_getvalue id, l))
                 (free_variables lam) lam
 
@@ -1849,6 +1909,7 @@ let transl_toplevel_item ~scopes item =
             transl_include_functor ~generative:true modl ccs scopes loc
       in
       let mid = Ident.create_local "include" in
+      let mid_duid = Lambda.debug_uid_none in
       let rec set_idents pos = function
         [] ->
           lambda_unit
@@ -1856,7 +1917,7 @@ let transl_toplevel_item ~scopes item =
           Lsequence(toploop_setvalue id
                       (Lprim(mod_field pos, [Lvar mid], Loc_unknown)),
                     set_idents (pos + 1) ids) in
-      Llet(Strict, Lambda.layout_module, mid, modl, set_idents 0 ids)
+      Llet(Strict, Lambda.layout_module, mid, mid_duid, modl, set_idents 0 ids)
   | Tstr_primitive descr ->
       record_primitive descr.val_val;
       lambda_unit
@@ -1871,6 +1932,7 @@ let transl_toplevel_item ~scopes item =
       | _ ->
           let ids = bound_value_identifiers od.open_bound_items in
           let mid = Ident.create_local "open" in
+          let mid_duid = Lambda.debug_uid_none in
           let rec set_idents pos = function
               [] ->
                 lambda_unit
@@ -1879,7 +1941,7 @@ let transl_toplevel_item ~scopes item =
                             (Lprim(mod_field pos, [Lvar mid], Loc_unknown)),
                           set_idents (pos + 1) ids)
           in
-          Llet(pure, Lambda.layout_module, mid,
+          Llet(pure, Lambda.layout_module, mid, mid_duid,
                transl_module ~scopes Tcoerce_none None od.open_expr,
                set_idents 0 ids)
       end
@@ -1968,8 +2030,9 @@ let transl_package_set_fields component_names target_name coercion =
               Loc_unknown)
       in
       let blk = Ident.create_local "block" in
+      let blk_duid = Lambda.debug_uid_none in
       (List.length pos_cc_list,
-       Llet (Strict, Lambda.layout_module, blk,
+       Llet (Strict, Lambda.layout_module, blk, blk_duid,
              apply_coercion Loc_unknown Strict coercion components,
              make_sequence
                (fun pos _id ->

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1536,7 +1536,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                         (* CR sspies: Can we find a better [debug_uid] here? *)
                           let id_duid = Lambda.debug_uid_none in
                           Llet(Alias, Lambda.layout_module_field, id, id_duid,
-                               Lprim(mod_Pfield pos,
+                               Lprim(mod_field pos,
                                      [Lvar mid], loc),
                                Lsequence(store_ident loc id,
                                          store_idents (pos + 1) idl))

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -101,7 +101,8 @@ let transl_type_extension ~scopes env rootpath tyext body =
           (field_path rootpath ext.ext_id) ext
       in
       (* CR sspies: Can we find a better [debug_uid] here? *)
-      Llet(Strict, Lambda.layout_block, ext.ext_id, Lambda.debug_uid_none, lam, body))
+      Llet(Strict, Lambda.layout_block, ext.ext_id,
+           Lambda.debug_uid_none, lam, body))
     tyext.tyext_constructors
     body
 
@@ -554,9 +555,9 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
   let params, body =
     List.fold_left (fun (params, body) (param, loc, arg_coercion) ->
         let param_duid = Lambda.debug_uid_none in
-        (* CR sspies: Add a debug uid to the functor argument via [Named] and then
-           propagate it here. Note that we use it twice below, once for param and once
-           for param'. *)
+        (* CR sspies: Add a debug uid to the functor argument via [Named] and
+           then propagate it here. Note that we use it twice below, once for
+           param and once for param'. *)
         let param' = Ident.rename param in
         let arg = apply_coercion loc Alias arg_coercion (Lvar param') in
         let params = {
@@ -1535,7 +1536,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                         (* CR sspies: Can we find a better [debug_uid] here? *)
                           let id_duid = Lambda.debug_uid_none in
                           Llet(Alias, Lambda.layout_module_field, id, id_duid,
-                               Lprim(mod_field pos,
+                               Lprim(mod_Pfield pos,
                                      [Lvar mid], loc),
                                Lsequence(store_ident loc id,
                                          store_idents (pos + 1) idl))

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1532,8 +1532,8 @@ let transl_store_structure ~scopes glob map prims aliases str =
                         [] -> transl_store ~scopes rootpath
                                 (add_idents true ids subst) cont rem
                       | id :: idl ->
+                        (* CR sspies: Can we find a better [debug_uid] here? *)
                           let id_duid = Lambda.debug_uid_none in
-                          (* CR sspies: Can we find a better [debug_uid] here? *)
                           Llet(Alias, Lambda.layout_module_field, id, id_duid,
                                Lprim(mod_field pos,
                                      [Lvar mid], loc),

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -99,7 +99,8 @@ let transl_label_init_general f =
          (* CR ncourant: this *should* not be too precise for the moment,
             but we should take care, or fix the underlying cause that led
             us to using [Popaque]. *)
-         Llet(Alias, layout, id, const, expr))
+         (* CR sspies: Can we find a better [debug_uid] here? *)
+         Llet(Alias, layout, id, Lambda.debug_uid_none, const, expr))
       consts expr
   in
   (*let expr =
@@ -114,6 +115,7 @@ let transl_label_init_general f =
 let transl_label_init_flambda f =
   assert(Config.flambda || Config.flambda2);
   let method_cache_id = Ident.create_local "method_cache" in
+  let method_cache_duid = Lambda.debug_uid_none in
   method_cache := Lvar method_cache_id;
   (* Calling f (usually Translmod.transl_struct) requires the
      method_cache variable to be initialised to be able to generate
@@ -123,6 +125,7 @@ let transl_label_init_flambda f =
     if !method_count = 0 then expr
     else
       Llet (Strict, Lambda.layout_array Pgenarray, method_cache_id,
+        method_cache_duid,
         Lprim (Pccall prim_makearray,
                [int !method_count; int 0],
                Loc_unknown),
@@ -192,6 +195,8 @@ let oo_wrap_gen env req f x =
                         Loc_unknown)
                 in
                 Llet(StrictOpt, Lambda.layout_class, id,
+                     Lambda.debug_uid_none,
+                     (* CR sspies: Can we find a better [debug_uid] here? *)
                      Lprim (Popaque Lambda.layout_class, [cl], Loc_unknown),
                      lambda))
              lambda !classes

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -502,8 +502,6 @@ let lifted_block_read_sem : Lambda.field_read_semantics = Reads_agree
 
 let no_loc = Debuginfo.Scoped_location.Loc_unknown
 
-(* CR sspies: The function [split_static_function] seems to replace a function,
-   so copying over debug_ids inside should be fine. *)
 let rec split_static_function lfun block_var local_idents lam :
   Lambda.lambda split_result =
   match lam with
@@ -891,6 +889,7 @@ let compile_letrec input_bindings body =
               }
             | _ ->
               let ctx_id = Ident.create_local "letrec_function_context" in
+              let ctx_id_duid = Lambda.debug_uid_none in
               begin match
                 split_static_function lfun ctx_id Ident.Set.empty def
               with
@@ -901,10 +900,9 @@ let compile_letrec input_bindings body =
               | Reachable ({ lfun; free_vars_block_size }, lam) ->
                 let functions = (id, duid, lfun) :: rev_bindings.functions in
                 let static =
-                  (ctx_id, duid, Regular_block free_vars_block_size, lam) ::
-                  rev_bindings.static
-                (* CR sspies: We are explicitly duplicating a debug_id here.
-                   Does that make sense? Seems to be the same source variable. *)
+                  (ctx_id, ctx_idx_duid,
+                    Regular_block free_vars_block_size, lam)
+                  :: rev_bindings.static
                 in
                 { rev_bindings with functions; static }
               end

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -900,7 +900,7 @@ let compile_letrec input_bindings body =
               | Reachable ({ lfun; free_vars_block_size }, lam) ->
                 let functions = (id, duid, lfun) :: rev_bindings.functions in
                 let static =
-                  (ctx_id, ctx_idx_duid,
+                  (ctx_id, ctx_id_duid,
                     Regular_block free_vars_block_size, lam)
                   :: rev_bindings.static
                 in

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -865,7 +865,8 @@ let compile_letrec input_bindings body =
     List.fold_left (fun rev_bindings (id, duid, rkind, def) ->
         match (rkind : Value_rec_types.recursive_binding_kind) with
         | Dynamic ->
-          { rev_bindings with dynamic = (id, duid, def) :: rev_bindings.dynamic }
+          { rev_bindings
+            with dynamic = (id, duid, def) :: rev_bindings.dynamic }
         | Static ->
           let size = compute_static_size def in
           begin match size with
@@ -877,7 +878,8 @@ let compile_letrec input_bindings body =
             let def =
               Lambda.subst (fun _ _ env -> env) subst_for_constants def
             in
-            { rev_bindings with dynamic = (id, duid, def) :: rev_bindings.dynamic }
+            { rev_bindings
+              with dynamic = (id, duid, def) :: rev_bindings.dynamic }
           | Block size ->
             { rev_bindings with
               static = (id, duid, size, def) :: rev_bindings.static }

--- a/lambda/value_rec_compiler.mli
+++ b/lambda/value_rec_compiler.mli
@@ -36,6 +36,6 @@
 *)
 
 val compile_letrec :
-  (Ident.t * Value_rec_types.recursive_binding_kind * Lambda.lambda) list ->
+  (Ident.t * Lambda.debug_uid * Value_rec_types.recursive_binding_kind * Lambda.lambda) list ->
   Lambda.lambda ->
   Lambda.lambda

--- a/lambda/value_rec_compiler.mli
+++ b/lambda/value_rec_compiler.mli
@@ -36,6 +36,9 @@
 *)
 
 val compile_letrec :
-  (Ident.t * Lambda.debug_uid * Value_rec_types.recursive_binding_kind * Lambda.lambda) list ->
+  (Ident.t *
+   Lambda.debug_uid *
+   Value_rec_types.recursive_binding_kind *
+   Lambda.lambda) list ->
   Lambda.lambda ->
   Lambda.lambda

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -497,7 +497,8 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
     CC.close_let_rec acc ccenv ~function_declarations:[func] ~body
       ~current_region:
         (Env.current_region env |> Option.map Env.Region_stack_element.region)
-  | Lmutlet (value_kind, id, defining_expr, body) ->
+  | Lmutlet (value_kind, id, _duid, defining_expr, body) ->
+    (* CR sspies: dropping [debug_uid]; address in subsequent PR. *)
     (* CR mshinwell: user-visibleness needs thinking about here *)
     let temp_id = Ident.create_local "let_mutable" in
     let_cont_nonrecursive_with_extra_params acc env ccenv ~is_exn_handler:false
@@ -514,9 +515,12 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
         CC.close_let acc ccenv
           [new_id, kind]
           User_visible (Simple (Var temp_id)) ~body)
-  | Llet ((Strict | Alias | StrictOpt), _, fun_id, Lfunction func, body) ->
+  | Llet ((Strict | Alias | StrictOpt), _, fun_id, duid, Lfunction func, body)
+    ->
     (* This case is here to get function names right. *)
-    let bindings = cps_function_bindings env [L.{ id = fun_id; def = func }] in
+    let bindings =
+      cps_function_bindings env [L.{ id = fun_id; debug_uid = duid; def = func }]
+    in
     let body acc ccenv = cps acc env ccenv body k k_exn in
     let let_expr =
       List.fold_left
@@ -528,7 +532,9 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
         body bindings
     in
     let_expr acc ccenv
-  | Llet ((Strict | Alias | StrictOpt), layout, id, Lconst const, body) ->
+  | Llet ((Strict | Alias | StrictOpt), layout, id, _duid, Lconst const, body)
+    ->
+    (* CR sspies: dropping [debug_uid]; address in subsequent PR. *)
     (* This case avoids extraneous continuations. *)
     let body acc ccenv = cps acc env ccenv body k k_exn in
     let kind =
@@ -542,6 +548,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
       ( ((Strict | Alias | StrictOpt) as let_kind),
         layout,
         id,
+        duid,
         Lprim (prim, args, loc),
         body ) -> (
     let env, result =
@@ -549,6 +556,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
     in
     match result with
     | Primitive (prim, args, loc) ->
+      (* CR sspies: dropping [debug_uid]; address in subsequent PR. *)
       (* This case avoids extraneous continuations. *)
       let exn_continuation : IR.exn_continuation option =
         if L.primitive_can_raise prim
@@ -598,13 +606,16 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
             ~body)
         k_exn
     | Transformed lam ->
-      cps acc env ccenv (L.Llet (let_kind, layout, id, lam, body)) k k_exn)
+      cps acc env ccenv (L.Llet (let_kind, layout, id, duid, lam, body)) k k_exn
+    )
   | Llet
       ( (Strict | Alias | StrictOpt),
         _,
         id,
+        _duid,
         Lassign (being_assigned, new_value),
         body ) ->
+    (* CR sspies: dropping [debug_uid]; address in subsequent PR. *)
     (* This case is also to avoid extraneous continuations in code that relies
        on the ref-conversion optimisation. *)
     if not (Env.is_mutable env being_assigned)
@@ -628,13 +639,17 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
           [new_id, value_kind]
           User_visible (Simple new_value) ~body)
       k_exn
-  | Llet ((Strict | Alias | StrictOpt), _layout, id, defining_expr, Lvar id')
+  | Llet
+      ((Strict | Alias | StrictOpt), _layout, id, _duid, defining_expr, Lvar id')
     when Ident.same id id' ->
+    (* CR sspies: dropping [debug_uid]; address in subsequent PR. *)
     (* Simplif already simplifies such bindings, but we can generate new ones
        when translating primitives (see the Lprim case below). *)
     (* This case must not be moved above the case for let-bound primitives. *)
     cps acc env ccenv defining_expr k k_exn
-  | Llet ((Strict | Alias | StrictOpt), layout, id, defining_expr, body) ->
+  | Llet ((Strict | Alias | StrictOpt), layout, id, _duid, defining_expr, body)
+    ->
+    (* CR sspies: dropping [debug_uid]; address in subsequent PR. *)
     let_cont_nonrecursive_with_extra_params acc env ccenv ~is_exn_handler:false
       ~params:[id, is_user_visible env id, layout]
       ~body:(fun acc env ccenv after_defining_expr ->
@@ -685,6 +700,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
          expression isn't a primitive. *)
       let name = Printlambda.name_of_primitive prim in
       let id = Ident.create_local name in
+      let id_duid = Lambda.debug_uid_none in
       let result_layout = L.primitive_result_layout prim in
       (match result_layout with
       | Pvalue _ | Punboxed_float _ | Punboxed_int _ | Punboxed_vector _
@@ -694,7 +710,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
         Misc.fatal_errorf "Invalid result layout %a for primitive %a"
           Printlambda.layout result_layout Printlambda.primitive prim);
       cps acc env ccenv
-        (L.Llet (Strict, result_layout, id, lam, L.Lvar id))
+        (L.Llet (Strict, result_layout, id, id_duid, lam, L.Lvar id))
         k k_exn)
   | Lswitch (scrutinee, switch, loc, kind) ->
     maybe_insert_let_cont "switch_result" kind k acc env ccenv
@@ -735,13 +751,17 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
           else Nonrecursive
         in
         let handler_env, params =
-          let args_arity = Flambda_arity.from_lambda_list (List.map snd args) in
+          let args_arity =
+            Flambda_arity.from_lambda_list
+              (List.map (fun (_, _, layout) -> layout) args)
+          in
           let unarized_per_arg =
             Flambda_arity.unarize_per_parameter args_arity
           in
           let handler_env, args =
             List.fold_left_map
-              (fun handler_env ((arg, layout), kinds) ->
+              (fun handler_env ((arg, _duid, layout), kinds) ->
+                (* CR sspies: dropping [debug_uid]; address in subsequent PR. *)
                 match kinds with
                 | [] -> handler_env, []
                 | [kind] -> handler_env, [arg, kind]
@@ -824,7 +844,8 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
               k_exn)
           k_exn)
       k_exn
-  | Ltrywith (body, id, handler, kind) ->
+  | Ltrywith (body, id, _duid, handler, kind) ->
+    (* CR sspies: dropping [debug_uid]; address in subsequent PR. *)
     let dbg = Debuginfo.none (* CR mshinwell: fix [Lambda] *) in
     let body_result = Ident.create_local "body_result" in
     let region = Ident.create_local "try_region" in
@@ -927,6 +948,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
     cps acc env ccenv loop k k_exn
   | Lfor
       { for_id = ident;
+        for_debug_uid = duid;
         for_loc = loc;
         for_from = start;
         for_to = stop;
@@ -934,8 +956,8 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
         for_body = body
       } ->
     let env, loop =
-      Lambda_to_lambda_transforms.rec_catch_for_for_loop env loc ident start
-        stop dir body
+      Lambda_to_lambda_transforms.rec_catch_for_for_loop env loc ident duid
+        start stop dir body
     in
     cps acc env ccenv loop k k_exn
   | Lassign (being_assigned, new_value) ->
@@ -1193,6 +1215,7 @@ and cps_function_bindings env (bindings : Lambda.rec_binding list) =
     List.map
       (fun L.
              { id = fun_id;
+               debug_uid = fun_duid;
                def =
                  { kind;
                    params;
@@ -1206,11 +1229,13 @@ and cps_function_bindings env (bindings : Lambda.rec_binding list) =
                  }
              } ->
         match
-          Simplif.split_default_wrapper ~id:fun_id ~kind ~params ~body:fbody
-            ~return ~attr ~loc ~ret_mode ~mode
+          Simplif.split_default_wrapper ~id:fun_id ~debug_uid:fun_duid ~kind
+            ~params ~body:fbody ~return ~attr ~loc ~ret_mode ~mode
         with
-        | [{ id; def = lfun }] -> [id, lfun]
-        | [{ id = id1; def = lfun1 }; { id = id2; def = lfun2 }] ->
+        (* CR sspies: dropping [debug_uid]; address in subsequent PR. *)
+        | [{ id; debug_uid = _duid; def = lfun }] -> [id, lfun]
+        | [ { id = id1; debug_uid = _duid1; def = lfun1 };
+            { id = id2; debug_uid = _duid2; def = lfun2 } ] ->
           [id1, lfun1; id2, lfun2]
         | [] | _ :: _ :: _ :: _ ->
           Misc.fatal_errorf
@@ -1429,8 +1454,9 @@ and cps_function env ~fid ~(recursive : Recursive.t) ?precomputed_free_idents
   let unboxed_products = ref Ident.Map.empty in
   let params =
     List.concat_map
-      (fun (({ name; layout; mode; attributes } : L.lparam), kinds) :
-           Function_decl.param list ->
+      (fun ( ({ name; debug_uid = _; layout; mode; attributes } : L.lparam),
+             kinds ) : Function_decl.param list ->
+        (* CR sspies: dropping [debug_uid]; address in subsequent PR. *)
         match kinds with
         | [] -> []
         | [kind] -> [{ name; kind; mode; attributes }]

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -37,6 +37,7 @@ let rec_catch_for_while_loop env cond body =
   let cont = L.next_raise_count () in
   let env = Env.mark_as_recursive_static_catch env cont in
   let cond_result = Ident.create_local "while_cond_result" in
+  let cond_result_duid = Lambda.debug_uid_none in
   let lam : L.lambda =
     Lstaticcatch
       ( Lstaticraise (cont, []),
@@ -45,6 +46,7 @@ let rec_catch_for_while_loop env cond body =
           ( Strict,
             L.layout_int,
             cond_result,
+            cond_result_duid,
             cond,
             Lifthenelse
               ( Lvar cond_result,
@@ -56,12 +58,14 @@ let rec_catch_for_while_loop env cond body =
   in
   env, lam
 
-let rec_catch_for_for_loop env loc ident start stop
+let rec_catch_for_for_loop env loc ident duid start stop
     (dir : Asttypes.direction_flag) body =
   let cont = L.next_raise_count () in
   let env = Env.mark_as_recursive_static_catch env cont in
   let start_ident = Ident.create_local "for_start" in
+  let start_ident_duid = Lambda.debug_uid_none in
   let stop_ident = Ident.create_local "for_stop" in
+  let stop_ident_duid = Lambda.debug_uid_none in
   let first_test : L.lambda =
     match dir with
     | Upto -> Lprim (Pintcomp Cle, [L.Lvar start_ident; L.Lvar stop_ident], loc)
@@ -85,17 +89,19 @@ let rec_catch_for_for_loop env loc ident start stop
       ( Strict,
         L.layout_int,
         start_ident,
+        start_ident_duid,
         start,
         Llet
           ( Strict,
             L.layout_int,
             stop_ident,
+            stop_ident_duid,
             stop,
             Lifthenelse
               ( first_test,
                 Lstaticcatch
                   ( Lstaticraise (cont, [L.Lvar start_ident]),
-                    (cont, [ident, L.layout_int]),
+                    (cont, [ident, duid, L.layout_int]),
                     Lsequence
                       ( body,
                         Lifthenelse
@@ -117,6 +123,7 @@ type initialize_array_element_width =
 let initialize_array0 env loc ~length array_set_kind width ~(init : L.lambda)
     creation_expr =
   let array = Ident.create_local "array" in
+  let array_duid = Lambda.debug_uid_none in
   (* If the element size is 32-bit, zero-initialize the last 64-bit word, to
      ensure reproducibility. *)
   (* CR mshinwell: why does e.g. caml_make_unboxed_int32_vect not do this? *)
@@ -150,7 +157,8 @@ let initialize_array0 env loc ~length array_set_kind width ~(init : L.lambda)
   in
   let env, initialize =
     let index = Ident.create_local "index" in
-    rec_catch_for_for_loop env loc index
+    let index_duid = Lambda.debug_uid_none in
+    rec_catch_for_for_loop env loc index index_duid
       (Lconst (L.const_int 0))
       (L.Lprim (Psubint, [length; Lconst (L.const_int 1)], loc))
       Upto
@@ -164,6 +172,7 @@ let initialize_array0 env loc ~length array_set_kind width ~(init : L.lambda)
       ( Strict,
         Pvalue { raw_kind = Pgenval; nullable = Non_nullable },
         array,
+        array_duid,
         creation_expr,
         Lsequence
           (maybe_zero_init_last_field, Lsequence (initialize, Lvar array)) )
@@ -296,6 +305,7 @@ let makearray_dynamic_scannable_unboxed_product0
       "Cannot compile Pmakearray_dynamic at unboxed product layouts without \
        stack allocation enabled";
   let args_array = Ident.create_local "args_array" in
+  let args_array_duid = Lambda.debug_uid_none in
   let array_layout = L.layout_array lambda_array_kind in
   let is_local =
     L.of_bool (match mode with Alloc_heap -> false | Alloc_local -> true)
@@ -312,6 +322,7 @@ let makearray_dynamic_scannable_unboxed_product0
       ( Strict,
         array_layout,
         args_array,
+        args_array_duid,
         Lprim
           ( Pmakearray (lambda_array_kind, Immutable, L.alloc_local),
             [init] (* will be unarized when this term is CPS converted *),
@@ -482,10 +493,15 @@ let arrayblit_expanded env ~(src_mutability : L.mutable_flag)
     let id = Ident.create_local in
     let bind = L.bind_with_layout in
     let src = id "src" in
+    let src_duid = Lambda.debug_uid_none in
     let src_start_pos = id "src_start_pos" in
+    let src_start_pos_duid = Lambda.debug_uid_none in
     let dst = id "dst" in
+    let dst_duid = Lambda.debug_uid_none in
     let dst_start_pos = id "dst_start_pos" in
+    let dst_start_pos_duid = Lambda.debug_uid_none in
     let length = id "length" in
+    let length_duid = Lambda.debug_uid_none in
     (* CR mshinwell: support indexing by other types apart from [int] *)
     let src_end_pos_exclusive =
       L.Lprim (Paddint, [Lvar src_start_pos; Lvar length], loc)
@@ -499,17 +515,20 @@ let arrayblit_expanded env ~(src_mutability : L.mutable_flag)
     let dst_start_pos_minus_src_start_pos_var =
       Ident.create_local "dst_start_pos_minus_src_start_pos"
     in
+    let dst_start_pos_minus_src_start_pos_var_duid = Lambda.debug_uid_none in
     let must_copy_backwards =
       L.Lprim (Pintcomp Cgt, [Lvar dst_start_pos; Lvar src_start_pos], loc)
     in
     let make_loop env (direction : Asttypes.direction_flag) =
       let src_index = Ident.create_local "index" in
+      let src_index_duid = Lambda.debug_uid_none in
       let start_pos, end_pos =
         match direction with
         | Upto -> L.Lvar src_start_pos, src_end_pos_inclusive
         | Downto -> src_end_pos_inclusive, L.Lvar src_start_pos
       in
-      rec_catch_for_for_loop env loc src_index start_pos end_pos direction
+      rec_catch_for_for_loop env loc src_index src_index_duid start_pos end_pos
+        direction
         (Lprim
            ( Parraysetu (dst_array_set_kind, Ptagged_int_index),
              [ Lvar dst;
@@ -540,13 +559,19 @@ let arrayblit_expanded env ~(src_mutability : L.mutable_flag)
     in
     let expr =
       (* Preserve right-to-left evaluation order. *)
-      bind Strict (length, L.layout_int) length_expr
-      @@ bind Strict (dst_start_pos, L.layout_int) dst_start_pos_expr
-      @@ bind Strict (dst, L.layout_any_value) dst_expr
-      @@ bind Strict (src_start_pos, L.layout_int) src_start_pos_expr
-      @@ bind Strict (src, L.layout_any_value) src_expr
+      bind Strict (length, length_duid, L.layout_int) length_expr
       @@ bind Strict
-           (dst_start_pos_minus_src_start_pos_var, L.layout_int)
+           (dst_start_pos, dst_start_pos_duid, L.layout_int)
+           dst_start_pos_expr
+      @@ bind Strict (dst, dst_duid, L.layout_any_value) dst_expr
+      @@ bind Strict
+           (src_start_pos, src_start_pos_duid, L.layout_int)
+           src_start_pos_expr
+      @@ bind Strict (src, src_duid, L.layout_any_value) src_expr
+      @@ bind Strict
+           ( dst_start_pos_minus_src_start_pos_var,
+             dst_start_pos_minus_src_start_pos_var_duid,
+             L.layout_int )
            dst_start_pos_minus_src_start_pos body
     in
     env, Transformed expr
@@ -587,33 +612,41 @@ let transform_primitive0 env (prim : L.primitive) args loc =
   match prim, args with
   | Psequor, [arg1; arg2] ->
     let const_true = Ident.create_local "const_true" in
+    let const_true_duid = Lambda.debug_uid_none in
     let cond = Ident.create_local "cond_sequor" in
+    let cond_duid = Lambda.debug_uid_none in
     Transformed
       (L.Llet
          ( Strict,
            L.layout_int,
            const_true,
+           const_true_duid,
            Lconst (Const_base (Const_int 1)),
            L.Llet
              ( Strict,
                L.layout_int,
                cond,
+               cond_duid,
                arg1,
                switch_for_if_then_else ~cond:(L.Lvar cond)
                  ~ifso:(L.Lvar const_true) ~ifnot:arg2 ~kind:L.layout_int ) ))
   | Psequand, [arg1; arg2] ->
     let const_false = Ident.create_local "const_false" in
+    let const_false_duid = Lambda.debug_uid_none in
     let cond = Ident.create_local "cond_sequand" in
+    let cond_duid = Lambda.debug_uid_none in
     Transformed
       (L.Llet
          ( Strict,
            L.layout_int,
            const_false,
+           const_false_duid,
            Lconst (Const_base (Const_int 0)),
            L.Llet
              ( Strict,
                L.layout_int,
                cond,
+               cond_duid,
                arg1,
                switch_for_if_then_else ~cond:(L.Lvar cond) ~ifso:arg2
                  ~ifnot:(L.Lvar const_false) ~kind:L.layout_int ) ))

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.mli
@@ -28,6 +28,7 @@ val rec_catch_for_for_loop :
   Lambda_to_flambda_env.t ->
   Lambda.scoped_location ->
   Ident.t ->
+  Lambda.debug_uid ->
   Lambda.lambda ->
   Lambda.lambda ->
   Asttypes.direction_flag ->

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -119,7 +119,7 @@ let close_phrase lam =
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)
     in
-    Llet(Strict, Lambda.layout_module_field, id, glob, l)
+    Llet(Strict, Lambda.layout_module_field, id, Lambda.debug_uid_none, glob, l)
   ) (free_variables lam) lam
 
 let toplevel_value id =

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -418,7 +418,8 @@ and function_body i ppf (body : function_body) =
       expression (i+1) ppf e
   | Tfunction_cases
       { fc_cases; fc_loc; fc_exp_extra; fc_attributes; fc_arg_mode;
-        fc_arg_sort; fc_param = _; fc_partial; fc_env = _; fc_ret_type = _ }
+        fc_arg_sort; fc_param = _; fc_param_debug_uid = _;
+        fc_partial; fc_env = _; fc_ret_type = _ }
     ->
       line i ppf "Tfunction_cases%a %a\n"
         fmt_partiality fc_partial

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -313,7 +313,7 @@ let function_body sub body =
   | Tfunction_cases
       { fc_cases; fc_exp_extra; fc_loc; fc_attributes; fc_env;
         fc_arg_mode = _; fc_arg_sort = _; fc_ret_type = _;
-        fc_partial = _; fc_param = _;
+        fc_partial = _; fc_param = _; fc_param_debug_uid = _;
       } ->
       List.iter (sub.case sub) fc_cases;
       Option.iter (extra sub) fc_exp_extra;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -339,6 +339,7 @@ let pat
 let function_param sub
     { fp_kind;
       fp_param;
+      fp_param_debug_uid;
       fp_arg_label;
       fp_partial;
       fp_curry;
@@ -365,6 +366,7 @@ let function_param sub
   in
   { fp_kind;
     fp_param;
+    fp_param_debug_uid;
     fp_arg_label;
     fp_partial;
     fp_curry;
@@ -389,7 +391,8 @@ let function_body sub body =
   | Tfunction_body body ->
       Tfunction_body (sub.expr sub body)
   | Tfunction_cases
-      { fc_cases; fc_partial; fc_param; fc_loc; fc_exp_extra; fc_attributes;
+      { fc_cases; fc_partial; fc_param; fc_param_debug_uid;
+        fc_loc; fc_exp_extra; fc_attributes;
         fc_arg_mode; fc_arg_sort; fc_env; fc_ret_type; }
     ->
       let fc_loc = sub.location sub fc_loc in
@@ -398,7 +401,8 @@ let function_body sub body =
       let fc_exp_extra = Option.map (extra sub) fc_exp_extra in
       let fc_env = sub.env sub fc_env in
       Tfunction_cases
-        { fc_cases; fc_partial; fc_param; fc_loc; fc_exp_extra; fc_attributes;
+        { fc_cases; fc_partial; fc_param; fc_param_debug_uid;
+          fc_loc; fc_exp_extra; fc_attributes;
           fc_arg_mode; fc_arg_sort; fc_env; fc_ret_type; }
 
 let expr sub x =
@@ -421,10 +425,12 @@ let expr sub x =
                         in
                         let comp_cb_iterator = match comp_cb_iterator with
                           | Texp_comp_range
-                              { ident; pattern; start; stop; direction }
+                              { ident; ident_debug_uid; pattern; start; stop;
+                                direction }
                             ->
                               Texp_comp_range
                                 { ident
+                                ; ident_debug_uid
                                 ; pattern
                                     (* Just mirroring [ident], ignored (see
                                        [Texp_for] *)
@@ -602,11 +608,13 @@ let expr sub x =
         Texp_object (sub.class_structure sub cl, sl)
     | Texp_pack mexpr ->
         Texp_pack (sub.module_expr sub mexpr)
-    | Texp_letop {let_; ands; param; param_sort; body; body_sort; partial} ->
+    | Texp_letop {let_; ands; param; param_debug_uid; param_sort;
+                  body; body_sort; partial} ->
         Texp_letop{
           let_ = sub.binding_op sub let_;
           ands = List.map (sub.binding_op sub) ands;
           param;
+          param_debug_uid;
           param_sort;
           body = sub.case sub body;
           body_sort;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4937,7 +4937,7 @@ let proper_exp_loc exp =
 let rec name_pattern default = function
     [] -> Ident.create_local default,
           Shape.Uid.internal_not_actually_unique
-          (* CR sspies: This code sits above Lambda, so we do not use
+          (* XCR sspies: This code sits above Lambda, so we do not use
              [Lambda.debug_uid_none] here. *)
   | p :: rem ->
     match p.pat_desc with
@@ -7448,6 +7448,14 @@ and type_function
             let param, param_uid = name_pattern "param" [ pat ] in
             Tparam_pat pat, param, param_uid
         | Some (default_arg, arg_label, default_arg_sort) ->
+          (* CR rtjoa: the fact that we use the dummy uid here means that we
+             won't have debug info for optional arguments, right? Could we call
+             [name_pattern] on [pat] like we do above?
+
+             I'm guessing the existing implementation prefixes the ident name
+             with "*opt*" for a reason, so this should probably be left as a
+             future CR rather than changed now.
+          *)
             let param = Ident.create_local ("*opt*" ^ arg_label) in
             let param_uid = Shape.Uid.internal_not_actually_unique in
             Tparam_optional_default (pat, default_arg, default_arg_sort),

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4937,8 +4937,6 @@ let proper_exp_loc exp =
 let rec name_pattern default = function
     [] -> Ident.create_local default,
           Shape.Uid.internal_not_actually_unique
-          (* XCR sspies: This code sits above Lambda, so we do not use
-             [Lambda.debug_uid_none] here. *)
   | p :: rem ->
     match p.pat_desc with
       Tpat_var (id, _, uid, _) -> id, uid
@@ -7448,14 +7446,6 @@ and type_function
             let param, param_uid = name_pattern "param" [ pat ] in
             Tparam_pat pat, param, param_uid
         | Some (default_arg, arg_label, default_arg_sort) ->
-          (* CR rtjoa: the fact that we use the dummy uid here means that we
-             won't have debug info for optional arguments, right? Could we call
-             [name_pattern] on [pat] like we do above?
-
-             I'm guessing the existing implementation prefixes the ident name
-             with "*opt*" for a reason, so this should probably be left as a
-             future CR rather than changed now.
-          *)
             let param = Ident.create_local ("*opt*" ^ arg_label) in
             let param_uid = Shape.Uid.internal_not_actually_unique in
             Tparam_optional_default (pat, default_arg, default_arg_sort),

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4935,11 +4935,14 @@ let proper_exp_loc exp =
 (* To find reasonable names for let-bound and lambda-bound idents *)
 
 let rec name_pattern default = function
-    [] -> Ident.create_local default
+    [] -> Ident.create_local default,
+          Shape.Uid.internal_not_actually_unique
+          (* CR sspies: This code sits above Lambda, so we do not use
+             [Lambda.debug_uid_none] here. *)
   | p :: rem ->
     match p.pat_desc with
-      Tpat_var (id, _, _, _) -> id
-    | Tpat_alias(_, id, _, _, _, _) -> id
+      Tpat_var (id, _, uid, _) -> id, uid
+    | Tpat_alias(_, id, _, uid, _, _) -> id, uid
     | _ -> name_pattern default rem
 
 let name_cases default lst =
@@ -6294,8 +6297,7 @@ and type_expect_
           (mk_expected ~explanation:For_loop_stop_index Predef.type_int)
       in
       let env = Env.add_share_lock For_loop env in
-      (* When we'll want to add Uid to for loops, we can take it from here. *)
-      let (for_id, _for_uid), new_env =
+      let (for_id, for_uid), new_env =
         type_for_loop_index ~loc ~env ~param
       in
       let new_env = Env.add_region_lock new_env in
@@ -6304,8 +6306,9 @@ and type_expect_
         type_statement ~explanation:For_loop_body ~position new_env sbody
       in
       rue {
-        exp_desc = Texp_for {for_id; for_pat = param; for_from; for_to;
-                             for_dir = dir; for_body; for_body_sort };
+        exp_desc = Texp_for {for_id; for_debug_uid = for_uid; for_pat = param;
+                             for_from; for_to; for_dir = dir; for_body;
+                             for_body_sort };
         exp_loc = loc; exp_extra = [];
         exp_type = instance Predef.type_unit;
         exp_attributes = sexp.pexp_attributes;
@@ -6755,7 +6758,7 @@ and type_expect_
         | [case] -> case
         | _ -> assert false
       in
-      let param = name_cases "param" cases in
+      let param, param_debug_uid = name_cases "param" cases in
       let let_ =
         { bop_op_name = slet.pbop_op;
           bop_op_path = op_path;
@@ -6767,7 +6770,8 @@ and type_expect_
           bop_loc = slet.pbop_loc; }
       in
       let desc =
-        Texp_letop{let_; ands; param; param_sort; body; body_sort; partial}
+        Texp_letop{let_; ands; param; param_debug_uid; param_sort; body;
+                   body_sort; partial}
       in
       rue { exp_desc = desc;
             exp_loc = sexp.pexp_loc;
@@ -7438,14 +7442,17 @@ and type_function
       else if is_position typed_arg_label && not_nolabel_function ty_ret then
         Location.prerr_warning pat.pat_loc
           Warnings.Unerasable_position_argument;
-      let fp_kind, fp_param =
+      let fp_kind, fp_param, fp_param_debug_uid =
         match default_arg with
         | None ->
-            let param = name_pattern "param" [ pat ] in
-            Tparam_pat pat, param
+            let param, param_uid = name_pattern "param" [ pat ] in
+            Tparam_pat pat, param, param_uid
         | Some (default_arg, arg_label, default_arg_sort) ->
             let param = Ident.create_local ("*opt*" ^ arg_label) in
-            Tparam_optional_default (pat, default_arg, default_arg_sort), param
+            let param_uid = Shape.Uid.internal_not_actually_unique in
+            Tparam_optional_default (pat, default_arg, default_arg_sort),
+            param,
+            param_uid
       in
       let param =
         { has_poly;
@@ -7453,6 +7460,7 @@ and type_function
             { fp_kind;
               fp_arg_label = typed_arg_label;
               fp_param;
+              fp_param_debug_uid;
               fp_partial = partial;
               fp_newtypes = newtypes;
               fp_sort = arg_sort;
@@ -8120,16 +8128,17 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
         let e = {texp with exp_type = ty_res; exp_desc = Texp_exclave e} in
         let cases = [ case eta_pat e ] in
         let cases_loc = { texp.exp_loc with loc_ghost = true } in
-        let param = name_cases "param" cases in
+        let param, param_uid = name_cases "param" cases in
         { texp with exp_type = ty_fun; exp_desc =
           Texp_function
             { params = [];
               body =
                 Tfunction_cases
                   { fc_cases = cases; fc_partial = Total; fc_param = param;
-                    fc_env = env; fc_ret_type = ty_res;
-                    fc_loc = cases_loc; fc_exp_extra = None;
-                    fc_attributes = []; fc_arg_mode = Alloc.disallow_right marg;
+                    fc_param_debug_uid = param_uid; fc_env = env;
+                    fc_ret_type = ty_res; fc_loc = cases_loc;
+                    fc_exp_extra = None; fc_attributes = [];
+                    fc_arg_mode = Alloc.disallow_right marg;
                     fc_arg_sort = arg_sort;
                   };
               ret_mode = Alloc.disallow_right mret;
@@ -9068,11 +9077,12 @@ and type_function_cases_expect
            (Tarrow ((Nolabel, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok)))
     in
     unify_exp_types loc env ty_fun (instance ty_expected);
-    let param = name_cases "param" cases in
+    let param , param_uid = name_cases "param" cases in
     let cases =
       { fc_cases = cases;
         fc_partial = partial;
         fc_param = param;
+        fc_param_debug_uid = param_uid;
         fc_loc = loc;
         fc_exp_extra = None;
         fc_env = env;
@@ -9899,14 +9909,15 @@ and type_comprehension_iterator
       let stop  = tbound ~explanation:Comprehension_for_stop  stop  in
       (* When we'll want to add Uid to comprehension bindings,
          we can take it from here. *)
-      let (ident, _uid) =
+      let (ident, uid) =
         type_comprehension_for_range_iterator_index
           tps
           ~loc
           ~env
           ~param:pattern
       in
-      Texp_comp_range { ident; pattern; start; stop; direction }
+      Texp_comp_range { ident; ident_debug_uid = uid; pattern; start; stop;
+                        direction }
   | Pcomp_in seq ->
       let value_reason =
         match (comprehension_type : comprehension_type) with

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -168,8 +168,8 @@ val optimise_allocations: unit -> unit
 val has_poly_constraint : Parsetree.pattern -> bool
 
 
-val name_pattern : string -> Typedtree.pattern list -> Ident.t
-val name_cases : string -> Typedtree.value Typedtree.case list -> Ident.t
+val name_pattern : string -> Typedtree.pattern list -> Ident.t * Uid.t
+val name_cases : string -> Typedtree.value Typedtree.case list -> Ident.t * Uid.t
 
 (* Why are we calling [submode]? This tells us why. *)
 type submode_reason =

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -169,7 +169,8 @@ val has_poly_constraint : Parsetree.pattern -> bool
 
 
 val name_pattern : string -> Typedtree.pattern list -> Ident.t * Uid.t
-val name_cases : string -> Typedtree.value Typedtree.case list -> Ident.t * Uid.t
+val name_cases :
+          string -> Typedtree.value Typedtree.case list -> Ident.t * Uid.t
 
 (* Why are we calling [submode]? This tells us why. *)
 type submode_reason =

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -265,6 +265,7 @@ and expression_desc =
     }
   | Texp_for of {
       for_id  : Ident.t;
+      for_debug_uid: Shape.Uid.t;
       for_pat : Parsetree.pattern;
       for_from : expression;
       for_to   : expression;
@@ -290,6 +291,7 @@ and expression_desc =
       let_ : binding_op;
       ands : binding_op list;
       param : Ident.t;
+      param_debug_uid : Shape.Uid.t;
       param_sort : Jkind.sort;
       body : value case;
       body_sort : Jkind.sort;
@@ -333,6 +335,7 @@ and comprehension_clause_binding =
 and comprehension_iterator =
   | Texp_comp_range of
       { ident     : Ident.t
+      ; ident_debug_uid : Shape.Uid.t
       ; pattern   : Parsetree.pattern
       ; start     : expression
       ; stop      : expression
@@ -356,6 +359,7 @@ and function_param =
   {
     fp_arg_label: arg_label;
     fp_param: Ident.t;
+    fp_param_debug_uid : Shape.Uid.t;
     fp_partial: partial;
     fp_kind: function_param_kind;
     fp_sort: Jkind.sort;
@@ -382,6 +386,7 @@ and function_cases =
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
     fc_param: Ident.t;
+    fc_param_debug_uid: Shape.Uid.t;
     fc_loc: Location.t;
     fc_exp_extra: exp_extra option;
     fc_attributes: attributes;

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -469,6 +469,7 @@ and expression_desc =
     }
   | Texp_for of {
       for_id  : Ident.t;
+      for_debug_uid: Shape.Uid.t;
       for_pat : Parsetree.pattern;
       for_from : expression;
       for_to   : expression;
@@ -494,6 +495,7 @@ and expression_desc =
       let_ : binding_op;
       ands : binding_op list;
       param : Ident.t;
+      param_debug_uid : Shape.Uid.t;
       param_sort : Jkind.sort;
       body : value case;
       body_sort : Jkind.sort;
@@ -524,6 +526,7 @@ and function_param =
     (** [fp_param] is the identifier that is to be used to name the
         parameter of the function.
     *)
+    fp_param_debug_uid: Shape.Uid.t;
     fp_partial: partial;
     (**
        [fp_partial] =
@@ -578,6 +581,7 @@ and function_cases =
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
     fc_param: Ident.t;
+    fc_param_debug_uid : Shape.Uid.t;
     fc_loc: Location.t;
     fc_exp_extra: exp_extra option;
     fc_attributes: attributes;
@@ -620,6 +624,7 @@ and comprehension_clause_binding =
 and comprehension_iterator =
   | Texp_comp_range of
       { ident     : Ident.t
+      ; ident_debug_uid : Shape.Uid.t
       ; pattern   : Parsetree.pattern (** Redundant with [ident] *)
       ; start     : expression
       ; stop      : expression

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -752,6 +752,7 @@ and module_type_constraint =
 
 and functor_parameter =
   | Unit
+  (* CR rtjoa: should [Named] store a uid? See comment in translmod *)
   | Named of Ident.t option * string option loc * module_type
 
 and module_expr_desc =

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -752,7 +752,13 @@ and module_type_constraint =
 
 and functor_parameter =
   | Unit
-  (* CR rtjoa: should [Named] store a uid? See comment in translmod *)
+  (* XCR rtjoa: should [Named] store a uid? See comment in translmod
+
+     sspies: I tried adding it in a separate branch. I realized that it adds quite a few
+     changes sprinkled throughout the compiler. I think this should be done in a separate
+     PR. I left a comment blow. *)
+  (* CR sspies: We should add an additional [debug_uid] here to support functor arguments
+     in the debugger. *)
   | Named of Ident.t option * string option loc * module_type
 
 and module_expr_desc =

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -752,11 +752,6 @@ and module_type_constraint =
 
 and functor_parameter =
   | Unit
-  (* XCR rtjoa: should [Named] store a uid? See comment in translmod
-
-     sspies: I tried adding it in a separate branch. I realized that it adds quite a few
-     changes sprinkled throughout the compiler. I think this should be done in a separate
-     PR. I left a comment blow. *)
   (* CR sspies: We should add an additional [debug_uid] here to support functor arguments
      in the debugger. *)
   | Named of Ident.t option * string option loc * module_type

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -752,8 +752,8 @@ and module_type_constraint =
 
 and functor_parameter =
   | Unit
-  (* CR sspies: We should add an additional [debug_uid] here to support functor arguments
-     in the debugger. *)
+  (* CR sspies: We should add an additional [debug_uid] here to support functor
+     arguments in the debugger. *)
   | Named of Ident.t option * string option loc * module_type
 
 and module_expr_desc =


### PR DESCRIPTION
This PR propagates identifiers for debugging (of type `debug_uid = Shape.Uid.t`) from the typed tree representation through the Lambda IR. It is based largely on #1912, but already addresses the comments mentioned in that PR. It is also substantially smaller, because the propagation stops after the Lambda IR. 

The intended semantics of the debugging identifiers is as follows:

- User visible variables (i.e., variables which exist at the source level) are associated with a debugging identifier. All other (internally generated) variables can freely use `Lambda.debug_uid_none`.
- The "ground truth" for the identifiers is the typed tree. We create them at this level to store relevant shape information for debugging.
- From the typed tree, we must propagate the identifiers through the lower level representations. This PR takes care of propagating them through Lambda and, for now, simply drops them once we reach Flambda.

In general, it is fine to duplicate a `debug_uid` in Lambda or lower (contrary to what the name indicates), since for debugging information it is only important that we can map the lower level representations to the source variables that they correspond to (and their types). Moreover, I did not take much care to find the correct debugging identifiers for modules and classes. I left several comments in places where it seems like we could provide additional debugging identifiers, but it's not clear to me that it is worth it in these cases. 


**Suggestions for reviewing.** The easiest way to review this PR is probably by following the flow of the compiler with one exception: it probably makes sense to take a look at the changes in `lambda.mli` first to see which Lambda constructs will get a debugging identifier.