### PR TITLE
Fix fixed in poly params

### DIFF
--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -400,3 +400,30 @@ Error: The syntactic arity of the function doesn't match the type constraint:
           where "gadt_pat" is the pattern with the GADT constructor that
           introduces the local type equation on "a".
 |}];;
+
+(* Check that we are getting the right behaviour for polymorphic variants
+   in polymorphic parameters. *)
+
+let poly_poly_var : [< `A | `B ] -> unit = function  | `A -> () | `B -> ()
+
+let accept_poly_poly_var (g : 'a. ([< `A | `B ] as 'a) -> unit) = g `A
+
+let () = accept_poly_poly_var poly_poly_var
+[%%expect {|
+val poly_poly_var : [< `A | `B ] -> unit = <fun>
+val accept_poly_poly_var : ('a. ([< `A | `B ] as 'a) -> unit) -> unit = <fun>
+Line 5, characters 30-43:
+5 | let () = accept_poly_poly_var poly_poly_var
+                                  ^^^^^^^^^^^^^
+Error: This argument has type "[< `A | `B ] -> unit" which is less general than
+         "'a. ([< `A | `B ] as 'a) -> unit"
+|}, Principal{|
+val poly_poly_var : [< `A | `B ] -> unit = <fun>
+val accept_poly_poly_var : ('a. ([< `A | `B ] as 'a) -> unit) -> unit = <fun>
+Line 5, characters 30-43:
+5 | let () = accept_poly_poly_var poly_poly_var
+                                  ^^^^^^^^^^^^^
+Error: This expression has type "[  ] -> unit"
+       but an expression was expected of type "[< `A | `B ] -> unit"
+       These two variant types have no intersection
+|}]

--- a/testsuite/tests/typing-poly/poly_params.ml
+++ b/testsuite/tests/typing-poly/poly_params.ml
@@ -412,18 +412,4 @@ let () = accept_poly_poly_var poly_poly_var
 [%%expect {|
 val poly_poly_var : [< `A | `B ] -> unit = <fun>
 val accept_poly_poly_var : ('a. ([< `A | `B ] as 'a) -> unit) -> unit = <fun>
-Line 5, characters 30-43:
-5 | let () = accept_poly_poly_var poly_poly_var
-                                  ^^^^^^^^^^^^^
-Error: This argument has type "[< `A | `B ] -> unit" which is less general than
-         "'a. ([< `A | `B ] as 'a) -> unit"
-|}, Principal{|
-val poly_poly_var : [< `A | `B ] -> unit = <fun>
-val accept_poly_poly_var : ('a. ([< `A | `B ] as 'a) -> unit) -> unit = <fun>
-Line 5, characters 30-43:
-5 | let () = accept_poly_poly_var poly_poly_var
-                                  ^^^^^^^^^^^^^
-Error: This expression has type "[  ] -> unit"
-       but an expression was expected of type "[< `A | `B ] -> unit"
-       These two variant types have no intersection
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1653,9 +1653,14 @@ let instance_poly' copy_scope ~keep_names ~fixed univars sch =
   let ty = copy_sep ~copy_scope ~fixed ~visited sch in
   vars, ty
 
-let instance_poly ?(keep_names=false) ~fixed univars sch =
+let instance_poly_fixed ?(keep_names=false) univars sch =
   For_copy.with_scope (fun copy_scope ->
-    instance_poly' copy_scope ~keep_names ~fixed univars sch
+    instance_poly' copy_scope ~keep_names ~fixed:true univars sch
+  )
+
+let instance_poly ?(keep_names=false) univars sch =
+  For_copy.with_scope (fun copy_scope ->
+    snd (instance_poly' copy_scope ~keep_names ~fixed:false univars sch)
   )
 
 let instance_label ~fixed lbl =
@@ -6469,7 +6474,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
     | (Tpoly (u1, []), Tpoly (u2, [])) ->
         subtype_rec env trace u1 u2 cstrs
     | (Tpoly (u1, tl1), Tpoly (u2, [])) ->
-        let _, u1' = instance_poly ~fixed:false tl1 u1 in
+        let u1' = instance_poly tl1 u1 in
         subtype_rec env trace u1' u2 cstrs
     | (Tpoly (u1, tl1), Tpoly (u2,tl2)) ->
         begin try

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -213,9 +213,15 @@ val instance_class:
         type_expr list -> class_type -> type_expr list * class_type
 
 val instance_poly:
-        ?keep_names:bool -> fixed:bool ->
-        type_expr list -> type_expr -> type_expr list * type_expr
+        ?keep_names:bool ->
+        type_expr list -> type_expr -> type_expr
         (* Take an instance of a type scheme containing free univars *)
+val instance_poly_fixed:
+        ?keep_names:bool ->
+        type_expr list -> type_expr -> type_expr list * type_expr
+        (* Take an instance of a type scheme containing free univars for
+           checking that an expression matches this scheme. *)
+
 val polyfy: Env.t -> type_expr -> type_expr list -> type_expr * bool
 val instance_label:
         fixed:bool ->

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -831,7 +831,7 @@ let rec class_field_first_pass self_loc cl_num sign self_scope acc cf =
                    Ctype.unify val_env (Ctype.newmono ty') ty;
                    Typecore.type_approx val_env sbody ty'
                | Tpoly (ty1, tl) ->
-                   let _, ty1' = Ctype.instance_poly ~fixed:false tl ty1 in
+                   let ty1' = Ctype.instance_poly tl ty1 in
                    Typecore.type_approx val_env sbody ty1'
                | _ -> assert false
              with Ctype.Unify err ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1832,7 +1832,7 @@ let solve_Ppat_constraint tps loc env mode sty expected_ty =
   let expected_ty' =
     match get_desc expected_ty' with
     | Tpoly (expected_ty', tl) ->
-        snd (instance_poly ~keep_names:true ~fixed:false tl expected_ty')
+        instance_poly ~keep_names:true tl expected_ty'
     | _ -> expected_ty'
   in
   (cty, ty, expected_ty')
@@ -4609,9 +4609,9 @@ let check_univars env kind exp ty_expected vars =
       match get_desc pty with
         Tpoly (body, tl) ->
           (* Enforce scoping for type_let:
-             since body is not generic,  instance_poly only makes
+             since body is not generic,  instance_poly_fixed only makes
              copies of nodes that have a Tunivar as descendant *)
-          let univars, ty' = instance_poly ~fixed:true tl body in
+          let univars, ty' = instance_poly_fixed tl body in
           let vars, exp_ty = instance_parameterized_type vars exp.exp_type in
           List.iter2 (fun uvar var ->
             (* This checks that the term doesn't require more specific jkinds
@@ -5215,7 +5215,7 @@ let split_function_ty
       if vars = [] then ty
       else begin
         with_level ~level:generic_level
-          (fun () -> snd (instance_poly ~keep_names:true ~fixed:false vars ty))
+          (fun () -> instance_poly ~keep_names:true vars ty)
       end
     end
   in
@@ -6390,7 +6390,7 @@ and type_expect_
             if !Clflags.principal && get_level typ <> generic_level then
               Location.prerr_warning loc
                 (Warnings.Not_principal "this use of a polymorphic method");
-            snd (instance_poly ~fixed:false tl ty)
+            instance_poly tl ty
         | Tvar _ ->
             let ty' = newvar (Jkind.Builtin.value ~why:Object_field) in
             unify env (instance typ) (newty(Tpoly(ty',[])));
@@ -6634,7 +6634,7 @@ and type_expect_
               with_local_level begin fun () ->
                 let vars, ty'' =
                   with_local_level_if_principal
-                    (fun () -> instance_poly ~fixed:true tl ty')
+                    (fun () -> instance_poly_fixed tl ty')
                     ~post:(fun (_,ty'') -> generalize_structure ty'')
                 in
                 let exp = type_expect env expected_mode sbody (mk_expected ty'') in
@@ -8245,11 +8245,11 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
             with_local_level begin fun () ->
               let vars, ty_arg' =
                 with_local_level_if separate begin fun () ->
-                  instance_poly ~fixed:false vars ty_arg'
+                  instance_poly_fixed vars ty_arg'
                 end ~post:(fun (_, ty_arg') -> generalize_structure ty_arg')
               in
               let (ty_arg0', vars0) = tpoly_get_poly ty_arg0 in
-              let vars0, ty_arg0' = instance_poly ~fixed:false vars0 ty_arg0' in
+              let vars0, ty_arg0' = instance_poly_fixed vars0 ty_arg0' in
               List.iter2 (fun ty ty' -> unify_var env ty ty') vars vars0;
               let arg =
                 type_argument ~overwrite:No_overwrite env expected_mode sarg ty_arg' ty_arg0'
@@ -9168,7 +9168,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
                   match get_desc pat.pat_type with
                   | Tpoly (ty, tl) ->
                       {pat with pat_type =
-                       snd (instance_poly ~keep_names:true ~fixed:false tl ty)}
+                         instance_poly ~keep_names:true tl ty}
                   | _ -> pat
                 in
                 let bound_expr = vb_exp_constraint binding in
@@ -9245,7 +9245,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
                 let vars, ty' =
                   with_local_level_if_principal
                     ~post:(fun (_,ty') -> generalize_structure ty')
-                    (fun () -> instance_poly ~keep_names:true ~fixed:true tl ty)
+                    (fun () -> instance_poly_fixed ~keep_names:true tl ty)
                 in
                 let exp =
                   Builtin_attributes.warning_scope pvb_attributes (fun () ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1309,7 +1309,7 @@ let rec check_constraints_rec env loc visited ty =
       end;
       List.iter (check_constraints_rec env loc visited) args
   | Tpoly (ty, tl) ->
-      let _, ty = Ctype.instance_poly ~fixed:false tl ty in
+      let ty = Ctype.instance_poly tl ty in
       check_constraints_rec env loc visited ty
   | _ ->
       Btype.iter_type_expr (check_constraints_rec env loc visited) ty
@@ -2527,8 +2527,7 @@ let check_regularity ~abs_env env loc path decl to_check =
           end;
           List.iter (check_subtype cpath args prev_exp trace ty) args'
       | Tpoly (ty, tl) ->
-          let (_, ty) =
-            Ctype.instance_poly ~keep_names:true ~fixed:false tl ty in
+          let ty = Ctype.instance_poly ~keep_names:true tl ty in
           check_regular cpath args prev_exp trace ty
       | _ ->
           Btype.iter_type_expr


### PR DESCRIPTION
This fixes a bug in the interaction between polymorphic variants and polymorphic parameters. The actual bug fix is just changing two `false`s to `true`s but I also changed the `instance_poly` interface to make similar mistakes less likely to happen.