### PR TITLE
Fix runtime5 on macOS x86

### DIFF
--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -588,10 +588,12 @@ CAMLexport int caml_rev_convert_signal_number(int signo)
   return signo;
 }
 
+#ifdef __linux__
 static size_t max_size_t(size_t a, size_t b)
 {
   return (a > b) ? a : b;
 }
+#endif
 
 void * caml_init_signal_stack(size_t* signal_stack_size)
 {

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -113,7 +113,11 @@ DECLARE_SIGNAL_HANDLER(segv_handler)
   char* protected_low = Protected_stack_page(block);
   char* protected_high = protected_low + caml_plat_pagesize;
   if ((fault_addr >= protected_low) && (fault_addr < protected_high)) {
+#ifdef SYS_macosx
+    context->uc_mcontext->__ss.__rip = (unsigned long long) &caml_raise_stack_overflow_nat;
+#else
     context->uc_mcontext.gregs[REG_RIP]= (greg_t) &caml_raise_stack_overflow_nat;
+#endif
   } else {
     act.sa_handler = SIG_DFL;
     act.sa_flags = 0;


### PR DESCRIPTION
I had to tweak a couple files to get runtime5 building on my 2019 Intel MacBook Pro.

In signals.c, I put `max_size_t` behind an `#ifdef __linux__` since it's only used in an `#ifdef __linux__` block below.

In signals_nat.c, I modified some code manipulating an `mcontext_t` in accordance with [runtime4/signals_osdep.h](https://github.com/ocaml-flambda/flambda-backend/blob/main/runtime4/signals_osdep.h#L181) and put it behind an `#ifdef SYS_macosx`.

With these changes, I was able to build and install the compiler with `--enable-runtime5`.

<img width="392" alt="Screenshot 2025-05-15 at 22 06 53" src="https://github.com/user-attachments/assets/8233d84a-96ad-4561-95d8-1f6b979790a6" />