### PR TITLE
Add [Thread.use_domains] to force us into the domains locking mode

### DIFF
--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -101,3 +101,5 @@ let wait_pid p = Unix.waitpid [] p
 external sigmask : Unix.sigprocmask_command -> int list -> int list @@ portable
    = "caml_thread_sigmask"
 external wait_signal : int list -> int @@ portable = "caml_wait_signal"
+
+external use_domains : unit -> unit @@ portable = "caml_thread_use_domains"

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -193,3 +193,9 @@ val set_uncaught_exception_handler : (exn -> unit) @ portable -> unit
 
     If the newly set uncaught exception handler raise an exception,
     {!default_uncaught_exception_handler} will be called. *)
+
+val use_domains : unit -> unit
+(** [Thread.use_domains ()] sets the internal locking system to the one
+    used by domains. This ensures that domains can be started from threads
+    other than the initial one. It prevents the use of a custom locking
+    scheme, such as the one used by pyocaml. *)

--- a/testsuite/tests/lib-domain/spawn_outside_main_thread.ml
+++ b/testsuite/tests/lib-domain/spawn_outside_main_thread.ml
@@ -1,0 +1,11 @@
+(* TEST
+   include systhreads;
+   hassysthreads;
+   runtime5;
+   { bytecode; }
+   { native; }
+*)
+
+let () =
+  Thread.join (Thread.create (fun () ->
+      Domain.join ((Domain.Safe.spawn [@alert "-unsafe_parallelism"]) (fun () -> ()))) ())

--- a/testsuite/tests/lib-domain/spawn_outside_main_thread.reference
+++ b/testsuite/tests/lib-domain/spawn_outside_main_thread.reference
@@ -1,0 +1,1 @@
+Thread 1 killed on uncaught exception Failure("Domain.spawn: first use must be from the main thread.")

--- a/testsuite/tests/lib-domain/use_domains.ml
+++ b/testsuite/tests/lib-domain/use_domains.ml
@@ -1,0 +1,13 @@
+(* TEST
+   include systhreads;
+   hassysthreads;
+   runtime5;
+   { bytecode; }
+   { native; }
+*)
+
+let () = Thread.use_domains ()
+
+let () =
+  Thread.join (Thread.create (fun () ->
+      Domain.join ((Domain.Safe.spawn [@alert "-unsafe_parallelism"]) (fun () -> ()))) ())

--- a/testsuite/tests/lib-domain/use_domains_outside_main_thread.ml
+++ b/testsuite/tests/lib-domain/use_domains_outside_main_thread.ml
@@ -1,0 +1,10 @@
+(* TEST
+   include systhreads;
+   hassysthreads;
+   runtime5;
+   { bytecode; }
+   { native; }
+*)
+
+let () =
+  Thread.join (Thread.create (fun () -> Thread.use_domains ()) ())

--- a/testsuite/tests/lib-domain/use_domains_outside_main_thread.reference
+++ b/testsuite/tests/lib-domain/use_domains_outside_main_thread.reference
@@ -1,0 +1,1 @@
+Thread 1 killed on uncaught exception Failure("Domain.use_domains: first use must be from the main thread.")


### PR DESCRIPTION
Currently, you cannot start your first domain from a thread other than the main one. Working around this restriction requires starting a dummy domain on the many thread first. However, this can be harder than it seems because you also can't fork once you've started any domains.

This PR adds a function that avoids this restriction: as long as you call [Thread.use_domains] on the main thread first, you are allowed to start your first domain from any thread you like.

This restriction will go away once we fix the locking scheme. At that point this function should be removed.