### PR TITLE
Allow signed and unsigned 16-bit integers in asm directives

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2688,11 +2688,7 @@ let end_assembly () =
           let l = label_to_asm_label ~section:Data l in
           ND.label l);
       efa_8 = (fun n -> ND.uint8 (Numbers.Uint8.of_nonnegative_int_exn n));
-      efa_16 =
-        (fun n ->
-          if n > 0x7fff (* 2^15 - 1 = 32767, the max signed 16-bit int *)
-          then ND.uint16 (Numbers.Uint16.of_nonnegative_int_exn n)
-          else ND.int16 (Numbers.Int16.of_int_exn n));
+      efa_16 = (fun n -> ND.uint16 (Numbers.Uint16.of_nonnegative_int_exn n));
       efa_32 = (fun n -> ND.int32 n);
       efa_word = (fun n -> ND.targetint (Targetint.of_int_exn n));
       efa_align = (fun n -> ND.align ~fill_x86_bin_emitter:Zero ~bytes:n);

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2688,7 +2688,8 @@ let end_assembly () =
           let l = label_to_asm_label ~section:Data l in
           ND.label l);
       efa_8 = (fun n -> ND.uint8 (Numbers.Uint8.of_nonnegative_int_exn n));
-      efa_16 = (fun n -> ND.uint16 (Numbers.Uint16.of_nonnegative_int_exn n));
+      efa_i16 = (fun n -> ND.int16 (Numbers.Int16.of_int_exn n));
+      efa_u16 = (fun n -> ND.uint16 (Numbers.Uint16.of_nonnegative_int_exn n));
       efa_32 = (fun n -> ND.int32 n);
       efa_word = (fun n -> ND.targetint (Targetint.of_int_exn n));
       efa_align = (fun n -> ND.align ~fill_x86_bin_emitter:Zero ~bytes:n);

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2688,10 +2688,11 @@ let end_assembly () =
           let l = label_to_asm_label ~section:Data l in
           ND.label l);
       efa_8 = (fun n -> ND.uint8 (Numbers.Uint8.of_nonnegative_int_exn n));
-      efa_16 = (fun n ->
-        if n > 0x7fff (* 2^15 - 1 = 32767, the max signed 16-bit int *)
-        then ND.uint16 (Numbers.Uint16.of_nonnegative_int_exn n)
-        else ND.int16 (Numbers.Int16.of_int_exn n));
+      efa_16 =
+        (fun n ->
+          if n > 0x7fff (* 2^15 - 1 = 32767, the max signed 16-bit int *)
+          then ND.uint16 (Numbers.Uint16.of_nonnegative_int_exn n)
+          else ND.int16 (Numbers.Int16.of_int_exn n));
       efa_32 = (fun n -> ND.int32 n);
       efa_word = (fun n -> ND.targetint (Targetint.of_int_exn n));
       efa_align = (fun n -> ND.align ~fill_x86_bin_emitter:Zero ~bytes:n);

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2688,7 +2688,10 @@ let end_assembly () =
           let l = label_to_asm_label ~section:Data l in
           ND.label l);
       efa_8 = (fun n -> ND.uint8 (Numbers.Uint8.of_nonnegative_int_exn n));
-      efa_16 = (fun n -> ND.int16 (Numbers.Int16.of_int_exn n));
+      efa_16 = (fun n ->
+        if n > 0x7fff (* 2^15 - 1 = 32767, the max signed 16-bit int *)
+        then ND.uint16 (Numbers.Uint16.of_nonnegative_int_exn n)
+        else ND.int16 (Numbers.Int16.of_int_exn n));
       efa_32 = (fun n -> ND.int32 n);
       efa_word = (fun n -> ND.targetint (Targetint.of_int_exn n));
       efa_align = (fun n -> ND.align ~fill_x86_bin_emitter:Zero ~bytes:n);

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2220,7 +2220,8 @@ let end_assembly () =
           D.type_label ~ty:Object lbl;
           D.label lbl);
       efa_8 = (fun n -> D.uint8 (Numbers.Uint8.of_nonnegative_int_exn n));
-      efa_16 = (fun n -> D.uint16 (Numbers.Uint16.of_nonnegative_int_exn n));
+      efa_i16 = (fun n -> D.int16 (Numbers.Int16.of_int_exn n));
+      efa_u16 = (fun n -> D.uint16 (Numbers.Uint16.of_nonnegative_int_exn n));
       (* CR sspies: for some reason, we can get negative numbers here *)
       efa_32 = (fun n -> D.int32 n);
       efa_word = (fun n -> D.targetint (Targetint.of_int_exn n));

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -101,7 +101,8 @@ type emit_frame_actions =
   { efa_code_label : Label.t -> unit;
     efa_data_label : Label.t -> unit;
     efa_8 : int -> unit;
-    efa_16 : int -> unit;
+    efa_i16 : int -> unit;  (** signed 16-bit integers *)
+    efa_u16 : int -> unit;  (** unsigned 16-bit integers *)
     efa_32 : int32 -> unit;
     efa_word : int -> unit;
     efa_align : int -> unit;

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -65,6 +65,8 @@ typedef struct {
   uint16_t frame_data; /* frame size and various flags */
   uint16_t num_live;
   uint16_t live_ofs[1 /* num_live */];
+  /* CR sspies: This is no longer correct. Due to recent changes in the compiler, the
+     offsets can now also be negative. */
   /*
     If frame_has_allocs(), alloc lengths follow:
         uint8_t num_allocs;


### PR DESCRIPTION
This PR splits `efa_16` into two versions, one for signed and one for unsigned integers.