### PR TITLE
Refactor lattice flipping for modes

### DIFF
--- a/typing/allowance.ml
+++ b/typing/allowance.ml
@@ -22,6 +22,10 @@ type right_only = disallowed * allowed
 
 type both = allowed * allowed
 
+type 'a pos = 'b * 'c constraint 'a = 'b * 'c
+
+type 'a neg = 'c * 'b constraint 'a = 'b * 'c
+
 module type Allow_disallow = sig
   type ('a, 'b, 'd) sided constraint 'd = 'l * 'r
 

--- a/typing/allowance.mli
+++ b/typing/allowance.mli
@@ -47,6 +47,14 @@ type right_only = disallowed * allowed
 
 type both = allowed * allowed
 
+(** Arrange the permissions appropriately for a positive lattice, by
+doing nothing. *)
+type 'a pos = 'b * 'c constraint 'a = 'b * 'c
+
+(** Arrange the permissions appropriately for a negative lattice, by
+    swapping left and right. *)
+type 'a neg = 'c * 'b constraint 'a = 'b * 'c
+
 module type Allow_disallow = sig
   type ('a, 'b, 'd) sided constraint 'd = 'l * 'r
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -692,9 +692,9 @@ module Record_diffing = struct
           | Immutable, Mutable _ -> Some Second
           | Mutable m1, Mutable m2 ->
             let open Mode.Alloc.Comonadic.Const in
-            (if not (eq m1 legacy) then
+            (if not (Misc.Le_result.equal ~le m1 legacy) then
               Misc.fatal_errorf "Unexpected mutable(%a)" print m1);
-            (if not (eq m2 legacy) then
+            (if not (Misc.Le_result.equal ~le m2 legacy) then
               Misc.fatal_errorf "Unexpected mutable(%a)" print m2);
             None
         in

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -197,7 +197,7 @@ module Axis = struct
 
   let get (type a) : a t -> (module Axis_ops with type t = a) = function
     | Modal axis ->
-      (module Accent_lattice ((val Mode.Alloc.lattice_of_axis axis)))
+      (module Accent_lattice ((val Mode.Alloc.Const.lattice_of_axis axis)))
     | Nonmodal Externality -> (module Externality)
     | Nonmodal Nullability -> (module Nullability)
     | Nonmodal Separability -> (module Separability)

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -177,7 +177,7 @@ module Axis = struct
   end
 
   type 'a t =
-    | Modal : ('m, 'a, 'd) Mode.Alloc.axis -> 'a t
+    | Modal : ('a, _, _) Mode.Alloc.axis -> 'a t
     | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed [@@unboxed]

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -177,7 +177,7 @@ module Axis = struct
   end
 
   type 'a t =
-    | Modal : ('a, _, _) Mode.Alloc.axis -> 'a t
+    | Modal : ('a, _, _) Mode.Alloc.Axis.t -> 'a t
     | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed [@@unboxed]
@@ -216,7 +216,7 @@ module Axis = struct
       Pack (Nonmodal Separability) ]
 
   let name (type a) : a t -> string = function
-    | Modal axis -> Format.asprintf "%a" Mode.Alloc.print_axis axis
+    | Modal axis -> Format.asprintf "%a" Mode.Alloc.Axis.print axis
     | Nonmodal Externality -> "externality"
     | Nonmodal Nullability -> "nullability"
     | Nonmodal Separability -> "separability"

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -59,7 +59,7 @@ module Axis : sig
 
   (** Represents an axis of a jkind *)
   type 'a t =
-    | Modal : ('m, 'a, 'd) Mode.Alloc.axis -> 'a t
+    | Modal : ('a, _, _) Mode.Alloc.axis -> 'a t
     | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed [@@unboxed]

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -59,7 +59,7 @@ module Axis : sig
 
   (** Represents an axis of a jkind *)
   type 'a t =
-    | Modal : ('a, _, _) Mode.Alloc.axis -> 'a t
+    | Modal : ('a, _, _) Mode.Alloc.Axis.t -> 'a t
     | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed [@@unboxed]

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1844,13 +1844,7 @@ module Monadic_gen (Obj : Obj) = struct
   let subtract c m = Solver.apply obj (Imply c) (Solver.disallow_left m)
 
   module Guts = struct
-    let _get_floor m = Solver.get_ceil obj m
-
     let get_ceil m = Solver.get_floor obj m
-
-    let _get_loose_floor m = Solver.get_loose_ceil obj m
-
-    let _get_loose_ceil m = Solver.get_loose_floor obj m
   end
 end
 [@@inline]

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -44,16 +44,22 @@ module type Lattice_product = sig
 
   type 'a axis
 
+  (** [min_axis ax] returns the [min] for the [ax] axis. *)
   val min_axis : 'a axis -> 'a
 
+  (** [max_axis ax] returns the [max] for the [ax] axis. *)
   val max_axis : 'a axis -> 'a
 
+  (** [min_with ax elt] returns [min] but with the axis [ax] set to [elt]. *)
   val min_with : 'a axis -> 'a -> t
 
+  (** [max_with ax elt] returns [max] but with the axis [ax] set to [elt]. *)
   val max_with : 'a axis -> 'a -> t
 
+  (** [le_axis ax] returns the [le] function for the [ax] axis. *)
   val le_axis : 'a axis -> 'a -> 'a -> bool
 
+  (** [print_axis ax] returns the [print] function for the [ax] axis. *)
   val print_axis : 'a axis -> Format.formatter -> 'a -> unit
 end
 
@@ -112,8 +118,12 @@ module type Common = sig
 
   val of_const : Const.t -> ('l * 'r) t
 
+  (** [imply c] is the right adjoint of [meet c]. That is,
+     [x <= imply c y] iff [meet c x <= y]. *)
   val imply : Const.t -> ('l * 'r) t -> (disallowed * 'r) t
 
+  (** [subtract c] is the left adjoint of [join c]. That is,
+     [subtract c x <= y] iff [x <= join c y]. *)
   val subtract : Const.t -> ('l * 'r) t -> ('l * disallowed) t
 
   val join_const : Const.t -> ('l * 'r) t -> ('l * 'r) t
@@ -511,11 +521,13 @@ module type S = sig
     val proj :
       ('a, 'l0 * 'r0, 'l1 * 'r1) Axis.t -> ('l0 * 'r0) t -> ('a, 'l1 * 'r1) mode
 
+    (** [max_with ax elt] returns [max] but with the axis [ax] set to [elt]. *)
     val max_with :
       ('a, 'l0 * 'r0, 'l1 * 'r1) Axis.t ->
       ('a, 'l1 * 'r1) mode ->
       (disallowed * 'r0) t
 
+    (** [min_with ax elt] returns [min] but with the axis [ax] set to [elt]. *)
     val min_with :
       ('a, 'l0 * 'r0, 'l1 * 'r1) Axis.t ->
       ('a, 'l1 * 'r1) mode ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1838,7 +1838,7 @@ let tree_of_label l =
     | Mutable m ->
         let mut =
           let open Alloc.Comonadic.Const in
-          if Misc.Le_result.equal ~le m Alloc.Comonadic.Const.legacy then
+          if Misc.Le_result.equal ~le m legacy then
             Om_mutable None
           else
             Om_mutable (Some "<non-legacy>")

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1837,7 +1837,8 @@ let tree_of_label l =
     match l.ld_mutable with
     | Mutable m ->
         let mut =
-          if Alloc.Comonadic.Const.eq m Alloc.Comonadic.Const.legacy then
+          let open Alloc.Comonadic.Const in
+          if Misc.Le_result.equal ~le m Alloc.Comonadic.Const.legacy then
             Om_mutable None
           else
             Om_mutable (Some "<non-legacy>")

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -34,6 +34,8 @@ type 'a error =
   }
 
 module Solver_mono (C : Lattices_mono) = struct
+  type nonrec 'a error = 'a error
+
   type any_morph = Any_morph : ('a, 'b, 'd) C.morph -> any_morph
 
   module VarMap = Map.Make (struct
@@ -98,6 +100,8 @@ module Solver_mono (C : Lattices_mono) = struct
 
   and ('b, 'd) morphvar =
     | Amorphvar : 'a var * ('a, 'b, 'd) C.morph -> ('b, 'd) morphvar
+    constraint 'd = _ * _
+  [@@ocaml.warning "-62"]
 
   let get_key (Amorphvar (v, m)) = v.id, Any_morph m
 
@@ -134,6 +138,8 @@ module Solver_mono (C : Lattices_mono) = struct
         'a * ('a, disallowed * 'r) morphvar VarMap.t
         -> ('a, disallowed * 'r) mode
         (** [Amodemeet a [mv0, mv1, ..]] represents [a meet mv0 meet mv1 meet ..]. *)
+    constraint 'd = _ * _
+  [@@ocaml.warning "-62"]
 
   (** Prints a mode variable, including the set of variables below it
       (recursively). To handle cycles, [traversed] is the set of variables that
@@ -169,7 +175,8 @@ module Solver_mono (C : Lattices_mono) = struct
           (var_map_to_list v.vlower)
 
   and print_morphvar :
-      type a d. ?traversed:VarSet.t -> a C.obj -> _ -> (a, d) morphvar -> _ =
+      type a l r.
+      ?traversed:VarSet.t -> a C.obj -> _ -> (a, l * r) morphvar -> _ =
    fun ?traversed dst ppf (Amorphvar (v, f)) ->
     let src = C.src dst f in
     Format.fprintf ppf "%a(%a)" (C.print_morph dst) f (print_var ?traversed src)
@@ -260,7 +267,7 @@ module Solver_mono (C : Lattices_mono) = struct
 
   let max (type a) (obj : a C.obj) = Amode (C.max obj)
 
-  let of_const a = Amode a
+  let of_const _obj a = Amode a
 
   let apply_morphvar dst morph (Amorphvar (var, morph')) =
     Amorphvar (var, C.compose dst morph morph')
@@ -688,165 +695,5 @@ module Solver_mono (C : Lattices_mono) = struct
         (fun _ mv -> assert (Result.is_ok (submode_mvmv obj ~log:None mu mv)))
         mvs;
       allow_left (Amodevar mu), true
-end
-[@@inline always]
-
-module Solvers_polarized (C : Lattices_mono) = struct
-  module S = Solver_mono (C)
-
-  type changes = S.changes
-
-  let empty_changes = S.empty_changes
-
-  let undo_changes = S.undo_changes
-
-  module type Solver_polarized =
-    Solver_polarized
-      with type ('a, 'b, 'd) morph := ('a, 'b, 'd) C.morph
-       and type 'a obj := 'a C.obj
-       and type 'a error := 'a error
-       and type changes := changes
-
-  module rec Positive :
-    (Solver_polarized
-      with type 'd polarized = 'd pos
-       and type ('a, 'd) mode_op = ('a, 'd) Negative.mode) = struct
-    type 'd polarized = 'd pos
-
-    type ('a, 'd) mode_op = ('a, 'd) Negative.mode
-
-    type ('a, 'd) mode = ('a, 'd) S.mode constraint 'd = 'l * 'r
-
-    include Magic_allow_disallow (S)
-
-    let newvar = S.newvar
-
-    let submode = S.submode
-
-    let join = S.join
-
-    let meet = S.meet
-
-    let of_const _ = S.of_const
-
-    let min = S.min
-
-    let max = S.max
-
-    let zap_to_floor = S.zap_to_floor
-
-    let zap_to_ceil = S.zap_to_ceil
-
-    let newvar_above = S.newvar_above
-
-    let newvar_below = S.newvar_below
-
-    let get_ceil = S.get_ceil
-
-    let get_floor = S.get_floor
-
-    let get_loose_ceil = S.get_loose_ceil
-
-    let get_loose_floor = S.get_loose_floor
-
-    let print ?(verbose = false) = S.print ~verbose
-
-    let via_monotone = S.apply
-
-    let via_antitone = S.apply
-  end
-
-  and Negative :
-    (Solver_polarized
-      with type 'd polarized = 'd neg
-       and type ('a, 'd) mode_op = ('a, 'd) Positive.mode) = struct
-    type 'd polarized = 'd neg
-
-    type ('a, 'd) mode_op = ('a, 'd) Positive.mode
-
-    type ('a, 'd) mode = ('a, 'r * 'l) S.mode constraint 'd = 'l * 'r
-
-    include Magic_allow_disallow (struct
-      type ('a, _, 'd) sided = ('a, 'd) mode
-
-      let disallow_right = S.disallow_left
-
-      let disallow_left = S.disallow_right
-
-      let allow_right = S.allow_left
-
-      let allow_left = S.allow_right
-    end)
-
-    let newvar = S.newvar
-
-    let submode obj m0 m1 ~log =
-      Result.map_error
-        (fun { left; right } -> { left = right; right = left })
-        (S.submode obj m1 m0 ~log)
-
-    let join = S.meet
-
-    let meet = S.join
-
-    let of_const _ = S.of_const
-
-    let min = S.max
-
-    let max = S.min
-
-    let zap_to_floor = S.zap_to_ceil
-
-    let zap_to_ceil = S.zap_to_floor
-
-    let newvar_above = S.newvar_below
-
-    let newvar_below = S.newvar_above
-
-    let get_ceil = S.get_floor
-
-    let get_floor = S.get_ceil
-
-    let get_loose_ceil = S.get_loose_floor
-
-    let get_loose_floor = S.get_loose_ceil
-
-    let print ?(verbose = false) = S.print ~verbose
-
-    let via_monotone = S.apply
-
-    let via_antitone = S.apply
-  end
-
-  (* Definitions to show that this solver works over a category. *)
-  module Category = struct
-    type 'a obj = 'a C.obj
-
-    type ('a, 'b, 'd) morph = ('a, 'b, 'd) C.morph
-
-    type ('a, 'd) mode =
-      | Positive of ('a, 'd pos) Positive.mode
-      | Negative of ('a, 'd neg) Negative.mode
-
-    let apply_into_positive :
-        type a b l r.
-        b obj ->
-        (a, b, l * r) morph ->
-        (a, l * r) mode ->
-        (b, l * r) Positive.mode =
-     fun obj morph -> function
-      | Positive mode -> Positive.via_monotone obj morph mode
-      | Negative mode -> Positive.via_antitone obj morph mode
-
-    let apply_into_negative :
-        type a b l r.
-        b obj ->
-        (a, b, l * r) morph ->
-        (a, l * r) mode ->
-        (b, r * l) Negative.mode =
-     fun obj morph -> function
-      | Positive mode -> Negative.via_antitone obj morph mode
-      | Negative mode -> Negative.via_monotone obj morph mode
-  end
 end
 [@@inline always]

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -61,7 +61,7 @@ module type Lattices_mono = sig
       - [disallowed], meaning the morphism cannot be on the left because
         it does not have right adjoint.
       Similar for ['r]. *)
-  type ('a, 'b, 'd) morph
+  type ('a, 'b, 'd) morph constraint 'd = 'l * 'r
 
   (* Due to the implementation in [solver.ml], a mode doesn't have sufficient
      information to infer the object it lives in,  whether at compile-time or
@@ -160,40 +160,39 @@ module type Lattices_mono = sig
   val print_morph : 'b obj -> Format.formatter -> ('a, 'b, 'd) morph -> unit
 end
 
-(** Arrange the permissions appropriately for a positive lattice, by
-    doing nothing. *)
-type 'a pos = 'b * 'c constraint 'a = 'b * 'c
-
-(** Arrange the permissions appropriately for a negative lattice, by
-    swapping left and right. *)
-type 'a neg = 'c * 'b constraint 'a = 'b * 'c
-
-module type Solver_polarized = sig
+module type Solver_mono = sig
   (* These first few types will be replaced with types from
      the Lattices_mono *)
 
   (** The morphism type from the [Lattices_mono] we're working with. See
       comments on [Lattices_mono.morph]. *)
-  type ('a, 'b, 'd) morph
+  type ('a, 'b, 'd) morph constraint 'd = 'l * 'r
 
   (** The object type from the [Lattices_mono] we're working with *)
   type 'a obj
 
   type 'a error
 
-  (** For a negative lattice, we reverse the direction of adjoints. We thus use
-      [neg] for [polarized] for negative lattices, which reverses ['l * 'r] to
-      ['r * 'l]. (Use [pos] for positive lattices.) *)
-  type 'd polarized constraint 'd = 'l * 'r
+  (* Backtracking facilities used by [types.ml] *)
 
+  (** Represents a sequence of state mutations caused by mode operations. All
+  mutating operations in this module take a [log:changes ref option] and
+  append to it all changes made, regardless of success or failure. It is
+  [option] only for performance reasons; the caller should never provide
+  [log:None]. The caller is responsible for taking care of the appended log:
+  they can either revert the changes using [undo_changes], or commit the
+  changes to the global log in [types.ml]. *)
   type changes
+
+  (** An empty sequence of changes. *)
+  val empty_changes : changes
+
+  (** Undo the sequence of changes recorded. *)
+  val undo_changes : changes -> unit
 
   (** A mode with carrier type ['a] and allowance ['d]. See
   Note [Allowance] in allowance.mli.*)
   type ('a, 'd) mode constraint 'd = 'l * 'r
-
-  (** The mode type for the opposite polarity. *)
-  type ('a, 'd) mode_op constraint 'd = 'l * 'r
 
   include Allow_disallow with type ('a, _, 'd) sided = ('a, 'd) mode
 
@@ -269,22 +268,11 @@ module type Solver_polarized = sig
   val print :
     ?verbose:bool -> 'a obj -> Format.formatter -> ('a, 'l * 'r) mode -> unit
 
-  (** Apply a monotone morphism whose source and target modes are of the
-      polarity of this enclosing module. That is, [Positive.apply_monotone]
-      takes a positive mode to a positive mode. *)
-  val via_monotone :
+  (** Apply a monotone morphism. *)
+  val apply :
     'b obj ->
-    ('a, 'b, ('l * 'r) polarized) morph ->
+    ('a, 'b, 'l * 'r) morph ->
     ('a, 'l * 'r) mode ->
-    ('b, 'l * 'r) mode
-
-  (** Apply an antitone morphism whose target mode is the mode defined in
-      this module and whose source mode is the dual mode. That is,
-      [Positive.apply_antitone] takes a negative mode to a positive one. *)
-  val via_antitone :
-    'b obj ->
-    ('a, 'b, ('l * 'r) polarized) morph ->
-    ('a, 'r * 'l) mode_op ->
     ('b, 'l * 'r) mode
 end
 
@@ -306,68 +294,9 @@ module type S = sig
 
   (** Solver that supports polarized lattices; needed because some morphisms
       are antitone  *)
-  module Solvers_polarized (C : Lattices_mono) : sig
-    (* Backtracking facilities used by [types.ml] *)
-
-    (** Represents a sequence of state mutations caused by mode operations. All
-      mutating operations in this module take a [log:changes ref option] and
-      append to it all changes made, regardless of success or failure. It is
-      [option] only for performance reasons; the caller should never provide
-      [log:None]. The caller is responsible for taking care of the appended log:
-      they can either revert the changes using [undo_changes], or commit the
-      changes to the global log in [types.ml]. *)
-    type changes
-
-    (** An empty sequence of changes. *)
-    val empty_changes : changes
-
-    (** Undo the sequence of changes recorded. *)
-    val undo_changes : changes -> unit
-
-    (* Construct a new category based on the original category [C]. Objects are
-       two copies of the objects in [C] of opposite polarity. The positive copy
-       is identical to the original lattice. The negative copy has its lattice
-       structure reversed. Morphism are four copies of the morphisms in [C], from
-       two copies of objects to two copies of objects. *)
-
-    module type Solver_polarized =
-      Solver_polarized
-        with type ('a, 'b, 'd) morph := ('a, 'b, 'd) C.morph
-         and type 'a obj := 'a C.obj
-         and type 'a error := 'a error
-         and type changes := changes
-
-    module rec Positive :
-      (Solver_polarized
-        with type 'd polarized = 'd pos
-         and type ('a, 'd) mode_op = ('a, 'd) Negative.mode)
-
-    and Negative :
-      (Solver_polarized
-        with type 'd polarized = 'd neg
-         and type ('a, 'd) mode_op = ('a, 'd) Positive.mode)
-
-    (* The following definitions show how this solver works over a category by
-       defining objects and morphisms. These definitions are not used in
-       practice. They are put into a module to make it easy to spot if we end up
-       using these in the future. *)
-    module Category : sig
-      type 'a obj = 'a C.obj
-
-      type ('a, 'b, 'd) morph = ('a, 'b, 'd) C.morph
-
-      type ('a, 'd) mode =
-        | Positive of ('a, 'd pos) Positive.mode
-        | Negative of ('a, 'd neg) Negative.mode
-
-      val apply_into_positive :
-        'b obj -> ('a, 'b, 'd) morph -> ('a, 'd) mode -> ('b, 'd) Positive.mode
-
-      val apply_into_negative :
-        'b obj ->
-        ('a, 'b, 'l * 'r) morph ->
-        ('a, 'l * 'r) mode ->
-        ('b, 'r * 'l) Negative.mode
-    end
-  end
+  module Solver_mono (C : Lattices_mono) :
+    Solver_mono
+      with type ('a, 'b, 'd) morph := ('a, 'b, 'd) C.morph
+       and type 'a obj := 'a C.obj
+       and type 'a error = 'a error
 end

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -292,8 +292,7 @@ module type S = sig
   module Magic_equal (X : Equal) :
     Equal with type ('a, 'b, 'c) t = ('a, 'b, 'c) X.t
 
-  (** Solver that supports polarized lattices; needed because some morphisms
-      are antitone  *)
+  (** Solver that supports lattices with monotone morphisms between them. *)
   module Solver_mono (C : Lattices_mono) :
     Solver_mono
       with type ('a, 'b, 'd) morph := ('a, 'b, 'd) C.morph

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -25,7 +25,7 @@ exception Error of Location.t * error
 
 module Axis_pair = struct
   type 'm t =
-    | Modal_axis_pair : ('a, _, _) Mode.Alloc.axis * 'a -> modal t
+    | Modal_axis_pair : ('a, _, _) Mode.Alloc.Axis.t * 'a -> modal t
     | Any_axis_pair : 'a Axis.t * 'a -> maybe_nonmodal t
     | Everything_but_nullability : maybe_nonmodal t
 
@@ -317,7 +317,7 @@ let transl_mode_annots annots : Alloc.Const.Option.t =
   let step modifiers_so_far annot =
     let { txt =
             Modal_axis_pair (type a d0 d1)
-              ((axis, mode) : (a, d0, d1) Mode.Alloc.axis * a);
+              ((axis, mode) : (a, d0, d1) Mode.Alloc.Axis.t * a);
           loc
         } =
       transl_annot ~annot_type:Mode ~required_mode_maturity:(Some Stable)

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -25,7 +25,7 @@ exception Error of Location.t * error
 
 module Axis_pair = struct
   type 'm t =
-    | Modal_axis_pair : ('m, 'a, 'd) Mode.Alloc.axis * 'a -> modal t
+    | Modal_axis_pair : ('a, _, _) Mode.Alloc.axis * 'a -> modal t
     | Any_axis_pair : 'a Axis.t * 'a -> maybe_nonmodal t
     | Everything_but_nullability : maybe_nonmodal t
 
@@ -316,8 +316,8 @@ let default_mode_annots (annots : Alloc.Const.Option.t) =
 let transl_mode_annots annots : Alloc.Const.Option.t =
   let step modifiers_so_far annot =
     let { txt =
-            Modal_axis_pair (type m a d)
-              ((axis, mode) : (m, a, d) Mode.Alloc.axis * a);
+            Modal_axis_pair (type a d0 d1)
+              ((axis, mode) : (a, d0, d1) Mode.Alloc.axis * a);
           loc
         } =
       transl_annot ~annot_type:Mode ~required_mode_maturity:(Some Stable)

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -274,11 +274,11 @@ let mutable_ (mut : Types.mutability) : mutable_flag =
   match mut with
   | Immutable -> Immutable
   | Mutable m ->
-      if Mode.Alloc.Comonadic.Const.eq m Mode.Alloc.Comonadic.Const.legacy then
+      let open Mode.Alloc.Comonadic.Const in
+      if Misc.Le_result.equal ~le:le m legacy then
         Mutable
       else
-        Misc.fatal_errorf "unexpected mutable(%a)"
-          Mode.Alloc.Comonadic.Const.print m
+        Misc.fatal_errorf "unexpected mutable(%a)" print m
 
 let label_declaration sub ld =
   let loc = sub.location sub ld.ld_loc in

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -275,7 +275,7 @@ let mutable_ (mut : Types.mutability) : mutable_flag =
   | Immutable -> Immutable
   | Mutable m ->
       let open Mode.Alloc.Comonadic.Const in
-      if Misc.Le_result.equal ~le:le m legacy then
+      if Misc.Le_result.equal ~le m legacy then
         Mutable
       else
         Misc.fatal_errorf "unexpected mutable(%a)" print m


### PR DESCRIPTION
Currently in `solver.ml` there is `Solver_mono` which can handle monotone morphisms. Based on that, there are two polarized solvers `Positive` and `Negative`, used for comonadic and monadic axes respectively. The intention is such that user code (`mode.ml`) doesn't need to think about the flipping. This has two issues:

- It turns out that `mode.ml` still needs to think about the flipping in some definitions but not all of them. This mixture, and the fact that both `mode.ml` and `solver.ml` handles flipping, makes the code more confusing.
- `Positive.t` and `Negative.t` are different types and complicates type polymorphism. In particular, `Value.Axis.t` is a complicated GADT.

So we remove both `Positive` and `Negative`, and let `mode.ml` to be the only file that cares about flipping. We move some code such that the flipping are concentrated to fewer places.

The downside is that code that uses `mode` might see `(Uniqueness.Const.t, allowed * disallowed) mode` instead of `(disallowed * allowed) Uniqueness.t`. The two types are the same, but ideally we want to show the latter.

# Review

Please review by commit.