### PR TITLE
Use [@opaque] in flambda-backend tests instead of [@inline never][@local never]

### DIFF
--- a/flambda-backend/tests/backend/vectorizer/test1.ml
+++ b/flambda-backend/tests/backend/vectorizer/test1.ml
@@ -7,8 +7,7 @@ type t2 =
     d1 : int
   }
 
-let[@inline never] [@local never] add_pairs_immutable_record (a : t2) (b : t2) :
-    t2 =
+let[@opaque] add_pairs_immutable_record (a : t2) (b : t2) : t2 =
   { d0 = a.d0 + b.d0; d1 = a.d1 + b.d1 }
 
 type t4 =
@@ -18,31 +17,27 @@ type t4 =
     d3 : int
   }
 
-let[@inline never] [@local never] add_fours_immutable_record (a : t4) (b : t4) :
-    t4 =
+let[@opaque] add_fours_immutable_record (a : t4) (b : t4) : t4 =
   { d0 = a.d0 + b.d0; d1 = a.d1 + b.d1; d2 = a.d2 + b.d2; d3 = a.d3 + b.d3 }
 
 (* Tuples *)
 
-let[@inline never] [@local never] add_int_tuples ((a0, a1) : int * int)
-    ((b0, b1) : int * int) =
+let[@opaque] add_int_tuples ((a0, a1) : int * int) ((b0, b1) : int * int) =
   a0 + b0, a1 + b1
 
-let[@inline never] [@local never] add_t2_to_t4 (a : t2) (b : t2) : t4 =
+let[@opaque] add_t2_to_t4 (a : t2) (b : t2) : t4 =
   { d0 = a.d0 + b.d0; d1 = a.d1 + b.d1; d2 = a.d0 + b.d0; d3 = a.d1 + b.d1 }
 
 (* CR gyorsh: can't vectorize, requires a shuffle because the order of the first
    vector access is not the same as the second. *)
-let[@inline never] [@local never] add_t2_to_t4_reordered (a : t2) (b : t2) : t4
-    =
+let[@opaque] add_t2_to_t4_reordered (a : t2) (b : t2) : t4 =
   { d0 = a.d0 + b.d0; d1 = a.d1 + b.d1; d3 = a.d0 + b.d0; d2 = a.d1 + b.d1 }
 
-let[@inline never] [@local never] copy_t2_to_t4_immutable_record (a : t2) : t4 =
+let[@opaque] copy_t2_to_t4_immutable_record (a : t2) : t4 =
   { d0 = a.d0; d1 = a.d1; d2 = a.d0; d3 = a.d1 }
 
 (* CR gyorsh: can't vectorize same load. *)
-let[@inline never] [@local never] same_value_in_both_fields_immutable_record
-    (a : t2) : t2 =
+let[@opaque] same_value_in_both_fields_immutable_record (a : t2) : t2 =
   let x = a.d0 in
   let y = a.d1 in
   let z = x + y in
@@ -53,15 +48,13 @@ type s2 =
     mutable f1 : int
   }
 
-let[@inline never] [@local never] copy_pairs_mutable_record (a : s2) (b : s2) :
-    unit =
+let[@opaque] copy_pairs_mutable_record (a : s2) (b : s2) : unit =
   b.f0 <- a.f0;
   b.f1 <- a.f1;
   ()
 
 (* CR gyorsh: dependency outside computation should only look at reg not mem *)
-let[@inline never] [@local never] copy_pairs_mutable_record_return (a : s2)
-    (b : s2) : s2 =
+let[@opaque] copy_pairs_mutable_record_return (a : s2) (b : s2) : s2 =
   b.f0 <- a.f0;
   b.f1 <- a.f1;
   b
@@ -73,16 +66,14 @@ type s4 =
     mutable f3 : int
   }
 
-let[@inline never] [@local never] copy_fours_mutable_record (a : s4) (b : s4) :
-    unit =
+let[@opaque] copy_fours_mutable_record (a : s4) (b : s4) : unit =
   a.f0 <- b.f0;
   a.f1 <- b.f1;
   a.f2 <- b.f2;
   a.f3 <- b.f3;
   ()
 
-let[@inline never] [@local never] add_fours_mutable_record (a : s4) (b : s4) :
-    unit =
+let[@opaque] add_fours_mutable_record (a : s4) (b : s4) : unit =
   a.f0 <- b.f0 + a.f0;
   a.f1 <- b.f1 + a.f1;
   a.f2 <- b.f2 + a.f2;

--- a/flambda-backend/tests/backend/vectorizer/test_float.ml
+++ b/flambda-backend/tests/backend/vectorizer/test_float.ml
@@ -5,24 +5,22 @@ type t1 =
     mutable d1 : float
   }
 
-let[@inline never] [@local never] [@specialize never] add_mutable_record
-    (a : t1) (b : t1) (c : t1) : t1 =
+let[@opaque] [@specialize never] add_mutable_record (a : t1) (b : t1) (c : t1) :
+    t1 =
   c.d0 <- Float.add a.d0 b.d0;
   c.d1 <- Float.add a.d1 b.d1;
   c
 
-let[@inline never] [@local never] [@specialize never] copy_mutable_record
-    (a : t1) (b : t1) : t1 =
+let[@opaque] [@specialize never] copy_mutable_record (a : t1) (b : t1) : t1 =
   b.d0 <- a.d0;
   b.d1 <- a.d1;
   b
 
-let[@inline never] [@local never] [@specialize never] add_mutable_record_fresh
-    (a : t1) (b : t1) : t1 =
+let[@opaque] [@specialize never] add_mutable_record_fresh (a : t1) (b : t1) : t1
+    =
   { d0 = Float.add a.d0 b.d0; d1 = Float.add a.d1 b.d1 }
 
-let[@inline never] [@local never] [@specialize never] copy_mutable_record_fresh
-    (a : t1) : t1 =
+let[@opaque] [@specialize never] copy_mutable_record_fresh (a : t1) : t1 =
   { d0 = a.d0; d1 = a.d1 }
 
 type t4 =
@@ -32,20 +30,18 @@ type t4 =
     mutable d3 : float
   }
 
-let[@inline never] [@local never] [@specialize never] add_mutable_record_t4
-    (a : t1) (b : t1) (c : t4) : t4 =
+let[@opaque] [@specialize never] add_mutable_record_t4 (a : t1) (b : t1)
+    (c : t4) : t4 =
   c.d0 <- Float.add a.d0 b.d0;
   c.d1 <- Float.add a.d1 b.d1;
   c.d2 <- Float.add a.d0 b.d0;
   c.d3 <- Float.add a.d1 b.d1;
   c
 
-let[@inline never] [@local never] [@specialize never] copy_mutable_record_t4
-    (a : t1) (b : t1) : t4 =
+let[@opaque] [@specialize never] copy_mutable_record_t4 (a : t1) (b : t1) : t4 =
   { d0 = a.d0; d1 = a.d1; d2 = b.d0; d3 = b.d1 }
 
-let[@inline never] [@local never] [@specialize never] dup_mutable_record_t4
-    (a : t1) : t4 =
+let[@opaque] [@specialize never] dup_mutable_record_t4 (a : t1) : t4 =
   { d0 = a.d0; d1 = a.d1; d2 = a.d0; d3 = a.d1 }
 
 let print_t1 ppf (t1 : t1) =

--- a/flambda-backend/tests/backend/vectorizer/test_float_unboxed.ml
+++ b/flambda-backend/tests/backend/vectorizer/test_float_unboxed.ml
@@ -24,7 +24,8 @@ let[@opaque][@specialize never] copy_mutable_record (a : t1) (b: t1) : unit =
 
 (* Currently, can't vectorize because of the specific floatmem operation (looks like
    it is treated overly conservatively. *)
-let[@opaque][@specialize never] add_mutable_record (a : t1) (b: t1) (c : t1) : t1 =
+let[@opaque][@specialize never] add_mutable_record (a : t1) (b: t1) (c : t1) :
+    t1 =
   c.d0 <- Float_u.add a.d0 b.d0;
   c.d1 <- Float_u.add a.d1 b.d1;
   c.d2 <- Float_u.add a.d2 b.d2;

--- a/flambda-backend/tests/backend/vectorizer/test_float_unboxed.ml
+++ b/flambda-backend/tests/backend/vectorizer/test_float_unboxed.ml
@@ -17,14 +17,14 @@ type t1 = { mutable d0: float#;
           }
 
 
-let[@inline never] [@local never][@specialize never] copy_mutable_record (a : t1) (b: t1) : unit =
+let[@opaque][@specialize never] copy_mutable_record (a : t1) (b: t1) : unit =
   b.d0 <- a.d0;
   b.d1 <- a.d1;
   ()
 
 (* Currently, can't vectorize because of the specific floatmem operation (looks like
    it is treated overly conservatively. *)
-let[@inline never] [@local never][@specialize never] add_mutable_record (a : t1) (b: t1) (c : t1) : t1 =
+let[@opaque][@specialize never] add_mutable_record (a : t1) (b: t1) (c : t1) : t1 =
   c.d0 <- Float_u.add a.d0 b.d0;
   c.d1 <- Float_u.add a.d1 b.d1;
   c.d2 <- Float_u.add a.d2 b.d2;

--- a/flambda-backend/tests/backend/vectorizer/test_int64.ml
+++ b/flambda-backend/tests/backend/vectorizer/test_int64.ml
@@ -6,26 +6,24 @@ type t1 =
   }
 
 (* Can't vectorize because int64 are boxed. *)
-let[@inline never] [@local never] [@specialize never] add_mutable_record
-    (a : t1) (b : t1) (c : t1) : t1 =
+let[@opaque] [@specialize never] add_mutable_record (a : t1) (b : t1) (c : t1) :
+    t1 =
   c.d0 <- Int64.add a.d0 b.d0;
   c.d1 <- Int64.add a.d1 b.d1;
   c
 
 (* Can't vectorize because memory write requires [caml_modify]. *)
-let[@inline never] [@local never] [@specialize never] copy_mutable_record
-    (a : t1) (b : t1) : t1 =
+let[@opaque] [@specialize never] copy_mutable_record (a : t1) (b : t1) : t1 =
   b.d0 <- a.d0;
   b.d1 <- a.d1;
   b
 
 (* Can't vectorize because int64 are boxed *)
-let[@inline never] [@local never] [@specialize never] add_mutable_record_fresh
-    (a : t1) (b : t1) : t1 =
+let[@opaque] [@specialize never] add_mutable_record_fresh (a : t1) (b : t1) : t1
+    =
   { d0 = Int64.add a.d0 b.d0; d1 = Int64.add a.d1 b.d1 }
 
-let[@inline never] [@local never] [@specialize never] copy_mutable_record_fresh
-    (a : t1) : t1 =
+let[@opaque] [@specialize never] copy_mutable_record_fresh (a : t1) : t1 =
   { d0 = a.d0; d1 = a.d1 }
 
 type t4 =
@@ -36,20 +34,18 @@ type t4 =
   }
 
 (* Can't vectorize because int64 are boxed. *)
-let[@inline never] [@local never] [@specialize never] add_mutable_record_t4
-    (a : t1) (b : t1) (c : t4) : t4 =
+let[@opaque] [@specialize never] add_mutable_record_t4 (a : t1) (b : t1)
+    (c : t4) : t4 =
   c.d0 <- Int64.add a.d0 b.d0;
   c.d1 <- Int64.add a.d1 b.d1;
   c.d2 <- Int64.add a.d0 b.d0;
   c.d3 <- Int64.add a.d1 b.d1;
   c
 
-let[@inline never] [@local never] [@specialize never] copy_mutable_record_t4
-    (a : t1) (b : t1) : t4 =
+let[@opaque] [@specialize never] copy_mutable_record_t4 (a : t1) (b : t1) : t4 =
   { d0 = a.d0; d1 = a.d1; d2 = b.d0; d3 = b.d1 }
 
-let[@inline never] [@local never] [@specialize never] dup_mutable_record_t4
-    (a : t1) : t4 =
+let[@opaque] [@specialize never] dup_mutable_record_t4 (a : t1) : t4 =
   { d0 = a.d0; d1 = a.d1; d2 = a.d0; d3 = a.d1 }
 
 let print_t1 ppf (t1 : t1) =

--- a/flambda-backend/tests/backend/vectorizer/test_int64_unboxed.ml
+++ b/flambda-backend/tests/backend/vectorizer/test_int64_unboxed.ml
@@ -12,12 +12,12 @@ end
 
 type t1 = { mutable d0 : int64# ; mutable d1: int64# }
 
-let[@inline never] [@local never][@specialize never] add_mutable_record (a : t1) (b: t1) (c : t1) : t1 =
+let[@opaque][@specialize never] add_mutable_record (a : t1) (b: t1) (c : t1) : t1 =
   c.d0 <- Int64_u.add a.d0 b.d0;
   c.d1 <- Int64_u.add a.d1 b.d1;
   c
 
-let[@inline never] [@local never][@specialize never] copy_mutable_record (a : t1) (b: t1) : unit =
+let[@opaque][@specialize never] copy_mutable_record (a : t1) (b: t1) : unit =
   b.d0 <- a.d0;
   b.d1 <- a.d1;
   ()
@@ -28,7 +28,7 @@ type t2 = {
   mutable d2: int64# ;
   mutable d3: int64# }
 
-let[@inline never] [@local never][@specialize never] add_fours_mutable_record (a : t1) (b: t1) (c : t2) : unit =
+let[@opaque][@specialize never] add_fours_mutable_record (a : t1) (b: t1) (c : t2) : unit =
   c.d0 <- Int64_u.add a.d0 b.d0;
   c.d1 <- Int64_u.add a.d1 b.d1;
   c.d2 <- Int64_u.add a.d0 b.d0;

--- a/flambda-backend/tests/backend/vectorizer/test_int64_unboxed.ml
+++ b/flambda-backend/tests/backend/vectorizer/test_int64_unboxed.ml
@@ -12,7 +12,8 @@ end
 
 type t1 = { mutable d0 : int64# ; mutable d1: int64# }
 
-let[@opaque][@specialize never] add_mutable_record (a : t1) (b: t1) (c : t1) : t1 =
+let[@opaque][@specialize never] add_mutable_record (a : t1) (b: t1) (c : t1) 
+     t1 =
   c.d0 <- Int64_u.add a.d0 b.d0;
   c.d1 <- Int64_u.add a.d1 b.d1;
   c
@@ -28,7 +29,8 @@ type t2 = {
   mutable d2: int64# ;
   mutable d3: int64# }
 
-let[@opaque][@specialize never] add_fours_mutable_record (a : t1) (b: t1) (c : t2) : unit =
+let[@opaque][@specialize never] add_fours_mutable_record (a : t1) (b: t1)
+    (c : t2) : unit =
   c.d0 <- Int64_u.add a.d0 b.d0;
   c.d1 <- Int64_u.add a.d1 b.d1;
   c.d2 <- Int64_u.add a.d0 b.d0;

--- a/flambda-backend/tests/backend/vectorizer/test_int64_unboxed.ml
+++ b/flambda-backend/tests/backend/vectorizer/test_int64_unboxed.ml
@@ -12,7 +12,7 @@ end
 
 type t1 = { mutable d0 : int64# ; mutable d1: int64# }
 
-let[@opaque][@specialize never] add_mutable_record (a : t1) (b: t1) (c : t1) 
+let[@opaque][@specialize never] add_mutable_record (a : t1) (b: t1) (c : t1) :
      t1 =
   c.d0 <- Int64_u.add a.d0 b.d0;
   c.d1 <- Int64_u.add a.d1 b.d1;

--- a/flambda-backend/tests/backend/vectorizer/test_spill_valx2.ml
+++ b/flambda-backend/tests/backend/vectorizer/test_spill_valx2.ml
@@ -48,7 +48,7 @@ type s =
 
 let ( + ) = Int64.add
 
-let[@inline never] [@local never] foo a =
+let[@opaque] foo a =
   let f0 = a.f0 in
   let f1 = a.f1 in
   let f2 = a.f2 in

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_inference.ml
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_inference.ml
@@ -22,7 +22,9 @@ let[@zero_alloc] f_call_var x = M_alloc_var.f_alloc2 x
    Here we show that if we give it a signature that passes the typechecker (the
    mli has [val[@zero_alloc (arity 1)] f_arity_one : int -> int -> int]), it
    correctly gets checked and gives a zero_alloc backend error. *)
-let f_arity_one x y = x + y
+let f_arity_one x =
+  let () = () in
+  fun y -> x + y
 
 (* Shadowing: the mli marks [f_shadow] zero_alloc. That check should only apply
    to the last such function in the file, so we get no error even though there
@@ -99,7 +101,7 @@ module type S = functor () -> sig
 end
 
 module F () = struct
-  let f x = Some x
+  let[@opaque] f x = Some x
 end
 
 module _ : S = F

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_inference.opt.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_inference.opt.output
@@ -1,14 +1,71 @@
-File "test_inference.ml", line 1:
-Error: The implementation test_inference.ml
-       does not match the interface test_inference.cmi: 
-       Values do not match:
-         val f_arity_one : int -> int -> int
-       is not included in
-         val f_arity_one : int -> int -> int [@@zero_alloc arity 1]
-       zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the syntactic arity of
-       the implementation must match the function type in the interface.
-       Here the former is 2 and the latter is 1.
-       File "test_inference.mli", line 11, characters 0-58:
-         Expected declaration
-       File "test_inference.ml", line 25, characters 4-15: Actual declaration
+File "test_inference.ml", line 6, characters 27-35:
+Error: Annotation check for zero_alloc failed on function Test_inference.f_alloc (camlTest_inference.f_alloc_HIDE_STAMP).
+
+File "test_inference.ml", line 6, characters 31-35:
+Error: allocation of 24 bytes
+
+File "test_inference.ml", line 15, characters 30-38:
+Error: Annotation check for zero_alloc failed on function Test_inference.M_alloc_var.f_alloc2 (camlTest_inference.f_alloc2_HIDE_STAMP).
+
+File "test_inference.ml", line 15, characters 34-38:
+Error: allocation of 24 bytes
+
+File "test_inference.ml", lines 25-27, characters 16-16:
+Error: Annotation check for zero_alloc failed on function Test_inference.f_arity_one (camlTest_inference.f_arity_one_HIDE_STAMP).
+
+File "test_inference.ml", line 27, characters 2-16:
+Error: allocation of 32 bytes for closure
+
+File "test_inference.ml", line 40, characters 19-27:
+Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc (camlTest_inference.f_shadow_alloc_HIDE_STAMP).
+
+File "test_inference.ml", line 40, characters 23-27:
+Error: allocation of 24 bytes
+
+File "test_inference.ml", line 46, characters 24-36:
+Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc_both (camlTest_inference.f_shadow_alloc_both_HIDE_STAMP).
+
+File "test_inference.ml", line 46, characters 28-36:
+Error: allocation of 24 bytes
+
+File "test_inference.ml", line 61, characters 17-25:
+Error: Annotation check for zero_alloc failed on function Test_inference.f_basic_fail (camlTest_inference.f_basic_fail_HIDE_STAMP).
+
+File "test_inference.ml", line 61, characters 21-25:
+Error: allocation of 24 bytes
+
+File "test_inference.ml", lines 66-71, characters 18-15:
+Error: Annotation check for zero_alloc strict failed on function Test_inference.f_strict_fail (camlTest_inference.f_strict_fail_HIDE_STAMP).
+
+File "test_inference.ml", line 70, characters 12-35:
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP) (test_inference.ml:70,12--35;printf.ml:48,18--43;printf.ml:46,2--31)
+
+File "test_inference.ml", line 70, characters 12-35:
+Error: called function may allocate on a path to exceptional return (indirect call)
+
+File "test_inference.ml", line 71, characters 10-15:
+Error: allocation of 24 bytes on a path to exceptional return
+
+File "test_inference.ml", line 82, characters 15-23:
+Error: Annotation check for zero_alloc failed on function Test_inference.f_opt_fail (camlTest_inference.f_opt_fail_HIDE_STAMP).
+
+File "test_inference.ml", line 82, characters 19-23:
+Error: allocation of 24 bytes
+
+File "test_inference.ml", lines 88-93, characters 22-15:
+Error: Annotation check for zero_alloc strict failed on function Test_inference.f_strict_opt_fail (camlTest_inference.f_strict_opt_fail_HIDE_STAMP).
+
+File "test_inference.ml", line 92, characters 12-35:
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP) (test_inference.ml:92,12--35;printf.ml:48,18--43;printf.ml:46,2--31)
+
+File "test_inference.ml", line 92, characters 12-35:
+Error: called function may allocate on a path to exceptional return (indirect call)
+
+File "test_inference.ml", line 93, characters 10-15:
+Error: allocation of 24 bytes on a path to exceptional return
+
+File "test_inference.ml", line 104, characters 17-27:
+Error: Annotation check for zero_alloc failed on function Test_inference.F.f (camlTest_inference.f_HIDE_STAMP).
+
+File "test_inference.ml", line 104, characters 21-27:
+Error: allocation of 16 bytes

--- a/flambda-backend/tests/backend/zero_alloc_checker/test_inference.output
+++ b/flambda-backend/tests/backend/zero_alloc_checker/test_inference.output
@@ -1,14 +1,53 @@
-File "test_inference.ml", line 1:
-Error: The implementation test_inference.ml
-       does not match the interface test_inference.cmi: 
-       Values do not match:
-         val f_arity_one : int -> int -> int
-       is not included in
-         val f_arity_one : int -> int -> int [@@zero_alloc arity 1]
-       zero_alloc arity mismatch:
-       When using "zero_alloc" in a signature, the syntactic arity of
-       the implementation must match the function type in the interface.
-       Here the former is 2 and the latter is 1.
-       File "test_inference.mli", line 11, characters 0-58:
-         Expected declaration
-       File "test_inference.ml", line 25, characters 4-15: Actual declaration
+File "test_inference.ml", line 6, characters 27-35:
+Error: Annotation check for zero_alloc failed on function Test_inference.f_alloc (camlTest_inference.f_alloc_HIDE_STAMP).
+
+File "test_inference.ml", line 6, characters 31-35:
+Error: allocation of 24 bytes
+
+File "test_inference.ml", line 15, characters 30-38:
+Error: Annotation check for zero_alloc failed on function Test_inference.M_alloc_var.f_alloc2 (camlTest_inference.f_alloc2_HIDE_STAMP).
+
+File "test_inference.ml", line 15, characters 34-38:
+Error: allocation of 24 bytes
+
+File "test_inference.ml", lines 25-27, characters 16-16:
+Error: Annotation check for zero_alloc failed on function Test_inference.f_arity_one (camlTest_inference.f_arity_one_HIDE_STAMP).
+
+File "test_inference.ml", line 27, characters 2-16:
+Error: allocation of 32 bytes for closure
+
+File "test_inference.ml", line 40, characters 19-27:
+Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc (camlTest_inference.f_shadow_alloc_HIDE_STAMP).
+
+File "test_inference.ml", line 40, characters 23-27:
+Error: allocation of 24 bytes
+
+File "test_inference.ml", line 46, characters 24-36:
+Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc_both (camlTest_inference.f_shadow_alloc_both_HIDE_STAMP).
+
+File "test_inference.ml", line 46, characters 28-36:
+Error: allocation of 24 bytes
+
+File "test_inference.ml", line 61, characters 17-25:
+Error: Annotation check for zero_alloc failed on function Test_inference.f_basic_fail (camlTest_inference.f_basic_fail_HIDE_STAMP).
+
+File "test_inference.ml", line 61, characters 21-25:
+Error: allocation of 24 bytes
+
+File "test_inference.ml", lines 66-71, characters 18-15:
+Error: Annotation check for zero_alloc strict failed on function Test_inference.f_strict_fail (camlTest_inference.f_strict_fail_HIDE_STAMP).
+
+File "test_inference.ml", line 70, characters 12-35:
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP) (test_inference.ml:70,12--35;printf.ml:48,18--43;printf.ml:46,2--31)
+
+File "test_inference.ml", line 70, characters 12-35:
+Error: called function may allocate on a path to exceptional return (indirect call)
+
+File "test_inference.ml", line 71, characters 10-15:
+Error: allocation of 24 bytes on a path to exceptional return
+
+File "test_inference.ml", line 104, characters 17-27:
+Error: Annotation check for zero_alloc failed on function Test_inference.F.f (camlTest_inference.f_HIDE_STAMP).
+
+File "test_inference.ml", line 104, characters 21-27:
+Error: allocation of 16 bytes


### PR DESCRIPTION
This is because the reaper will still see through those attributes, which is not what we want here.

This PR also fixes a recent regression introduced in these tests with auto-formatting.