### PR TITLE
Add the ability to emit module entry functions into a separate section

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -232,6 +232,12 @@ let load_symbol_addr (s : Cmm.symbol) arg =
    supported on the target system. *)
 
 let emit_named_text_section ?(suffix = "") func_name =
+  (* CR-someday ksvetlitski: In the future we should consider extending this to
+     also place other known-cold functions in a separate section (specifically
+     [.text.unlikely.caml]). This would necessitate adding a new constructor to
+     [Cfg.codegen_option], and at that point we could add a constructor for
+     module-entry-functions too so that we don't have to inspect [func_name]
+     like we do now. *)
   if !Flambda_backend_flags.module_entry_functions_section
      && String.ends_with func_name ~suffix:"__entry"
   then (
@@ -245,7 +251,7 @@ let emit_named_text_section ?(suffix = "") func_name =
          does not support function sections. *) ->
       assert false
     | _ ->
-      D.switch_to_section_raw ~names:[".text.entry"] ~flags:(Some "ax")
+      D.switch_to_section_raw ~names:[".text.startup.caml"] ~flags:(Some "ax")
         ~args:["@progbits"] ~is_delayed:false;
       (* Warning: We set the internal section ref to Text here, because it
          currently does not supported named text sections. In the rest of this

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -232,7 +232,29 @@ let load_symbol_addr (s : Cmm.symbol) arg =
    supported on the target system. *)
 
 let emit_named_text_section ?(suffix = "") func_name =
-  if !Clflags.function_sections || !Flambda_backend_flags.basic_block_sections
+  if !Flambda_backend_flags.module_entry_functions_section
+     && String.ends_with func_name ~suffix:"__entry"
+  then (
+    match[@ocaml.warning "-4"] system with
+    | S_macosx
+    (* Names of section segments in macosx are restricted to 16 characters, but
+       function names are often longer, especially anonymous functions. *)
+    | S_win64 | S_mingw64
+    | S_cygwin
+      (* Win systems provide named text sections, but configure on these systems
+         does not support function sections. *) ->
+      assert false
+    | _ ->
+      D.switch_to_section_raw ~names:[".text.entry"] ~flags:(Some "ax")
+        ~args:["@progbits"] ~is_delayed:false;
+      (* Warning: We set the internal section ref to Text here, because it
+         currently does not supported named text sections. In the rest of this
+         file, we pretend the section is called Text rather than the function
+         specific text section. *)
+      (* CR sspies: Add proper support for named text sections. *)
+      D.unsafe_set_internal_section_ref Text)
+  else if !Clflags.function_sections
+          || !Flambda_backend_flags.basic_block_sections
   then (
     match[@ocaml.warning "-4"] system with
     | S_macosx

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -132,12 +132,13 @@ let mk_basic_block_sections f =
 let mk_module_entry_functions_section f =
   if Config.function_sections then
     "-module-entry-functions-section",  Arg.Unit f,
-    " Emit all module entry functions into a separate section if the target supports it. Requires \
-     -ocamlcfg."
+    " Emit all module entry functions into a separate section if the target \
+      supports it. Requires -ocamlcfg."
   else
     let err () =
       raise (Arg.Bad "OCaml has been configured without support for \
-                      -function-sections which is required for -module-entry-functions-section")
+                      -function-sections which is required for \
+                      -module-entry-functions-section")
     in
     "-module-entry-functions-section", Arg.Unit err, " (option not available)"
 ;;
@@ -1434,7 +1435,8 @@ module Extra_params = struct
     | "reorder-blocks-random" ->
        set_int_option' Flambda_backend_flags.reorder_blocks_random
     | "basic-block-sections" -> set' Flambda_backend_flags.basic_block_sections
-    | "module-entry-functions-section" -> set' Flambda_backend_flags.module_entry_functions_section
+    | "module-entry-functions-section" ->
+      set' Flambda_backend_flags.module_entry_functions_section
     | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
     | "zero-alloc-check" ->
       (match Zero_alloc_annotations.Check.of_string v with

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -1434,6 +1434,7 @@ module Extra_params = struct
     | "reorder-blocks-random" ->
        set_int_option' Flambda_backend_flags.reorder_blocks_random
     | "basic-block-sections" -> set' Flambda_backend_flags.basic_block_sections
+    | "module-entry-functions-section" -> set' Flambda_backend_flags.module_entry_functions_section
     | "heap-reduction-threshold" -> set_int' Flambda_backend_flags.heap_reduction_threshold
     | "zero-alloc-check" ->
       (match Zero_alloc_annotations.Check.of_string v with

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -129,6 +129,19 @@ let mk_basic_block_sections f =
     "-basic-block-sections", Arg.Unit err, " (option not available)"
 ;;
 
+let mk_module_entry_functions_section f =
+  if Config.function_sections then
+    "-module-entry-functions-section",  Arg.Unit f,
+    " Emit all module entry functions into a separate section if the target supports it. Requires \
+     -ocamlcfg."
+  else
+    let err () =
+      raise (Arg.Bad "OCaml has been configured without support for \
+                      -function-sections which is required for -module-entry-functions-section")
+    in
+    "-module-entry-functions-section", Arg.Unit err, " (option not available)"
+;;
+
 let mk_dasm_comments f =
   "-dasm-comments", Arg.Unit f, " Add comments in .s files (e.g. for DWARF)"
 
@@ -758,6 +771,7 @@ module type Flambda_backend_options = sig
 
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit
+  val module_entry_functions_section : unit -> unit
 
   val dasm_comments : unit -> unit
   val dno_asm_comments : unit -> unit
@@ -895,6 +909,7 @@ struct
 
     mk_reorder_blocks_random F.reorder_blocks_random;
     mk_basic_block_sections F.basic_block_sections;
+    mk_module_entry_functions_section F.module_entry_functions_section;
 
     mk_dasm_comments F.dasm_comments;
     mk_dno_asm_comments F.dno_asm_comments;
@@ -1069,6 +1084,8 @@ module Flambda_backend_options_impl = struct
     Flambda_backend_flags.reorder_blocks_random := Some seed
   let basic_block_sections () =
     set' Flambda_backend_flags.basic_block_sections ()
+  let module_entry_functions_section () =
+    set' Flambda_backend_flags.module_entry_functions_section ()
 
   let dasm_comments =
     set' Flambda_backend_flags.dasm_comments

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -51,6 +51,7 @@ module type Flambda_backend_options = sig
 
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit
+  val module_entry_functions_section : unit -> unit
 
   val dasm_comments : unit -> unit
   val dno_asm_comments : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -38,7 +38,8 @@ let cfg_eliminate_dead_trap_handlers = ref false  (* -cfg-eliminate-dead-trap-ha
 
 let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 let basic_block_sections = ref false    (* -basic-block-sections *)
-let module_entry_functions_section = ref false    (* -module-entry-functions-section *)
+(* -module-entry-functions-section *)
+let module_entry_functions_section = ref false
 
 let dasm_comments = ref false (* -dasm-comments *)
 

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -38,6 +38,7 @@ let cfg_eliminate_dead_trap_handlers = ref false  (* -cfg-eliminate-dead-trap-ha
 
 let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 let basic_block_sections = ref false    (* -basic-block-sections *)
+let module_entry_functions_section = ref false    (* -module-entry-functions-section *)
 
 let dasm_comments = ref false (* -dasm-comments *)
 

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -37,6 +37,7 @@ val cfg_eliminate_dead_trap_handlers : bool ref
 
 val reorder_blocks_random : int option ref
 val basic_block_sections : bool ref
+val module_entry_functions_section : bool ref
 
 val dasm_comments : bool ref
 


### PR DESCRIPTION
Module entry functions are ice-cold after startup, so for the sake of improving iTLB usage it is desirable to place all of them together in a separate section so that they aren't mixed in with hot code. This behavior is opt-in via the new command line flag `-module-entry-functions-section`.