### PR TITLE
Make the AST version mismatch error message more descriptive

### DIFF
--- a/driver/pparse.ml
+++ b/driver/pparse.ml
@@ -146,16 +146,21 @@ exception Outdated_version
 
 let open_and_check_magic inputfile ast_magic =
   let ic = open_in_bin inputfile in
+  let buffer = ref "" in
   let is_ast_file =
     try
-      let buffer = really_input_string ic (String.length ast_magic) in
-      if buffer = ast_magic then true
-      else if String.sub buffer 0 9 = String.sub ast_magic 0 9 then
+      buffer := really_input_string ic (String.length ast_magic);
+      if !buffer = ast_magic then true
+      else if String.sub !buffer 0 9 = String.sub ast_magic 0 9 then
         raise Outdated_version
       else false
     with
       Outdated_version ->
-        Misc.fatal_error "OCaml and preprocessor have incompatible versions"
+        Misc.fatal_errorf {|
+OCaml and preprocessor have incompatible versions
+  - OCaml compiler version: %s
+  - Preprocessor version (from [ppxlib/astlib/ast_999.ml]): %s
+|} ast_magic !buffer
     | _ -> false
   in
   (ic, is_ast_file)


### PR DESCRIPTION
Today I spent nearly 2 hours trying to understand why I was failing to build our internal codebase with an older build of the compiler. Ultimately the issue was that the magic number hard-coded in `ppxlib/astlib/ast_99.ml` didn't match the magic number of the compiler (even though in this case the parse-trees were still compatible). To save others the pain of having to figure this out in the future, I've made the error message produced in this scenario more descriptive.