### PR TITLE
Refactor test for simd arrays

### DIFF
--- a/flambda-backend/tests/simd/arrays.ml
+++ b/flambda-backend/tests/simd/arrays.ml
@@ -594,13 +594,13 @@ end
 
 module Float_arrays = struct
 
-  external interleave_low_32 : float32x4 -> float32x4 -> float32x4 = "caml_vec128_unreachable" "caml_sse_vec128_interleave_low_32"
+  external interleave_low_32 : float32x4 -> float32x4 -> float32x4 = "caml_vec128_unreachable" "caml_simd_vec128_interleave_low_32"
     [@@noalloc] [@@unboxed] [@@builtin]
 
-  external interleave_low_64s : float32x4 -> float32x4 -> float32x4 = "caml_vec128_unreachable" "caml_sse2_vec128_interleave_low_64"
+  external interleave_low_64s : float32x4 -> float32x4 -> float32x4 = "caml_vec128_unreachable" "caml_simd_vec128_interleave_low_64"
     [@@noalloc] [@@unboxed] [@@builtin]
 
-  external interleave_low_64 : float64x2 -> float64x2 -> float64x2 = "caml_vec128_unreachable" "caml_sse2_vec128_interleave_low_64"
+  external interleave_low_64 : float64x2 -> float64x2 -> float64x2 = "caml_vec128_unreachable" "caml_simd_vec128_interleave_low_64"
     [@@noalloc] [@@unboxed] [@@builtin]
 
   external low_of64 : float -> float64x2 = "caml_vec128_unreachable" "caml_float64x2_low_of_float"

--- a/flambda-backend/tests/simd/arrays_u.ml
+++ b/flambda-backend/tests/simd/arrays_u.ml
@@ -609,13 +609,13 @@ end
 
 module Float_arrays = struct
 
-  external interleave_low_32 : float32x4 -> float32x4 -> float32x4 = "caml_vec128_unreachable" "caml_sse_vec128_interleave_low_32"
+  external interleave_low_32 : float32x4 -> float32x4 -> float32x4 = "caml_vec128_unreachable" "caml_simd_vec128_interleave_low_32"
     [@@noalloc] [@@unboxed] [@@builtin]
 
-  external interleave_low_64s : float32x4 -> float32x4 -> float32x4 = "caml_vec128_unreachable" "caml_sse2_vec128_interleave_low_64"
+  external interleave_low_64s : float32x4 -> float32x4 -> float32x4 = "caml_vec128_unreachable" "caml_simd_vec128_interleave_low_64"
     [@@noalloc] [@@unboxed] [@@builtin]
 
-  external interleave_low_64 : float64x2 -> float64x2 -> float64x2 = "caml_vec128_unreachable" "caml_sse2_vec128_interleave_low_64"
+  external interleave_low_64 : float64x2 -> float64x2 -> float64x2 = "caml_vec128_unreachable" "caml_simd_vec128_interleave_low_64"
     [@@noalloc] [@@unboxed] [@@builtin]
 
   external low_of64 : float -> float64x2 = "caml_vec128_unreachable" "caml_float64x2_low_of_float"

--- a/flambda-backend/tests/simd/stubs.c
+++ b/flambda-backend/tests/simd/stubs.c
@@ -364,6 +364,9 @@ BUILTIN(caml_int_popcnt_tagged_to_untagged);
 BUILTIN(caml_int_clz_untagged_to_untagged);
 BUILTIN(caml_int_clz_tagged_to_untagged);
 
+BUILTIN(caml_simd_vec128_interleave_low_32)
+BUILTIN(caml_simd_vec128_interleave_low_64)
+
 #include <float.h>
 #include <math.h>
 


### PR DESCRIPTION
Use "caml_simd*" instead of "caml_sse*" builtins in simd array tests.