### PR TITLE
Fix name abstraction when simplifying switch

### DIFF
--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -115,8 +115,9 @@ let rec simplify_expr dacc expr ~down_to_up =
     Simplify_apply_cont_expr.simplify_apply_cont dacc apply_cont ~down_to_up
   | Switch switch ->
     Simplify_switch_expr.simplify_switch
-      ~simplify_let:Simplify_let_expr.simplify_let ~simplify_function_body dacc
-      switch ~down_to_up
+      ~simplify_let_with_bound_pattern:
+        Simplify_let_expr.simplify_let_with_bound_pattern
+      ~simplify_function_body dacc switch ~down_to_up
   | Invalid { message } ->
     (* CR mshinwell: Make sure that a program can be simplified to just
        [Invalid]. *)

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -359,3 +359,13 @@ let simplify_let ~simplify_expr ~simplify_function_body dacc let_expr
     ~f:
       (simplify_let0 ~simplify_expr ~simplify_function_body dacc let_expr
          ~down_to_up)
+
+let simplify_let_with_bound_pattern ~simplify_expr_with_bound_pattern
+    ~simplify_function_body dacc let_expr ~down_to_up =
+  let module L = Flambda.Let in
+  L.pattern_match let_expr ~f:(fun bound_pattern ->
+      simplify_let0
+        ~simplify_expr:(fun dacc body ~down_to_up ->
+          simplify_expr_with_bound_pattern dacc (bound_pattern, body)
+            ~down_to_up)
+        ~simplify_function_body dacc let_expr ~down_to_up bound_pattern)

--- a/middle_end/flambda2/simplify/simplify_let_expr.mli
+++ b/middle_end/flambda2/simplify/simplify_let_expr.mli
@@ -20,3 +20,9 @@ val simplify_let :
   simplify_expr:Expr.t Simplify_common.expr_simplifier ->
   simplify_function_body:Simplify_common.simplify_function_body ->
   Let.t Simplify_common.expr_simplifier
+
+val simplify_let_with_bound_pattern :
+  simplify_expr_with_bound_pattern:
+    (Bound_pattern.t * Expr.t) Simplify_common.expr_simplifier ->
+  simplify_function_body:Simplify_common.simplify_function_body ->
+  Let.t Simplify_common.expr_simplifier

--- a/middle_end/flambda2/simplify/simplify_switch_expr.mli
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.mli
@@ -15,8 +15,9 @@
 (**************************************************************************)
 
 val simplify_switch :
-  simplify_let:
-    (simplify_expr:Flambda.Expr.t Simplify_common.expr_simplifier ->
+  simplify_let_with_bound_pattern:
+    (simplify_expr_with_bound_pattern:
+       (Bound_pattern.t * Flambda.Expr.t) Simplify_common.expr_simplifier ->
     simplify_function_body:Simplify_common.simplify_function_body ->
     Flambda.Let.t Simplify_common.expr_simplifier) ->
   simplify_function_body:Simplify_common.simplify_function_body ->

--- a/middle_end/flambda2/tests/mlexamples/lift_rec_cont.flt
+++ b/middle_end/flambda2/tests/mlexamples/lift_rec_cont.flt
@@ -50,9 +50,8 @@ let code loopify(never) size(50) newer_version_of(f_0)
        cont k2 (Paddint))
     where k2 (y : imm tagged) =
       let prim = %int_comp 0 <= y in
-      (switch prim
-         | 0 -> k5 (0)
-         | 1 -> k5 (1)
+      ((let tagged_scrutinee = %Tag_imm prim in
+        cont k5 (tagged_scrutinee))
          where rec k5 (i : imm tagged) =
            (apply g (i) -> k1_1 * k1
               where k1_1 (param) =

--- a/middle_end/flambda2/tests/mlexamples/tests15.flt
+++ b/middle_end/flambda2/tests/mlexamples/tests15.flt
@@ -164,9 +164,8 @@ let code loopify(never) size(14) newer_version_of(is_c_1)
         : imm tagged =
   let prim = %get_tag param in
   let eq = %int_comp imm prim = 2i in
-  switch eq
-    | 0 -> k (0)
-    | 1 -> k (1)
+  let tagged_scrutinee = %Tag_imm eq in
+  cont k (tagged_scrutinee)
 in
 let $camlTests15__is_c_8 = closure is_c_1_1 @is_c in
 let code loopify(never) size(5) newer_version_of(set_to_x_2)


### PR DESCRIPTION
When simplifying a switch expression, we introduce a new variable to represent the tagged version of the scrutinee, which is a naked immediate.

This variable is (presumably) added only so that it can get picked up by CSE when performing simplifications in the cases where a tagged version of the scrutinee is not otherwise available (e.g. the scrutinee comes from an `Is_int` or `Get_tag` primitive), and is marked as `used_in_current_handler` for this purpose.

However the actual processing of this variable is delegated to `simplify_let`, which immediately opens its name abstraction -- causing a desynchronisation between the variable that we recorded as being used and the one that actually ends up in the CSE equations / the typing env.

This patch introduces a new `simplify_let_with_bound_pattern` that forwards the `Bound_pattern.t` after opening the name abstraction and uses it to record the proper variable as used, causing it to appear in the `required_names` and allowing simplifications to proceed.

## Concrete changes

Before this patch, functions such as `Option.is_none` and `Option.is_some` get compiled to a switch. After this patch, they get compiled to `Tag_imm (Is_int .)` and `Boolean_not (Tag_imm (Is_int .))`, respectively.

Functions that manually compute the tag of a block by returning the appropriate integer also now get compiled to `Tag_imm (Get_tag .)` earlier (before this patch it was done by `To_cmm`, after this patch it happens inside flambda2).