### PR TITLE
Add a fixed_explanation for Tof_kind

### DIFF
--- a/jane/doc/proposals/kind-inference.md
+++ b/jane/doc/proposals/kind-inference.md
@@ -482,7 +482,7 @@ m_portability = portable
     Γ ⊢ κᵢ ≤ χᵢ
   κ₀' = κ₀{τsⱼ/[['aᵢ]]}
   ∀ Ξ:
-    mode m_Ξ ≤ Ξ(κ₀')
+    mode mⱼ_Ξ ≤ Ξ(κ₀')
     ∀ σ ∈ types_for(Ξ, field_typesⱼ), with σ ≤ Ξ(κ₀')
   value ≤ lay(κ₀')
 if [@@unboxed]:

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1255,27 +1255,13 @@ type 'a contended : immutable_data with 'a @@ contended
 type 'a contended_with_int : immutable_data with 'a @@ contended
 |}]
 
-(* Parsing implemented, but kind-checking not yet implemented *)
 type 'a abstract
 type existential_abstract : immutable_data with (type : value mod portable) abstract =
   | Mk : ('a : value mod portable) abstract -> existential_abstract
 [%%expect{|
 type 'a abstract
-Lines 2-3, characters 0-67:
-2 | type existential_abstract : immutable_data with (type : value mod portable) abstract =
-3 |   | Mk : ('a : value mod portable) abstract -> existential_abstract
-Error: The kind of type "existential_abstract" is value mod non_float
-         because it's a boxed variant type.
-       But the kind of type "existential_abstract" must be a subkind of
-         immutable_data with (type : value mod portable) abstract
-         because of the annotation on the declaration of the type existential_abstract.
-|}]
-
-type test_printing = (type : value) * (type : value) * (x:(type : value) -> int) -> (type : value)
-[%%expect{|
-type test_printing =
-    (type : value) * (type : value) * (x:(type : value) -> int) -> (type :
-    value)
+type existential_abstract =
+    Mk : ('a : value mod portable). 'a abstract -> existential_abstract
 |}]
 
 (* not yet supported *)

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -646,3 +646,13 @@ Line 8, characters 24-29:
                             ^^^^^
 Error: This value is "contended" but expected to be "uncontended".
 |}]
+
+(*********************************************************)
+(* Unifying Tof_kind row_mores *)
+
+(* this case is reduced from a real failure *)
+type 'a t1 constraint 'a = [< `A ]
+type 'a t2 = 'a t1
+type 'a t3 = T : 'a t2 -> 'a t3
+
+[%%expect]

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -655,4 +655,8 @@ type 'a t1 constraint 'a = [< `A ]
 type 'a t2 = 'a t1
 type 'a t3 = T : 'a t2 -> 'a t3
 
-[%%expect]
+[%%expect{|
+type 'a t1 constraint 'a = [< `A ]
+type 'a t2 = 'a t1 constraint 'a = [< `A ]
+type 'a t3 = T : 'b t2 -> ([< `A ] as 'b) t3
+|}]

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -61,12 +61,8 @@ type t = Foo : ('a : immutable_data). 'a -> t
 |}]
 
 let foo (t : t @ contended) = use_uncontended t
-(* CR layouts v2.8: fix this *)
 [%%expect {|
-Line 1, characters 46-47:
-1 | let foo (t : t @ contended) = use_uncontended t
-                                                  ^
-Error: This value is "contended" but expected to be "uncontended".
+val foo : t @ contended -> unit = <fun>
 |}]
 
 let foo (t : t @ local) = use_global t [@nontail]
@@ -85,21 +81,16 @@ type 'a t = Foo : 'a -> 'a t
 |}]
 
 let foo (t : int t @ once) = use_many t
-(* CR layouts v2.8: fix this *)
 [%%expect {|
-Line 1, characters 38-39:
-1 | let foo (t : int t @ once) = use_many t
-                                          ^
-Error: This value is "once" but expected to be "many".
+val foo : int t @ once -> unit = <fun>
 |}]
 
-let foo (t : t @ aliased) = use_unique t
+let foo (t : int t @ aliased) = use_unique t
 [%%expect {|
-Line 1, characters 13-14:
-1 | let foo (t : t @ aliased) = use_unique t
-                 ^
-Error: The type constructor "t" expects 1 argument(s),
-       but is here applied to 0 argument(s)
+Line 1, characters 43-44:
+1 | let foo (t : int t @ aliased) = use_unique t
+                                               ^
+Error: This value is "aliased" but expected to be "unique".
 |}]
 
 (***********************************************************************)
@@ -158,4 +149,500 @@ Uncaught exception: Misc.Fatal_error
 |}]
 
 (*****************************************)
-(* CR layouts v2.8: write more gadt tests *)
+
+type ('a, 'b) t : immutable_data with 'a = { inner : 'a }
+[%%expect{|
+type ('a, 'b) t = { inner : 'a; }
+|}]
+
+(* We can have existential variables, as long as they don't end up in our with-bounds *)
+type 'a u : immutable_data with 'a =
+| P1 : ('a1, 'b) t -> 'a1 u
+| P2 : ('a2, 'b) t -> 'a2 u
+[%%expect{|
+type 'a u = P1 : ('a1, 'b) t -> 'a1 u | P2 : ('a2, 'b) t -> 'a2 u
+|}]
+
+(* Any existentials in the with-bounds turn into [(type : kind)] then get normalized away.
+   (this test intentionally causes a subkind error to make sure that the existentials
+   don't show up in the with-bounds)
+*)
+type 'x u : immediate =
+| P1 : ('b, 'a1) t -> 'a1 u
+[%%expect{|
+Lines 1-2, characters 0-27:
+1 | type 'x u : immediate =
+2 | | P1 : ('b, 'a1) t -> 'a1 u
+Error: The kind of type "u" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "u" must be a subkind of immediate
+         because of the annotation on the declaration of the type u.
+|}]
+
+type 'a u : immutable_data =
+| P1 : ('b, 'a) t -> 'a u
+[%%expect{|
+Lines 1-2, characters 0-25:
+1 | type 'a u : immutable_data =
+2 | | P1 : ('b, 'a) t -> 'a u
+Error: The kind of type "u" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "u" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type u.
+|}]
+
+(* CR layouts v2.8: It'd also be OK to infer or accept [immutable_data with 'y] here. *)
+type ('x, 'y) t : immutable_data with 'x with 'y =
+  | T : 'a -> ('a, 'a) t
+  | U : 'c -> ('b,  'c) t
+[%%expect{|
+type ('x, 'y) t = T : 'a -> ('a, 'a) t | U : 'c -> ('b, 'c) t
+|}]
+
+type 'a t : immediate =
+  | A : 'b -> 'b option t
+[%%expect{|
+Lines 1-2, characters 0-25:
+1 | type 'a t : immediate =
+2 |   | A : 'b -> 'b option t
+Error: The kind of type "t" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of immediate
+         because of the annotation on the declaration of the type t.
+|}]
+
+type 'a t : immutable_data =
+  | A : ('b : immutable_data). 'b -> 'b option t
+[%%expect{|
+type 'a t = A : ('b : immutable_data). 'b -> 'b option t
+|}]
+
+type 'a t : immediate =
+  | A : ('b : immutable_data). 'b -> 'b option t
+[%%expect{|
+Lines 1-2, characters 0-48:
+1 | type 'a t : immediate =
+2 |   | A : ('b : immutable_data). 'b -> 'b option t
+Error: The kind of type "t" is immutable_data
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of immediate
+         because of the annotation on the declaration of the type t.
+|}]
+
+type 'a cell : mutable_data with 'a =
+  | Nil : 'a cell
+  | Cons of { value : 'a; mutable next: 'a cell }
+[%%expect{|
+type 'a cell =
+    Nil : 'a cell
+  | Cons of { value : 'a; mutable next : 'a cell; }
+|}]
+
+type 'a cell : mutable_data with 'a =
+  | Nil
+  | Cons : { value : 'b; mutable next: 'b cell } -> 'b cell
+[%%expect{|
+type 'a cell =
+    Nil
+  | Cons : { value : 'b; mutable next : 'b cell; } -> 'b cell
+|}]
+
+(* Existentials that are the type arguments to abstract types should end up as [type :
+   kind] in the with-bounds.
+
+   This test intentionally triggers a kind error to check this via the printed kind in the
+   error message. *)
+type 'a abstract : value mod portable
+type existential_abstract : immediate =
+  | P : ('a : value mod portable). 'a abstract -> existential_abstract
+[%%expect{|
+type 'a abstract : value mod portable
+Lines 2-3, characters 0-70:
+2 | type existential_abstract : immediate =
+3 |   | P : ('a : value mod portable). 'a abstract -> existential_abstract
+Error: The kind of type "existential_abstract" is immutable_data
+         with (type : value mod portable) abstract
+         because it's a boxed variant type.
+       But the kind of type "existential_abstract" must be a subkind of
+         immediate
+         because of the annotation on the declaration of the type existential_abstract.
+|}]
+
+type existential_abstract : immutable_data with (type : value mod portable) abstract =
+  | P : ('a : value mod portable). 'a abstract -> existential_abstract
+[%%expect{|
+type existential_abstract =
+    P : ('a : value mod portable). 'a abstract -> existential_abstract
+|}]
+
+type existential_abstract : value mod portable =
+  | P : ('a : value mod portable). 'a abstract -> existential_abstract
+[%%expect{|
+type existential_abstract =
+    P : ('a : value mod portable). 'a abstract -> existential_abstract
+|}]
+
+let foo (x : existential_abstract @ nonportable) =
+  use_portable x
+
+module M : sig
+  type t : immutable_data with (type : value mod portable) abstract
+end = struct
+  type t = P : ('a : value mod portable). 'a abstract -> t
+end
+[%%expect{|
+val foo : existential_abstract -> unit = <fun>
+module M :
+  sig type t : immutable_data with (type : value mod portable) abstract end
+|}]
+
+module M : sig
+  type t : immutable_data with (type : value) abstract
+end = struct
+  type t = P : ('a : immediate). 'a abstract -> t
+end
+(* CR layouts v2.8: This might be safe to accept, but it's tricky and unlikely to be
+   especially useful. Revisit later. It will require descending into arguments of non-best
+   Tconstrs, checking to see if corresponding arguments are in a sub-kind relationship --
+   but only if at least the argument on the right is best. Subtle. *)
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = P : ('a : immediate). 'a abstract -> t
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = P : ('a : immediate). 'a abstract -> t end
+       is not included in
+         sig type t : immutable_data with (type : value) abstract end
+       Type declarations do not match:
+         type t = P : ('a : immediate). 'a abstract -> t
+       is not included in
+         type t : immutable_data with (type : value) abstract
+       The kind of the first is immutable_data
+         with (type : immediate) abstract
+         because of the definition of t at line 4, characters 2-49.
+       But the kind of the first must be a subkind of immutable_data
+         with (type : value) abstract
+         because of the definition of t at line 2, characters 2-54.
+|}]
+
+(* Some hard recursive types with existentials *)
+type existential_abstract : value mod portable with (type : value mod portable) abstract =
+  | P : ('a : value mod portable). 'a abstract t2 -> existential_abstract
+and 'a t2 = P : { contents : 'a; other : ('b : value mod portable) option } -> 'a t2
+and 'a abstract : value mod portable
+[%%expect{|
+type existential_abstract =
+    P : ('a : value mod portable). 'a abstract t2 -> existential_abstract
+and 'a t2 =
+    P : 'a ('b : value mod portable). { contents : 'a; other : 'b option;
+    } -> 'a t2
+and 'a abstract : value mod portable
+|}]
+
+(* Actually mode crossing for [type : kind] *)
+
+module type S = sig
+  type 'a b
+  type t = P : ('a : value mod portable) b -> t
+end
+[%%expect{|
+module type S =
+  sig type 'a b type t = P : ('a : value mod portable). 'a b -> t end
+|}]
+
+module F1(M : S) = struct
+  let foo (x : M.t @ nonportable) = use_portable x
+end
+[%%expect{|
+Line 2, characters 49-50:
+2 |   let foo (x : M.t @ nonportable) = use_portable x
+                                                     ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+module F2(M : S with type 'a b = int) = struct
+  type t : immutable_data = M.t
+  let foo1 (x : M.t @ nonportable) = use_portable x
+  let foo2 (x : M.t @ contended) = use_uncontended x
+end
+[%%expect{|
+module F2 :
+  functor
+    (M : sig
+           type 'a b = int
+           type t = P : ('a : value mod portable). 'a b -> t
+         end)
+    ->
+    sig
+      type t = M.t
+      val foo1 : M.t -> unit
+      val foo2 : M.t @ contended -> unit
+    end
+|}]
+
+module F3(M : S with type 'a b = 'a) = struct
+  type t : value mod portable = M.t
+  let foo (x : t @ nonportable) = use_portable x
+end
+[%%expect{|
+module F3 :
+  functor
+    (M : sig
+           type 'a b = 'a
+           type t = P : ('a : value mod portable). 'a b -> t
+         end)
+    -> sig type t = M.t val foo : t -> unit end
+|}]
+
+module F4(M : S with type 'a b = 'a) = struct
+  let foo (x : M.t @ contended) = use_uncontended x
+end
+[%%expect{|
+Line 2, characters 50-51:
+2 |   let foo (x : M.t @ contended) = use_uncontended x
+                                                      ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+(* _ in parameters *)
+
+(* CR layouts v2.8: Printing [_] here is not wrong (and in fact the overall inferred kind
+   is correct), but it's a little strange and will probably be confusing to users.
+   Probably the best thing to do is to number the distinct [_]s when printing and print
+   them as something like [_1], [_2], etc. *)
+
+type _ box = Box : 'a -> 'a box
+[%%expect{|
+type _ box = Box : 'a -> 'a box
+|}]
+
+let foo (x : int box @ contended) = use_uncontended x
+[%%expect{|
+val foo : int box @ contended -> unit = <fun>
+|}]
+
+let should_reject (x : int ref box @ contended) = use_uncontended x
+[%%expect{|
+Line 1, characters 66-67:
+1 | let should_reject (x : int ref box @ contended) = use_uncontended x
+                                                                      ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+
+type (_, _) box2 = Box2 : 'a -> ('a, 'a) box2
+[%%expect{|
+type (_, _) box2 = Box2 : 'a -> ('a, 'a) box2
+|}]
+
+let foo (x : (int, int) box2 @ contended) = use_uncontended x
+[%%expect{|
+val foo : (int, int) box2 @ contended -> unit = <fun>
+|}]
+
+let should_reject (x : (int ref, int ref) box2 @ contended) = use_uncontended x
+[%%expect{|
+Line 1, characters 78-79:
+1 | let should_reject (x : (int ref, int ref) box2 @ contended) = use_uncontended x
+                                                                                  ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+type show_me_the_kind : immediate = (int ref, int ref) box2
+[%%expect{|
+Line 1, characters 0-59:
+1 | type show_me_the_kind : immediate = (int ref, int ref) box2
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "(int ref, int ref) box2" is mutable_data
+         because of the definition of box2 at line 1, characters 0-45.
+       But the kind of type "(int ref, int ref) box2" must be a subkind of
+         immediate
+         because of the definition of show_me_the_kind at line 1, characters 0-59.
+|}]
+
+(* Demonstrate that this is only a printing issue *)
+type _ box : immediate = Box : 'a -> 'a box
+
+[%%expect{|
+Line 1, characters 0-43:
+1 | type _ box : immediate = Box : 'a -> 'a box
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "box" is immutable_data with _
+         because it's a boxed variant type.
+       But the kind of type "box" must be a subkind of immediate
+         because of the annotation on the declaration of the type box.
+|}]
+
+(* Only the first type parameter matters *)
+
+let crosses (x : (int, int ref) box2 @ contended) = use_uncontended x
+[%%expect{|
+val crosses : (int, int ref) box2 @ contended -> unit = <fun>
+|}]
+
+let doesn't_cross (x : (int ref, int) box2 @ contended) = use_uncontended x
+(* CR layouts v2.8: arguably this should be accepted if [crosses] is accepted (even though
+   x is uninhabited) *)
+[%%expect{|
+Line 1, characters 74-75:
+1 | let doesn't_cross (x : (int ref, int) box2 @ contended) = use_uncontended x
+                                                                              ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+(* Constraints and existentials *)
+
+type 'a t constraint 'a = 'b option
+type 'c t2 : immutable_data with (type : value) option t =
+  | K : 'd t -> 'd t2
+[%%expect{|
+type 'a t constraint 'a = 'b option
+type 'c t2 = K : 'a option t -> 'a option t2
+|}]
+
+type 'a t constraint 'a = 'b option
+type 'c t2 : immediate =
+  | K : 'd t -> 'd t2
+[%%expect{|
+type 'a t constraint 'a = 'b option
+Lines 2-3, characters 0-21:
+2 | type 'c t2 : immediate =
+3 |   | K : 'd t -> 'd t2
+Error: The kind of type "t2" is immutable_data with (type : value) option t
+         because it's a boxed variant type.
+       But the kind of type "t2" must be a subkind of immediate
+         because of the annotation on the declaration of the type t2.
+|}]
+
+(* Existential row variables *)
+
+type exist_row1 = Mk : ([< `A | `B of int ref] as 'a) -> exist_row1
+[%%expect{|
+type exist_row1 = Mk : [< `A | `B of int ref ] -> exist_row1
+|}]
+
+type show_me_the_kind : immediate = exist_row1
+[%%expect{|
+Line 1, characters 0-46:
+1 | type show_me_the_kind : immediate = exist_row1
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "exist_row1" is immutable_data
+         with [< `A | `B of int ref ]
+         because of the definition of exist_row1 at line 1, characters 0-67.
+       But the kind of type "exist_row1" must be a subkind of immediate
+         because of the definition of show_me_the_kind at line 1, characters 0-46.
+|}]
+
+let foo (x : exist_row1 @ nonportable) = use_portable x
+(* CR layouts v2.8: This should be accepted *)
+[%%expect{|
+Line 1, characters 54-55:
+1 | let foo (x : exist_row1 @ nonportable) = use_portable x
+                                                          ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+let foo (x : exist_row1 @ contended) = use_uncontended x
+[%%expect{|
+Line 1, characters 55-56:
+1 | let foo (x : exist_row1 @ contended) = use_uncontended x
+                                                           ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+type exist_row2 = Mk : ([> `A | `B of int ref] as 'a) -> exist_row2
+[%%expect{|
+type exist_row2 = Mk : [> `A | `B of int ref ] -> exist_row2
+|}]
+
+type show_me_the_kind : immediate = exist_row2
+[%%expect{|
+Line 1, characters 0-46:
+1 | type show_me_the_kind : immediate = exist_row2
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "exist_row2" is immutable_data
+         with [> `A | `B of int ref ]
+         because of the definition of exist_row2 at line 1, characters 0-67.
+       But the kind of type "exist_row2" must be a subkind of immediate
+         because of the definition of show_me_the_kind at line 1, characters 0-46.
+|}]
+
+let foo (x : exist_row2 @ nonportable) = use_portable x
+[%%expect{|
+Line 1, characters 54-55:
+1 | let foo (x : exist_row2 @ nonportable) = use_portable x
+                                                          ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+let foo (x : exist_row2 @ contended) = use_uncontended x
+[%%expect{|
+Line 1, characters 55-56:
+1 | let foo (x : exist_row2 @ contended) = use_uncontended x
+                                                           ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+type 'a exist_row3 = Mk : ([> `A | `B of int ref] as 'a) -> 'a option exist_row3
+[%%expect{|
+type 'a exist_row3 =
+    Mk : 'a -> ([> `A | `B of int ref ] as 'a) option exist_row3
+|}]
+
+type 'a show_me_the_kind : immediate = 'a option exist_row3
+[%%expect{|
+Line 1, characters 0-59:
+1 | type 'a show_me_the_kind : immediate = 'a option exist_row3
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "'a option exist_row3" is immutable_data
+         with [> `A | `B of int ref ]
+         because of the definition of exist_row3 at line 1, characters 0-80.
+       But the kind of type "'a option exist_row3" must be a subkind of
+         immediate
+         because of the definition of show_me_the_kind at line 1, characters 0-59.
+|}]
+
+let foo (x : [`A | `B of int ref] option exist_row3 @ contended) = use_uncontended x
+[%%expect{|
+Line 1, characters 83-84:
+1 | let foo (x : [`A | `B of int ref] option exist_row3 @ contended) = use_uncontended x
+                                                                                       ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+(* This would be lovely to accept, but it seems beyond the
+   expressiveness of our design. Specifically, we'd need to have some way
+   of connecting mode-crossing behavior to the choice of [option] in the
+   argument to [exist_row3]. *)
+let foo (x : [`A | `B of int ref] option exist_row3 @ nonportable) = use_portable x
+[%%expect{|
+Line 1, characters 82-83:
+1 | let foo (x : [`A | `B of int ref] option exist_row3 @ nonportable) = use_portable x
+                                                                                      ^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+(* In the future, maybe local equations will let us figure out that something mode crosses
+   more than we would know otherwise. *)
+type 'a idx = | I : int idx | Br : bool ref idx
+type exist = Exist : ('a : value mod portable). 'a * 'a idx -> exist
+let foo (exist : exist @ contended) eq =
+  match exist with
+  | Exist (x, idx) -> begin
+    match idx with
+      | I ->
+        use_uncontended exist;
+        x
+    | Br -> 0
+  end
+(* CR layouts v2.8: Maybe this should be accepted? *)
+[%%expect{|
+type 'a idx = I : int idx | Br : bool ref idx
+type exist = Exist : ('a : value mod portable). 'a * 'a idx -> exist
+Line 8, characters 24-29:
+8 |         use_uncontended exist;
+                            ^^^^^
+Error: This value is "contended" but expected to be "uncontended".
+|}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -369,21 +369,17 @@ Error: Signature mismatch:
          because of the definition of t at line 3, characters 2-34.
 |}]
 
-(* CR layouts v2.8: gadts shouldn't be "best" because we intend to give them more refined
-   jkinds in the future. So this program will error in the future. *)
 type gadt = Foo : int -> gadt
 module M : sig
   type t : value mod portable with gadt
 end = struct
-  type t
+  type t : value mod portable
 end
 [%%expect {|
 type gadt = Foo : int -> gadt
-module M : sig type t end
+module M : sig type t : value mod portable end
 |}]
 
-(* CR layouts v2.8: gadts shouldn't be "best". But maybe they should track quality along
-   individual axes, and so this should be accepted anyways? *)
 type gadt = Foo : int -> gadt
 module M : sig
   type t : value mod global with gadt
@@ -392,7 +388,23 @@ end = struct
 end
 [%%expect {|
 type gadt = Foo : int -> gadt
-module M : sig type t end
+Lines 4-6, characters 6-3:
+4 | ......struct
+5 |   type t
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t end
+       is not included in
+         sig type t : value mod unyielding end
+       Type declarations do not match:
+         type t
+       is not included in
+         type t : value mod unyielding
+       The kind of the first is value
+         because of the definition of t at line 5, characters 2-8.
+       But the kind of the first must be a subkind of value mod unyielding
+         because of the definition of t at line 3, characters 2-37.
 |}]
 
 type gadt = Foo : int -> gadt [@@unboxed]

--- a/tools/debug_printers.ml
+++ b/tools/debug_printers.ml
@@ -1,5 +1,7 @@
 let type_expr = Printtyp.raw_type_expr
+let type_set = Btype.TypeSet.debug_print
 let row_field = Printtyp.raw_field
+let row_desc = Printtyp.raw_row_desc
 let ident = Ident.print_with_scope
 let path = Path.print
 let ctype_global_state = Ctype.print_global_state

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -157,6 +157,7 @@ let merge_fixed_explanation fixed1 fixed2 =
   | Some Fixed_private as x, _ | _, (Some Fixed_private as x) -> x
   | Some Reified _ as x, _ | _, (Some Reified _ as x) -> x
   | Some Rigid as x, _ | _, (Some Rigid as x) -> x
+  | Some Fixed_existential as x, _ | _, (Some Fixed_existential as x) -> x
   | None, None -> None
 
 
@@ -169,6 +170,7 @@ let fixed_explanation row =
       | Tvar _ | Tnil -> None
       | Tunivar _ -> Some (Univar ty)
       | Tconstr (p,_,_) -> Some (Reified p)
+      | Tof_kind _ -> Some Fixed_existential
       | _ -> assert false
 
 let is_fixed row = match row_fixed row with

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -20,6 +20,11 @@ open Types
 
 open Local_store
 
+(**** Forward declarations ****)
+
+let print_raw =
+  ref (fun _ -> assert false : Format.formatter -> type_expr -> unit)
+
 (**** Sets, maps and hashtables of types ****)
 
 let wrap_repr f ty = f (Transient_expr.repr ty)
@@ -34,6 +39,13 @@ module TypeSet = struct
   let exists p = TransientTypeSet.exists (wrap_type_expr p)
   let elements set =
     List.map Transient_expr.type_expr (TransientTypeSet.elements set)
+  let debug_print ppf t =
+    Format.(
+      fprintf ppf "{ %a }"
+        (pp_print_seq
+           ~pp_sep:(fun ppf () -> fprintf ppf ";@,")
+           !print_raw)
+        (to_seq t |> Seq.map Transient_expr.type_expr))
 end
 module TransientTypeMap = Map.Make(TransientTypeOps)
 module TypeMap = struct
@@ -95,10 +107,6 @@ module TypePairs = struct
         f (type_expr t1, type_expr t2))
 end
 
-(**** Forward declarations ****)
-
-let print_raw =
-  ref (fun _ -> assert false : Format.formatter -> type_expr -> unit)
 
 (**** Type level management ****)
 
@@ -285,6 +293,7 @@ let fold_row f init row =
 
 let iter_row f row =
   fold_row (fun () v -> f v) () row
+
 
 let fold_type_expr f init ty =
   match get_desc ty with

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -27,6 +27,7 @@ module TypeSet : sig
   val singleton: type_expr -> t
   val exists: (type_expr -> bool) -> t -> bool
   val elements: t -> type_expr list
+  val debug_print : Format.formatter -> t -> unit
 end
 module TransientTypeMap : Map.S with type key = transient_expr
 module TypeMap : sig

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -535,6 +535,8 @@ val free_variables: ?env:Env.t -> type_expr -> type_expr list
            returns both normal variables and row variables*)
 val free_non_row_variables_of_list: type_expr list -> type_expr list
         (* gets only non-row variables *)
+val free_variable_set_of_list: Env.t -> type_expr list -> Btype.TypeSet.t
+        (* post-condition: all elements in the set are Tvars *)
 
 val exists_free_variable : (type_expr -> jkind_lr -> bool) -> type_expr -> bool
         (* Check if there exists a free variable that satisfies the

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -29,12 +29,12 @@ let free_vars ?(param=false) ty =
       | Tvar _ ->
           ret := TypeSet.add ty !ret
       | Tvariant row ->
-          iter_row loop row;
-          if not (static_row row) then begin
-            match get_desc (row_more row) with
-            | Tvar _ when param -> ret := TypeSet.add ty !ret
-            | _ -> loop (row_more row)
-          end
+        iter_row loop row;
+        if not (static_row row) then begin
+          match get_desc (row_more row) with
+          | Tvar _ when param -> ret := TypeSet.add ty !ret
+          | _ -> loop (row_more row)
+        end
       (* XXX: What about Tobject ? *)
       | _ ->
           iter_type_expr loop ty

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2371,10 +2371,12 @@ let for_non_float ~(why : History.value_creation_reason) =
     { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
     ~annotation:None ~why:(Value_creation why)
 
-let for_boxed_variant cstrs =
+let for_boxed_variant ~decl_params ~type_apply ~free_vars cstrs =
   let open Types in
   if List.for_all
-       (fun cstr ->
+       (* CR layouts v12: This code assumes that all voids mode-cross. I
+          think that's probably not what we want. *)
+         (fun cstr ->
          match cstr.cd_args with
          | Cstr_tuple args ->
            List.for_all (fun arg -> Sort.Const.(equal void arg.ca_sort)) args
@@ -2390,32 +2392,196 @@ let for_boxed_variant cstrs =
           | Cstr_record lbls -> has_mutable_label lbls)
         cstrs
     in
-    let has_gadt_constructor =
-      List.exists
-        (fun cstr -> match cstr.cd_res with None -> false | Some _ -> true)
-        cstrs
+    let base =
+      (if is_mutable then Builtin.mutable_data else Builtin.immutable_data)
+        ~why:Boxed_variant
+      |> mark_best
     in
-    if has_gadt_constructor
-       (* CR layouts v2.8: This is sad, but I don't know how to account for
-          existentials in the with_bounds. See doc named "Existential
-          with_bounds". *)
-    then for_non_float ~why:Boxed_variant
-    else
-      let base =
-        (if is_mutable then Builtin.mutable_data else Builtin.immutable_data)
-          ~why:Boxed_variant
-        |> mark_best
-      in
-      let add_cstr_args cstr jkind =
+    (* Note [With-bounds for GADTs]
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+       Inferring the with-bounds for a variant requires gathering bounds from
+       each constructor. We thus loop over each constructor:
+
+       A. If a constructor is not a GADT
+       constructor, just add its fields and their modalities as with-bounds.
+
+       B. If a constructor uses GADT syntax:
+
+       GADT constructors introduce their own local scope. That is, when we
+       see
+
+       {[
+         type 'a t = K : 'b option -> 'b t
+       ]}
+
+       the ['b] in the constructor is distinct from the ['a] in the type header.
+       This would be true even if we wrote ['a] in the constructor: the
+       variables introduced in the type head never scope over GADT constructors.
+
+       So in order to get properly-scoped with-bounds, we must substitute.
+       But what, exactly, do we substitute? The domain is the bare
+       variables that appear as arguments in the return type. The range is
+       the corresponding variables in the type head (even if those are written
+       as [_]s; which are turned into proper type variables by now).
+
+       We use [Ctype.apply] (passed in as [type_apply]) to perform the
+       substitution.
+
+       We thus have
+
+         * STEP B1. Gather such variables from the result type, matching them
+         with their corresponding variables in the type head. We'll call these
+         B1 variables.
+
+       We do not actually substitute quite yet.
+
+       There may still be other free type variables in the constructor
+       type. Here are some examples:
+
+       {[
+         type 'a t =
+           | K1 : 'o -> int t
+           | K2 : 'o -> 'o option t
+           | K3 : 'o -> 'b t
+       ]}
+
+       In each constructor, the type variable ['o] is not a B1 variable.
+       (The ['b] in [K3] /is/ a B1 variable.) We call
+       these variables /orphaned/. All existential variables are orphans
+       (as we see in [K1] and [K3]), but even non-existential variables
+       can be orphan (as we see in [K2]; note that ['o] appears in the
+       result).
+
+       We wish to replace each orphaned type variable with a [Tof_kind], holding
+       just its kind. Since [Tof_kind] has a *best* kind, they'll just get
+       normalized away during normalization, except in the case that they show
+       up as an argument to a type constructor representing an abstract type -
+       in which case, they still end up in the (fully normalized)
+       with-bounds. For example, the following type:
+
+       {[
+         type t : A : ('a : value mod portable). 'a abstract -> t
+       ]}
+
+       has kind:
+
+       {[
+         immutable_data with (type : value mod portable) abstract
+       ]}
+
+       This use of the [(type : <<kind>>)] construct is the reason we have
+       [Tof_kind] in the first place.
+
+       We thus have
+
+         * STEP B2. Gather the orphaned variables
+         * STEP B3. Build the [Tof_kind] types to use in the substitution
+         * STEP B4. Perform the substitution
+
+       There is one notable wrinkle:
+
+       BW. For repeated types on arguments, e.g. in the following type:
+
+       {[
+         type ('x, 'y) t = A : 'a -> ('a, 'a) t
+       ]}
+
+       we substitute only the *first* time we see an argument.
+       That means that in the
+       above type, we'll map all instances of ['a] to ['x] and infer a
+       kind of [immutable_data with 'x]. This is sound, but somewhat
+       restrictive; in a perfect world, we'd infer a kind of [immutable_data
+       with ('x OR 'y)], but that goes beyond what with-bounds can describe
+       (which, if we implemented it, would introduce a disjunction in type
+       inference, requiring backtracking). At some point in the future, we
+       should at least change the subsumption algorithm to accept either
+       [immutable_data with 'x] or [immutable_data with 'y] (* CR layouts v2.8:
+       do that *)
+    *)
+    let add_with_bounds_for_cstr jkind_so_far cstr =
+      let cstr_arg_tys, cstr_arg_modalities =
         match cstr.cd_args with
         | Cstr_tuple args ->
-          List.fold_right
-            (fun arg ->
-              add_with_bounds ~modality:arg.ca_modalities ~type_expr:arg.ca_type)
-            args jkind
-        | Cstr_record lbls -> add_labels_as_with_bounds lbls jkind
+          List.fold_left
+            (fun (tys, ms) arg -> arg.ca_type :: tys, arg.ca_modalities :: ms)
+            ([], []) args
+        | Cstr_record lbls ->
+          List.fold_left
+            (fun (tys, ms) lbl -> lbl.ld_type :: tys, lbl.ld_modalities :: ms)
+            ([], []) lbls
       in
-      List.fold_right add_cstr_args cstrs base
+      let cstr_arg_tys =
+        match cstr.cd_res with
+        | None -> cstr_arg_tys
+        | Some res ->
+          let apply_subst domain range tys =
+            if Misc.Stdlib.List.is_empty domain
+            then tys
+            else List.map (fun ty -> type_apply domain ty range) tys
+          in
+          (* STEP B1 from Note [With-bounds for GADTs]: *)
+          let res_args =
+            match Types.get_desc res with
+            | Tconstr (_, args, _) -> args
+            | _ -> Misc.fatal_error "cd_res must be Tconstr"
+          in
+          let domain, range, seen =
+            List.fold_left2
+              (fun ((domain, range, seen) as acc) arg param ->
+                if Btype.TypeSet.mem arg seen
+                then
+                  (* We've already seen this type parameter, so don't add it
+                     again.  See wrinkle BW from Note [With-bounds for GADTs] *)
+                  acc
+                else
+                  match Types.get_desc arg with
+                  | Tvar _ ->
+                    (* Only add types which are direct variables. Note that
+                       types which aren't variables might themselves /contain/
+                       variables; if those variables don't show up on another
+                       parameter, they're treated as orphaned. See example K2
+                       from Note [With-bounds for GADTs] *)
+                    arg :: domain, param :: range, Btype.TypeSet.add arg seen
+                  | _ -> acc)
+              ([], [], Btype.TypeSet.empty)
+              res_args decl_params
+          in
+          (* STEP B2 from Note [With-bounds for GADTs]: *)
+          let free_var_set = free_vars cstr_arg_tys in
+          let orphaned_type_var_set = Btype.TypeSet.diff free_var_set seen in
+          let orphaned_type_var_list =
+            Btype.TypeSet.elements orphaned_type_var_set
+          in
+          (* STEP B3 from Note [With-bounds for GADTs]: *)
+          let mk_type_of_kind ty =
+            match Types.get_desc ty with
+            (* use [newgenty] not [newty] here because we've already
+               generalized the decl and want to keep things at
+               generic_level *)
+            | Tvar { jkind; name = _ } -> Btype.newgenty (Tof_kind jkind)
+            | _ ->
+              Misc.fatal_error
+                "post-condition of [free_variable_set_of_list] violated"
+          in
+          let type_of_kind_list =
+            List.map mk_type_of_kind orphaned_type_var_list
+          in
+          (* STEP B4 from Note [With-bounds for GADTs]: *)
+          let cstr_arg_tys =
+            apply_subst
+              (orphaned_type_var_list @ domain)
+              (type_of_kind_list @ range)
+              cstr_arg_tys
+          in
+          cstr_arg_tys
+      in
+      List.fold_left2
+        (fun jkind type_expr modality ->
+          add_with_bounds ~modality ~type_expr jkind)
+        jkind_so_far cstr_arg_tys cstr_arg_modalities
+    in
+    List.fold_left add_with_bounds_for_cstr base cstrs
 
 let for_boxed_tuple elts =
   List.fold_right

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -497,8 +497,20 @@ val for_boxed_record : Types.label_declaration list -> Types.jkind_l
 (** Choose an appropriate jkind for an unboxed record type. *)
 val for_unboxed_record : Types.label_declaration list -> Types.jkind_l
 
-(** Choose an appropriate jkind for a boxed variant type. *)
-val for_boxed_variant : Types.constructor_declaration list -> Types.jkind_l
+(** Choose an appropriate jkind for a boxed variant type.
+
+    [decl_params] is the parameters in the head of the type declaration. [type_apply]
+    should be [Ctype.apply] partially applied to an [env]. *)
+val for_boxed_variant :
+  decl_params:Types.type_expr list ->
+  type_apply:
+    (Types.type_expr list ->
+    Types.type_expr ->
+    Types.type_expr list ->
+    Types.type_expr) ->
+  free_vars:(Types.type_expr list -> Btype.TypeSet.t) ->
+  Types.constructor_declaration list ->
+  Types.jkind_l
 
 (** Choose an appropriate jkind for a boxed tuple type. *)
 val for_boxed_tuple : (string option * Types.type_expr) list -> Types.jkind_l

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -732,6 +732,7 @@ and raw_row_fixed ppf = function
 | Some Types.Rigid -> fprintf ppf "Some Rigid"
 | Some Types.Univar t -> fprintf ppf "Some(Univar(%a))" raw_type t
 | Some Types.Reified p -> fprintf ppf "Some(Reified(%a))" path p
+| Some Types.Fixed_existential -> fprintf ppf "Some Fixed_existential"
 
 and raw_field ppf rf =
   match_row_field
@@ -3043,6 +3044,7 @@ let explain_fixed_row pos expl = match expl with
            print_path p ppf))
       p
   | Rigid -> ignore
+  | Fixed_existential -> ignore
 
 let explain_variant (type variety) : variety Errortrace.variant -> _ = function
   (* Common *)
@@ -3066,7 +3068,7 @@ let explain_variant (type variety) : variety Errortrace.variant -> _ = function
         dprintf "@,@[%t,@ %a@]" (explain_fixed_row pos e)
           explain_fixed_row_case k
       )
-  | Errortrace.Fixed_row (_,_, Rigid) ->
+  | Errortrace.Fixed_row (_,_, (Rigid | Fixed_existential)) ->
       (* this case never happens *)
       None
   (* Equality & Moregen *)

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -662,6 +662,22 @@ and raw_lid_type_list tl =
   raw_list (fun ppf (lid, typ) ->
              fprintf ppf "(@,%a,@,%a)" longident lid raw_type typ)
     tl
+and raw_row_desc ppf row =
+  let Row {fields; more; name; fixed; closed} = row_repr row in
+  fprintf ppf
+    "@[<hov1>{@[%s@,%a;@]@ @[%s@,%a;@]@ %s%B;@ %s%a;@ @[<1>%s%t@]}@]"
+    "row_fields="
+    (raw_list (fun ppf (l, f) ->
+       fprintf ppf "@[%s,@ %a@]" l raw_field f))
+    fields
+    "row_more=" raw_type more
+    "row_closed=" closed
+    "row_fixed=" raw_row_fixed fixed
+    "row_name="
+    (fun ppf ->
+       match name with None -> fprintf ppf "None"
+                     | Some(p,tl) ->
+                       fprintf ppf "Some(@,%a,@,%a)" path p raw_type_list tl)
 and raw_type_desc ppf = function
     Tvar { name; jkind } ->
       fprintf ppf "Tvar (@,%a,@,%a)"
@@ -704,21 +720,7 @@ and raw_type_desc ppf = function
         raw_type t
         raw_type_list tl
   | Tvariant row ->
-      let Row {fields; more; name; fixed; closed} = row_repr row in
-      fprintf ppf
-        "@[<hov1>{@[%s@,%a;@]@ @[%s@,%a;@]@ %s%B;@ %s%a;@ @[<1>%s%t@]}@]"
-        "row_fields="
-        (raw_list (fun ppf (l, f) ->
-          fprintf ppf "@[%s,@ %a@]" l raw_field f))
-        fields
-        "row_more=" raw_type more
-        "row_closed=" closed
-        "row_fixed=" raw_row_fixed fixed
-        "row_name="
-        (fun ppf ->
-          match name with None -> fprintf ppf "None"
-          | Some(p,tl) ->
-              fprintf ppf "Some(@,%a,@,%a)" path p raw_type_list tl)
+    raw_row_desc ppf row
   | Tpackage (p, fl) ->
       fprintf ppf "@[<hov1>Tpackage(@,%a,@,%a)@]" path p
         raw_lid_type_list fl

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -41,6 +41,7 @@ val strings_of_paths: namespace -> Path.t list -> string list
     (** Print a list of paths, using the same naming context to
         avoid name collisions *)
 
+val raw_row_desc : formatter -> row_desc -> unit
 val raw_type_expr: formatter -> type_expr -> unit
 val raw_field : formatter -> row_field -> unit
 val string_of_label: Types.arg_label -> string

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -474,7 +474,7 @@ let rec typexp copy_scope s ty =
               let more' =
                 match mored with
                   Tsubst (ty, None) -> ty
-                | Tconstr _ | Tnil -> typexp copy_scope s more
+                | Tconstr _ | Tnil | Tof_kind _ -> typexp copy_scope s more
                 | Tunivar _ | Tvar _ ->
                     if should_duplicate_vars then newpersty mored
                     else if dup && is_Tvar more then newgenty mored

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1955,7 +1955,13 @@ let rec update_decl_jkind env dpath decl =
           (idx+1,cstr::cstrs)
         ) (0,[]) cstrs
       in
-      let jkind = Jkind.for_boxed_variant cstrs in
+      let jkind =
+        Jkind.for_boxed_variant
+          ~decl_params:decl.type_params
+          ~type_apply:(Ctype.apply env)
+          ~free_vars:(Ctype.free_variable_set_of_list env)
+          cstrs
+      in
       List.rev cstrs, rep, jkind
     | (([] | (_ :: _)), Variant_unboxed | _, Variant_extensible) ->
       assert false

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -365,7 +365,11 @@ and row_desc =
       row_fixed: fixed_explanation option;
       row_name: (Path.t * type_expr list) option }
 and fixed_explanation =
-  | Univar of type_expr | Fixed_private | Reified of Path.t | Rigid
+  | Univar of type_expr
+  | Fixed_private
+  | Reified of Path.t
+  | Rigid
+  | Fixed_existential
 and row_field = [`some] row_field_gen
 and _ row_field_gen =
     RFpresent : type_expr option -> [> `some] row_field_gen

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -1285,7 +1285,7 @@ module Transient_expr = struct
     match ty.desc with
     | Tvar { name; _ } ->
       set_desc ty (Tvar { name; jkind = jkind' })
-    | _ -> assert false
+    | _ -> Misc.fatal_error "set_var_jkind called on non-var"
   let coerce ty = ty
   let repr = repr
   let type_expr ty = ty

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -245,8 +245,7 @@ and type_desc =
 
       These types are uninhabited, and any appearing in translation will cause an error.
       They are only used to represent the kinds of existentially-quantified types
-      mentioned in with-bounds. *)
-      (* CR reisenberg: add link to test once one exists *)
+      mentioned in with-bounds. See test typing-jkind-bounds/gadt.ml *)
 
 (** This is used in the Typedtree. It is distinct from
     {{!Asttypes.arg_label}[arg_label]} because Position argument labels are

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -268,6 +268,8 @@ and fixed_explanation =
   | Fixed_private (** The row type is private *)
   | Reified of Path.t (** The row was reified *)
   | Rigid (** The row type was made rigid during constraint verification *)
+  | Fixed_existential (** The row type is existential in a with-bound.
+                      See Note [With-bounds for GADTs] in Jkind. *)
 
 (** [abbrev_memo] allows one to keep track of different expansions of a type
     alias. This is done for performance purposes.
@@ -569,6 +571,11 @@ val row_fields: row_desc -> (label * row_field) list
       some incompletness in type inference.
 
     * [Tnil]: Used to denote a static polymorphic variant (with no [>] or [<]).
+
+    * [Tof_kind]: See Wrinkle BW2 in Note [With-bounds for GADTs] in Jkind.
+    Briefly, [Tof_kind] can appear as a [row_more] when computing the kind
+    of a GADT with an existentially-bound row variable. The [fixed_explanation]
+    will be [Fixed_existential].
 
     ----------------------------------------
 


### PR DESCRIPTION
This fixes a problem seen in the nightly build.

Please review by commit. Should be quick. Note that the last commit is just formatting.

Review: @glittershark 

This branches from before #3814 was reverted. When merging, I will unrevert #3814 first.