### PR TITLE
arm64: fix mov register encoding

### DIFF
--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -121,6 +121,8 @@ module DSL : sig
 
   val emit_reg_v2d : Reg.t -> Arm64_ast.Operand.t
 
+  val emit_reg_v16b : Reg.t -> Arm64_ast.Operand.t
+
   val imm : int -> Arm64_ast.Operand.t
 
   val imm_float : float -> Arm64_ast.Operand.t
@@ -243,6 +245,8 @@ end = struct
   let emit_reg_v4s reg = reg_v4s (reg_index reg)
 
   let emit_reg_v2d reg = reg_v2d (reg_index reg)
+
+  let emit_reg_v16b reg = reg_v16b (reg_index reg)
 
   let emit_reg_w reg = reg_w (reg_index reg)
 
@@ -1263,7 +1267,7 @@ let move (src : Reg.t) (dst : Reg.t) =
     | Float, Reg _, Float, Reg _ | Float32, Reg _, Float32, Reg _ ->
       DSL.ins I.FMOV [| DSL.emit_reg dst; DSL.emit_reg src |]
     | (Vec128 | Valx2), Reg _, (Vec128 | Valx2), Reg _ ->
-      DSL.ins I.MOV [| DSL.emit_reg_v2d dst; DSL.emit_reg_v2d src |]
+      DSL.ins I.MOV [| DSL.emit_reg_v16b dst; DSL.emit_reg_v16b src |]
     | (Int | Val | Addr), Reg _, (Int | Val | Addr), Reg _ ->
       DSL.ins I.MOV [| DSL.emit_reg dst; DSL.emit_reg src |]
     | _, Reg _, _, Stack _ ->

--- a/backend/arm64_ast.ml
+++ b/backend/arm64_ast.ml
@@ -148,6 +148,10 @@ module Reg = struct
     reg_array ~last:Neon_reg_name.last
       (Reg_name.Neon (Neon_reg_name.Vector V8B))
 
+  let reg_v16b_array =
+    reg_array ~last:Neon_reg_name.last
+      (Reg_name.Neon (Neon_reg_name.Vector V16B))
+
   (* for special GP registers we use the last index *)
   let sp = create (GP SP) GP_reg_name.last
 
@@ -671,6 +675,8 @@ module Operand = struct
   let reg_v2d = Array.map (fun x -> Reg x) Reg.reg_v2d_array
 
   let reg_v8b = Array.map (fun x -> Reg x) Reg.reg_v8b_array
+
+  let reg_v16b = Array.map (fun x -> Reg x) Reg.reg_v16b_array
 end
 
 module Instruction = struct
@@ -802,6 +808,8 @@ module DSL = struct
     Operand.Reg (Reg.create (Reg_name.Neon (Vector V4S)) index)
 
   let reg_v2d index = Operand.reg_v2d.(index)
+
+  let reg_v16b index = Operand.reg_v16b.(index)
 
   let reg_v8b index = Operand.reg_v8b.(index)
 

--- a/backend/arm64_ast.mli
+++ b/backend/arm64_ast.mli
@@ -324,6 +324,8 @@ module DSL : sig
 
   val reg_v8b : int -> Operand.t
 
+  val reg_v16b : int -> Operand.t
+
   val reg_b : int -> Operand.t
 
   val reg_s : int -> Operand.t

--- a/testsuite/tests/typing-layouts-arrays/test_vec128_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_vec128_u_array.ml
@@ -2,7 +2,6 @@
  readonly_files = "gen_u_array.ml test_gen_u_array.ml";
  modules = "${readonly_files} stubs.c";
  include stdlib_upstream_compatible;
- arch_amd64;
  flambda2;
  {
    flags = "-extension layouts_beta -extension simd_beta";


### PR DESCRIPTION
It should fix github ci failure on ubuntu in https://github.com/ocaml-flambda/flambda-backend/pull/3687 and vec128 test.