### PR TITLE
Remove `Join_const` and `Subtract`

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1689,14 +1689,13 @@ let with_locality_and_yielding (locality, yielding) m =
     Option.value ~default:(Alloc.proj (Comonadic Yielding) m) yielding
   in
   Yielding.equate_exn (Alloc.proj (Comonadic Yielding) m') yielding;
-  Alloc.submode_exn m' (Alloc.join_const
-    { Alloc.Const.min with
-      areality = Locality.Const.max;
-      yielding = Yielding.Const.max} m);
-  Alloc.submode_exn (Alloc.meet_const
-    { Alloc.Const.max with
+  let c =
+    { Alloc.Comonadic.Const.max with
       areality = Locality.Const.min;
-      yielding = Yielding.Const.min} m) m';
+      yielding = Yielding.Const.min}
+  in
+  Alloc.submode_exn (Alloc.meet_const c m') m;
+  Alloc.submode_exn (Alloc.meet_const c m) m';
   m'
 
 let curry_mode alloc arg : Alloc.Const.t =

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3215,7 +3215,7 @@ let share_mode ~errors ~env ~loc ~item ~lid vmode shared_context =
         (Once_value_used_in (item, lid, shared_context))
   | Ok () ->
     let mode =
-      Mode.Value.join_with (Monadic Uniqueness) Mode.Uniqueness.Const.Aliased
+      Mode.Value.join_with Uniqueness Mode.Uniqueness.Const.Aliased
         vmode.mode
     in
     {mode; context = Some shared_context}

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -25,18 +25,34 @@ type nonrec disallowed = disallowed
 
 type nonrec equate_step = equate_step
 
-module type BiHeyting = sig
-  (** Extend the [Lattice] interface with operations of bi-Heyting algebras *)
+module type Heyting = sig
+  (** Extend the [Lattice] interface with operations of Heyting algebras *)
 
   include Lattice
 
   (** [imply c] is the right adjoint of [meet c]; That is, for any [a] and [b],
       [meet c a <= b] iff [a <= imply c b] *)
   val imply : t -> t -> t
+end
+
+module type CoHeyting = sig
+  (** Extend the [Lattice] interface with operations of co-Heyting algebras *)
+
+  include Lattice
 
   (** [subtract _ c] is the left adjoint of [join c]. That is, for any [a] and [b],
       [subtract a c <= b] iff [a <= join c b] *)
   val subtract : t -> t -> t
+end
+
+module type BiHeyting = sig
+  (** A bi-heyting algebra is both heyting and co-heyting. *)
+
+  type t
+
+  include Heyting with type t := t
+
+  include CoHeyting with type t := t
 end
 
 (* Even though our lattices are all bi-heyting algebras, that knowledge is
@@ -686,7 +702,7 @@ module Lattices = struct
   end
   [@@inline]
 
-  module Opposite (L : BiHeyting) : BiHeyting with type t = L.t = struct
+  module Opposite (L : CoHeyting) : Heyting with type t = L.t = struct
     type t = L.t
 
     let min = L.max
@@ -706,8 +722,6 @@ module Lattices = struct
     let print = L.print
 
     let imply a b = L.subtract b a
-
-    let subtract a b = L.imply b a
   end
   [@@inline]
 
@@ -856,22 +870,6 @@ module Lattices = struct
     | Comonadic_with_regionality -> Comonadic_with_regionality.imply a b
     | Monadic_op -> Monadic_op.imply a b
 
-  let subtract : type a. a obj -> a -> a -> a =
-   fun obj a b ->
-    match obj with
-    | Locality -> Locality.subtract a b
-    | Regionality -> Regionality.subtract a b
-    | Uniqueness_op -> Uniqueness_op.subtract a b
-    | Contention_op -> Contention_op.subtract a b
-    | Visibility_op -> Visibility_op.subtract a b
-    | Linearity -> Linearity.subtract a b
-    | Portability -> Portability.subtract a b
-    | Yielding -> Yielding.subtract a b
-    | Statefulness -> Statefulness.subtract a b
-    | Comonadic_with_locality -> Comonadic_with_locality.subtract a b
-    | Comonadic_with_regionality -> Comonadic_with_regionality.subtract a b
-    | Monadic_op -> Monadic_op.subtract a b
-
   (* not hotpath, Ok to curry *)
   let print : type a. a obj -> _ -> a -> unit = function
     | Locality -> Locality.print
@@ -999,10 +997,6 @@ module Lattices_mono = struct
         (** Meet the input with the parameter *)
     | Imply : 'a -> ('a, 'a, disallowed * 'r) morph
         (** The right adjoint of [Meet_with] *)
-    | Join_with : 'a -> ('a, 'a, 'l * 'r) morph
-        (** Join the input with the parameter *)
-    | Subtract : 'a -> ('a, 'a, 'l * disallowed) morph
-        (** The left adjoint of [Join_with] *)
     | Proj : 't obj * ('t, 'r_) Axis.t -> ('t, 'r_, 'l * 'r) morph
         (** Project from a product to an axis *)
     | Max_with : ('t, 'r_) Axis.t -> ('r_, 't, disallowed * 'r) morph
@@ -1051,8 +1045,6 @@ module Lattices_mono = struct
       | Proj (src, ax) -> Proj (src, ax)
       | Min_with ax -> Min_with ax
       | Meet_with c -> Meet_with c
-      | Join_with c -> Join_with c
-      | Subtract c -> Subtract c
       | Compose (f, g) ->
         let f = allow_left f in
         let g = allow_left g in
@@ -1073,7 +1065,6 @@ module Lattices_mono = struct
       | Id -> Id
       | Proj (src, ax) -> Proj (src, ax)
       | Max_with ax -> Max_with ax
-      | Join_with c -> Join_with c
       | Meet_with c -> Meet_with c
       | Imply c -> Imply c
       | Compose (f, g) ->
@@ -1097,8 +1088,6 @@ module Lattices_mono = struct
       | Proj (src, ax) -> Proj (src, ax)
       | Min_with ax -> Min_with ax
       | Max_with ax -> Max_with ax
-      | Join_with c -> Join_with c
-      | Subtract c -> Subtract c
       | Meet_with c -> Meet_with c
       | Imply c -> Imply c
       | Compose (f, g) ->
@@ -1124,8 +1113,6 @@ module Lattices_mono = struct
       | Proj (src, ax) -> Proj (src, ax)
       | Min_with ax -> Min_with ax
       | Max_with ax -> Max_with ax
-      | Join_with c -> Join_with c
-      | Subtract c -> Subtract c
       | Meet_with c -> Meet_with c
       | Imply c -> Imply c
       | Compose (f, g) ->
@@ -1182,10 +1169,8 @@ module Lattices_mono = struct
     | Proj (src, _) -> src
     | Max_with ax -> proj_obj ax dst
     | Min_with ax -> proj_obj ax dst
-    | Join_with _ -> dst
     | Meet_with _ -> dst
     | Imply _ -> dst
-    | Subtract _ -> dst
     | Compose (f, g) ->
       let mid = src dst f in
       src mid g
@@ -1231,9 +1216,7 @@ module Lattices_mono = struct
            not requird to be complete: i.e., it's allowed to return [None] when
            it should return [Some]. It would cause duplication but not error. *)
         if c0 = c1 then Some Refl else None
-      | Join_with c0, Join_with c1 -> if c0 = c1 then Some Refl else None
       | Imply c0, Imply c1 -> if c0 = c1 then Some Refl else None
-      | Subtract c0, Subtract c1 -> if c0 = c1 then Some Refl else None
       | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Some Refl
       | Comonadic_to_monadic a0, Comonadic_to_monadic a1 -> (
         match eq_obj a0 a1 with None -> None | Some Refl -> Some Refl)
@@ -1250,12 +1233,11 @@ module Lattices_mono = struct
           match equal g0 g1 with None -> None | Some Refl -> Some Refl))
       | Map_comonadic f, Map_comonadic g -> (
         match equal f g with Some Refl -> Some Refl | None -> None)
-      | ( ( Id | Proj _ | Max_with _ | Min_with _ | Meet_with _ | Join_with _
+      | ( ( Id | Proj _ | Max_with _ | Min_with _ | Meet_with _
           | Monadic_to_comonadic_min | Comonadic_to_monadic _
           | Monadic_to_comonadic_max | Local_to_regional
           | Locality_as_regionality | Global_to_regional | Regional_to_local
-          | Regional_to_global | Compose _ | Map_comonadic _ | Imply _
-          | Subtract _ ),
+          | Regional_to_global | Compose _ | Map_comonadic _ | Imply _ ),
           _ ) ->
         None
   end)
@@ -1266,10 +1248,8 @@ module Lattices_mono = struct
       type a b l r. b obj -> Format.formatter -> (a, b, l * r) morph -> unit =
    fun dst ppf -> function
     | Id -> Format.fprintf ppf "id"
-    | Join_with c -> Format.fprintf ppf "join(%a)" (print dst) c
     | Meet_with c -> Format.fprintf ppf "meet(%a)" (print dst) c
     | Imply c -> Format.fprintf ppf "imply(%a)" (print dst) c
-    | Subtract c -> Format.fprintf ppf "subtract_%a" (print dst) c
     | Proj (_, ax) -> Format.fprintf ppf "proj_%a" Axis.print ax
     | Max_with ax -> Format.fprintf ppf "max_with_%a" Axis.print ax
     | Min_with ax -> Format.fprintf ppf "min_with_%a" Axis.print ax
@@ -1392,9 +1372,7 @@ module Lattices_mono = struct
     | Max_with ax -> max_with dst ax a
     | Min_with ax -> min_with dst ax a
     | Meet_with c -> meet dst c a
-    | Join_with c -> join dst c a
     | Imply c -> imply dst c a
-    | Subtract c -> subtract dst a c
     | Monadic_to_comonadic_min -> monadic_to_comonadic_min dst a
     | Comonadic_to_monadic src -> comonadic_to_monadic src a
     | Monadic_to_comonadic_max -> monadic_to_comonadic_max dst a
@@ -1418,34 +1396,20 @@ module Lattices_mono = struct
       (a, c, l * r) morph option =
    fun dst m0 m1 ->
     let is_max c = le dst (max dst) c in
-    let is_min c = le dst c (min dst) in
     let is_mid_max c =
       let mid = src dst m0 in
       le mid (max mid) c
-    in
-    let is_mid_min c =
-      let mid = src dst m0 in
-      le mid c (min mid)
     in
     match m0, m1 with
     | Id, m -> Some m
     | m, Id -> Some m
     | Meet_with c0, Meet_with c1 -> Some (Meet_with (meet dst c0 c1))
-    | Join_with c0, Join_with c1 -> Some (Join_with (join dst c0 c1))
     | Imply c0, Imply c1 -> Some (Imply (meet dst c0 c1))
-    | Subtract c0, Subtract c1 -> Some (Subtract (join dst c0 c1))
-    | Imply c0, Join_with c1 when le dst c0 c1 -> Some (Join_with (max dst))
     | Imply c0, Meet_with c1 when le dst c0 c1 -> Some (Imply c0)
-    | Subtract c0, Meet_with c1 when le dst c1 c0 -> Some (Meet_with (min dst))
-    | Subtract c0, Join_with c1 when le dst c1 c0 -> Some (Subtract c0)
     | Meet_with c0, m1 when is_max c0 -> Some m1
-    | Join_with c0, m1 when is_min c0 -> Some m1
     | Imply c0, m1 when is_max c0 -> Some m1
-    | Subtract c0, m1 when is_min c0 -> Some m1
     | m1, Meet_with c0 when is_mid_max c0 -> Some m1
-    | m1, Join_with c0 when is_mid_min c0 -> Some m1
     | m1, Imply c0 when is_mid_max c0 -> Some m1
-    | m1, Subtract c0 when is_mid_min c0 -> Some m1
     | Compose (f0, f1), g -> (
       let mid = src dst f0 in
       match maybe_compose mid f1 g with
@@ -1458,8 +1422,6 @@ module Lattices_mono = struct
       | None -> None)
     | Proj (mid, ax), Meet_with c ->
       Some (compose dst (Meet_with (Axis.proj ax c)) (Proj (mid, ax)))
-    | Proj (mid, ax), Join_with c ->
-      Some (compose dst (Join_with (Axis.proj ax c)) (Proj (mid, ax)))
     | Proj (_, ax0), Max_with ax1 -> (
       match Axis.eq ax0 ax1 with None -> None | Some Refl -> Some Id)
     | Proj (_, ax0), Min_with ax1 -> (
@@ -1479,41 +1441,21 @@ module Lattices_mono = struct
       let dst0 = proj_obj Areality dst in
       Some (Map_comonadic (compose dst0 f g))
     | Regional_to_local, Local_to_regional -> Some Id
-    | Regional_to_local, Global_to_regional -> Some (Join_with Locality.Local)
+    | Regional_to_local, Global_to_regional -> Some (Imply Locality.Global)
     | Regional_to_local, Locality_as_regionality -> Some Id
     | Regional_to_local, Meet_with c ->
       Some (compose dst (Meet_with (regional_to_local c)) Regional_to_local)
-    | Regional_to_local, Join_with c ->
-      Some (compose dst (Join_with (regional_to_local c)) Regional_to_local)
-    | Regional_to_global, Join_with c ->
-      Some (compose dst (Join_with (regional_to_global c)) Regional_to_global)
     | Regional_to_global, Meet_with c ->
       Some (compose dst (Meet_with (regional_to_global c)) Regional_to_global)
     | Local_to_regional, Meet_with c ->
       Some (compose dst (Meet_with (local_to_regional c)) Local_to_regional)
-    | Local_to_regional, Join_with c ->
-      Some (compose dst (Join_with (local_to_regional c)) Local_to_regional)
     | Global_to_regional, Meet_with c ->
       Some (compose dst (Meet_with (global_to_regional c)) Global_to_regional)
-    | Global_to_regional, Join_with c ->
-      Some (compose dst (Join_with (global_to_regional c)) Global_to_regional)
     | Locality_as_regionality, Meet_with c ->
       Some
         (compose dst
            (Meet_with (locality_as_regionality c))
            Locality_as_regionality)
-    | Locality_as_regionality, Join_with c ->
-      Some
-        (compose dst
-           (Join_with (locality_as_regionality c))
-           Locality_as_regionality)
-    | Map_comonadic f, Join_with c ->
-      let dst0 = proj_obj Areality dst in
-      let areality = Axis.proj Areality c in
-      Some
-        (compose dst
-           (Join_with (set_areality (min dst0) c))
-           (Map_comonadic (compose dst0 f (Join_with areality))))
     | Map_comonadic f, Meet_with c ->
       let dst0 = proj_obj Areality dst in
       let areality = Axis.proj Areality c in
@@ -1528,13 +1470,6 @@ module Lattices_mono = struct
         (compose dst
            (Imply (set_areality (max dst0) c))
            (Map_comonadic (compose dst0 f (Imply areality))))
-    | Map_comonadic f, Subtract c ->
-      let dst0 = proj_obj Areality dst in
-      let areality = Axis.proj Areality c in
-      Some
-        (compose dst
-           (Subtract (set_areality (min dst0) c))
-           (Map_comonadic (compose dst0 f (Subtract areality))))
     | Regional_to_global, Locality_as_regionality -> Some Id
     | Regional_to_global, Local_to_regional -> Some (Meet_with Locality.Global)
     | Local_to_regional, Regional_to_local -> None
@@ -1548,12 +1483,8 @@ module Lattices_mono = struct
     | Max_with _, _ -> None
     | _, Meet_with _ -> None
     | Meet_with _, _ -> None
-    | _, Join_with _ -> None
-    | Join_with _, _ -> None
     | _, Imply _ -> None
     | Imply _, _ -> None
-    | _, Subtract _ -> None
-    | Subtract _, _ -> None
     | _, Proj _ -> None
     | Map_comonadic _, _ -> None
     | Monadic_to_comonadic_min, _ -> None
@@ -1592,7 +1523,6 @@ module Lattices_mono = struct
       let f' = left_adjoint dst f in
       let g' = left_adjoint mid g in
       Compose (g', f')
-    | Join_with c -> Subtract c
     | Meet_with _c ->
       (* The downward closure of [Meet_with c]'s image is all [x <= c].
          For those, [x <= meet c y] is equivalent to [x <= y]. *)
@@ -1623,11 +1553,6 @@ module Lattices_mono = struct
       let g' = right_adjoint mid g in
       Compose (g', f')
     | Meet_with c -> Imply c
-    | Subtract c -> Join_with c
-    | Join_with _c ->
-      (* The upward closure of [Join_with c]'s image is all [x >= c].
-         For those, [join c y <= x] is equivalent to [y <= x]. *)
-      Id
     | Comonadic_to_monadic _ -> Monadic_to_comonadic_max
     | Monadic_to_comonadic_min -> Comonadic_to_monadic dst
     | Local_to_regional -> Regional_to_local
@@ -1775,11 +1700,7 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let meet_const c m = Solver.apply obj (Meet_with c) m
 
-  let join_const c m = Solver.apply obj (Join_with c) m
-
   let imply c m = Solver.apply obj (Imply c) (Solver.disallow_left m)
-
-  let subtract c m = Solver.apply obj (Subtract c) (Solver.disallow_right m)
 
   module Guts = struct
     let get_floor m = Solver.get_floor obj m
@@ -1855,11 +1776,7 @@ module Monadic_gen (Obj : Obj) = struct
 
   let of_const : type l r. const -> (l * r) t = fun a -> Solver.of_const obj a
 
-  let meet_const c m = Solver.apply Obj.obj (Join_with c) m
-
   let join_const c m = Solver.apply Obj.obj (Meet_with c) m
-
-  let imply c m = Solver.apply obj (Subtract c) (Solver.disallow_right m)
 
   let subtract c m = Solver.apply obj (Imply c) (Solver.disallow_left m)
 
@@ -2147,8 +2064,6 @@ module Comonadic_with (Areality : Areality) = struct
   let max_with ax m =
     Solver.apply Obj.obj (Max_with ax) (Solver.disallow_left m)
 
-  let join_with ax c m = join_const (Const.min_with ax c) m
-
   let meet_with ax c m = meet_const (Const.max_with ax c) m
 
   let zap_to_legacy m : Const.t =
@@ -2275,8 +2190,6 @@ module Monadic = struct
     Solver.apply Obj.obj (Max_with ax) (Solver.disallow_left m)
 
   let join_with ax c m = join_const (Const.min_with ax c) m
-
-  let meet_with ax c m = meet_const (Const.max_with ax c) m
 
   let zap_to_legacy m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
@@ -2785,37 +2698,13 @@ module Value_with (Areality : Areality) = struct
     | Monadic ax -> min_with_monadic ax m
     | Comonadic ax -> min_with_comonadic ax m
 
-  let join_with_monadic ax c { monadic; comonadic } =
+  let join_with ax c { monadic; comonadic } =
     let monadic = Monadic.join_with ax c monadic in
     { monadic; comonadic }
 
-  let join_with_comonadic ax c { monadic; comonadic } =
-    let comonadic = Comonadic.join_with ax c comonadic in
-    { comonadic; monadic }
-
-  let join_with :
-      type a l0 l1 r0 r1.
-      (a, l0 * r0, l1 * r1) Axis.t -> a -> (l0 * r0) t -> (l0 * r0) t =
-   fun ax c m ->
-    match ax with
-    | Monadic ax -> join_with_monadic ax c m
-    | Comonadic ax -> join_with_comonadic ax c m
-
-  let meet_with_monadic ax c { monadic; comonadic } =
-    let monadic = Monadic.meet_with ax c monadic in
-    { monadic; comonadic }
-
-  let meet_with_comonadic ax c { monadic; comonadic } =
+  let meet_with ax c { monadic; comonadic } =
     let comonadic = Comonadic.meet_with ax c comonadic in
     { comonadic; monadic }
-
-  let meet_with :
-      type a l0 r0 l1 r1.
-      (a, l0 * r0, l1 * r1) Axis.t -> a -> (l0 * r0) t -> (l0 * r0) t =
-   fun ax c m ->
-    match ax with
-    | Monadic ax -> meet_with_monadic ax c m
-    | Comonadic ax -> meet_with_comonadic ax c m
 
   let join l =
     let como, mo =
@@ -2846,27 +2735,11 @@ module Value_with (Areality : Areality) = struct
     S.apply Comonadic.Obj.obj Monadic_to_comonadic_min (Monadic.disallow_left m)
 
   let meet_const c { comonadic; monadic } =
-    let c = split c in
-    let comonadic = Comonadic.meet_const c.comonadic comonadic in
-    let monadic = Monadic.meet_const c.monadic monadic in
+    let comonadic = Comonadic.meet_const c comonadic in
     { monadic; comonadic }
 
   let join_const c { comonadic; monadic } =
-    let c = split c in
-    let comonadic = Comonadic.join_const c.comonadic comonadic in
-    let monadic = Monadic.join_const c.monadic monadic in
-    { monadic; comonadic }
-
-  let imply c { comonadic; monadic } =
-    let c = split c in
-    let comonadic = Comonadic.imply c.comonadic comonadic in
-    let monadic = Monadic.imply c.monadic monadic in
-    { monadic; comonadic }
-
-  let subtract c { comonadic; monadic } =
-    let c = split c in
-    let comonadic = Comonadic.subtract c.comonadic comonadic in
-    let monadic = Monadic.subtract c.monadic monadic in
+    let monadic = Monadic.join_const c monadic in
     { monadic; comonadic }
 
   let zap_to_ceil { comonadic; monadic } =

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -118,18 +118,6 @@ module type Common = sig
 
   val of_const : Const.t -> ('l * 'r) t
 
-  (** [imply c] is the right adjoint of [meet c]. That is,
-     [x <= imply c y] iff [meet c x <= y]. *)
-  val imply : Const.t -> ('l * 'r) t -> (disallowed * 'r) t
-
-  (** [subtract c] is the left adjoint of [join c]. That is,
-     [subtract c x <= y] iff [x <= join c y]. *)
-  val subtract : Const.t -> ('l * 'r) t -> ('l * disallowed) t
-
-  val join_const : Const.t -> ('l * 'r) t -> ('l * 'r) t
-
-  val meet_const : Const.t -> ('l * 'r) t -> ('l * 'r) t
-
   val zap_to_ceil : ('l * allowed) t -> Const.t
 
   val zap_to_floor : (allowed * 'r) t -> Const.t
@@ -418,6 +406,8 @@ module type S = sig
         with type Const.t = Areality.Const.t comonadic_with
          and type 'a axis := (Areality.Const.t comonadic_with, 'a) Axis.t
 
+    module Axis' := Axis
+
     module Axis : sig
       (** Represents a mode axis in this product whose constant is ['a], and whose
       allowance is ['d1] given the product's allowance ['d0]. *)
@@ -527,6 +517,10 @@ module type S = sig
     val proj :
       ('a, 'l0 * 'r0, 'l1 * 'r1) Axis.t -> ('l0 * 'r0) t -> ('a, 'l1 * 'r1) mode
 
+    val meet_const : Comonadic.Const.t -> ('l * 'r) t -> ('l * 'r) t
+
+    val join_const : Monadic.Const.t -> ('l * 'r) t -> ('l * 'r) t
+
     (** [max_with ax elt] returns [max] but with the axis [ax] set to [elt]. *)
     val max_with :
       ('a, 'l0 * 'r0, 'l1 * 'r1) Axis.t ->
@@ -540,10 +534,10 @@ module type S = sig
       ('l0 * disallowed) t
 
     val meet_with :
-      ('a, 'l0 * 'r0, 'l1 * 'r1) Axis.t -> 'a -> ('l0 * 'r0) t -> ('l0 * 'r0) t
+      (Comonadic.Const.t, 'a) Axis'.t -> 'a -> ('l0 * 'r0) t -> ('l0 * 'r0) t
 
     val join_with :
-      ('a, 'l0 * 'r0, 'l1 * 'r1) Axis.t -> 'a -> ('l0 * 'r0) t -> ('l0 * 'r0) t
+      (Monadic.Const.t, 'a) Axis'.t -> 'a -> ('l0 * 'r0) t -> ('l0 * 'r0) t
 
     val zap_to_legacy : lr -> Const.t
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -477,7 +477,7 @@ let check_tail_call_local_returning loc env ap_mode {region_mode; _} =
 
 let meet_regional mode =
   let mode = Value.disallow_left mode in
-  Value.meet_with (Comonadic Areality) Regionality.Const.Regional mode
+  Value.meet_with Areality Regionality.Const.Regional mode
 
 let mode_default mode =
   { position = RNontail;
@@ -533,10 +533,15 @@ let mode_with_position mode position =
 let mode_max_with_position position =
   { mode_max with position }
 
+(** Take the expected mode of [exclave_ exp], return the expected mode of [exp].
+    [expected_mode] must be higher than [regional]. *)
 let mode_exclave expected_mode =
   let mode =
-    Value.join_with (Comonadic Areality)
-      Regionality.Const.Local (as_single_mode expected_mode)
+     as_single_mode expected_mode
+     (* if we expect an exclave to be [regional], then inside the exclave the body should
+        be [local] *)
+     |> value_to_alloc_r2l
+     |> alloc_as_value
   in
   { (mode_default mode)
     with strictly_local = true
@@ -554,18 +559,23 @@ let mode_lazy expected_mode =
   let expected_mode =
     mode_coerce (
       Value.max_with (Comonadic Areality) Regionality.global
-      |> Value.meet_with (Comonadic Yielding) Yielding.Const.Unyielding)
+      |> Value.meet_with Yielding Yielding.Const.Unyielding)
       expected_mode
   in
+  let mode_crossing =
+    Crossing.of_bounds {
+      comonadic = {
+        Alloc.Comonadic.Const.max with
+        (* The thunk is evaluated only once, so we only require it to be [once],
+          even if the [lazy] is [many]. *)
+        linearity = Many;
+        (* The thunk is evaluated only when the [lazy] is [uncontended], so we only require it
+          to be [nonportable], even if the [lazy] is [portable]. *)
+        portability = Portable };
+      monadic = Alloc.Monadic.Const.min }
+  in
   let closure_mode =
-    expected_mode
-    |> as_single_mode
-    (* The thunk is evaluated only once, so we only require it to be [once],
-       even if the [lazy] is [many]. *)
-    |> Value.join_with (Comonadic Linearity) Linearity.Const.Once
-    (* The thunk is evaluated only when the [lazy] is [uncontended], so we only require it
-       to be [nonportable], even if the [lazy] is [portable]. *)
-    |> Value.join_with (Comonadic Portability) Portability.Const.Nonportable
+    expected_mode |> as_single_mode |> Crossing.apply_right mode_crossing
   in
   {expected_mode with locality_context = Some Lazy }, closure_mode
 
@@ -663,8 +673,9 @@ let tuple_pat_mode mode tuple_modes =
 
 let global_pat_mode {mode; _}=
   let mode =
-    Value.meet_with (Comonadic Areality) Regionality.Const.Global mode
-    |> Value.meet_with (Comonadic Yielding) Yielding.Const.Unyielding
+    mode
+    |> Value.meet_with Areality Regionality.Const.Global
+    |> Value.meet_with Yielding Yielding.Const.Unyielding
   in
   simple_pat_mode mode
 
@@ -1014,10 +1025,10 @@ let check_construct_mutability ~loc ~env mutability ty ?modalities block_mode =
 (** The [expected_mode] of the record when projecting a mutable field. *)
 let mode_project_mutable =
   let mode =
-    Contention.Const.Shared
-    |> Contention.of_const
-    |> Value.max_with (Monadic Contention)
-    |> Value.meet_with (Monadic Visibility) Visibility.Const.Read
+    { Value.Const.max with
+      visibility = Visibility.Const.Read;
+      contention = Contention.Const.Shared }
+    |> Value.of_const
   in
   { (mode_default mode) with
     contention_context = Some Read_mutable;
@@ -1026,10 +1037,10 @@ let mode_project_mutable =
 (** The [expected_mode] of the record when mutating a mutable field. *)
 let mode_mutate_mutable =
   let mode =
-    Contention.Const.Uncontended
-    |> Contention.of_const
-    |> Value.max_with (Monadic Contention)
-    |> Value.meet_with (Monadic Visibility) Visibility.Const.Read_write
+    { Value.Const.max with
+      visibility = Read_write;
+      contention = Uncontended }
+    |> Value.of_const
   in
   { (mode_default mode) with
     contention_context = Some Write_mutable;
@@ -6851,11 +6862,7 @@ and type_expect_
            exp_attributes = sexp.pexp_attributes;
            exp_env = env }
   | Pexp_stack e ->
-      let expected_mode' =
-        mode_morph (Value.join_with (Comonadic Areality) Regionality.Const.Local)
-          expected_mode
-      in
-      let exp = type_expect env expected_mode' e ty_expected_explained in
+      let exp = type_expect env expected_mode e ty_expected_explained in
       let unsupported category =
         raise (Error (exp.exp_loc, env, Unsupported_stack_allocation category))
       in
@@ -6916,9 +6923,10 @@ and type_expect_
         (* The overwritten cell has to be unique
            and should have the areality expected here: *)
         Value.newvar_below
-          (Value.meet_with (Monadic Uniqueness) Uniqueness.Const.Unique
-             (Value.max_with (Comonadic Areality)
-                (Value.proj (Comonadic Areality) expected_mode.mode)))
+          (Value.meet [
+            Value.max_with (Monadic Uniqueness) Uniqueness.(of_const Const.Unique);
+            Value.max_with (Comonadic Areality)
+                (Value.proj (Comonadic Areality) expected_mode.mode)])
       in
       let cell_type =
         (* CR uniqueness: this could be the jkind of exp2 *)
@@ -6930,14 +6938,18 @@ and type_expect_
            We enforce that here, by asking the allocation to be global.
            This makes the block alloc_heap, but we ignore that information anyway. *)
         (* CR uniqueness: this shouldn't mention yielding *)
-        { Value.Const.max with
+        { Value.Comonadic.Const.max with
           areality = Regionality.Const.Global
         ; yielding = Yielding.Const.Unyielding }
       in
       let exp2 =
         let exp2_mode =
           mode_coerce
-            (Value.(meet_const new_fields_mode max |> disallow_left))
+            Value.({
+              comonadic = new_fields_mode;
+              monadic = Monadic.Const.max}
+              |> Const.merge
+              |> of_const)
             expected_mode
         in
         (* When typing holes, we will enforce: fields_mode <= expected_mode.


### PR DESCRIPTION
This PR removes `Join_with` and `Subtract` from `Lattices_mono.morph`, because:
- For comonadic axes, we only need `Meet_with` and `Imply`
- For monadic axes, we only need `join_const` and `subtract`, which is backed by `Meet_with` and `Imply` in the underlying `Lattices_mono`.

This simplifies `mode.ml`, particularly the `compose` function.