### PR TITLE
Fix miscompilation / liveness errors for string operations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,12 +200,14 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: HOMEBREW_NO_INSTALL_CLEANUP=TRUE brew install autoconf
 
+      # NB. The "rev" number in the cache key below must be updated each time
+      # the patch file is changed!
     - name: Cache OCaml 4.14, dune and menhir
       uses: actions/cache@v4
       id: cache
       with:
         path: ${{ github.workspace }}/ocaml-414/_install
-        key: ${{ matrix.os }}-cache-ocaml-414-patched-dune-3152-menhir-20231231
+        key: ${{ matrix.os }}-cache-ocaml-414-patched-dune-3152-menhir-20231231-rev13
 
     - name: Checkout OCaml 4.14
       uses: actions/checkout@master
@@ -285,13 +287,22 @@ jobs:
           --with-dune=$GITHUB_WORKSPACE/ocaml-414/_install/bin/dune \
           ${{ matrix.config }}
 
-    - name: Setup for saving core files (not for macOS at the moment)
+    - name: Setup for saving core files (not for macOS)
       if: matrix.os != 'macos-latest'
       run: |
         sudo mkdir /cores
         sudo chmod 777 /cores
         # Core filenames will be of the form executable.pid.timestamp:
         sudo bash -c 'echo "/cores/%e.%p.%t" > /proc/sys/kernel/core_pattern'
+
+    - name: Setup for saving core files (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        sudo chmod 1777 /cores
+        sudo sysctl kern.coredump=1
+        /usr/libexec/PlistBuddy -c "Add :com.apple.security.get-task-allow bool true" /tmp/core.entitlements
+        codesign -s - -f --entitlements /tmp/core.entitlements $GITHUB_WORKSPACE/ocaml-414/_install/bin/ocamlc.opt
+        codesign -s - -f --entitlements /tmp/core.entitlements $GITHUB_WORKSPACE/ocaml-414/_install/bin/ocamlopt.opt
 
     - name: Build, install and test Flambda backend
       working-directory: flambda_backend
@@ -313,25 +324,35 @@ jobs:
       run: |
         PATH=$GITHUB_WORKSPACE/ocaml-414/_install/bin:$PATH make check_all_arches
 
-# CR-soon xclerc for xclerc: re-enable the "upload-artifact" action
-# (they are failing @4 because the names are not unique)
-#    - uses: actions/upload-artifact@v4
-#      if: ${{ failure() }} && matrix.os != 'macos-latest'
-#      with:
-#        name: cores-${{ github.sha }}
-#        path: /cores
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: cores-${{ github.sha }}-${{ github.run_id }}-${{ matrix.name }}
+        path: /cores
+
+#     - uses: actions/upload-artifact@v4
+#       if: ${{ failure() }}
+#       with:
+#         name: ocaml-414-${{ github.sha }}-${{ github.run_id }}-${{ matrix.name }}
+#         path: ${{ github.workspace }}/ocaml-414/_install
+
+     - uses: actions/upload-artifact@v4
+       if: ${{ failure() }} && matrix.os == 'macos-latest'
+       with:
+         name: DiagnosticReports-${{ github.sha }}-${{ github.run_id }}-${{ matrix.name }}
+         path: /Users/runner/Library/Logs/DiagnosticReports
+
+#     - uses: actions/upload-artifact@v4
+#       if: ${{ failure() }}
+#       with:
+#         name: _build-${{ github.sha }}-${{ github.run_id }}-${{ matrix.name }}
+#         path: ${{ github.workspace }}/flambda_backend/_build
 #
-#    - uses: actions/upload-artifact@v4
-#      if: ${{ failure() }} && matrix.os != 'macos-latest'
-#      with:
-#        name: _build-${{ github.sha }}
-#        path: $GITHUB_WORKSPACE/_build
-#
-#    - uses: actions/upload-artifact@v4
-#      if: ${{ failure() }} && matrix.os != 'macos-latest'
-#      with:
-#        name: _runtest-${{ github.sha }}
-#        path: $GITHUB_WORKSPACE/_runtest
+#     - uses: actions/upload-artifact@v4
+#       if: ${{ failure() }}
+#       with:
+#         name: _runtest-${{ github.sha }}-${{ github.run_id }}-${{ matrix.name }}
+#         path: ${{ github.workspace }}/flambda_backend/_runtest
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/arm64-issue-debug-upstream.patch
+++ b/arm64-issue-debug-upstream.patch
@@ -1,67 +1,274 @@
-diff --git a/driver/compenv.ml b/driver/compenv.ml
-index 8b1c4e5559..3e7de2533d 100644
---- a/driver/compenv.ml
-+++ b/driver/compenv.ml
-@@ -489,6 +489,7 @@ let read_one_param ppf position name v =
- let read_OCAMLPARAM ppf position =
-   try
-     let s = Sys.getenv "OCAMLPARAM" in
-+    Warnings.parsed_ocamlparam := s;
-     if s <> "" then
-       let (before, after) =
-         try
-diff --git a/utils/warnings.ml b/utils/warnings.ml
-index 895ef2be07..dc7a23b6c9 100644
---- a/utils/warnings.ml
-+++ b/utils/warnings.ml
-@@ -459,7 +459,10 @@ let name_to_number =
+diff --git a/asmcomp/cmm_helpers.ml b/asmcomp/cmm_helpers.ml
+index 7ad42ceaea..0cb43b7ecd 100644
+--- a/asmcomp/cmm_helpers.ml
++++ b/asmcomp/cmm_helpers.ml
+@@ -137,6 +137,8 @@ let rec add_const c n dbg =
+ let incr_int c dbg = add_const c 1 dbg
+ let decr_int c dbg = add_const c (-1) dbg
  
- (* Must be the max number returned by the [number] function. *)
- 
--let letter = function
-+let parsed_ocamlparam = ref "<not-set>"
++let add_int_addr c1 c2 dbg = Cop (Cadda, [c1; c2], dbg)
 +
-+(* CR-soon xclerc for xclerc: remove the `for_debug` parameter... *)
-+let letter for_debug = function
-   | 'a' ->
-      let rec loop i = if i = 0 then [] else i :: loop (i - 1) in
-      loop last_warning_number
-@@ -488,7 +491,9 @@ let letter = function
-   | 'x' -> [14; 15; 16; 17; 18; 19; 20; 21; 22; 23; 24; 30]
-   | 'y' -> [26]
-   | 'z' -> [27]
--  | _ -> assert false
-+  | chr ->
-+     let ocamlparam_from_env = match Sys.getenv_opt "OCAMLPARAM" with None -> "-" | Some  value -> value in
-+     Misc.fatal_errorf "Warnings.letter %C (for_debug=%S, ocamlparam_from_env=%S ocamlparam_from_compenv=%S)" chr for_debug ocamlparam_from_env !parsed_ocamlparam
- ;;
+ let rec add_int c1 c2 dbg =
+   match (c1, c2) with
+   | (Cconst_int (n, _), c) | (c, Cconst_int (n, _)) ->
+@@ -1103,12 +1105,12 @@ let make_unsigned_int bi arg dbg =
  
- type state =
-@@ -745,7 +750,7 @@ let parse_opt error active errflag s =
-           | None -> if c = lc then Clear else Set
-           | Some m -> m
-         in
--        List.iter (action modifier) (letter lc)
-+        List.iter (action modifier) (letter s lc)
-     | Num(n1,n2,modifier) ->
-         for n = n1 to Int.min n2 last_warning_number do action modifier n done
-   in
-@@ -1131,7 +1136,7 @@ let help_warnings () =
-   print_endline "  A all warnings";
-   for i = Char.code 'b' to Char.code 'z' do
-     let c = Char.chr i in
--    match letter c with
-+    match letter "<help-warnings>" c with
-     | [] -> ()
-     | [n] ->
-         Printf.printf "  %c Alias for warning %i.\n" (Char.uppercase_ascii c) n
-diff --git a/utils/warnings.mli b/utils/warnings.mli
-index 3d9ea91f38..70d17a9181 100644
---- a/utils/warnings.mli
-+++ b/utils/warnings.mli
-@@ -161,3 +161,5 @@ type description =
-     description : string; }
+ let unaligned_load_16 ptr idx dbg =
+   if Arch.allow_unaligned_access
+-  then Cop(Cload (Sixteen_unsigned, Mutable), [add_int ptr idx dbg], dbg)
++  then Cop(Cload (Sixteen_unsigned, Mutable), [add_int_addr ptr idx dbg], dbg)
+   else
+     let cconst_int i = Cconst_int (i, dbg) in
+-    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx dbg], dbg) in
++    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int_addr ptr idx dbg], dbg) in
+     let v2 = Cop(Cload (Byte_unsigned, Mutable),
+-                 [add_int (add_int ptr idx dbg) (cconst_int 1) dbg], dbg) in
++                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1) dbg], dbg) in
+     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
+     Cop(Cor, [lsl_int b1 (cconst_int 8) dbg; b2], dbg)
  
- val descriptions : description list
-+
-+val parsed_ocamlparam : string ref
+@@ -1116,7 +1118,7 @@ let unaligned_set_16 ptr idx newval dbg =
+   if Arch.allow_unaligned_access
+   then
+     Cop(Cstore (Sixteen_unsigned, Assignment),
+-      [add_int ptr idx dbg; newval], dbg)
++      [add_int_addr ptr idx dbg; newval], dbg)
+   else
+     let cconst_int i = Cconst_int (i, dbg) in
+     let v1 =
+@@ -1126,24 +1128,24 @@ let unaligned_set_16 ptr idx newval dbg =
+     let v2 = Cop(Cand, [newval; cconst_int 0xFF], dbg) in
+     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
+     Csequence(
+-        Cop(Cstore (Byte_unsigned, Assignment), [add_int ptr idx dbg; b1], dbg),
++        Cop(Cstore (Byte_unsigned, Assignment), [add_int_addr ptr idx dbg; b1], dbg),
+         Cop(Cstore (Byte_unsigned, Assignment),
+-            [add_int (add_int ptr idx dbg) (cconst_int 1) dbg; b2], dbg))
++            [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1) dbg; b2], dbg))
+ 
+ let unaligned_load_32 ptr idx dbg =
+   if Arch.allow_unaligned_access
+-  then Cop(Cload (Thirtytwo_unsigned, Mutable), [add_int ptr idx dbg], dbg)
++  then Cop(Cload (Thirtytwo_unsigned, Mutable), [add_int_addr ptr idx dbg], dbg)
+   else
+     let cconst_int i = Cconst_int (i, dbg) in
+-    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx dbg], dbg) in
++    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int_addr ptr idx dbg], dbg) in
+     let v2 = Cop(Cload (Byte_unsigned, Mutable),
+-                 [add_int (add_int ptr idx dbg) (cconst_int 1) dbg], dbg)
++                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1) dbg], dbg)
+     in
+     let v3 = Cop(Cload (Byte_unsigned, Mutable),
+-                 [add_int (add_int ptr idx dbg) (cconst_int 2) dbg], dbg)
++                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 2) dbg], dbg)
+     in
+     let v4 = Cop(Cload (Byte_unsigned, Mutable),
+-                 [add_int (add_int ptr idx dbg) (cconst_int 3) dbg], dbg)
++                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 3) dbg], dbg)
+     in
+     let b1, b2, b3, b4 =
+       if Arch.big_endian
+@@ -1158,7 +1160,7 @@ let unaligned_load_32 ptr idx dbg =
+ let unaligned_set_32 ptr idx newval dbg =
+   if Arch.allow_unaligned_access
+   then
+-    Cop(Cstore (Thirtytwo_unsigned, Assignment), [add_int ptr idx dbg; newval],
++    Cop(Cstore (Thirtytwo_unsigned, Assignment), [add_int_addr ptr idx dbg; newval],
+       dbg)
+   else
+     let cconst_int i = Cconst_int (i, dbg) in
+@@ -1179,39 +1181,39 @@ let unaligned_set_32 ptr idx newval dbg =
+     Csequence(
+         Csequence(
+             Cop(Cstore (Byte_unsigned, Assignment),
+-                [add_int ptr idx dbg; b1], dbg),
++                [add_int_addr ptr idx dbg; b1], dbg),
+             Cop(Cstore (Byte_unsigned, Assignment),
+-                [add_int (add_int ptr idx dbg) (cconst_int 1) dbg; b2],
++                [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1) dbg; b2],
+                 dbg)),
+         Csequence(
+             Cop(Cstore (Byte_unsigned, Assignment),
+-                [add_int (add_int ptr idx dbg) (cconst_int 2) dbg; b3],
++                [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 2) dbg; b3],
+                 dbg),
+             Cop(Cstore (Byte_unsigned, Assignment),
+-                [add_int (add_int ptr idx dbg) (cconst_int 3) dbg; b4],
++                [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 3) dbg; b4],
+                 dbg)))
+ 
+ let unaligned_load_64 ptr idx dbg =
+   assert(size_int = 8);
+   if Arch.allow_unaligned_access
+-  then Cop(Cload (Word_int, Mutable), [add_int ptr idx dbg], dbg)
++  then Cop(Cload (Word_int, Mutable), [add_int_addr ptr idx dbg], dbg)
+   else
+     let cconst_int i = Cconst_int (i, dbg) in
+-    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int ptr idx dbg], dbg) in
++    let v1 = Cop(Cload (Byte_unsigned, Mutable), [add_int_addr ptr idx dbg], dbg) in
+     let v2 = Cop(Cload (Byte_unsigned, Mutable),
+-                 [add_int (add_int ptr idx dbg) (cconst_int 1) dbg], dbg) in
++                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1) dbg], dbg) in
+     let v3 = Cop(Cload (Byte_unsigned, Mutable),
+-                 [add_int (add_int ptr idx dbg) (cconst_int 2) dbg], dbg) in
++                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 2) dbg], dbg) in
+     let v4 = Cop(Cload (Byte_unsigned, Mutable),
+-                 [add_int (add_int ptr idx dbg) (cconst_int 3) dbg], dbg) in
++                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 3) dbg], dbg) in
+     let v5 = Cop(Cload (Byte_unsigned, Mutable),
+-                 [add_int (add_int ptr idx dbg) (cconst_int 4) dbg], dbg) in
++                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 4) dbg], dbg) in
+     let v6 = Cop(Cload (Byte_unsigned, Mutable),
+-                 [add_int (add_int ptr idx dbg) (cconst_int 5) dbg], dbg) in
++                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 5) dbg], dbg) in
+     let v7 = Cop(Cload (Byte_unsigned, Mutable),
+-                 [add_int (add_int ptr idx dbg) (cconst_int 6) dbg], dbg) in
++                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 6) dbg], dbg) in
+     let v8 = Cop(Cload (Byte_unsigned, Mutable),
+-                 [add_int (add_int ptr idx dbg) (cconst_int 7) dbg], dbg) in
++                 [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 7) dbg], dbg) in
+     let b1, b2, b3, b4, b5, b6, b7, b8 =
+       if Arch.big_endian
+       then v1, v2, v3, v4, v5, v6, v7, v8
+@@ -1233,7 +1235,7 @@ let unaligned_load_64 ptr idx dbg =
+ let unaligned_set_64 ptr idx newval dbg =
+   assert(size_int = 8);
+   if Arch.allow_unaligned_access
+-  then Cop(Cstore (Word_int, Assignment), [add_int ptr idx dbg; newval], dbg)
++  then Cop(Cstore (Word_int, Assignment), [add_int_addr ptr idx dbg; newval], dbg)
+   else
+     let cconst_int i = Cconst_int (i, dbg) in
+     let v1 =
+@@ -1273,32 +1275,32 @@ let unaligned_set_64 ptr idx newval dbg =
+         Csequence(
+             Csequence(
+                 Cop(Cstore (Byte_unsigned, Assignment),
+-                    [add_int ptr idx dbg; b1],
++                    [add_int_addr ptr idx dbg; b1],
+                     dbg),
+                 Cop(Cstore (Byte_unsigned, Assignment),
+-                    [add_int (add_int ptr idx dbg) (cconst_int 1) dbg; b2],
++                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 1) dbg; b2],
+                     dbg)),
+             Csequence(
+                 Cop(Cstore (Byte_unsigned, Assignment),
+-                    [add_int (add_int ptr idx dbg) (cconst_int 2) dbg; b3],
++                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 2) dbg; b3],
+                     dbg),
+                 Cop(Cstore (Byte_unsigned, Assignment),
+-                    [add_int (add_int ptr idx dbg) (cconst_int 3) dbg; b4],
++                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 3) dbg; b4],
+                     dbg))),
+         Csequence(
+             Csequence(
+                 Cop(Cstore (Byte_unsigned, Assignment),
+-                    [add_int (add_int ptr idx dbg) (cconst_int 4) dbg; b5],
++                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 4) dbg; b5],
+                     dbg),
+                 Cop(Cstore (Byte_unsigned, Assignment),
+-                    [add_int (add_int ptr idx dbg) (cconst_int 5) dbg; b6],
++                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 5) dbg; b6],
+                     dbg)),
+             Csequence(
+                 Cop(Cstore (Byte_unsigned, Assignment),
+-                    [add_int (add_int ptr idx dbg) (cconst_int 6) dbg; b7],
++                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 6) dbg; b7],
+                     dbg),
+                 Cop(Cstore (Byte_unsigned, Assignment),
+-                    [add_int (add_int ptr idx dbg) (cconst_int 7) dbg; b8],
++                    [add_int_addr (add_int_addr ptr idx dbg) (cconst_int 7) dbg; b8],
+                     dbg))))
+ 
+ let max_or_zero a dbg =
+@@ -2279,7 +2281,7 @@ let int_comp_caml cmp arg1 arg2 dbg =
+ 
+ let stringref_unsafe arg1 arg2 dbg =
+   tag_int(Cop(Cload (Byte_unsigned, Mutable),
+-              [add_int arg1 (untag_int arg2 dbg) dbg],
++              [add_int_addr arg1 (untag_int arg2 dbg) dbg],
+               dbg)) dbg
+ 
+ let stringref_safe arg1 arg2 dbg =
+@@ -2289,7 +2291,7 @@ let stringref_safe arg1 arg2 dbg =
+         Csequence(
+           make_checkbound dbg [string_length str dbg; idx],
+           Cop(Cload (Byte_unsigned, Mutable),
+-            [add_int str idx dbg], dbg))))) dbg
++            [add_int_addr str idx dbg], dbg))))) dbg
+ 
+ let string_load size unsafe arg1 arg2 dbg =
+   box_sized size dbg
+@@ -2397,7 +2399,7 @@ let setfield_computed ptr init arg1 arg2 arg3 dbg =
+ 
+ let bytesset_unsafe arg1 arg2 arg3 dbg =
+       return_unit dbg (Cop(Cstore (Byte_unsigned, Assignment),
+-                      [add_int arg1 (untag_int arg2 dbg) dbg;
++                      [add_int_addr arg1 (untag_int arg2 dbg) dbg;
+                        ignore_high_bit_int (untag_int arg3 dbg)], dbg))
+ 
+ let bytesset_safe arg1 arg2 arg3 dbg =
+@@ -2408,7 +2410,7 @@ let bytesset_safe arg1 arg2 arg3 dbg =
+         Csequence(
+           make_checkbound dbg [string_length str dbg; idx],
+           Cop(Cstore (Byte_unsigned, Assignment),
+-              [add_int str idx dbg; newval],
++              [add_int_addr str idx dbg; newval],
+               dbg))))))
+ 
+ let arrayset_unsafe kind arg1 arg2 arg3 dbg =
+diff --git a/asmcomp/comballoc.ml b/asmcomp/comballoc.ml
+index f03bb3e66f..510029d63c 100644
+--- a/asmcomp/comballoc.ml
++++ b/asmcomp/comballoc.ml
+@@ -63,7 +63,9 @@ let rec combine i allocstate =
+           i.arg i.res i.dbg next, allocstate)
+       end
+   | Iop(Icall_ind | Icall_imm _ | Iextcall _ |
+-        Itailcall_ind | Itailcall_imm _ | Ipoll _) ->
++        Itailcall_ind | Itailcall_imm _ | Ipoll _
++        | Ispecific _ (* XXX *) | Iintop Icheckbound
++        | Iintop_imm (Icheckbound, _)) ->
+       let newnext = combine_restart i.next in
+       (instr_cons_debug i.desc i.arg i.res i.dbg newnext,
+        allocstate)
+diff --git a/asmcomp/selectgen.ml b/asmcomp/selectgen.ml
+index 6a56cc2a27..0c7f6e7cb1 100644
+--- a/asmcomp/selectgen.ml
++++ b/asmcomp/selectgen.ml
+@@ -323,12 +323,13 @@ method is_simple_expr = function
+   | Cop(op, args, _) ->
+       begin match op with
+         (* The following may have side effects *)
+-      | Capply _ | Cextcall _ | Calloc | Cstore _ | Craise _ | Copaque -> false
++      | Capply _ | Cextcall _ | Calloc | Cstore _ | Craise _ | Copaque
++      | Ccheckbound -> false
+         (* The remaining operations are simple if their args are *)
+       | Cload _ | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi | Cand | Cor
+       | Cxor | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Ccmpa _ | Cnegf
+       | Cabsf | Caddf | Csubf | Cmulf | Cdivf | Cfloatofint | Cintoffloat
+-      | Ccmpf _ | Ccheckbound -> List.for_all self#is_simple_expr args
++      | Ccmpf _ -> List.for_all self#is_simple_expr args
+       end
+   | Cassign _ | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _
+   | Ctrywith _ -> false
+diff --git a/runtime/startup_nat.c b/runtime/startup_nat.c
+index b75732596a..0b8f93449b 100644
+--- a/runtime/startup_nat.c
++++ b/runtime/startup_nat.c
+@@ -113,12 +113,14 @@ value caml_startup_common(char_os **argv, int pooling)
+   caml_init_domain();
+   /* Determine options */
+ #ifdef DEBUG
+-  caml_verb_gc = 0x3F;
++  /* Silenced for flambda-backend builds to avoid excessively large CI logs */
++  /* caml_verb_gc = 0x3F; */
+ #endif
+   caml_parse_ocamlrunparam();
+   CAML_EVENTLOG_INIT();
+ #ifdef DEBUG
+-  caml_gc_message (-1, "### OCaml runtime: debug mode ###\n");
++  /* Silenced for flambda-backend builds to avoid excessively large CI logs */
++  /* caml_gc_message (-1, "### OCaml runtime: debug mode ###\n"); */
+ #endif
+   if (caml_cleanup_on_exit)
+     pooling = 1;

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -404,6 +404,15 @@ let rec sub_int c1 c2 dbg =
         add_const (sub_int c1 c2 dbg) n1 dbg
       | c1, c2 -> Cop (Csubi, [c1; c2], dbg))
 
+let add_int_addr c1 c2 dbg = Cop (Cadda, [c1; c2], dbg)
+
+let add_int_ptr ~ptr_out_of_heap c1 c2 dbg =
+  (* The [add_int_addr] case is only used for string access, and it seems
+     unlikely that the optimizations done for [add_int] will apply.
+
+     For out-of-heap accesses, we use [add_int], thus allowing more CSE. *)
+  if ptr_out_of_heap then add_int c1 c2 dbg else add_int_addr c1 c2 dbg
+
 let neg_int c dbg = sub_int (Cconst_int (0, dbg)) c dbg
 
 (** This function conservatively approximates the number of significant bits in its signed
@@ -2305,26 +2314,39 @@ let unbox_int dbg bi =
 let make_unsigned_int bi arg dbg =
   if bi = Primitive.Unboxed_int32 then zero_extend ~bits:32 arg ~dbg else arg
 
-let unaligned_load_16 ptr idx dbg =
+let unaligned_load_16 ~ptr_out_of_heap ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop (mk_load_mut Sixteen_unsigned, [add_int ptr idx dbg], dbg)
+  then
+    Cop
+      ( mk_load_mut Sixteen_unsigned,
+        [add_int_ptr ~ptr_out_of_heap ptr idx dbg],
+        dbg )
   else
     let cconst_int i = Cconst_int (i, dbg) in
-    let v1 = Cop (mk_load_mut Byte_unsigned, [add_int ptr idx dbg], dbg) in
+    let v1 =
+      Cop
+        ( mk_load_mut Byte_unsigned,
+          [add_int_ptr ~ptr_out_of_heap ptr idx dbg],
+          dbg )
+    in
     let v2 =
       Cop
         ( mk_load_mut Byte_unsigned,
-          [add_int (add_int ptr idx dbg) (cconst_int 1) dbg],
+          [ add_int_addr
+              (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+              (cconst_int 1) dbg ],
           dbg )
     in
     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
     Cop (Cor, [lsl_int b1 (cconst_int 8) dbg; b2], dbg)
 
-let unaligned_set_16 ptr idx newval dbg =
+let unaligned_set_16 ~ptr_out_of_heap ptr idx newval dbg =
   if Arch.allow_unaligned_access
   then
     Cop
-      (Cstore (Sixteen_unsigned, Assignment), [add_int ptr idx dbg; newval], dbg)
+      ( Cstore (Sixteen_unsigned, Assignment),
+        [add_int_ptr ~ptr_out_of_heap ptr idx dbg; newval],
+        dbg )
   else
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 =
@@ -2333,34 +2355,55 @@ let unaligned_set_16 ptr idx newval dbg =
     let v2 = Cop (Cand, [newval; cconst_int 0xFF], dbg) in
     let b1, b2 = if Arch.big_endian then v1, v2 else v2, v1 in
     Csequence
-      ( Cop (Cstore (Byte_unsigned, Assignment), [add_int ptr idx dbg; b1], dbg),
+      ( Cop
+          ( Cstore (Byte_unsigned, Assignment),
+            [add_int_ptr ~ptr_out_of_heap ptr idx dbg; b1],
+            dbg ),
         Cop
           ( Cstore (Byte_unsigned, Assignment),
-            [add_int (add_int ptr idx dbg) (cconst_int 1) dbg; b2],
+            [ add_int_addr
+                (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+                (cconst_int 1) dbg;
+              b2 ],
             dbg ) )
 
-let unaligned_load_32 ptr idx dbg =
+let unaligned_load_32 ~ptr_out_of_heap ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop (mk_load_mut Thirtytwo_unsigned, [add_int ptr idx dbg], dbg)
+  then
+    Cop
+      ( mk_load_mut Thirtytwo_unsigned,
+        [add_int_ptr ~ptr_out_of_heap ptr idx dbg],
+        dbg )
   else
     let cconst_int i = Cconst_int (i, dbg) in
-    let v1 = Cop (mk_load_mut Byte_unsigned, [add_int ptr idx dbg], dbg) in
+    let v1 =
+      Cop
+        ( mk_load_mut Byte_unsigned,
+          [add_int_ptr ~ptr_out_of_heap ptr idx dbg],
+          dbg )
+    in
     let v2 =
       Cop
         ( mk_load_mut Byte_unsigned,
-          [add_int (add_int ptr idx dbg) (cconst_int 1) dbg],
+          [ add_int_addr
+              (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+              (cconst_int 1) dbg ],
           dbg )
     in
     let v3 =
       Cop
         ( mk_load_mut Byte_unsigned,
-          [add_int (add_int ptr idx dbg) (cconst_int 2) dbg],
+          [ add_int_addr
+              (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+              (cconst_int 2) dbg ],
           dbg )
     in
     let v4 =
       Cop
         ( mk_load_mut Byte_unsigned,
-          [add_int (add_int ptr idx dbg) (cconst_int 3) dbg],
+          [ add_int_addr
+              (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+              (cconst_int 3) dbg ],
           dbg )
     in
     let b1, b2, b3, b4 =
@@ -2375,12 +2418,12 @@ let unaligned_load_32 ptr idx dbg =
           Cop (Cor, [lsl_int b3 (cconst_int 8) dbg; b4], dbg) ],
         dbg )
 
-let unaligned_set_32 ptr idx newval dbg =
+let unaligned_set_32 ~ptr_out_of_heap ptr idx newval dbg =
   if Arch.allow_unaligned_access
   then
     Cop
       ( Cstore (Thirtytwo_unsigned, Assignment),
-        [add_int ptr idx dbg; newval],
+        [add_int_ptr ~ptr_out_of_heap ptr idx dbg; newval],
         dbg )
   else
     let cconst_int i = Cconst_int (i, dbg) in
@@ -2403,68 +2446,97 @@ let unaligned_set_32 ptr idx newval dbg =
       ( Csequence
           ( Cop
               ( Cstore (Byte_unsigned, Assignment),
-                [add_int ptr idx dbg; b1],
+                [add_int_ptr ~ptr_out_of_heap ptr idx dbg; b1],
                 dbg ),
             Cop
               ( Cstore (Byte_unsigned, Assignment),
-                [add_int (add_int ptr idx dbg) (cconst_int 1) dbg; b2],
+                [ add_int_addr
+                    (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+                    (cconst_int 1) dbg;
+                  b2 ],
                 dbg ) ),
         Csequence
           ( Cop
               ( Cstore (Byte_unsigned, Assignment),
-                [add_int (add_int ptr idx dbg) (cconst_int 2) dbg; b3],
+                [ add_int_addr
+                    (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+                    (cconst_int 2) dbg;
+                  b3 ],
                 dbg ),
             Cop
               ( Cstore (Byte_unsigned, Assignment),
-                [add_int (add_int ptr idx dbg) (cconst_int 3) dbg; b4],
+                [ add_int_addr
+                    (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+                    (cconst_int 3) dbg;
+                  b4 ],
                 dbg ) ) )
 
-let unaligned_load_64 ptr idx dbg =
+let unaligned_load_64 ~ptr_out_of_heap ptr idx dbg =
   if Arch.allow_unaligned_access
-  then Cop (mk_load_mut Word_int, [add_int ptr idx dbg], dbg)
+  then
+    Cop (mk_load_mut Word_int, [add_int_ptr ~ptr_out_of_heap ptr idx dbg], dbg)
   else
     let cconst_int i = Cconst_int (i, dbg) in
-    let v1 = Cop (mk_load_mut Byte_unsigned, [add_int ptr idx dbg], dbg) in
+    let v1 =
+      Cop
+        ( mk_load_mut Byte_unsigned,
+          [add_int_ptr ~ptr_out_of_heap ptr idx dbg],
+          dbg )
+    in
     let v2 =
       Cop
         ( mk_load_mut Byte_unsigned,
-          [add_int (add_int ptr idx dbg) (cconst_int 1) dbg],
+          [ add_int_addr
+              (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+              (cconst_int 1) dbg ],
           dbg )
     in
     let v3 =
       Cop
         ( mk_load_mut Byte_unsigned,
-          [add_int (add_int ptr idx dbg) (cconst_int 2) dbg],
+          [ add_int_addr
+              (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+              (cconst_int 2) dbg ],
           dbg )
     in
     let v4 =
       Cop
         ( mk_load_mut Byte_unsigned,
-          [add_int (add_int ptr idx dbg) (cconst_int 3) dbg],
+          [ add_int_addr
+              (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+              (cconst_int 3) dbg ],
           dbg )
     in
     let v5 =
       Cop
         ( mk_load_mut Byte_unsigned,
-          [add_int (add_int ptr idx dbg) (cconst_int 4) dbg],
+          [ add_int_addr
+              (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+              (cconst_int 4) dbg ],
           dbg )
     in
     let v6 =
       Cop
         ( mk_load_mut Byte_unsigned,
-          [add_int (add_int ptr idx dbg) (cconst_int 5) dbg],
+          [ add_int_addr
+              (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+              (cconst_int 5) dbg ],
           dbg )
     in
     let v7 =
       Cop
         ( mk_load_mut Byte_unsigned,
-          [add_int (add_int ptr idx dbg) (cconst_int 6) dbg],
+          [ add_int_addr
+              (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+              (cconst_int 6) dbg ],
           dbg )
     in
     let v8 =
       Cop
         ( mk_load_mut Byte_unsigned,
-          [add_int (add_int ptr idx dbg) (cconst_int 7) dbg],
+          [ add_int_addr
+              (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+              (cconst_int 7) dbg ],
           dbg )
     in
     let b1, b2, b3, b4, b5, b6, b7, b8 =
@@ -2498,9 +2570,13 @@ let unaligned_load_64 ptr idx dbg =
               dbg ) ],
         dbg )
 
-let unaligned_set_64 ptr idx newval dbg =
+let unaligned_set_64 ~ptr_out_of_heap ptr idx newval dbg =
   if Arch.allow_unaligned_access
-  then Cop (Cstore (Word_int, Assignment), [add_int ptr idx dbg; newval], dbg)
+  then
+    Cop
+      ( Cstore (Word_int, Assignment),
+        [add_int_ptr ~ptr_out_of_heap ptr idx dbg; newval],
+        dbg )
   else
     let cconst_int i = Cconst_int (i, dbg) in
     let v1 =
@@ -2553,70 +2629,100 @@ let unaligned_set_64 ptr idx newval dbg =
           ( Csequence
               ( Cop
                   ( Cstore (Byte_unsigned, Assignment),
-                    [add_int ptr idx dbg; b1],
+                    [add_int_ptr ~ptr_out_of_heap ptr idx dbg; b1],
                     dbg ),
                 Cop
                   ( Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 1) dbg; b2],
+                    [ add_int_addr
+                        (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+                        (cconst_int 1) dbg;
+                      b2 ],
                     dbg ) ),
             Csequence
               ( Cop
                   ( Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 2) dbg; b3],
+                    [ add_int_addr
+                        (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+                        (cconst_int 2) dbg;
+                      b3 ],
                     dbg ),
                 Cop
                   ( Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 3) dbg; b4],
+                    [ add_int_addr
+                        (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+                        (cconst_int 3) dbg;
+                      b4 ],
                     dbg ) ) ),
         Csequence
           ( Csequence
               ( Cop
                   ( Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 4) dbg; b5],
+                    [ add_int_addr
+                        (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+                        (cconst_int 4) dbg;
+                      b5 ],
                     dbg ),
                 Cop
                   ( Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 5) dbg; b6],
+                    [ add_int_addr
+                        (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+                        (cconst_int 5) dbg;
+                      b6 ],
                     dbg ) ),
             Csequence
               ( Cop
                   ( Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 6) dbg; b7],
+                    [ add_int_addr
+                        (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+                        (cconst_int 6) dbg;
+                      b7 ],
                     dbg ),
                 Cop
                   ( Cstore (Byte_unsigned, Assignment),
-                    [add_int (add_int ptr idx dbg) (cconst_int 7) dbg; b8],
+                    [ add_int_addr
+                        (add_int_ptr ~ptr_out_of_heap ptr idx dbg)
+                        (cconst_int 7) dbg;
+                      b8 ],
                     dbg ) ) ) )
 
-let unaligned_load_f32 ptr idx dbg =
-  Cop (mk_load_mut (Single { reg = Float32 }), [add_int ptr idx dbg], dbg)
-
-let unaligned_set_f32 ptr idx newval dbg =
+let unaligned_load_f32 ~ptr_out_of_heap ptr idx dbg =
   Cop
-    ( Cstore (Single { reg = Float32 }, Assignment),
-      [add_int ptr idx dbg; newval],
+    ( mk_load_mut (Single { reg = Float32 }),
+      [add_int_ptr ~ptr_out_of_heap ptr idx dbg],
       dbg )
 
-let unaligned_load_128 ptr idx dbg =
-  assert (size_vec128 = 16);
-  Cop (mk_load_mut Onetwentyeight_unaligned, [add_int ptr idx dbg], dbg)
+let unaligned_set_f32 ~ptr_out_of_heap ptr idx newval dbg =
+  Cop
+    ( Cstore (Single { reg = Float32 }, Assignment),
+      [add_int_ptr ~ptr_out_of_heap ptr idx dbg; newval],
+      dbg )
 
-let unaligned_set_128 ptr idx newval dbg =
+let unaligned_load_128 ~ptr_out_of_heap ptr idx dbg =
+  assert (size_vec128 = 16);
+  Cop
+    ( mk_load_mut Onetwentyeight_unaligned,
+      [add_int_ptr ~ptr_out_of_heap ptr idx dbg],
+      dbg )
+
+let unaligned_set_128 ~ptr_out_of_heap ptr idx newval dbg =
   assert (size_vec128 = 16);
   Cop
     ( Cstore (Onetwentyeight_unaligned, Assignment),
-      [add_int ptr idx dbg; newval],
+      [add_int_ptr ~ptr_out_of_heap ptr idx dbg; newval],
       dbg )
 
-let aligned_load_128 ptr idx dbg =
+let aligned_load_128 ~ptr_out_of_heap ptr idx dbg =
   assert (size_vec128 = 16);
-  Cop (mk_load_mut Onetwentyeight_aligned, [add_int ptr idx dbg], dbg)
+  Cop
+    ( mk_load_mut Onetwentyeight_aligned,
+      [add_int_ptr ~ptr_out_of_heap ptr idx dbg],
+      dbg )
 
-let aligned_set_128 ptr idx newval dbg =
+let aligned_set_128 ~ptr_out_of_heap ptr idx newval dbg =
   assert (size_vec128 = 16);
   Cop
     ( Cstore (Onetwentyeight_aligned, Assignment),
-      [add_int ptr idx dbg; newval],
+      [add_int_ptr ~ptr_out_of_heap ptr idx dbg; newval],
       dbg )
 
 let opaque e dbg = Cop (Copaque, [e], dbg)

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -90,6 +90,9 @@ val or_int : expression -> expression -> Debuginfo.t -> expression
 
 val xor_int : expression -> expression -> Debuginfo.t -> expression
 
+(** Like [add_int] but produces a result with machtype [Addr]. *)
+val add_int_addr : expression -> expression -> Debuginfo.t -> expression
+
 (** Integer tagging. [tag_int x = (x lsl 1) + 1] *)
 val tag_int : expression -> Debuginfo.t -> expression
 
@@ -407,35 +410,71 @@ val unbox_int :
 val make_unsigned_int :
   Primitive.unboxed_integer -> expression -> Debuginfo.t -> expression
 
-val unaligned_load_16 : expression -> expression -> Debuginfo.t -> expression
+val unaligned_load_16 :
+  ptr_out_of_heap:bool -> expression -> expression -> Debuginfo.t -> expression
 
 val unaligned_set_16 :
-  expression -> expression -> expression -> Debuginfo.t -> expression
+  ptr_out_of_heap:bool ->
+  expression ->
+  expression ->
+  expression ->
+  Debuginfo.t ->
+  expression
 
-val unaligned_load_32 : expression -> expression -> Debuginfo.t -> expression
+val unaligned_load_32 :
+  ptr_out_of_heap:bool -> expression -> expression -> Debuginfo.t -> expression
 
 val unaligned_set_32 :
-  expression -> expression -> expression -> Debuginfo.t -> expression
+  ptr_out_of_heap:bool ->
+  expression ->
+  expression ->
+  expression ->
+  Debuginfo.t ->
+  expression
 
-val unaligned_load_f32 : expression -> expression -> Debuginfo.t -> expression
+val unaligned_load_f32 :
+  ptr_out_of_heap:bool -> expression -> expression -> Debuginfo.t -> expression
 
 val unaligned_set_f32 :
-  expression -> expression -> expression -> Debuginfo.t -> expression
+  ptr_out_of_heap:bool ->
+  expression ->
+  expression ->
+  expression ->
+  Debuginfo.t ->
+  expression
 
-val unaligned_load_64 : expression -> expression -> Debuginfo.t -> expression
+val unaligned_load_64 :
+  ptr_out_of_heap:bool -> expression -> expression -> Debuginfo.t -> expression
 
 val unaligned_set_64 :
-  expression -> expression -> expression -> Debuginfo.t -> expression
+  ptr_out_of_heap:bool ->
+  expression ->
+  expression ->
+  expression ->
+  Debuginfo.t ->
+  expression
 
-val unaligned_load_128 : expression -> expression -> Debuginfo.t -> expression
+val unaligned_load_128 :
+  ptr_out_of_heap:bool -> expression -> expression -> Debuginfo.t -> expression
 
 val unaligned_set_128 :
-  expression -> expression -> expression -> Debuginfo.t -> expression
+  ptr_out_of_heap:bool ->
+  expression ->
+  expression ->
+  expression ->
+  Debuginfo.t ->
+  expression
 
-val aligned_load_128 : expression -> expression -> Debuginfo.t -> expression
+val aligned_load_128 :
+  ptr_out_of_heap:bool -> expression -> expression -> Debuginfo.t -> expression
 
 val aligned_set_128 :
-  expression -> expression -> expression -> Debuginfo.t -> expression
+  ptr_out_of_heap:bool ->
+  expression ->
+  expression ->
+  expression ->
+  Debuginfo.t ->
+  expression
 
 (** Primitives *)
 

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -309,13 +309,17 @@ let array_load ~dbg (array_kind : P.Array_kind.t)
   | Unboxed_product _, Naked_int32s ->
     C.unboxed_mutable_int32_unboxed_product_array_ref arr ~array_index:index dbg
   | (Immediates | Naked_floats), Naked_vec128s ->
-    array_load_128 ~dbg ~element_width_log2:3 ~has_custom_ops:false arr index
+    array_load_128 ~ptr_out_of_heap:false ~dbg ~element_width_log2:3
+      ~has_custom_ops:false arr index
   | (Naked_int64s | Naked_nativeints), Naked_vec128s ->
-    array_load_128 ~dbg ~element_width_log2:3 ~has_custom_ops:true arr index
+    array_load_128 ~ptr_out_of_heap:false ~dbg ~element_width_log2:3
+      ~has_custom_ops:true arr index
   | (Naked_int32s | Naked_float32s), Naked_vec128s ->
-    array_load_128 ~dbg ~element_width_log2:2 ~has_custom_ops:true arr index
+    array_load_128 ~ptr_out_of_heap:false ~dbg ~element_width_log2:2
+      ~has_custom_ops:true arr index
   | Naked_vec128s, Naked_vec128s ->
-    array_load_128 ~dbg ~element_width_log2:4 ~has_custom_ops:true arr index
+    array_load_128 ~ptr_out_of_heap:false ~dbg ~element_width_log2:4
+      ~has_custom_ops:true arr index
   | ( ( Naked_floats | Naked_int32s | Naked_float32s | Naked_int64s
       | Naked_nativeints | Naked_vec128s ),
       Values ) ->
@@ -385,17 +389,17 @@ let array_set0 ~dbg (array_kind : P.Array_kind.t)
     C.unboxed_mutable_int32_unboxed_product_array_set arr ~array_index:index
       ~new_value dbg
   | (Immediates | Naked_floats), Naked_vec128s ->
-    array_set_128 ~dbg ~element_width_log2:3 ~has_custom_ops:false arr index
-      new_value
+    array_set_128 ~ptr_out_of_heap:false ~dbg ~element_width_log2:3
+      ~has_custom_ops:false arr index new_value
   | (Naked_int64s | Naked_nativeints), Naked_vec128s ->
-    array_set_128 ~dbg ~element_width_log2:3 ~has_custom_ops:true arr index
-      new_value
+    array_set_128 ~ptr_out_of_heap:false ~dbg ~element_width_log2:3
+      ~has_custom_ops:true arr index new_value
   | (Naked_int32s | Naked_float32s), Naked_vec128s ->
-    array_set_128 ~dbg ~element_width_log2:2 ~has_custom_ops:true arr index
-      new_value
+    array_set_128 ~ptr_out_of_heap:false ~dbg ~element_width_log2:2
+      ~has_custom_ops:true arr index new_value
   | Naked_vec128s, Naked_vec128s ->
-    array_set_128 ~dbg ~element_width_log2:4 ~has_custom_ops:true arr index
-      new_value
+    array_set_128 ~ptr_out_of_heap:false ~dbg ~element_width_log2:4
+      ~has_custom_ops:true arr index new_value
   | ( ( Naked_floats | Naked_int32s | Naked_float32s | Naked_int64s
       | Naked_nativeints | Naked_vec128s ),
       Values _ ) ->
@@ -456,49 +460,59 @@ let bigarray_store ~dbg kind ~bigarray ~index ~new_value =
 (* String and bytes access. For these functions, [index] is an untagged
    integer. *)
 
-let string_like_load_aux ~dbg width ~str ~index =
+let string_like_load_aux ~ptr_out_of_heap ~dbg width ~str ~index =
   match (width : P.string_accessor_width) with
-  | Eight -> C.load ~dbg Byte_unsigned Mutable ~addr:(C.add_int str index dbg)
-  | Sixteen -> C.unaligned_load_16 str index dbg
+  | Eight ->
+    (* CR mshinwell: should not be Mutable for [string] *)
+    C.load ~dbg Byte_unsigned Mutable ~addr:(C.add_int_addr str index dbg)
+  | Sixteen -> C.unaligned_load_16 ~ptr_out_of_heap str index dbg
   | Thirty_two ->
-    C.sign_extend ~bits:32 ~dbg (C.unaligned_load_32 str index dbg)
-  | Single -> C.unaligned_load_f32 str index dbg
-  | Sixty_four -> C.unaligned_load_64 str index dbg
-  | One_twenty_eight { aligned = true } -> C.aligned_load_128 str index dbg
-  | One_twenty_eight { aligned = false } -> C.unaligned_load_128 str index dbg
+    C.sign_extend ~bits:32 ~dbg
+      (C.unaligned_load_32 ~ptr_out_of_heap str index dbg)
+  | Single -> C.unaligned_load_f32 ~ptr_out_of_heap str index dbg
+  | Sixty_four -> C.unaligned_load_64 ~ptr_out_of_heap str index dbg
+  | One_twenty_eight { aligned = true } ->
+    C.aligned_load_128 ~ptr_out_of_heap str index dbg
+  | One_twenty_eight { aligned = false } ->
+    C.unaligned_load_128 ~ptr_out_of_heap str index dbg
 
 let string_like_load ~dbg kind width ~str ~index =
   match (kind : P.string_like_value) with
-  | String | Bytes -> string_like_load_aux ~dbg width ~str ~index
+  | String | Bytes ->
+    string_like_load_aux ~ptr_out_of_heap:false ~dbg width ~str ~index
   | Bigstring ->
     let ba_data_addr = C.field_address str 1 dbg in
     let ba_data = C.load ~dbg Word_int Mutable ~addr:ba_data_addr in
     C.bind "ba_data" ba_data (fun str ->
-        string_like_load_aux ~dbg width ~str ~index)
+        string_like_load_aux ~ptr_out_of_heap:true ~dbg width ~str ~index)
 
-let bytes_or_bigstring_set_aux ~dbg width ~bytes ~index ~new_value =
+let bytes_or_bigstring_set_aux ~ptr_out_of_heap ~dbg width ~bytes ~index
+    ~new_value =
   match (width : P.string_accessor_width) with
   | Eight ->
-    let addr = C.add_int bytes index dbg in
+    let addr = C.add_int_addr bytes index dbg in
     C.store ~dbg Byte_unsigned Assignment ~addr ~new_value
-  | Sixteen -> C.unaligned_set_16 bytes index new_value dbg
-  | Thirty_two -> C.unaligned_set_32 bytes index new_value dbg
-  | Single -> C.unaligned_set_f32 bytes index new_value dbg
-  | Sixty_four -> C.unaligned_set_64 bytes index new_value dbg
+  | Sixteen -> C.unaligned_set_16 ~ptr_out_of_heap bytes index new_value dbg
+  | Thirty_two -> C.unaligned_set_32 ~ptr_out_of_heap bytes index new_value dbg
+  | Single -> C.unaligned_set_f32 ~ptr_out_of_heap bytes index new_value dbg
+  | Sixty_four -> C.unaligned_set_64 ~ptr_out_of_heap bytes index new_value dbg
   | One_twenty_eight { aligned = false } ->
-    C.unaligned_set_128 bytes index new_value dbg
+    C.unaligned_set_128 ~ptr_out_of_heap bytes index new_value dbg
   | One_twenty_eight { aligned = true } ->
-    C.aligned_set_128 bytes index new_value dbg
+    C.aligned_set_128 ~ptr_out_of_heap bytes index new_value dbg
 
 let bytes_or_bigstring_set ~dbg kind width ~bytes ~index ~new_value =
   let expr =
     match (kind : P.bytes_like_value) with
-    | Bytes -> bytes_or_bigstring_set_aux ~dbg width ~bytes ~index ~new_value
+    | Bytes ->
+      bytes_or_bigstring_set_aux ~ptr_out_of_heap:false ~dbg width ~bytes ~index
+        ~new_value
     | Bigstring ->
       let addr = C.field_address bytes 1 dbg in
       let ba_data = C.load ~dbg Word_int Mutable ~addr in
       C.bind "ba_data" ba_data (fun bytes ->
-          bytes_or_bigstring_set_aux ~dbg width ~bytes ~index ~new_value)
+          bytes_or_bigstring_set_aux ~ptr_out_of_heap:true ~dbg width ~bytes
+            ~index ~new_value)
   in
   C.return_unit dbg expr
 


### PR DESCRIPTION
This fixes the random CI failures seen on arm64.

It turns out that the Cmm machtypes given to "pointer + offset" calculations used for all of the different varieties of string reads and writes are wrong.  Some of them have been wrong for a very long time (30 years).  They are currently given type `Int`, but in the case where the pointers may be into the OCaml heap (e.g. for `string` and `bytes` rather than `Bigstring.t`) they must have type `Addr`.  Otherwise, CSE may apply, causing pointers into the middle of values to be live across a GC.  For example in `warnings.ml`:
```ocaml
  and loop_letter_num tokens modifier i =
    if i >= String.length s then error () else
    match s.[i] with  (* first string access *)
    | '0' .. '9' ->
        let i, n1, n2 = get_range i in
        loop (Num(n1,n2,modifier)::tokens) i
    | 'A' .. 'Z' | 'a' .. 'z' ->
       loop (Letter(s.[i],Some modifier)::tokens) (i+1)  (* repeated string access after potential GC *)
    | _ -> error ()
```

This patch affects the system compiler as well as the flambda-backend compiler, hence the use of a patch file to fix the former.  I will deal with getting this fixed upstream.  The system compiler patch isn't currently as good as the flambda-backend patch since it doesn't special-case out-of-heap accesses.

There are a couple of other changes currently in here too, which can be discussed and maybe split:
- fixes to stop the system compiler applying `Comballoc` across `Ccheckbound`, which can raise an exception.  I need to discuss this with @stedolan though, maybe this is only required if the allocation is on the major heap?  (This problem does not arise with the flambda-backend compiler since bounds checks are expanded before Flambda 2.)
- fixes to silence the debug runtime with the system compiler, which I think was causing excessive CI logs in some cases.

This bug was very troublesome to track down and @xclerc must be thanked for his help with this, especially since we thought there was a second bug, which was actually caused by a mistake in my hack for tracking down the first bug!  Some of the CI changes in this PR were written by @xclerc .

Once the dust has settled I will re-enable the arm64 builds as required.