### PR TITLE
Document the separability axis

### DIFF
--- a/jane/doc/extensions/_05-kinds/non-modal.md
+++ b/jane/doc/extensions/_05-kinds/non-modal.md
@@ -40,7 +40,7 @@ be `non_null` if none of its values are `NULL`.
 
 The kind of values with `NULL` added as a possibility is written
 `value_or_null`. The more common `value` kind is an abbreviation for
-`value_or_null mod non_null`.
+`value_or_null mod non_null separable`.
 
 Types that don't have `NULL` as a possible value are
 compatible with `or_null`, a non-allocating option type that is built into
@@ -53,4 +53,12 @@ type ('a : value) or_null : value_or_null =
 
 ## Separability
 
-CR reisenberg: TODO
+The separability axis records whether a type can have float or non-float elements.
+This axis has three possible values, with `non_float < separable < non_separable`.
+A float OCaml value is a pointer to a block with the `Double_tag`. A type is `non_float`
+if none of its elements are floats, while a type is `separable` if either all or none
+of its elements are floats. Separability is used to track types for which it is safe
+to apply the float array optimization.
+
+`value_or_null` is considered `non_separable`, since `float or_null` has both float
+and non-float elements. However, all types in vanilla OCaml are `separable`.

--- a/jane/doc/extensions/_05-kinds/non-modal.md
+++ b/jane/doc/extensions/_05-kinds/non-modal.md
@@ -53,9 +53,8 @@ type ('a : value) or_null : value_or_null =
 
 ## Separability
 
-The separability axis records whether a type can have float or non-float elements.
+The separability axis records whether a type can have float value or non-float value elements, where a float OCaml value is a pointer to an allocated block with the `Double_tag`.
 This axis has three possible values, with `non_float < separable < non_separable`.
-A float OCaml value is a pointer to a block with the `Double_tag`. A type is `non_float`
 if none of its elements are floats, while a type is `separable` if either all or none
 of its elements are floats. Separability is used to track types for which it is safe
 to apply the float array optimization.

--- a/jane/doc/extensions/_05-kinds/non-modal.md
+++ b/jane/doc/extensions/_05-kinds/non-modal.md
@@ -54,9 +54,7 @@ type ('a : value) or_null : value_or_null =
 ## Separability
 
 The separability axis records whether a type can have float or non-float values, where a float value is a pointer to an allocated block tagged with `Double_tag` (which is what `float` values look like).
-This axis has three possible values, with `non_float < separable < non_separable`.
-if none of its elements are floats, while a type is `separable` if either all or none
-of its elements are floats. Separability is used to track types for which it is safe
+This axis has three possible values, with `non_float < separable < non_separable`. A type is `non_float` if none of its elements are floats, and a type is `separable` if either all or none of its elements are floats. Separability is used to track types for which it is safe
 to apply the float array optimization.
 
 `value_or_null` is considered `non_separable`, since `float or_null` has both float

--- a/jane/doc/extensions/_05-kinds/non-modal.md
+++ b/jane/doc/extensions/_05-kinds/non-modal.md
@@ -53,7 +53,7 @@ type ('a : value) or_null : value_or_null =
 
 ## Separability
 
-The separability axis records whether a type can have float value or non-float value elements, where a float OCaml value is a pointer to an allocated block with the `Double_tag`.
+The separability axis records whether a type can have float or non-float values, where a float value is a pointer to an allocated block tagged with `Double_tag` (which is what `float` values look like).
 This axis has three possible values, with `non_float < separable < non_separable`.
 if none of its elements are floats, while a type is `separable` if either all or none
 of its elements are floats. Separability is used to track types for which it is safe

--- a/jane/doc/extensions/_05-kinds/syntax.md
+++ b/jane/doc/extensions/_05-kinds/syntax.md
@@ -177,7 +177,7 @@ The abbreviations defined in the language are as follows:
 * `sync_data = value mod many contended portable unyielding stateless non_float`
 
    This is a suitable kind of plain old data that can only be mutated
-   thread-safely, similar to the `Sync` trait in Rust.
+   safely in parallel, similar to the `Sync` trait in Rust.
 
 * `mutable_data = value mod many portable unyielding stateless non_float`
 

--- a/jane/doc/extensions/_05-kinds/syntax.md
+++ b/jane/doc/extensions/_05-kinds/syntax.md
@@ -177,7 +177,7 @@ The abbreviations defined in the language are as follows:
 * `sync_data = value mod many contended portable unyielding stateless non_float`
 
    This is a suitable kind of plain old data that can only be mutated
-   synchronously, similar to the `Sync` trait in Rust.
+   thread-safely, similar to the `Sync` trait in Rust.
 
 * `mutable_data = value mod many portable unyielding stateless non_float`
 

--- a/jane/doc/extensions/_05-kinds/syntax.md
+++ b/jane/doc/extensions/_05-kinds/syntax.md
@@ -176,7 +176,7 @@ The abbreviations defined in the language are as follows:
 
 * `sync_data = value mod many contended portable unyielding stateless non_float`
 
-   This is a suitable kind of plain old data that can only be mutated
+   This is a suitable kind of plain old data that the type system guarantees can be mutated only
    safely in parallel, similar to the `Sync` trait in Rust.
 
 * `mutable_data = value mod many portable unyielding stateless non_float`

--- a/jane/doc/extensions/_05-kinds/syntax.md
+++ b/jane/doc/extensions/_05-kinds/syntax.md
@@ -98,7 +98,7 @@ We thus give the non-primitive `value` the shorter name.
 
 Beyond just kind abbreviations, we also have one bounds abbreviation:
 `everything`. `everything` describes a maximal amount of crossing on
-*deep* axes: modal axes and externality. `nullability` and `separability`, due to
+*deep* axes: modal axes and externality. The `nullability` and `separability` bounds, due to
 their shallowness, are considered separately.
 
 The abbreviations defined in the language are as follows:

--- a/jane/doc/extensions/_05-kinds/types.md
+++ b/jane/doc/extensions/_05-kinds/types.md
@@ -108,10 +108,10 @@ treatment like that for existentials in variant type declarations.)
 be able to improve this, analyzing `S` for mode-crossing opportunities.)
 
 * The type `'a array` has kind `mutable_data with 'a`. The kind of `'a` must
-be a subkind of `any mod non_null`.
+be a subkind of `any mod non_null separable`.
 
 * The type `'a iarray` has kind `immutable_data with 'a`. The kind of `'a` must
-be a subkind of `any mod non_null`.
+be a subkind of `any mod non_null separable`.
 
 * The type `'a lazy_t` has kind `value mod non_float`. The kind of `'a` must be
 a subkind of `value`.


### PR DESCRIPTION
Title.

Note that: 

`mod everything` excludes nullability and separability by design.

`immediate_or_null` is `non_separable` for technical reasons (it is the kind of `or_null`, and with-bounds do not affect separability).