### PR TITLE
Set a default for major_heap_increment

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -244,10 +244,10 @@ typedef uint64_t uintnat;
 /* Default size of the minor zone. (words)  */
 #define Minor_heap_def 1048576
 
-/* Minimum size increment when growing the heap (words).
-   Must be a multiple of [Page_size / sizeof (value)]. */
-#define Heap_chunk_min (15 * Page_size)
-
+/* Default size increment when growing the heap.
+   If this is <= 1000, it's a percentage of the current heap size.
+   If it is > 1000, it's a number of words. */
+#define Heap_chunk_def 15
 
 /* Default speed setting for the major GC.  The heap will grow until
    the dead objects and the free list represent this percentage of the

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -94,6 +94,7 @@ static void init_startup_params(void)
   params.init_custom_major_ratio = Custom_major_ratio_def;
   params.init_custom_minor_ratio = Custom_minor_ratio_def;
   params.init_custom_minor_max_bsz = Custom_minor_max_bsz_def;
+  params.init_major_heap_increment = Heap_chunk_def;
   params.init_max_stack_wsz = Max_stack_def;
   params.max_domains = Max_domains_def;
   params.runtime_events_log_wsize = Default_runtime_events_log_wsize;


### PR DESCRIPTION
We put major_heap_increment back into runtime5, but forgot to set a default value for it. This is not very bad - you'll just get a succession of 8 MiB chunks - but worth fixing.

(Also the adjacent `Heap_chunk_min` default is not used in runtime5, so I've taken it out).