### PR TITLE
Better memory mapping names

### DIFF
--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -104,6 +104,14 @@ struct stack_info {
  * .        Red Zone        .
  * |                        |
  * +------------------------+ <--- Stack_base
+ * [ if guard pages:
+ * .                        .
+ * |    caml_plat_pagesize  |      mprotect()ed
+ * .                        .
+ * +------------------------+ <--- Protected_stack_page
+ * .      (padding)         .
+ * .                        .
+ * ]
  * |   struct stack_info    |
  * +------------------------+ <--- Caml_state->current_stack
  */

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -110,6 +110,8 @@ void *caml_plat_mem_map(uintnat size, uintnat flags, const char* name);
 void *caml_plat_mem_commit(void *, uintnat, const char*);
 void caml_plat_mem_decommit(void *, uintnat, const char*);
 void caml_plat_mem_unmap(void *, uintnat);
+void caml_plat_mem_name_map(void *, size_t, const char *);
+
 
 #ifdef _WIN32
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -445,6 +445,11 @@ void* caml_mem_map(uintnat size, uintnat flags, const char* name);
 void* caml_mem_commit(void* mem, uintnat size, const char* name);
 void caml_mem_decommit(void* mem, uintnat size, const char* name);
 void caml_mem_unmap(void* mem, uintnat size);
+void caml_mem_name_map(void* mem, size_t length, const char* format, ...)
+#ifdef __GNUC__
+  __attribute__ ((format (printf, 3, 4)))
+#endif
+;
 
 
 CAMLnoret void caml_plat_fatal_error(const char * action, int err);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -58,6 +58,7 @@ extern uintnat caml_pool_min_chunk_bsz;  /* see shared_heap.c */
 extern uintnat caml_percent_sweep_per_mark; /* see major_gc.c */
 extern uintnat caml_gc_pacing_policy;       /* see major_gc.c */
 extern uintnat caml_gc_overhead_adjustment; /* see major_gc.c */
+extern uintnat caml_nohugepage_stacks;    /* see fiber.c */
 
 CAMLprim value caml_gc_quick_stat(value v)
 {
@@ -443,6 +444,7 @@ static struct gc_tweak gc_tweaks[] = {
   { "percent_sweep_per_mark", &caml_percent_sweep_per_mark, 0 },
   { "gc_pacing_policy", &caml_gc_pacing_policy, 0 },
   { "gc_overhead_adjustment", &caml_gc_overhead_adjustment, 0 },
+  { "nohugepage_stacks", &caml_nohugepage_stacks, 0 },
 };
 
 enum {N_GC_TWEAKS = sizeof(gc_tweaks)/sizeof(gc_tweaks[0])};

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -406,8 +406,8 @@ void* caml_mem_map(uintnat size, uintnat flags, const char* name)
 
   if (mem == 0) {
     CAML_GC_MESSAGE(ADDRSPACE,
-                    "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d bytes failed",
-                    size);
+                    "mmap %" ARCH_INTNAT_PRINTF_FORMAT "d bytes (%s) failed",
+                    size, name);
     return 0;
   }
 
@@ -443,6 +443,20 @@ void caml_mem_unmap(void* mem, uintnat size)
                   "munmap %" ARCH_INTNAT_PRINTF_FORMAT "d"
                   " bytes at %p\n", size, mem);
   caml_plat_mem_unmap(mem, size);
+}
+
+void caml_mem_name_map(void* mem, size_t length, const char* format, ...)
+{
+  va_list args;
+  char mapping_name[64];
+  va_start(args, format);
+  int n = vsnprintf(mapping_name, sizeof(mapping_name), format, args);
+  va_end(args);
+  CAMLassert(n > 0);
+  CAMLassert(n < sizeof(mapping_name));
+  /* if we successfully made a string, give it to the OS. */
+  if ((n > 0) && (n < sizeof(mapping_name)))
+    caml_plat_mem_name_map(mem, length, mapping_name);
 }
 
 #define Min_sleep_ns       10000 // 10 us


### PR DESCRIPTION
On Linux, we give names to our memory mappings, but these could be better. For example, every fiber stack gets a name including the kernel's TID for the original creating thread; this includes the initial fiber stack of every thread, which gets the TID of the _parent_ thread. So if one thread makes many children threads, all the stack mappings get the same name. Also, for each fiber stack, the same name is given to the stack info page mapping, the protected guard page mapping, and the main stack.
Here I've created a general-purpose `caml_mem_name_map` and used it for stack mappings, so at least those three mappings get usefully distinct names; and included the original fiber ID in the name (note that fiber stacks are cached, so these names may not be current in a core dump, but they should make it easy to find the corresponding stack info mapping and thence the runtime fiber data structures etc: we could create some GDB automation for this).
Based on #4001 because review of that led to this. My work here is just the most recent commit, which could be rebased onto main.