### PR TITLE
Add multidomain config option & CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,18 @@ jobs:
             config: --enable-middle-end=flambda2 --enable-runtime5
             os: ubuntu-latest
 
+          - name: flambda2_stack_checks
+            config: --enable-middle-end=flambda2 --enable-runtime5 --enable-stack-checks
+            os: ubuntu-latest
+
+          - name: flambda2_poll_insertion
+            config: --enable-middle-end=flambda2 --enable-runtime5 --enable-poll-insertion
+            os: ubuntu-latest
+
+          - name: flambda2_multidomain
+            config: --enable-middle-end=flambda2 --enable-runtime5 --enable-stack-checks --enable-poll-insertion --enable-multidomain
+            os: ubuntu-latest
+
           - name: flambda2_dev
             config: --enable-middle-end=flambda2 --enable-dev
             os: ubuntu-latest

--- a/configure.ac
+++ b/configure.ac
@@ -189,7 +189,7 @@ AS_IF([test x"$enable_runtime5" = xyes],
       [runtime_suffix=4])
 
 AC_ARG_ENABLE([stack_checks],
-  [AS_HELP_STRING([--enable-stack_checks],
+  [AS_HELP_STRING([--enable-stack-checks],
     [Enable stack checks])])
 
 ## Output variables
@@ -361,6 +361,7 @@ AC_SUBST([compute_deps])
 AC_SUBST([intel_jcc_bug_cflags])
 AC_SUBST([stack_allocation])
 AC_SUBST([poll_insertion])
+AC_SUBST([multidomain])
 AC_SUBST([dune])
 AC_SUBST([ocaml_bindir])
 AC_SUBST([ocaml_libdir])
@@ -699,6 +700,10 @@ AC_ARG_ENABLE([stack-allocation],
 
 AC_ARG_ENABLE([poll-insertion],
   [AS_HELP_STRING([--enable-poll-insertion],
+    [enable insertion of poll points])])
+
+AC_ARG_ENABLE([multidomain],
+  [AS_HELP_STRING([--enable-multidomain],
     [enable insertion of poll points])])
 
 AC_ARG_WITH([flexdll],
@@ -2834,6 +2839,15 @@ AS_IF([test x"$enable_poll_insertion" = "xyes"],
   [AC_DEFINE([POLL_INSERTION])
    poll_insertion=true],
   [poll_insertion=false])
+
+AS_IF([test x"$enable_multidomain" = "xno"],
+  [multidomain=false],
+  [AS_IF([test x"$enable_stack_checks" = "xyes" &&
+          test x"$enable_poll_insertion" = "xyes"],
+    [AC_DEFINE([MULTIDOMAIN])
+     multidomain=true],
+    [AC_MSG_ERROR([Creating multiple domains is only supported when stack checks \
+and poll insertion are enabled.])])])
 
 oc_cflags="$common_cflags $internal_cflags"
 oc_cppflags="$common_cppflags $internal_cppflags"

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1360,6 +1360,14 @@ let no_poll_insertion = Actions.make
     "Poll insertion disabled"
     "Poll insertion enabled")
 
+let multidomain = Actions.make
+  ~name:"multidomain"
+  ~description:"Passes if multiple domains is enabled"
+  ~does_something:false
+  (Actions_helpers.predicate Config.multidomain
+    "Multidomain disabled"
+    "Multidomain enabled")
+
 let runtime4 = Actions.make
   ~name:"runtime4"
   ~description:"Passes if the OCaml 4.x runtime is being used"
@@ -1591,6 +1599,7 @@ let init () =
     codegen;
     cc;
     ocamlobjinfo;
+    multidomain;
     runtime4;
     runtime5
   ]

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -28,15 +28,19 @@ extern "C" {
 #include "mlvalues.h"
 #include "domain_state.h"
 
+#ifdef MULTIDOMAIN
 #ifdef ARCH_SIXTYFOUR
 #define Max_domains_def 128
 #else
 #define Max_domains_def 16
 #endif
-
 /* Upper limit for the number of domains. Chosen to be arbitrarily large. Used
  * for sanity checking [max_domains] value in OCAMLRUNPARAM. */
 #define Max_domains_max 4096
+#else
+#define Max_domains_def 1
+#define Max_domains_max 1
+#endif
 
 /* is the minor heap full or an external interrupt has been triggered */
 Caml_inline int caml_check_gc_interrupt(caml_domain_state * dom_st)

--- a/testsuite/tests/capsule-api/condition.ml
+++ b/testsuite/tests/capsule-api/condition.ml
@@ -2,6 +2,7 @@
  include stdlib_alpha;
  flags = "-extension-universe alpha -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/compaction/test_compact_manydomains.ml
+++ b/testsuite/tests/compaction/test_compact_manydomains.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/compaction/test_compact_multi.ml
+++ b/testsuite/tests/compaction/test_compact_multi.ml
@@ -5,6 +5,7 @@
    skip;
  }{
    runtime5;
+   multidomain;
    { bytecode; }
    { native; }
  }

--- a/testsuite/tests/effects-api/portable.ml
+++ b/testsuite/tests/effects-api/portable.ml
@@ -1,6 +1,7 @@
 (* TEST
  include stdlib_alpha;
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/effects/test_lazy.ml
+++ b/testsuite/tests/effects/test_lazy.ml
@@ -1,5 +1,6 @@
 (* TEST
    runtime5;
+   multidomain;
    { bytecode; }
    { native; }
 *)

--- a/testsuite/tests/lazy/lazy2.ml
+++ b/testsuite/tests/lazy/lazy2.ml
@@ -2,6 +2,7 @@
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  ocamlopt_flags += " -O3 ";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lazy/lazy3.ml
+++ b/testsuite/tests/lazy/lazy3.ml
@@ -2,6 +2,7 @@
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  ocamlopt_flags += " -O3 ";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lazy/lazy5.ml
+++ b/testsuite/tests/lazy/lazy5.ml
@@ -2,6 +2,7 @@
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  ocamlopt_flags += " -O3 ";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lazy/lazy6.ml
+++ b/testsuite/tests/lazy/lazy6.ml
@@ -2,6 +2,7 @@
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  ocamlopt_flags += " -O3 ";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lazy/lazy7.ml
+++ b/testsuite/tests/lazy/lazy7.ml
@@ -2,6 +2,7 @@
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  ocamlopt_flags += " -O3 ";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lazy/lazy8.ml
+++ b/testsuite/tests/lazy/lazy8.ml
@@ -2,6 +2,7 @@
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  ocamlopt_flags += " -O3 ";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lf_skiplist/test_parallel.ml
+++ b/testsuite/tests/lf_skiplist/test_parallel.ml
@@ -3,6 +3,7 @@
  modules = "stubs.c";
  no-tsan;
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lib-atomic/test_atomic_domain.ml
+++ b/testsuite/tests/lib-atomic/test_atomic_domain.ml
@@ -1,6 +1,7 @@
 (* TEST
    flags = "-alert -unsafe_multidomain";
    runtime5;
+   multidomain;
    native;
    bytecode;
 *)

--- a/testsuite/tests/lib-channels/refcounting.ml
+++ b/testsuite/tests/lib-channels/refcounting.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  expect;
 *)
 

--- a/testsuite/tests/lib-dynlink-domains/main.ml
+++ b/testsuite/tests/lib-dynlink-domains/main.ml
@@ -1,5 +1,6 @@
 (* TEST
  runtime5;
+ multidomain;
  include dynlink;
  libraries = "";
  readonly_files = "store.ml main.ml Plugin_0.ml Plugin_0_0.ml Plugin_0_0_0.ml Plugin_0_0_0_0.ml Plugin_0_0_0_1.ml Plugin_0_0_0_2.ml Plugin_1.ml Plugin_1_0.ml Plugin_1_0_0.ml Plugin_1_0_0_0.ml Plugin_1_1.ml Plugin_1_2.ml Plugin_1_2_0.ml Plugin_1_2_0_0.ml Plugin_1_2_1.ml Plugin_1_2_2.ml Plugin_1_2_2_0.ml Plugin_1_2_3.ml Plugin_1_2_3_0.ml";

--- a/testsuite/tests/lib-format/domains.ml
+++ b/testsuite/tests/lib-format/domains.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lib-format/mc_pr586_par.ml
+++ b/testsuite/tests/lib-format/mc_pr586_par.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lib-format/mc_pr586_par2.ml
+++ b/testsuite/tests/lib-format/mc_pr586_par2.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lib-marshal/intext_par.ml
+++ b/testsuite/tests/lib-marshal/intext_par.ml
@@ -3,6 +3,7 @@
  modules = "intextaux_par.c";
  no-tsan;
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lib-random/parallel.ml
+++ b/testsuite/tests/lib-random/parallel.ml
@@ -2,6 +2,7 @@
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  include unix;
  runtime5;
+ multidomain;
  libunix;
  {
    bytecode;

--- a/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_parallel.ml
@@ -5,6 +5,7 @@
  }{
    include runtime_events;
    runtime5;
+   multidomain;
    flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
    { bytecode; }
    { native; }

--- a/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
+++ b/testsuite/tests/lib-runtime-events/test_caml_slot_reuse.ml
@@ -5,6 +5,7 @@
  }{
    include runtime_events;
    runtime5;
+   multidomain;
    flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
    { bytecode; }
    { native; }

--- a/testsuite/tests/lib-runtime-events/test_dropped_events.ml
+++ b/testsuite/tests/lib-runtime-events/test_dropped_events.ml
@@ -5,6 +5,7 @@
  }{
    include runtime_events;
    runtime5;
+   multidomain;
    flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
    include unix;
    set OCAMLRUNPARAM = "e=6";

--- a/testsuite/tests/lib-str/parallel.ml
+++ b/testsuite/tests/lib-str/parallel.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  include str;
  hasstr;
  {

--- a/testsuite/tests/lib-sync/prodcons.ml
+++ b/testsuite/tests/lib-sync/prodcons.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/lib-systhreads/multicore_lifecycle.ml
+++ b/testsuite/tests/lib-systhreads/multicore_lifecycle.ml
@@ -3,6 +3,7 @@
  include systhreads;
  hassysthreads;
  runtime5;
+ multidomain;
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  include unix;
  hasunix;
  not-windows;

--- a/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
+++ b/testsuite/tests/lib-unix/common/multicore_fork_domain_alone2.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  include unix;
  hasunix;
  not-windows;

--- a/testsuite/tests/memory-model/forbidden.ml
+++ b/testsuite/tests/memory-model/forbidden.ml
@@ -4,6 +4,7 @@
  not-bsd;
  no-tsan; (* tsan detects the intentional data races and fails *)
  runtime5;
+ multidomain;
  {
    bytecode;
  }{

--- a/testsuite/tests/memory-model/publish.ml
+++ b/testsuite/tests/memory-model/publish.ml
@@ -4,6 +4,7 @@
  not-bsd;
  no-tsan; (* tsan detects data races and fails *)
  runtime5;
+ multidomain;
  {
    not-windows;
    bytecode;

--- a/testsuite/tests/parallel/atomics.ml
+++ b/testsuite/tests/parallel/atomics.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/backup_thread.ml
+++ b/testsuite/tests/parallel/backup_thread.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  include unix;
  hasunix;
  {

--- a/testsuite/tests/parallel/backup_thread_pipe.ml
+++ b/testsuite/tests/parallel/backup_thread_pipe.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  include unix;
  hasunix;
  {

--- a/testsuite/tests/parallel/catch_break.ml
+++ b/testsuite/tests/parallel/catch_break.ml
@@ -6,6 +6,7 @@ not-windows;
 poll-insertion;
 no-tsan;
 runtime5;
+multidomain;
 {
   bytecode;
 }{

--- a/testsuite/tests/parallel/churn.ml
+++ b/testsuite/tests/parallel/churn.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/constpromote.ml
+++ b/testsuite/tests/parallel/constpromote.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/domain_dls.ml
+++ b/testsuite/tests/parallel/domain_dls.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/domain_dls2.ml
+++ b/testsuite/tests/parallel/domain_dls2.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/domain_id.ml
+++ b/testsuite/tests/parallel/domain_id.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/fib_threads.ml
+++ b/testsuite/tests/parallel/fib_threads.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  include systhreads;
  hassysthreads;
  {

--- a/testsuite/tests/parallel/join.ml
+++ b/testsuite/tests/parallel/join.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/major_gc_wait_backup.ml
+++ b/testsuite/tests/parallel/major_gc_wait_backup.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  include unix;
  hasunix;
  {

--- a/testsuite/tests/parallel/max_domains2.ml
+++ b/testsuite/tests/parallel/max_domains2.ml
@@ -2,6 +2,7 @@
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  ocamlrunparam += ",d=129";
  runtime5;
+ multidomain;
  { native; }
 *)
 

--- a/testsuite/tests/parallel/multicore_systhreads.ml
+++ b/testsuite/tests/parallel/multicore_systhreads.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  include systhreads;
  hassysthreads;
  {

--- a/testsuite/tests/parallel/pingpong.ml
+++ b/testsuite/tests/parallel/pingpong.ml
@@ -2,6 +2,7 @@
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  no-tsan; (* TSan detects the intentional data race *)
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/poll.ml
+++ b/testsuite/tests/parallel/poll.ml
@@ -4,6 +4,7 @@
  include unix;
  hasunix;
  runtime5;
+ multidomain;
  {
    bytecode;
  }{

--- a/testsuite/tests/parallel/prodcons_domains.ml
+++ b/testsuite/tests/parallel/prodcons_domains.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/tak.ml
+++ b/testsuite/tests/parallel/tak.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/test_c_thread_register.ml
+++ b/testsuite/tests/parallel/test_c_thread_register.ml
@@ -2,6 +2,7 @@
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  modules = "test_c_thread_register_cstubs.c";
  runtime5;
+ multidomain;
  include systhreads;
  hassysthreads;
  {

--- a/testsuite/tests/parallel/test_issue_11094.ml
+++ b/testsuite/tests/parallel/test_issue_11094.ml
@@ -1,5 +1,6 @@
 (* TEST
  runtime5;
+ multidomain;
  set OCAMLRUNPARAM = "Xmain_stack_size=1000";
  {
    bytecode;
@@ -57,9 +58,7 @@ let run =
   in
   let domains =
     Array.init num_domains (fun _ ->
-        (* With mmaped stacks, the minimum size is a few pages, so we can only create
-           on the order of 10k fibers at once without ooming in CI. *)
-        Domain.spawn (fun () -> spawn (work 10000)))
+        Domain.spawn (fun () -> spawn (work 100000)))
   in
   Array.iter Domain.join domains;
   print_endline "OK"

--- a/testsuite/tests/parallel/unsafe_alert.ml
+++ b/testsuite/tests/parallel/unsafe_alert.ml
@@ -1,5 +1,6 @@
 (* TEST
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/weak-ephe-final/finaliser2.ml
+++ b/testsuite/tests/weak-ephe-final/finaliser2.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/weak-ephe-final/finaliser_handover.ml
+++ b/testsuite/tests/weak-ephe-final/finaliser_handover.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/weak-ephe-final/weak_array_par.ml
+++ b/testsuite/tests/weak-ephe-final/weak_array_par.ml
@@ -1,5 +1,6 @@
 (* TEST
    runtime5;
+   multidomain;
    { bytecode; }
    { native; }
 *)

--- a/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
+++ b/testsuite/tests/weak-ephe-final/weaktest_par_load.ml
@@ -1,6 +1,7 @@
 (* TEST
  flags += "-alert -unsafe_parallelism -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -105,4 +105,6 @@ let reserved_header_bits =
 
 let no_stack_checks = "@enable_stack_checks@" <> "yes"
 
+let multidomain = "@enable_multidomain" = "yes"
+
 let tsan = @tsan@

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -300,6 +300,10 @@ val runtime5 : bool
 val no_stack_checks : bool
 (** [true] if stack checks are disabled; used only if [runtime5] is [true]. *)
 
+val multidomain : bool
+(** Whether creating multiple domains is allowed.
+    Requires stack checks and poll insertion. *)
+
 val tsan : bool
 (** Whether ThreadSanitizer instrumentation is enabled *)
 


### PR DESCRIPTION
To get multiple domains, you now need to configure with `--enable-multidomain`.
Multidomain requires also enabling `--enable-stack-checks` and `--enable-poll-insertion`.

- Adds a `multidomain` test predicate and adds it to all tests that spawn domains.
- Adds CI jobs for stack-checks-only, poll-insertion-only, and multidomain.

We have a lot of CI jobs now and some of them are mostly redundant, so we should consider removing some.