### PR TITLE
Skip the 80ch check on autoformatted files

### DIFF
--- a/.github/workflows/80ch.sh
+++ b/.github/workflows/80ch.sh
@@ -49,8 +49,13 @@ do
   # (a more sophisticated script would instead remove %%expect blocks)
   [[ "$changed_file" == testsuite/tests/* ]] && continue
 
+  # Don't check autoformatted files (there's a bug in `ocamlformat` that
+  # sometimes produces lines over 80 characters)
+  ocamlformat --print-config "$changed_file" 2>&1 \
+  | grep -q disable=false && continue
+
   # Bash doesn't allow for comments on multiline commands, so excuse the
-  # workaround of putting groups of argument in a variable
+  # workaround of putting a group of arguments in a variable
   f='--old-line-format= --unchanged-line-format= --new-line-format=%dn:%L'
   #  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ |^^^^^^^^^^^^^^^^^^^^^^^
   #  Don't print deleted or unchanged lines      Show added lines (%L),

--- a/.github/workflows/80ch.yml
+++ b/.github/workflows/80ch.yml
@@ -11,6 +11,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        ocaml-compiler:
+          - "4.14.0"
 
     steps:
     - name: Checkout the Flambda backend repo
@@ -19,5 +21,16 @@ jobs:
     - name: Checkout the parent branch
       run: git fetch origin HEAD --deepen 1
 
+    - name: Setup OCaml ${{ matrix.ocaml-compiler }}
+      uses: ocaml/setup-ocaml@v3
+      with:
+        ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+    - name: Install a recent version of re
+      run: opam install 're>=1.10.0'
+
+    - name: Install ocamlformat 0.24.1
+      run: opam pin -y ocamlformat 0.24.1
+
     - name: Check for new >80 character lines
-      run: bash .github/workflows/80ch.sh
+      run: opam exec -- bash .github/workflows/80ch.sh


### PR DESCRIPTION
See (https://github.com/ocaml-flambda/flambda-backend/pull/4005) for an example