### PR TITLE
Add option to enable validation in standalone `regalloc` tool

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -151,11 +151,12 @@ let save_cfg_before_regalloc (cfg_with_infos : Cfg_with_infos.t) =
     cfg_before_regalloc_unit_info.items
       <- Cfg_format.(
            Cfg_before_regalloc
-             { cfg_with_layout =
-                 copy (Cfg_with_infos.cfg_with_layout cfg_with_infos);
+             { cfg_with_layout_and_relocatable_regs =
+                 copy
+                   ( Cfg_with_infos.cfg_with_layout cfg_with_infos,
+                     Reg.all_relocatable_regs () );
                cmm_label = Cmm.cur_label ();
-               reg_stamp = Reg.For_testing.get_stamp ();
-               relocatable_regs = copy @@ Reg.all_relocatable_regs ()
+               reg_stamp = Reg.For_testing.get_stamp ()
              })
          :: cfg_before_regalloc_unit_info.items);
   cfg_with_infos

--- a/file_formats/cfg_format.ml
+++ b/file_formats/cfg_format.ml
@@ -20,10 +20,11 @@ type cfg_item_info =
   | Cfg of Cfg_with_layout.t
   | Data of Cmm.data_item list
   | Cfg_before_regalloc of {
-    cfg_with_layout : Cfg_with_layout.t;
+    (* `cfg_with_layout` and `relocatable_regs` need to be marshalled together
+       in order to preserve sharing. *)
+    cfg_with_layout_and_relocatable_regs : Cfg_with_layout.t * (Reg.t list);
     cmm_label: Label.t;
     reg_stamp: int;
-    relocatable_regs : Reg.t list;
   } 
 
 type cfg_unit_info =

--- a/file_formats/cfg_format.mli
+++ b/file_formats/cfg_format.mli
@@ -23,10 +23,9 @@ type cfg_item_info =
   | Cfg of Cfg_with_layout.t
   | Data of Cmm.data_item list
   | Cfg_before_regalloc of {
-    cfg_with_layout : Cfg_with_layout.t;
+    cfg_with_layout_and_relocatable_regs : Cfg_with_layout.t * (Reg.t list);
     cmm_label: Label.t;
     reg_stamp: int;
-    relocatable_regs : Reg.t list;
   }
 
 type cfg_unit_info =


### PR DESCRIPTION
As per title; also fixes a bug: the CFG
and the list of registers were marshalled
separately, and it was thus breaking
sharing.