### PR TITLE
Use OxCaml instead of OCaml

### DIFF
--- a/jane/doc/extensions/_01-stack-allocation/intro.md
+++ b/jane/doc/extensions/_01-stack-allocation/intro.md
@@ -9,7 +9,7 @@ title: Intro
 See also the full feature [reference](../reference) and
 [common pitfalls](../pitfalls).
 
-This page describes how OCaml sometimes allocates values on a stack,
+This page describes how OxCaml sometimes allocates values on a stack,
 as opposed to its usual behavior of allocating on the heap.
 This helps performance in a couple of ways: first, the same few hot
 cache lines are constantly reused, so the cache footprint is lower than
@@ -48,7 +48,7 @@ let foo () =
 Error: This value escapes its region
 ```
 
-Most allocations in OCaml can be stack-allocated: tuples, records, variants,
+Most allocations in OxCaml can be stack-allocated: tuples, records, variants,
 closures, boxed numbers, etc. Stack allocations are also possible from C stubs,
 although this requires code changes to use the new `caml_alloc_local` instead of
 `caml_alloc`. A few types of allocation cannot be stack-allocated, though,

--- a/jane/doc/extensions/_01-stack-allocation/reference.md
+++ b/jane/doc/extensions/_01-stack-allocation/reference.md
@@ -6,7 +6,7 @@ title: Reference
 # Stack Allocations Reference
 
 The goal of this document is to be a reasonably complete reference to stack
-allocations in OCaml. For a gentler introduction, see [the
+allocations in OxCaml. For a gentler introduction, see [the
 introduction](../intro).
 
 The stack allocations language extension allows the compiler to
@@ -44,7 +44,7 @@ let f = ref (stack_ `Foo)
 Error: This expression is not an allocation site.
 ```
 
-Most OCaml types can be stack-allocated, including records, variants,
+Most OxCaml types can be stack-allocated, including records, variants,
 polymorphic variants, closures, boxed numbers and strings. However, certain
 values cannot be stack-allocated, and will always be on the GC heap,
 including:
@@ -60,7 +60,7 @@ including:
 ### Runtime behavior
 
 At runtime, stack allocations do not take place on the function call stack, but on a
-separately-allocated stack that follows the same layout as the OCaml
+separately-allocated stack that follows the same layout as the stock OCaml
 minor heap. In particular, this enables local-returning functions
 without the need to copy returned values. See "Use `exclave_` to return a local value"
 below for more details.
@@ -720,7 +720,7 @@ value when the younger one's region ends.
 
 ## Curried functions
 
-The function type constructor in OCaml is right-associative, so that these are
+The function type constructor in stock OCaml is right-associative, so that these are
 equal types:
 
 ```ocaml
@@ -834,7 +834,7 @@ the local or global status of parts of a value, but rather tracks this
 only once per variable or expression. There is one exception to this
 rule, as follows.
 
-In OCaml, it is possible to simultaneously match on multiple values:
+In stock OCaml, it is possible to simultaneously match on multiple values:
 
 ```ocaml
 match x, y, z with
@@ -862,7 +862,7 @@ let a, b, c =
   x, y, z
 ```
 
-Again, there is no actual syntax for this in OCaml: that's a binding
+Again, there is no actual syntax for this in stock OCaml: that's a binding
 of the single value `(x, y, z)` against the single pattern `(a, b,
 c)`. Since it's usually thought of as the simultaneous binding of
 several variables, the type-checker treats it as such rather than

--- a/jane/doc/extensions/_01-stack-allocation/reference.md
+++ b/jane/doc/extensions/_01-stack-allocation/reference.md
@@ -60,7 +60,7 @@ including:
 ### Runtime behavior
 
 At runtime, stack allocations do not take place on the function call stack, but on a
-separately-allocated stack that follows the same layout as the stock OCaml
+separately-allocated stack that follows the same layout as the OCaml
 minor heap. In particular, this enables local-returning functions
 without the need to copy returned values. See "Use `exclave_` to return a local value"
 below for more details.
@@ -720,7 +720,7 @@ value when the younger one's region ends.
 
 ## Curried functions
 
-The function type constructor in stock OCaml is right-associative, so that these are
+The function type constructor in OCaml is right-associative, so that these are
 equal types:
 
 ```ocaml
@@ -834,7 +834,7 @@ the local or global status of parts of a value, but rather tracks this
 only once per variable or expression. There is one exception to this
 rule, as follows.
 
-In stock OCaml, it is possible to simultaneously match on multiple values:
+In OCaml, it is possible to simultaneously match on multiple values:
 
 ```ocaml
 match x, y, z with
@@ -862,7 +862,7 @@ let a, b, c =
   x, y, z
 ```
 
-Again, there is no actual syntax for this in stock OCaml: that's a binding
+Again, there is no actual syntax for this in OCaml: that's a binding
 of the single value `(x, y, z)` against the single pattern `(a, b,
 c)`. Since it's usually thought of as the simultaneous binding of
 several variables, the type-checker treats it as such rather than

--- a/jane/doc/extensions/_02-unboxed-types/intro.md
+++ b/jane/doc/extensions/_02-unboxed-types/intro.md
@@ -194,7 +194,7 @@ for more details.
 The unboxed product layout describes types that work like normal products (e.g.,
 tuples or records), but which are represented without a box.
 
-In OCaml, a tuple is a pointer to a block containing the elements of the tuple. If
+In stock OCaml, a tuple is a pointer to a block containing the elements of the tuple. If
 you pass a tuple to a function, it is passed by reference in one register. The
 function can access the tuple's elements through the pointer. Records and
 their fields are treated similarly. By contrast, an

--- a/jane/doc/extensions/_04-modes/reference.md
+++ b/jane/doc/extensions/_04-modes/reference.md
@@ -5,7 +5,7 @@ title: Reference
 ---
 
 The goal of this document is to be a reasonably complete reference to the mode system in
-OCaml.
+OxCaml.
 
 <!-- CR zqian: For a gentler introduction, see [the introduction](../intro). -->
 

--- a/jane/doc/extensions/_05-kinds/non-modal.md
+++ b/jane/doc/extensions/_05-kinds/non-modal.md
@@ -17,7 +17,7 @@ The axis has three possible values, with `external_ < external64 < internal`.
 * `external_` means that all values of the type are safely ignored by the
   GC.
 * `external64` means that all values of the type are safely ignored by the GC
-  _on 64-bit systems_. The only 32-bit target currently supported by the OCaml
+  _on 64-bit systems_. The only 32-bit target currently supported by the OxCaml
   compiler is bytecode. Note that, although JavaScript and WASM are 32-bit
   platforms and the compiler goes through bytecode to reach them, they still
   count as 64-bit systems for the purpose of this axis because of their unique

--- a/jane/doc/extensions/_05-kinds/syntax.md
+++ b/jane/doc/extensions/_05-kinds/syntax.md
@@ -313,7 +313,7 @@ about its implementation.)
 
 ## Kind annotations on variables
 
-Type variables come in two flavors in OxCaml: rigid and unifiable. Rigid type
+Type variables come in two flavors in OCaml: rigid and unifiable. Rigid type
 variables are explicitly bound before a `.`, as in `let f : 'a 'b. ... = ...` or
 `val f : 'a 'b. ...` or `type t = { f : 'a 'b. ... }`. All other type variables
 are unifiable, including those in type declarations.

--- a/jane/doc/extensions/_05-kinds/syntax.md
+++ b/jane/doc/extensions/_05-kinds/syntax.md
@@ -313,7 +313,7 @@ about its implementation.)
 
 ## Kind annotations on variables
 
-Type variables come in two flavors in OCaml: rigid and unifiable. Rigid type
+Type variables come in two flavors in OxCaml: rigid and unifiable. Rigid type
 variables are explicitly bound before a `.`, as in `let f : 'a 'b. ... = ...` or
 `val f : 'a 'b. ...` or `type t = { f : 'a 'b. ... }`. All other type variables
 are unifiable, including those in type declarations.

--- a/jane/doc/extensions/_08-miscellaneous-extensions/polymorphic-parameters.md
+++ b/jane/doc/extensions/_08-miscellaneous-extensions/polymorphic-parameters.md
@@ -76,7 +76,7 @@ let r = create forty_two
 ## Limitations
 
 All polymorphic parameter require an annotation. Without an annotation
-OCaml will assume that the parameter is monomorphic.
+OxCaml will assume that the parameter is monomorphic.
 
 Rather than annotating `f` directly, you can also annotate `create` as
 a whole:


### PR DESCRIPTION
When relevant, according to my understanding. And I may have missed
some
