### PR TITLE
Fix binary emitter VEX encoding bug

### DIFF
--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -875,12 +875,12 @@ let emit_MOV b dst src =
 
 let emit_vex3 buf ~rexr ~rexx ~rexb ~vex_m ~vex_w ~vex_v ~vex_l ~vex_p =
   buf_int8 buf 0xC4; (* We only emit 3-byte VEX instructions. *)
-  buf_int8 buf (((lnot rexr) lsl 7) lor
-                ((lnot rexx) lsl 6) lor
-                ((lnot rexb) lsl 5) lor
+  buf_int8 buf (((rexr lxor 1) lsl 7) lor
+                ((rexx lxor 1) lsl 6) lor
+                ((rexb lxor 1) lsl 5) lor
                 vex_m);
   buf_int8 buf ((vex_w lsl 7) lor
-                ((lnot vex_v) lsl 3) lor
+                ((vex_v lxor 15) lsl 3) lor
                 (vex_l lsl 2) lor
                 vex_p)
 


### PR DESCRIPTION
These bitwise negations are wrong; they should only flip the bottom 1 / 4 bits respectively.
The results still happen to be correct for the only existing VEX instructions (pdep and pext), but #3966 requires the fix.