### PR TITLE
Function sections for cached generic functions

### DIFF
--- a/tools/generate_cached_generic_functions.ml
+++ b/tools/generate_cached_generic_functions.ml
@@ -60,6 +60,7 @@ let main filename =
   let unix = (module Unix : Compiler_owee.Unix_intf.S) in
   Clflags.native_code := true;
   Clflags.use_linscan := true;
+  Clflags.function_sections := Config.function_sections;
   Compmisc.init_path ();
   let file_prefix = Filename.remove_extension filename ^ ext_lib in
   let genfns_partitions = Generic_fns.Cache.all () in


### PR DESCRIPTION
FDO may move generic functions like `caml_apply` into hot section, but cached ones didn't have their own function sections. 

Fixed by this PR. Tested by running locally `bin/generate_cached_generic_functions.exe cached-generic-functions` and `readelf -SW cached-generic-functions.a` to confirm the presence of sections of the form `.text.caml.caml_apply90` .