### PR TITLE
Linscan: simplify the interval orders

### DIFF
--- a/backend/regalloc/regalloc_ls_utils.ml
+++ b/backend/regalloc/regalloc_ls_utils.ml
@@ -151,19 +151,9 @@ module Interval = struct
     && Int.equal left.end_ right.end_
     && DLL.equal Range.equal left.ranges right.ranges
 
-  let compare_asc_begin left right =
-    match Int.compare left.begin_ right.begin_ with
-    | 0 ->
-      (* note: not necessary, used to enforce a unique order *)
-      Reg.compare left.reg right.reg
-    | c -> c
+  let compare_asc_begin left right = left.begin_ - right.begin_
 
-  let compare_desc_end left right =
-    match Int.compare right.end_ left.end_ with
-    | 0 ->
-      (* note: not necessary, used to enforce a unique order *)
-      Reg.compare right.reg left.reg
-    | c -> c
+  let compare_desc_end left right = right.end_ - left.end_
 
   let copy t =
     { reg = t.reg;


### PR DESCRIPTION
The orders can be simplified to only
take into account one bound of the
interval. The only reason we were
using a stronger comparison was to
be sure we would get the very same
result with different implementations
(recently skip lists and doubly-linked
lists whose contents was first sorted
using an array).