### PR TITLE
Delete Flambda_kind.to_lambda

### DIFF
--- a/middle_end/flambda2/kinds/flambda_kind.ml
+++ b/middle_end/flambda2/kinds/flambda_kind.ml
@@ -81,21 +81,6 @@ let region = Region
 
 let rec_info = Rec_info
 
-let to_lambda (t : t) : Lambda.layout =
-  match t with
-  | Value -> Lambda.layout_any_value
-  | Naked_number Naked_immediate ->
-    Misc.fatal_error "Can't convert kind [Naked_immediate] to lambda layout"
-  | Naked_number Naked_float -> Punboxed_float Unboxed_float64
-  | Naked_number Naked_float32 -> Punboxed_float Unboxed_float32
-  | Naked_number Naked_int32 -> Punboxed_int Unboxed_int32
-  | Naked_number Naked_int64 -> Punboxed_int Unboxed_int64
-  | Naked_number Naked_nativeint -> Punboxed_int Unboxed_nativeint
-  | Naked_number Naked_vec128 -> Punboxed_vector Unboxed_vec128
-  | Region -> Misc.fatal_error "Can't convert kind [Region] to lambda layout"
-  | Rec_info ->
-    Misc.fatal_error "Can't convert kind [Rec_info] to lambda layout"
-
 include Container_types.Make (struct
   type nonrec t = t
 

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -72,8 +72,6 @@ val is_value : t -> bool
 
 val is_naked_float : t -> bool
 
-val to_lambda : t -> Lambda.layout
-
 include Container_types.S with type t := t
 
 type flat_suffix_element = private


### PR DESCRIPTION
This dead code discourages being able to forget information when translating a `Lambda.layout` to a `Flambda_kind.t`. 