### PR TITLE
Restore gc_regs_buckets after stack overflow

### DIFF
--- a/flambda-backend/tests/simd/callback.ml
+++ b/flambda-backend/tests/simd/callback.ml
@@ -26,6 +26,32 @@ external add : float32x4 -> float32x4 -> float32x4
   = "caml_vec128_unreachable" "caml_sse_float32x4_add"
   [@@noalloc] [@@unboxed] [@@builtin]
 
+let callback0 () =
+  let x0 = low_of 0.0s in
+  let x1 = low_of 1.0s in
+  let x2 = low_of 2.0s in
+  let x3 = low_of 3.0s in
+  let x4 = low_of 4.0s in
+  let x5 = low_of 5.0s in
+  let x6 = low_of 6.0s in
+  let x7 = low_of 7.0s in
+  let x8 = low_of 8.0s in
+  let x9 = low_of 9.0s in
+  let x10 = low_of 10.0s in
+  let x11 = low_of 11.0s in
+  let x12 = low_of 12.0s in
+  let x13 = low_of 13.0s in
+  let x14 = low_of 14.0s in
+  let x15 = low_of 15.0s in
+  let x16 = low_of 16.0s in
+  let sum =
+    add x16
+      (add
+         (add (add (add x0 x1) (add x2 x3)) (add (add x4 x5) (add x6 x7)))
+         (add (add (add x8 x9) (add x10 x11)) (add (add x12 x13) (add x14 x15))))
+  in
+  assert (low_to sum = 136.s)
+
 let callback () =
   let x0 = low_of 0.0s in
   let x1 = low_of 1.0s in
@@ -44,6 +70,7 @@ let callback () =
   let x14 = low_of 14.0s in
   let x15 = low_of 15.0s in
   let x16 = low_of 16.0s in
+  callback0 ();
   let sum =
     add x16
       (add

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -653,7 +653,11 @@ CFI_STARTPROC
         RESTORE_ALL_REGS
         LEAVE_FUNCTION
         ret
-1:      SWITCH_OCAML_TO_C
+1:      /* Restore the gc_regs bucket popped by SAVE_ALL_REGS */
+        movq    Caml_state(gc_regs_buckets), %r11;
+        movq    %r11, 0(%r15); /* next ptr */
+        movq    %r15, Caml_state(gc_regs_buckets);
+        SWITCH_OCAML_TO_C
         LEA_VAR(caml_exn_Stack_overflow, %rdi)
         C_call  (GCALL(caml_raise_async))
 CFI_ENDPROC


### PR DESCRIPTION
`caml_call_realloc_stack` pops a `gc_regs` bucket to save registers before calling `caml_try_realloc_stack`.
If the reallocation fails, it does not restore the bucket before raising the stack overflow async exn.
If the program then needs to spill gc_regs (e.g. tries to grow the stack again), it will crash due the bucket list being empty.

It now restores the bucket in the stack overflow case. I've updated `callback.ml` to fail without this change.

Also, I noticed in `arm64.S`, `caml_call_realloc_stack` does not switch back to the C stack before raising the async exn -- is that wrong? It also restores the registers, which means it doesn't have the gc_regs issue.