### PR TITLE
Add bounds checks to the frame table emission code

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2621,9 +2621,20 @@ let end_assembly () =
   emit_frames
     { efa_code_label = (fun l -> D.qword (ConstLabel (emit_label l)));
       efa_data_label = (fun l -> D.qword (ConstLabel (emit_label l)));
-      efa_8 = (fun n -> D.byte (const n));
-      efa_16 = (fun n -> D.word (const n));
-      efa_32 = (fun n -> D.long (const_32 n));
+      (* Below, we emit constants of different sizes. The x86 emitter internally
+         uses int64 to represent their value and the directives [D.byte], ...,
+         [D.qword] control which assembly directive will be used to emit them.
+         Thus, even though we cast them to integers of larger sizes here (i.e.,
+         [int64]), they do not take up more space than indicated by the
+         directive. *)
+      efa_i8 = (fun n -> D.byte (Const (Int64.of_int (Numbers.Int8.to_int n))));
+      efa_i16 =
+        (fun n -> D.word (Const (Int64.of_int (Numbers.Int16.to_int n))));
+      efa_i32 = (fun n -> D.long (Const (Int64.of_int32 n)));
+      efa_u8 = (fun n -> D.byte (Const (Int64.of_int (Numbers.Uint8.to_int n))));
+      efa_u16 =
+        (fun n -> D.word (Const (Int64.of_int (Numbers.Uint16.to_int n))));
+      efa_u32 = (fun n -> D.long (Const (Numbers.Uint32.to_int64 n)));
       efa_word = (fun n -> D.qword (const n));
       efa_align = D.align ~data:true;
       efa_label_rel =

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2219,10 +2219,12 @@ let end_assembly () =
           let lbl = label_to_asm_label ~section:Data lbl in
           D.type_label ~ty:Object lbl;
           D.label lbl);
-      efa_8 = (fun n -> D.uint8 (Numbers.Uint8.of_nonnegative_int_exn n));
-      efa_16 = (fun n -> D.uint16 (Numbers.Uint16.of_nonnegative_int_exn n));
-      (* CR sspies: for some reason, we can get negative numbers here *)
-      efa_32 = (fun n -> D.int32 n);
+      efa_i8 = (fun n -> D.int8 n);
+      efa_i16 = (fun n -> D.int16 n);
+      efa_i32 = (fun n -> D.int32 n);
+      efa_u8 = (fun n -> D.uint8 n);
+      efa_u16 = (fun n -> D.uint16 n);
+      efa_u32 = (fun n -> D.uint32 n);
       efa_word = (fun n -> D.targetint (Targetint.of_int_exn n));
       efa_align = (fun n -> D.align ~bytes:n);
       efa_label_rel =

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -100,9 +100,12 @@ val record_frame_descr :
 type emit_frame_actions =
   { efa_code_label : Label.t -> unit;
     efa_data_label : Label.t -> unit;
-    efa_8 : int -> unit;
-    efa_16 : int -> unit;
-    efa_32 : int32 -> unit;
+    efa_i8 : Numbers.Int8.t -> unit;
+    efa_i16 : Numbers.Int16.t -> unit;
+    efa_i32 : Int32.t -> unit;
+    efa_u8 : Numbers.Uint8.t -> unit;
+    efa_u16 : Numbers.Uint16.t -> unit;
+    efa_u32 : Numbers.Uint32.t -> unit;
     efa_word : int -> unit;
     efa_align : int -> unit;
     efa_label_rel : Label.t -> int32 -> unit;

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -60,7 +60,6 @@
 #define FRAME_RETURN_TO_C 0xFFFF
 #define FRAME_LONG_MARKER 0x7FFF
 
-
 typedef struct {
   int32_t retaddr_rel; /* offset of return address from &retaddr_rel */
   uint16_t frame_data; /* frame size and various flags */

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -60,6 +60,14 @@
 #define FRAME_RETURN_TO_C 0xFFFF
 #define FRAME_LONG_MARKER 0x7FFF
 
+
+/* CR sspies: The frame descriptions below are no longer accurate with respect to
+   whether the integers in the description are signed or unsigned. Due to recent compiler
+   changes, the live offsets can now be negative. To make the integer ranges explicit,
+   the frame table code in [emit_aux.ml] now contains explicit range checks. The fields
+   below, specifically, for frame_data, number of live offsets, and the live offsets
+   should now be signed.  */
+
 typedef struct {
   int32_t retaddr_rel; /* offset of return address from &retaddr_rel */
   uint16_t frame_data; /* frame size and various flags */

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -61,13 +61,6 @@
 #define FRAME_LONG_MARKER 0x7FFF
 
 
-/* CR sspies: The frame descriptions below are no longer accurate with respect to
-   whether the integers in the description are signed or unsigned. Due to recent compiler
-   changes, the live offsets can now be negative. To make the integer ranges explicit,
-   the frame table code in [emit_aux.ml] now contains explicit range checks. The fields
-   below, specifically, for frame_data, number of live offsets, and the live offsets
-   should now be signed.  */
-
 typedef struct {
   int32_t retaddr_rel; /* offset of return address from &retaddr_rel */
   uint16_t frame_data; /* frame size and various flags */

--- a/runtime4/caml/stack.h
+++ b/runtime4/caml/stack.h
@@ -86,6 +86,10 @@ struct caml_context {
 };
 
 /* Structure of frame descriptors */
+/* Warning: The live offsets of frame descriptors are declared as unsigned integers below.
+   However, on runtime 4, they can also be negative, so values above 0x7f...ff should be
+   interpreted as negative.  */
+
 typedef struct {
   int32_t retaddr_rel;
   unsigned short frame_size;


### PR DESCRIPTION
In preparation of re-enabling #3931, this PR adds bounds checks to the emission code for frame tables. Due to recent compiler changes, some integers that used to be non-negative (the live offsets in the frame table) can now be negative. The changes in this PR make it clear which ranges are expected for various constants in the frame table emission code. 

Notably, I have left `efa_word` alone for now. I believe it is a signed integer of target-platform width, but I wasn't completely sure.