### PR TITLE
New computation for signal stack sizes

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -134,6 +134,7 @@ struct caml_thread_struct {
   char * async_exn_handler;  /* saved value of Caml_state->async_exn_handler */
   memprof_thread_t memprof;  /* memprof's internal thread data structure */
   void * signal_stack;       /* this thread's signal stack */
+  size_t signal_stack_size;  /* size of this thread's signal stack in bytes */
   int is_main;               /* whether this is the main thread of its domain */
 
 #ifndef NATIVE_CODE
@@ -782,7 +783,7 @@ static void thread_detach_from_runtime(void)
   caml_threadstatus_terminate(Terminated(th->descr));
   /* Remove signal stack */
   CAMLassert(th->signal_stack != NULL);
-  caml_free_signal_stack(th->signal_stack);
+  caml_free_signal_stack(th->signal_stack, th->signal_stack_size);
   /* The following also sets Active_thread to a sane value in case the
      backup thread does a GC before the domain lock is acquired
      again.  It also removes the thread from memprof. */
@@ -798,7 +799,7 @@ static void thread_init_current(caml_thread_t th)
 {
   st_tls_set(caml_thread_key, th);
   restore_runtime_state(th);
-  th->signal_stack = caml_init_signal_stack();
+  th->signal_stack = caml_init_signal_stack(&th->signal_stack_size);
 }
 
 /* Create a thread */

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -78,8 +78,8 @@ value caml_process_pending_actions_with_root_exn (value extra_root);
 void caml_init_signal_handling(void);
 void caml_init_signals(void);
 void caml_terminate_signals(void);
-CAMLextern void * caml_init_signal_stack(void);
-CAMLextern void caml_free_signal_stack(void *);
+CAMLextern void * caml_init_signal_stack(size_t* returned_signal_stack_size);
+CAMLextern void caml_free_signal_stack(void *, size_t signal_stack_size);
 
 /* These hooks are not modified after other threads are spawned. */
 CAMLextern void (*caml_enter_blocking_section_hook)(void);

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1241,9 +1241,11 @@ static void* domain_thread_func(void* v)
   struct domain_ml_values *ml_values = p->ml_values;
 
 #ifndef _WIN32
-  void * signal_stack = caml_init_signal_stack();
+  errno = 0;
+  size_t signal_stack_size = 0;
+  void * signal_stack = caml_init_signal_stack(&signal_stack_size);
   if (signal_stack == NULL) {
-    caml_fatal_error("Failed to create domain: signal stack");
+    caml_fatal_error("Failed to create domain: signal stack (errno %d)", errno);
   }
 #endif
 
@@ -1303,7 +1305,7 @@ static void* domain_thread_func(void* v)
     free_domain_ml_values(ml_values);
   }
 #ifndef _WIN32
-  caml_free_signal_stack(signal_stack);
+  caml_free_signal_stack(signal_stack, signal_stack_size);
 #endif
   return 0;
 }

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -37,6 +37,10 @@
 #include "caml/memprof.h"
 #include "caml/finalise.h"
 #include "caml/printexc.h"
+#ifdef __linux__
+#include <sys/auxv.h>
+#include <linux/auxvec.h>
+#endif
 
 /* The set of pending signals (received but not yet processed).
    It is represented as a bit vector.
@@ -584,12 +588,26 @@ CAMLexport int caml_rev_convert_signal_number(int signo)
   return signo;
 }
 
-void * caml_init_signal_stack(void)
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+
+void * caml_init_signal_stack(size_t* signal_stack_size)
 {
 #ifdef POSIX_SIGNALS
   stack_t stk;
   stk.ss_flags = 0;
-  stk.ss_size = SIGSTKSZ;
+
+#ifdef __linux__
+  /* On some systems, e.g. when AMX has been enabled, the dynamic value of
+     MINSIGSTKSZ might be larger than SIGSTKSZ and/or any compile-time
+     MINSIGSTKSZ.  The "4 * " scaling factor matches current glibc
+     behaviour for determining SIGSTKSZ. */
+  stk.ss_size = MAX(SIGSTKSZ, 4 * MAX(MINSIGSTKSZ, getauxval(AT_MINSIGSTKSZ)));
+#else
+  /* In this case one would hope that MINSIGSTKSZ <= SIGSTKSZ, but never
+     say never. */
+  stk.ss_size = MAX(SIGSTKSZ, MINSIGSTKSZ);
+#endif
+
   /* The memory used for the alternate signal stack must not free'd before
      calling sigaltstack with SS_DISABLE. malloc/mmap is therefore used rather
      than caml_stat_alloc_noexc so that if a shutdown path erroneously fails
@@ -602,7 +620,7 @@ void * caml_init_signal_stack(void)
   if (stk.ss_sp == MAP_FAILED)
     return NULL;
   if (sigaltstack(&stk, NULL) < 0) {
-    munmap(stk.ss_sp, SIGSTKSZ);
+    munmap(stk.ss_sp, stk.ss_size);
     return NULL;
   }
 #else
@@ -614,19 +632,21 @@ void * caml_init_signal_stack(void)
     return NULL;
   }
 #endif /* USE_MMAP_MAP_STACK */
+  *signal_stack_size = stk.ss_size;
   return stk.ss_sp;
 #else
+  *signal_stack_size = 0;
   return NULL;
 #endif /* POSIX_SIGNALS */
 }
 
-void caml_free_signal_stack(void * signal_stack)
+void caml_free_signal_stack(void * signal_stack, size_t signal_stack_size)
 {
 #ifdef POSIX_SIGNALS
   stack_t stk, disable;
   disable.ss_flags = SS_DISABLE;
   disable.ss_sp = NULL;  /* not required but avoids a valgrind false alarm */
-  disable.ss_size = SIGSTKSZ; /* macOS wants a valid size here */
+  disable.ss_size = signal_stack_size; /* macOS wants a valid size here */
   if (sigaltstack(&disable, &stk) < 0) {
     caml_fatal_error("Failed to reset signal stack (err %d)", errno);
   }
@@ -638,7 +658,7 @@ void caml_free_signal_stack(void * signal_stack)
   /* Memory was allocated with malloc/mmap directly (see
      caml_init_signal_stack) */
 #ifdef USE_MMAP_MAP_STACK
-  munmap(signal_stack, SIGSTKSZ);
+  munmap(signal_stack, signal_stack_size);
 #else
   free(signal_stack);
 #endif /* USE_MMAP_MAP_STACK */
@@ -648,15 +668,18 @@ void caml_free_signal_stack(void * signal_stack)
 #ifdef POSIX_SIGNALS
 /* This is the alternate signal stack block for domain 0 */
 static void * caml_signal_stack_0 = NULL;
+static size_t caml_signal_stack_0_size = 0;
 #endif
 
 void caml_init_signals(void)
 {
   /* Set up alternate signal stack for domain 0 */
 #ifdef POSIX_SIGNALS
-  caml_signal_stack_0 = caml_init_signal_stack();
+  errno = 0;
+  caml_signal_stack_0 = caml_init_signal_stack(&caml_signal_stack_0_size);
   if (caml_signal_stack_0 == NULL) {
-    caml_fatal_error("Failed to allocate signal stack for domain 0");
+    caml_fatal_error("Failed to allocate signal stack for domain 0 (errno %d)",
+      errno);
   }
 
   /* gprof installs a signal handler for SIGPROF.
@@ -679,7 +702,7 @@ void caml_init_signals(void)
 void caml_terminate_signals(void)
 {
 #ifdef POSIX_SIGNALS
-  caml_free_signal_stack(caml_signal_stack_0);
+  caml_free_signal_stack(caml_signal_stack_0, caml_signal_stack_0_size);
   caml_signal_stack_0 = NULL;
 #endif
 }


### PR DESCRIPTION
The existing computation for signal stack sizes can be wrong on Intel machines with AMX extensions, causing `sigaltstack` to fail.  On Linux at least it is necessary to take into account the "dynamic" minimum signal stack size returned by `getauxval` in addition to any values for e.g. `SIGSTKSZ` (which may or may not be constant) in the C library.  For example, with a C library that has a constant `SIGSTKSZ` and `MINSIGSTKSZ`, the required minimum that becomes enforced by `sigaltstack` after AMX context initialisation can actually be larger than both of these quantities. A similar problem is described here: https://bugs.python.org/issue46968

For the moment this is conditionalised for Linux only, it can be extended in the future if necessary.

This PR also adds some reporting of `errno` in case of these failures.