### PR TITLE
Fix product layouts and shallow axes

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/modalities.ml
@@ -130,21 +130,4 @@ Line 1, characters 64-65:
 1 | let foo (t : (string -> string) t @ nonportable) = use_portable t
                                                                     ^
 Error: This value is "nonportable" but expected to be "portable".
-|}, Principal{|
-Line 1, characters 64-65:
-1 | let foo (t : (string -> string) t @ nonportable) = use_portable t
-                                                                    ^
-Error: This expression has type "(string -> string) t"
-       but an expression was expected of type "('a : value & value)"
-       The kind of (string -> string) t is
-         immediate with string -> string @@ global & immediate
-         with string -> string @@ global
-         because of the definition of t at line 4, characters 0-51.
-       But the kind of (string -> string) t must be a subkind of
-         value & value
-         because of the definition of use_portable at line 3, characters 4-16.
-
-       The first mode-crosses less than the second along:
-         nullability: mod non_null with string -> string ≰ mod non_null
-         separability: mod non_float with string -> string ≰ mod separable
 |}]

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -841,7 +841,7 @@ type a = #{ a : t_maybesep_val; }
 
 type b = #{ a : int; b: t_maybesep_val; c: float# }
 
-type ('b : value & value & float64 mod everything non_float) fails = unit constraint 'b = b
+type ('b : value & value & float64 mod non_null non_float) fails = unit constraint 'b = b
 
 (* CR layouts v3.4: separability of 2+ element unboxed records should always be
    non-float.
@@ -850,19 +850,7 @@ type ('b : value & value & float64 mod everything non_float) fails = unit constr
 
 [%%expect{|
 type b = #{ a : int; b : t_maybesep_val; c : float#; }
-Line 3, characters 85-91:
-3 | type ('b : value & value & float64 mod everything non_float) fails = unit constraint 'b = b
-                                                                                         ^^^^^^
-Error: The type constraints are not consistent.
-       Type "('b : immediate & immediate & float64 mod everything)"
-       is not compatible with type "b"
-       The kind of b is
-         immediate with t_maybesep_val & immediate with t_maybesep_val
-         & float64 mod everything with t_maybesep_val
-         because of the definition of b at line 1, characters 0-51.
-       But the kind of b must be a subkind of
-         immediate & immediate & float64 mod everything
-         because of the annotation on 'b in the declaration of the type fails.
+type 'a fails = unit constraint 'a = b
 |}]
 
 type c = #( float * float or_null * float# )
@@ -872,38 +860,9 @@ type c = #( float * float or_null * float# )
 
    Also, this error is horrible. *)
 
-type ('c : value & value & float64 mod everything non_float) fails = unit constraint 'c = c
+type ('c : value & value & float64 mod non_null non_float) fails = unit constraint 'c = c
 
 [%%expect{|
 type c = #(float * float or_null * float#)
-Line 8, characters 85-91:
-8 | type ('c : value & value & float64 mod everything non_float) fails = unit constraint 'c = c
-                                                                                         ^^^^^^
-Error: The type constraints are not consistent.
-       Type "('c : immediate & immediate & float64 mod everything)"
-       is not compatible with type "c" = "#(float * float or_null * float#)"
-       The kind of c is
-         value_or_null mod many unyielding stateless immutable
-         & value_or_null mod many unyielding stateless immutable
-         & float64 mod many unyielding stateless immutable
-         because it is an unboxed tuple.
-       But the kind of c must be a subkind of
-         immediate & immediate & float64 mod everything
-         because of the annotation on 'c in the declaration of the type fails.
-|}, Principal{|
-type c = #(float * float or_null * float#)
-Line 8, characters 85-91:
-8 | type ('c : value & value & float64 mod everything non_float) fails = unit constraint 'c = c
-                                                                                         ^^^^^^
-Error: The type constraints are not consistent.
-       Type "('c : immediate & immediate & float64 mod everything)"
-       is not compatible with type "c" = "#(float * float or_null * float#)"
-       The kind of c is
-         immediate with float with float or_null with float# & immediate
-         with float with float or_null with float# & float64 mod everything
-         with float with float or_null with float#
-         because it is an unboxed tuple.
-       But the kind of c must be a subkind of
-         immediate & immediate & float64 mod everything
-         because of the annotation on 'c in the declaration of the type fails.
+type 'a fails = unit constraint 'a = c
 |}]

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -843,22 +843,12 @@ type b = #{ a : int; b: t_maybesep_val; c: float# }
 
 type ('b : value & value & float64 mod non_null non_float) fails = unit constraint 'b = b
 
-(* CR layouts v3.4: separability of 2+ element unboxed records should always be
-   non-float.
-
-   Also, this error is horrible. *)
-
 [%%expect{|
 type b = #{ a : int; b : t_maybesep_val; c : float#; }
 type 'a fails = unit constraint 'a = b
 |}]
 
 type c = #( float * float or_null * float# )
-
-(* CR layouts v3.4: separability of unboxed tuples should always be
-   non-float.
-
-   Also, this error is horrible. *)
 
 type ('c : value & value & float64 mod non_null non_float) fails = unit constraint 'c = c
 

--- a/testsuite/tests/typing-layouts-products/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-products/basics_alpha.ml
@@ -56,22 +56,14 @@ type t2 : any_non_null
 type t3 = #(t1 * t2)
 |}]
 
-(* Should not be allowed. *)
+(* Should be allowed -- any 2+ element product is non-null. *)
 type t1 : any
 type t2 : any mod non_null separable
 type t3 : any mod non_null separable = #(t1 * t2);;
 [%%expect{|
 type t1 : any
 type t2 : any_non_null
-Line 3, characters 0-49:
-3 | type t3 : any mod non_null separable = #(t1 * t2);;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "#(t1 * t2)" is
-         any_non_null mod everything mod non_float with t1 with t2
-         & any_non_null mod everything mod non_float with t1 with t2
-         because it is an unboxed tuple.
-       But the kind of type "#(t1 * t2)" must be a subkind of any_non_null
-         because of the definition of t3 at line 3, characters 0-49.
+type t3 = #(t1 * t2)
 |}]
 
 type t1 : any
@@ -80,16 +72,7 @@ type t3 : any & any mod non_null separable = #(t1 * t2);;
 [%%expect{|
 type t1 : any
 type t2 : any_non_null
-Line 3, characters 0-55:
-3 | type t3 : any & any mod non_null separable = #(t1 * t2);;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "#(t1 * t2)" is
-         any_non_null mod everything mod non_float with t1 with t2
-         & any_non_null mod everything mod non_float with t1 with t2
-         because it is an unboxed tuple.
-       But the kind of type "#(t1 * t2)" must be a subkind of
-         any_non_null & any_non_null
-         because of the definition of t3 at line 3, characters 0-55.
+type t3 = #(t1 * t2)
 |}]
 
 type t1 : any
@@ -98,14 +81,5 @@ type t3 : (any mod non_null separable) & (any mod non_null separable) = #(t1 * t
 [%%expect{|
 type t1 : any
 type t2 : any_non_null
-Line 3, characters 0-82:
-3 | type t3 : (any mod non_null separable) & (any mod non_null separable) = #(t1 * t2);;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "#(t1 * t2)" is
-         any_non_null mod everything mod non_float with t1 with t2
-         & any_non_null mod everything mod non_float with t1 with t2
-         because it is an unboxed tuple.
-       But the kind of type "#(t1 * t2)" must be a subkind of
-         any_non_null & any_non_null
-         because of the definition of t3 at line 3, characters 0-82.
+type t3 = #(t1 * t2)
 |}]

--- a/testsuite/tests/typing-modal-kinds/unboxed.ml
+++ b/testsuite/tests/typing-modal-kinds/unboxed.ml
@@ -199,22 +199,6 @@ let f (x : (int -> int) t @ nonportable) = use_portable_vv x
 
 [%%expect{|
 val f : (int -> int) t -> unit = <fun>
-|}, Principal{|
-Line 1, characters 59-60:
-1 | let f (x : (int -> int) t @ nonportable) = use_portable_vv x
-                                                               ^
-Error: This expression has type "(int -> int) t"
-       but an expression was expected of type "('a : value & value)"
-       The kind of (int -> int) t is
-         immediate with int -> int @@ portable & immediate
-         with int -> int @@ portable
-         because of the definition of t at lines 1-2, characters 0-45.
-       But the kind of (int -> int) t must be a subkind of value & value
-         because of the definition of use_portable_vv at line 6, characters 64-75.
-
-       The first mode-crosses less than the second along:
-         nullability: mod non_null with int -> int ≰ mod non_null
-         separability: mod non_float with int -> int ≰ mod separable
 |}]
 (* CR layouts v2.8: fix principality *)
 
@@ -228,23 +212,6 @@ type t2 = (int -> int) t require_portable_vv
 
 [%%expect{|
 type t2 = (int -> int) t require_portable_vv
-|}, Principal{|
-Line 1, characters 10-24:
-1 | type t2 = (int -> int) t require_portable_vv
-              ^^^^^^^^^^^^^^
-Error: This type "(int -> int) t" should be an instance of type
-         "('a : value mod portable & value mod portable)"
-       The kind of (int -> int) t is
-         immediate with int -> int @@ portable & immediate
-         with int -> int @@ portable
-         because of the definition of t at lines 1-2, characters 0-45.
-       But the kind of (int -> int) t must be a subkind of
-         value mod portable & value mod portable
-         because of the definition of require_portable_vv at line 1, characters 0-58.
-
-       The first mode-crosses less than the second along:
-         nullability: mod non_null with int -> int ≰ mod non_null
-         separability: mod non_float with int -> int ≰ mod separable
 |}]
 (* CR layouts v2.8: fix principality *)
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -751,8 +751,8 @@ module With_bounds = struct
       With_bounds (With_bounds_types.singleton type_expr type_info)
     | With_bounds bounds -> With_bounds (add_bound type_expr type_info bounds)
 
-  let add_modality ~relevant_for_shallow
-      ~modality ~type_expr (t : (allowed * 'r) t) : (allowed * 'r) t =
+  let add_modality ~relevant_for_shallow ~modality ~type_expr
+      (t : (allowed * 'r) t) : (allowed * 'r) t =
     let relevant_axes =
       relevant_axes_of_modality ~relevant_for_shallow ~modality
     in
@@ -1903,9 +1903,8 @@ module Const = struct
         { layout = base.layout;
           mod_bounds = base.mod_bounds;
           with_bounds =
-            With_bounds.add_modality ~modality
-              ~relevant_for_shallow:`Irrelevant ~type_expr:type_
-              base.with_bounds
+            With_bounds.add_modality ~modality ~relevant_for_shallow:`Irrelevant
+              ~type_expr:type_ base.with_bounds
         })
     | Default | Kind_of _ -> raise ~loc:jkind.pjkind_loc Unimplemented_syntax
 
@@ -1974,8 +1973,7 @@ module Jkind_desc = struct
   let unsafely_set_bounds t ~from =
     { t with mod_bounds = from.mod_bounds; with_bounds = from.with_bounds }
 
-  let add_with_bounds ~relevant_for_shallow
-      ~type_expr ~modality t =
+  let add_with_bounds ~relevant_for_shallow ~type_expr ~modality t =
     match Types.get_desc type_expr with
     | Tarrow (_, _, _, _) ->
       (* Optimization: all arrow types have the same (with-bound-free) jkind, so
@@ -1991,8 +1989,8 @@ module Jkind_desc = struct
     | _ ->
       { t with
         with_bounds =
-          With_bounds.add_modality ~relevant_for_shallow
-            ~type_expr ~modality t.with_bounds
+          With_bounds.add_modality ~relevant_for_shallow ~type_expr ~modality
+            t.with_bounds
       }
 
   let max = of_const Const.max
@@ -2071,16 +2069,14 @@ module Jkind_desc = struct
     let relevant_for_shallow =
       (* Shallow axes like nullability or separability are relevant for
          1-field unboxed records and irrelevant for everything else. *)
-      match List.length layouts with
-      | 1 -> `Relevant
-      | _ -> `Irrelevant
+      match List.length layouts with 1 -> `Relevant | _ -> `Irrelevant
     in
     let mod_bounds = Mod_bounds.min in
     let with_bounds =
       List.fold_right
         (fun (type_expr, modality) bounds ->
-          With_bounds.add_modality
-            ~relevant_for_shallow ~type_expr ~modality bounds)
+          With_bounds.add_modality ~relevant_for_shallow ~type_expr ~modality
+            bounds)
         tys_modalities No_with_bounds
     in
     { layout; mod_bounds; with_bounds }


### PR DESCRIPTION
Make product kinds be always `non_null` and `non_float`. Separability doesn't make sense for product kinds, as we don't apply the float array optimization for arrays of product kinds. Nullability could make sense, but if we decide to implement that, we could look at the jkinds of the product components directly.

See tests. Note that the behavior of one-element unboxed records is unchanged, see the full file at `testsuite/tests/typing-layouts-or-null/separability.ml`.