### PR TITLE
Fix incorrect sort in `type_argument`

### DIFF
--- a/testsuite/tests/typing-layouts/omitted_arguments.ml
+++ b/testsuite/tests/typing-layouts/omitted_arguments.ml
@@ -72,3 +72,17 @@ let evaluate =
 let _ =
   Printf.printf "\"real\" code (3.14): %.2f\n"
     (box_float (evaluate [|2; 3; 4|] ~size:1))
+
+(* Omitting optional arg, where let binding is needed for function. *)
+module M = struct
+  (* Putting this in a module defeats an optimization in simplif that removes an
+     intermediate let binding where the bug occurs (it reduces [let x = y in
+     ...], but only if [y] is precisely a variable, which a projection from a
+     module is not). *)
+  let to_string ?(explicit_plus = false) x =
+    if explicit_plus then "blah" else string_of_float (box_float x)
+end
+
+let pi_to_string ~value_to_string = value_to_string #3.14
+let pi = pi_to_string ~value_to_string:M.to_string
+let () = Printf.printf "Omitting optional arg (3.14): %s\n" pi

--- a/testsuite/tests/typing-layouts/omitted_arguments.reference
+++ b/testsuite/tests/typing-layouts/omitted_arguments.reference
@@ -2,3 +2,4 @@ Omitting named arg (6.29): 6.29
 Omitting named arg (6.27): 6.27
 Omitting named arg (9.42): 9.42
 "real" code (3.14): 3.14
+Omitting optional arg (3.14): 3.14

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8146,10 +8146,16 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
           (Warnings.Non_principal_labels "eliminated omittable argument");
       (* let-expand to have side effects *)
       let let_pat, let_var = var_pair ~mode:exp_mode "arg" texp.exp_type in
+      let let_pat_sort =
+        (* The sort of the let-bound variable, which here is always a function
+           (observe it is passed to [func], which builds an application of
+           it). *)
+        Jkind.Sort.value
+      in
       re { texp with exp_type = ty_fun;
              exp_desc =
                Texp_let (Nonrecursive,
-                         [{vb_pat=let_pat; vb_expr=texp; vb_sort=arg_sort;
+                         [{vb_pat=let_pat; vb_expr=texp; vb_sort=let_pat_sort;
                            vb_attributes=[]; vb_loc=Location.none;
                            vb_rec_kind = Dynamic;
                           }],


### PR DESCRIPTION
This fixes the sort of a let binding constructed in the case where `type_argument` is coercing a function with missing optional arguments to meet a type without those arguments. As a result, an flambda2 assertion failure is tripped.

The case is pretty hard to hit: I believe you have to be doing the above, the function's next argument has to be a non-value, and you also must avoid an optimization in `simplif` that removes the relevant let binding when the function being used is a variable.

I left a comment that hopefully explains what was wrong in more detail. There is also a test case.  I couldn't easily do a commit with just the failing test, because it doesn't fail on bytecode, but you can try running the new test through the compiler before this patch to witness the flambda2 failure.