### PR TITLE
Record that we have switched locking schemes

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -350,6 +350,7 @@ CAMLexport void caml_switch_runtime_locking_scheme(struct caml_locking_scheme* n
     caml_fatal_error("Switching locking scheme is unsupported in multicore programs");
   CAMLassert (!caml_domain_is_multicore());
   save_runtime_state();
+  domain_lockmode = LOCKMODE_CUSTOM_SCHEME;
   old = atomic_exchange(&Locking_scheme(dom_id), new);
   /* We hold 'old', but it is no longer the runtime lock */
   old->unlock(old->context);

--- a/testsuite/tests/lib-systhreads/swapgil_then_domains.ml
+++ b/testsuite/tests/lib-systhreads/swapgil_then_domains.ml
@@ -1,0 +1,21 @@
+(* TEST
+ flags = "-g";
+ modules = "swapgil_stubs.c";
+ include systhreads;
+ runtime5;
+ hasunix;
+ native;
+*)
+
+external setup : unit -> unit = "swap_gil_setup"
+let () = setup ()
+
+external swap_gil : unit -> unit = "swap_gil"
+
+(* Test that one cannot spawn a domain after switching locking schemes *)
+
+let () = (swap_gil ();
+          try
+            Domain.join ((Domain.Safe.spawn [@alert "-unsafe_parallelism"]) (fun () -> ()))
+          with exn ->
+            print_endline (Printexc.to_string exn))

--- a/testsuite/tests/lib-systhreads/swapgil_then_domains.reference
+++ b/testsuite/tests/lib-systhreads/swapgil_then_domains.reference
@@ -1,0 +1,1 @@
+Failure("Domain.spawn cannot be used with a non-default runtime locking scheme.")


### PR DESCRIPTION
It was possible to spawn domains after switching locking schemes, because we weren't setting the obvious variable. Also added a test. Found while reviewing #4013.