### PR TITLE
fix: genprintval should not call `is_null` on a `value` layout

### DIFF
--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -75,7 +75,17 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
 
     type t = O.t
 
-    external is_null : O.t -> bool = "%is_null"
+    (* Normally, [Obj.t] has layout [value], but we need to handle nullable
+       values at toplevel. flambda2 is allowed to optimise calls to [is_null]
+       on an argument with [value] layout to [false], so first convert
+       (opaquely!) to a type with [value_or_null] layout. *)
+    type obj_or_null : value_or_null
+
+    external obj_or_null : t -> obj_or_null = "%opaque"
+
+    external is_null : obj_or_null -> bool = "%is_null"
+
+    let[@inline] is_null obj = is_null (obj_or_null obj)
 
     (* Normally, [Obj.is_block] can't be called on [value_or_null]s.
        But here we need to handle nullable values at toplevel. *)


### PR DESCRIPTION
Genprintval uses calls to `is_null` on values of type `Obj.t` in order to be able to deal with nullable values at toplevel. In the native version, flambda2 will happily simplify these calls to `false` in certain circumstances, since `Obj.t` has layout `value` and values of type `Obj.t` cannot be null.

This patch first converts to an `or_null` value (using %opaque) before calling `is_null` to ensure this does not happen.