### PR TITLE
Optimize a couple of equal/compare functions

### DIFF
--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -649,48 +649,24 @@ let map_shallow f = function
     | Cconst_vec128 _ | Cconst_symbol _ | Cvar _ ) as c ->
     c
 
-let compare_machtype_component (left : machtype_component)
-    (right : machtype_component) =
-  match left, right with
-  | Val, Val
-  | Addr, Addr
-  | Int, Int
-  | Float, Float
-  | Vec128, Vec128
-  | Float32, Float32
-  | Valx2, Valx2 ->
-    0
-  | Val, (Addr | Int | Float | Vec128 | Float32 | Valx2) -> -1
-  | (Addr | Int | Float | Vec128 | Float32 | Valx2), Val -> 1
-  | Addr, (Int | Float | Vec128 | Float32 | Valx2) -> -1
-  | (Int | Float | Vec128 | Float32 | Valx2), Addr -> 1
-  | Int, (Float | Vec128 | Float32 | Valx2) -> -1
-  | (Float | Vec128 | Float32 | Valx2), Int -> 1
-  | Float, (Vec128 | Float32 | Valx2) -> -1
-  | (Vec128 | Float32 | Valx2), Float -> 1
-  | Vec128, (Float32 | Valx2) -> -1
-  | (Float32 | Valx2), Vec128 -> 1
-  | Float32, Valx2 -> -1
-  | Valx2, Float32 -> 1
+let rank_machtype_component : machtype_component -> int = function
+  | Val -> 0
+  | Addr -> 1
+  | Int -> 2
+  | Float -> 3
+  | Vec128 -> 4
+  | Float32 -> 5
+  | Valx2 -> 6
 
-let equal_machtype_component (left : machtype_component)
-    (right : machtype_component) =
-  match left, right with
-  | Val, Val -> true
-  | Addr, Addr -> true
-  | Int, Int -> true
-  | Float, Float -> true
-  | Vec128, Vec128 -> true
-  | Float32, Float32 -> true
-  | Valx2, Valx2 -> true
-  | Valx2, (Val | Addr | Int | Float | Vec128 | Float32)
-  | Val, (Addr | Int | Float | Vec128 | Float32 | Valx2)
-  | Addr, (Val | Int | Float | Vec128 | Float32 | Valx2)
-  | Int, (Val | Addr | Float | Vec128 | Float32 | Valx2)
-  | Float, (Val | Addr | Int | Vec128 | Float32 | Valx2)
-  | Vec128, (Val | Addr | Int | Float | Float32 | Valx2)
-  | Float32, (Val | Addr | Int | Float | Vec128 | Valx2) ->
-    false
+let compare_machtype_component
+    ((Val | Addr | Int | Float | Vec128 | Float32 | Valx2) as left :
+      machtype_component) (right : machtype_component) =
+  rank_machtype_component left - rank_machtype_component right
+
+let equal_machtype_component
+    ((Val | Addr | Int | Float | Vec128 | Float32 | Valx2) as left :
+      machtype_component) (right : machtype_component) =
+  rank_machtype_component left = rank_machtype_component right
 
 let equal_exttype left right =
   match left, right with

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -47,23 +47,22 @@ module WorkList = struct
     | Colored
     | Select_stack
 
-  let equal left right =
-    match left, right with
-    | Unknown_list, Unknown_list
-    | Precolored, Precolored
-    | Initial, Initial
-    | Simplify, Simplify
-    | Freeze, Freeze
-    | Spill, Spill
-    | Spilled, Spilled
-    | Coalesced, Coalesced
-    | Colored, Colored
-    | Select_stack, Select_stack ->
-      true
-    | ( ( Unknown_list | Precolored | Initial | Simplify | Freeze | Spill
-        | Spilled | Coalesced | Colored | Select_stack ),
-        _ ) ->
-      false
+  let rank = function
+    | Unknown_list -> 0
+    | Precolored -> 1
+    | Initial -> 2
+    | Simplify -> 3
+    | Freeze -> 4
+    | Spill -> 5
+    | Spilled -> 6
+    | Coalesced -> 7
+    | Colored -> 8
+    | Select_stack -> 9
+
+  let equal
+      (( Unknown_list | Precolored | Initial | Simplify | Freeze | Spill
+       | Spilled | Coalesced | Colored | Select_stack ) as left) right =
+    rank left = rank right
 
   let to_string = function
     | Unknown_list -> "unknown_list"


### PR DESCRIPTION
As noted in #3914, the way we write
`equal` and `compare` functions
leads to slow code when the type is
a simple sum type.

This pull request rewrites a couple
of `equal` and `compare` functions
to produce more compact (and
inlinable code). The functions were
not chosen randomly: they did take
a couple of percents on some
regalloc benchmarking.
`equal_machtype_component` is
particularly important: after a recent
refactoring it is called by `Reg.same`
which in turn is used in numerous
places (maps, sets, tables, etc).