### PR TITLE
(arm64+tsan) Save/Restore 128-bit registers

### DIFF
--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -620,14 +620,14 @@ FUNCTION(caml_c_call)
 #if defined(WITH_THREAD_SANITIZER)
     /* Save return value registers. Since the called function could be
        anything, it may have returned its result (if any) either in x0
-       or d0:d1. */
+       or q0:q1. */
         stp     x0, x1, [sp, -16]!
         CFI_ADJUST(16)
-        stp     d0, d1, [sp, -16]!
+        stp     q0, q1, [sp, -32]!
         CFI_ADJUST(16)
         TSAN_EXIT_FUNCTION
     /* Restore return value registers */
-        ldp     d0, d1, [sp], 16
+        ldp     q0, q1, [sp], 32
         CFI_ADJUST(-16)
         ldp     x0, x1, [sp], 16
         CFI_ADJUST(-16)


### PR DESCRIPTION
(follow-up for https://github.com/ocaml-flambda/flambda-backend/pull/3979)

The code in `arm64.S` around `TSAN_EXIT_FUNCTION` saves/restores some registers. I can't figure out how it was originally determined which registers to save/restore.  The code does not match aarch64 PCS or C abi as far as I can tell. It seems safe to update the code to save/restore `q0:q1` instead of `d0:d1`.  