### PR TITLE
More informative error for mixed product arrays

### DIFF
--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -125,8 +125,9 @@ Line 1, characters 37-51:
 1 | let f_bad (x : #(string * float#)) = make_vect 42 x
                                          ^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -166,8 +167,9 @@ Line 3, characters 21-29:
 3 | let make_bad_app x = make_bad x
                          ^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -217,8 +219,9 @@ Line 1, characters 43-48:
 1 | let f_bad (x : #(string * float#) array) = len x
                                                ^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -245,8 +248,9 @@ Line 2, characters 20-29:
 2 | let len_bad_app x = len_bad x
                         ^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -298,8 +302,9 @@ Line 1, characters 43-51:
 1 | let f_bad (x : #(string * float#) array) = get x 42
                                                ^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -337,8 +342,9 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -388,8 +394,9 @@ Line 1, characters 43-64:
 1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -430,8 +437,9 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -485,8 +493,9 @@ Line 1, characters 43-51:
 1 | let f_bad (x : #(string * float#) array) = get x 42
                                                ^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -524,8 +533,9 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -576,8 +586,9 @@ Line 1, characters 43-64:
 1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -618,8 +629,9 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -673,8 +685,9 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42L
                                                ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -713,8 +726,9 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -768,8 +782,9 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -811,8 +826,9 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -866,8 +882,9 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42L
                                                ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -906,8 +923,9 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -960,8 +978,9 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1003,8 +1022,9 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1058,8 +1078,9 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42l
                                                ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1098,8 +1119,9 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1153,8 +1175,9 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1196,8 +1219,9 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1251,8 +1275,9 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42l
                                                ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1291,8 +1316,9 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1346,8 +1372,9 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1389,8 +1416,9 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1445,8 +1473,9 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42n
                                                ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1488,8 +1517,9 @@ Line 4, characters 22-33:
 4 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1543,8 +1573,9 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1588,8 +1619,9 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1644,8 +1676,9 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42n
                                                ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1687,8 +1720,9 @@ Line 4, characters 22-33:
 4 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1742,8 +1776,9 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1787,8 +1822,9 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1842,8 +1878,9 @@ Line 1, characters 43-57:
 1 | let f_bad (x : #(string * float#) array) = blit x 0 x 2 3
                                                ^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1887,8 +1924,9 @@ Line 5, characters 35-59:
 5 | let blit_bad_app a1 i1 a2 i2 len = blit_bad a1 i1 a2 i2 len
                                        ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -2062,8 +2100,9 @@ Line 2, characters 47-63:
 2 |       (x : float#) (y : a) (z : bool option) = [| #(x, y, z) |]
                                                    ^^^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(float# * a * bool option), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 let f_illegal_empty_literal (type a : value mod external_)
@@ -2073,8 +2112,9 @@ Lines 1-2, characters 28-45:
 1 | ............................(type a : value mod external_)
 2 |   : #(float# * a * bool option) array = [| |]
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(float# * 'a * bool option), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (*************************************************)
@@ -2111,8 +2151,9 @@ Line 3, characters 4-18:
 3 |   | [| #(a,b,c) |] -> 1
         ^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(float# * bool option * int), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 let f_illegal_empty_literal : #(float# * bool option * int) array -> int =
@@ -2124,8 +2165,9 @@ Line 3, characters 4-9:
 3 |   | [| |] -> 0
         ^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(float# * bool option * int), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (***************************************************)

--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -130,6 +130,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -174,6 +176,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -228,6 +232,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -259,6 +265,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -315,6 +323,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -357,6 +367,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -411,6 +423,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -456,6 +470,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -514,6 +530,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -556,6 +574,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -611,6 +631,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -656,6 +678,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -714,6 +738,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -757,6 +783,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -815,6 +843,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -861,6 +891,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -919,6 +951,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -962,6 +996,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1019,6 +1055,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1065,6 +1103,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1123,6 +1163,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1166,6 +1208,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1224,6 +1268,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1270,6 +1316,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1328,6 +1376,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1371,6 +1421,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1429,6 +1481,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1475,6 +1529,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1534,6 +1590,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1580,6 +1638,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1638,6 +1698,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1686,6 +1748,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1745,6 +1809,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1791,6 +1857,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1849,6 +1917,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1897,6 +1967,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1955,6 +2027,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -2003,6 +2077,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -2181,6 +2257,8 @@ Error: An unboxed product array element must be formed from all
        #(float# * a * bool option), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 let f_illegal_empty_literal (type a : value mod external_)
@@ -2195,6 +2273,8 @@ Error: An unboxed product array element must be formed from all
        #(float# * 'a * bool option), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (*************************************************)
@@ -2236,6 +2316,8 @@ Error: An unboxed product array element must be formed from all
        #(float# * bool option * int), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 let f_illegal_empty_literal : #(float# * bool option * int) array -> int =
@@ -2252,6 +2334,8 @@ Error: An unboxed product array element must be formed from all
        #(float# * bool option * int), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (***************************************************)

--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -128,7 +128,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -171,7 +172,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -224,7 +226,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -254,7 +257,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -309,7 +313,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -350,7 +355,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -403,7 +409,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -447,7 +454,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -504,7 +512,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -545,7 +554,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -599,7 +609,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -643,7 +654,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -700,7 +712,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -742,7 +755,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -799,7 +813,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -844,7 +859,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -901,7 +917,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -943,7 +960,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -999,7 +1017,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1044,7 +1063,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1101,7 +1121,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1143,7 +1164,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1200,7 +1222,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1245,7 +1268,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1302,7 +1326,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1344,7 +1369,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1401,7 +1427,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1446,7 +1473,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1504,7 +1532,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1549,7 +1578,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1606,7 +1636,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1653,7 +1684,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1711,7 +1743,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1756,7 +1789,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1813,7 +1847,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1860,7 +1895,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1917,7 +1953,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1964,7 +2001,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -2141,7 +2179,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(float# * a * bool option), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 let f_illegal_empty_literal (type a : value mod external_)
@@ -2154,7 +2193,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(float# * 'a * bool option), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (*************************************************)
@@ -2194,7 +2234,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(float# * bool option * int), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 let f_illegal_empty_literal : #(float# * bool option * int) array -> int =
@@ -2209,7 +2250,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(float# * bool option * int), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (***************************************************)

--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -125,10 +125,10 @@ Line 1, characters 37-51:
 1 | let f_bad (x : #(string * float#)) = make_vect 42 x
                                          ^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -171,10 +171,10 @@ Line 3, characters 21-29:
 3 | let make_bad_app x = make_bad x
                          ^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -227,10 +227,10 @@ Line 1, characters 43-48:
 1 | let f_bad (x : #(string * float#) array) = len x
                                                ^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -260,10 +260,10 @@ Line 2, characters 20-29:
 2 | let len_bad_app x = len_bad x
                         ^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -318,10 +318,10 @@ Line 1, characters 43-51:
 1 | let f_bad (x : #(string * float#) array) = get x 42
                                                ^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -362,10 +362,10 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -418,10 +418,10 @@ Line 1, characters 43-64:
 1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -465,10 +465,10 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -525,10 +525,10 @@ Line 1, characters 43-51:
 1 | let f_bad (x : #(string * float#) array) = get x 42
                                                ^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -569,10 +569,10 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -626,10 +626,10 @@ Line 1, characters 43-64:
 1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -673,10 +673,10 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -733,10 +733,10 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42L
                                                ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -778,10 +778,10 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -838,10 +838,10 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -886,10 +886,10 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -946,10 +946,10 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42L
                                                ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -991,10 +991,10 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1050,10 +1050,10 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1098,10 +1098,10 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1158,10 +1158,10 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42l
                                                ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1203,10 +1203,10 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1263,10 +1263,10 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1311,10 +1311,10 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1371,10 +1371,10 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42l
                                                ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1416,10 +1416,10 @@ Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1476,10 +1476,10 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1524,10 +1524,10 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1585,10 +1585,10 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42n
                                                ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1633,10 +1633,10 @@ Line 4, characters 22-33:
 4 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1693,10 +1693,10 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1743,10 +1743,10 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1804,10 +1804,10 @@ Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42n
                                                ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1852,10 +1852,10 @@ Line 4, characters 22-33:
 4 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1912,10 +1912,10 @@ Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -1962,10 +1962,10 @@ Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -2022,10 +2022,10 @@ Line 1, characters 43-57:
 1 | let f_bad (x : #(string * float#) array) = blit x 0 x 2 3
                                                ^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -2072,10 +2072,10 @@ Line 5, characters 35-59:
 5 | let blit_bad_app a1 i1 a2 i2 len = blit_bad a1 i1 a2 i2 len
                                        ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -2252,10 +2252,10 @@ Line 2, characters 47-63:
 2 |       (x : float#) (y : a) (z : bool option) = [| #(x, y, z) |]
                                                    ^^^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(float# * a * bool option), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(float# * a * bool option), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -2268,10 +2268,10 @@ Lines 1-2, characters 28-45:
 1 | ............................(type a : value mod external_)
 2 |   : #(float# * a * bool option) array = [| |]
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(float# * 'a * bool option), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(float# * 'a * bool option), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -2311,10 +2311,10 @@ Line 3, characters 4-18:
 3 |   | [| #(a,b,c) |] -> 1
         ^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(float# * bool option * int), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(float# * bool option * int), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -2329,10 +2329,10 @@ Line 3, characters 4-9:
 3 |   | [| |] -> 0
         ^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(float# * bool option * int), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(float# * bool option * int), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.

--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -124,10 +124,11 @@ let f_bad (x : #(string * float#)) = make_vect 42 x
 Line 1, characters 37-51:
 1 | let f_bad (x : #(string * float#)) = make_vect 42 x
                                          ^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -166,10 +167,11 @@ external make_bad : int -> #(string * float#) -> #(string * float#) array
 Line 3, characters 21-29:
 3 | let make_bad_app x = make_bad x
                          ^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -218,10 +220,11 @@ let f_bad (x : #(string * float#) array) = len x
 Line 1, characters 43-48:
 1 | let f_bad (x : #(string * float#) array) = len x
                                                ^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -247,10 +250,11 @@ external len_bad : #(string * float#) array -> int = "%array_length"
 Line 2, characters 20-29:
 2 | let len_bad_app x = len_bad x
                         ^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -301,10 +305,11 @@ let f_bad (x : #(string * float#) array) = get x 42
 Line 1, characters 43-51:
 1 | let f_bad (x : #(string * float#) array) = get x 42
                                                ^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -341,10 +346,11 @@ external get_bad : #(string * float#) array -> int -> #(string * float#)
 Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -393,10 +399,11 @@ let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
 Line 1, characters 43-64:
 1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -436,10 +443,11 @@ external set_bad :
 Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -492,10 +500,11 @@ let f_bad (x : #(string * float#) array) = get x 42
 Line 1, characters 43-51:
 1 | let f_bad (x : #(string * float#) array) = get x 42
                                                ^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -532,10 +541,11 @@ external get_bad : #(string * float#) array -> int -> #(string * float#)
 Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -585,10 +595,11 @@ let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
 Line 1, characters 43-64:
 1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -628,10 +639,11 @@ external set_bad :
 Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -684,10 +696,11 @@ let f_bad (x : #(string * float#) array) = get x #42L
 Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42L
                                                ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -725,10 +738,11 @@ external get_bad : #(string * float#) array -> int64# -> #(string * float#)
 Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -781,10 +795,11 @@ let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
 Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -825,10 +840,11 @@ external set_bad :
 Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -881,10 +897,11 @@ let f_bad (x : #(string * float#) array) = get x #42L
 Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42L
                                                ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -922,10 +939,11 @@ external get_bad : #(string * float#) array -> int64# -> #(string * float#)
 Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -977,10 +995,11 @@ let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
 Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1021,10 +1040,11 @@ external set_bad :
 Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1077,10 +1097,11 @@ let f_bad (x : #(string * float#) array) = get x #42l
 Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42l
                                                ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1118,10 +1139,11 @@ external get_bad : #(string * float#) array -> int32# -> #(string * float#)
 Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1174,10 +1196,11 @@ let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
 Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1218,10 +1241,11 @@ external set_bad :
 Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1274,10 +1298,11 @@ let f_bad (x : #(string * float#) array) = get x #42l
 Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42l
                                                ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1315,10 +1340,11 @@ external get_bad : #(string * float#) array -> int32# -> #(string * float#)
 Line 3, characters 22-33:
 3 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1371,10 +1397,11 @@ let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
 Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1415,10 +1442,11 @@ external set_bad :
 Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1472,10 +1500,11 @@ let f_bad (x : #(string * float#) array) = get x #42n
 Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42n
                                                ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1516,10 +1545,11 @@ external get_bad :
 Line 4, characters 22-33:
 4 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1572,10 +1602,11 @@ let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
 Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1618,10 +1649,11 @@ external set_bad :
 Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1675,10 +1707,11 @@ let f_bad (x : #(string * float#) array) = get x #42n
 Line 1, characters 43-53:
 1 | let f_bad (x : #(string * float#) array) = get x #42n
                                                ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1719,10 +1752,11 @@ external get_bad :
 Line 4, characters 22-33:
 4 | let get_bad_app a i = get_bad a i
                           ^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1775,10 +1809,11 @@ let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
 Line 1, characters 43-66:
 1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1821,10 +1856,11 @@ external set_bad :
 Line 4, characters 24-37:
 4 | let set_bad_app a i x = set_bad a i x
                             ^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -1877,10 +1913,11 @@ let f_bad (x : #(string * float#) array) = blit x 0 x 2 3
 Line 1, characters 43-57:
 1 | let f_bad (x : #(string * float#) array) = blit x 0 x 2 3
                                                ^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* And similarly if we specialize it at declaration time. *)
@@ -1923,10 +1960,11 @@ external blit_bad :
 Line 5, characters 35-59:
 5 | let blit_bad_app a1 i1 a2 i2 len = blit_bad a1 i1 a2 i2 len
                                        ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* Unboxed vectors are also rejected. *)
@@ -2099,10 +2137,11 @@ let f_illegal_literal (type a : value mod external_)
 Line 2, characters 47-63:
 2 |       (x : float#) (y : a) (z : bool option) = [| #(x, y, z) |]
                                                    ^^^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(float# * a * bool option), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(float# * a * bool option), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 let f_illegal_empty_literal (type a : value mod external_)
@@ -2111,10 +2150,11 @@ let f_illegal_empty_literal (type a : value mod external_)
 Lines 1-2, characters 28-45:
 1 | ............................(type a : value mod external_)
 2 |   : #(float# * a * bool option) array = [| |]
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(float# * 'a * bool option), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(float# * 'a * bool option), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (*************************************************)
@@ -2150,10 +2190,11 @@ let f_illegal_literal : #(float# * bool option * int) array -> int =
 Line 3, characters 4-18:
 3 |   | [| #(a,b,c) |] -> 1
         ^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(float# * bool option * int), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(float# * bool option * int), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 let f_illegal_empty_literal : #(float# * bool option * int) array -> int =
@@ -2164,10 +2205,11 @@ let f_illegal_empty_literal : #(float# * bool option * int) array -> int =
 Line 3, characters 4-9:
 3 |   | [| |] -> 0
         ^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(float# * bool option * int), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(float# * bool option * int), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (***************************************************)

--- a/testsuite/tests/typing-layouts-products/product_iarrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_iarrays.ml
@@ -45,6 +45,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* array length *)
@@ -80,6 +82,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* safe get *)
@@ -115,6 +119,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* unsafe get *)
@@ -150,6 +156,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* safe get indexed by int64# *)
@@ -185,6 +193,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* unsafe get indexed by int64# *)
@@ -220,6 +230,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* safe get indexed by int32# *)
@@ -255,6 +267,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* unsafe get indexed by int32# *)
@@ -290,6 +304,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* safe get indexed by nativeint# *)
@@ -326,6 +342,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* unsafe get indexed by nativeint# *)
@@ -362,6 +380,8 @@ Error: An unboxed product array element must be formed from all
        #(string * float#), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* expression literals *)
@@ -413,6 +433,8 @@ Error: An unboxed product array element must be formed from all
        #(float# * a * bool option), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 let f_illegal_empty_literal (type a : value mod external_)
@@ -427,6 +449,8 @@ Error: An unboxed product array element must be formed from all
        #(float# * 'a * bool option), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 (* pattern literals *)
@@ -468,6 +492,8 @@ Error: An unboxed product array element must be formed from all
        #(float# * bool option * int), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]
 
 let f_illegal_empty_literal : #(float# * bool option * int) iarray -> int =
@@ -484,4 +510,6 @@ Error: An unboxed product array element must be formed from all
        #(float# * bool option * int), which is an unboxed product that cannot be ignored
        (as it is not [external]) and contains a type with the non-scannable
        layout float64.
+       Hint: if the array contents should not be scanned, annotating
+       contained abstract types as [mod external] may resolve this error.
 |}]

--- a/testsuite/tests/typing-layouts-products/product_iarrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_iarrays.ml
@@ -43,7 +43,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* array length *)
@@ -77,7 +78,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* safe get *)
@@ -111,7 +113,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* unsafe get *)
@@ -145,7 +148,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* safe get indexed by int64# *)
@@ -179,7 +183,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* unsafe get indexed by int64# *)
@@ -213,7 +218,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* safe get indexed by int32# *)
@@ -247,7 +253,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* unsafe get indexed by int32# *)
@@ -281,7 +288,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* safe get indexed by nativeint# *)
@@ -316,7 +324,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* unsafe get indexed by nativeint# *)
@@ -351,7 +360,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* expression literals *)
@@ -401,7 +411,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(float# * a * bool option), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 let f_illegal_empty_literal (type a : value mod external_)
@@ -414,7 +425,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(float# * 'a * bool option), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 (* pattern literals *)
@@ -454,7 +466,8 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(float# * bool option * int), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]
 
 let f_illegal_empty_literal : #(float# * bool option * int) iarray -> int =
@@ -469,5 +482,6 @@ Error: An unboxed product array element must be formed from all
        gc-ignorable types or all gc-scannable types. But this array
        operation is peformed for an array whose element type is
        #(float# * bool option * int), which is an unboxed product that cannot be ignored
-       (as it is not [external]) but contains the non-scannable sort float64.
+       (as it is not [external]) and contains a type with the non-scannable
+       layout float64.
 |}]

--- a/testsuite/tests/typing-layouts-products/product_iarrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_iarrays.ml
@@ -40,10 +40,10 @@ Line 1, characters 40-54:
 1 | let make_bad (x : #(string * float#)) = make_vect 42 x
                                             ^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -77,10 +77,10 @@ Line 1, characters 49-54:
 1 | let length_bad (x : #(string * float#) iarray) = len x
                                                      ^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -114,10 +114,10 @@ Line 1, characters 46-54:
 1 | let get_bad (x : #(string * float#) iarray) = get x 42
                                                   ^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -151,10 +151,10 @@ Line 1, characters 46-54:
 1 | let get_bad (x : #(string * float#) iarray) = get x 42
                                                   ^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -188,10 +188,10 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42L
                                                   ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -225,10 +225,10 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42L
                                                   ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -262,10 +262,10 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42l
                                                   ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -299,10 +299,10 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42l
                                                   ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -337,10 +337,10 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42n
                                                   ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -375,10 +375,10 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42n
                                                   ^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(string * float#), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(string * float#), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -428,10 +428,10 @@ Line 2, characters 47-63:
 2 |       (x : float#) (y : a) (z : bool option) = [: #(x, y, z) :]
                                                    ^^^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(float# * a * bool option), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(float# * a * bool option), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -444,10 +444,10 @@ Lines 1-2, characters 28-46:
 1 | ............................(type a : value mod external_)
 2 |   : #(float# * a * bool option) iarray = [: :]
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(float# * 'a * bool option), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(float# * 'a * bool option), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -487,10 +487,10 @@ Line 3, characters 4-18:
 3 |   | [: #(a,b,c) :] -> 1
         ^^^^^^^^^^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(float# * bool option * int), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(float# * bool option * int), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.
@@ -505,10 +505,10 @@ Line 3, characters 4-9:
 3 |   | [: :] -> 0
         ^^^^^
 Error: An unboxed product array element must be formed from all
-       gc-ignorable types or all gc-scannable types. But this array
-       operation is peformed for an array whose element type is
-       #(float# * bool option * int), which is an unboxed product that cannot be ignored
-       (as it is not [external]) and contains a type with the non-scannable
+       external types (which are ignored by the gc) or all gc-scannable types.
+       But this array operation is peformed for an array whose
+       element type is #(float# * bool option * int), which is an unboxed product
+       that is not external and contains a type with the non-scannable
        layout float64.
        Hint: if the array contents should not be scanned, annotating
        contained abstract types as [mod external] may resolve this error.

--- a/testsuite/tests/typing-layouts-products/product_iarrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_iarrays.ml
@@ -39,10 +39,11 @@ let make_bad (x : #(string * float#)) = make_vect 42 x
 Line 1, characters 40-54:
 1 | let make_bad (x : #(string * float#)) = make_vect 42 x
                                             ^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* array length *)
@@ -72,10 +73,11 @@ let length_bad (x : #(string * float#) iarray) = len x
 Line 1, characters 49-54:
 1 | let length_bad (x : #(string * float#) iarray) = len x
                                                      ^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* safe get *)
@@ -105,10 +107,11 @@ let get_bad (x : #(string * float#) iarray) = get x 42
 Line 1, characters 46-54:
 1 | let get_bad (x : #(string * float#) iarray) = get x 42
                                                   ^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* unsafe get *)
@@ -138,10 +141,11 @@ let get_bad (x : #(string * float#) iarray) = get x 42
 Line 1, characters 46-54:
 1 | let get_bad (x : #(string * float#) iarray) = get x 42
                                                   ^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* safe get indexed by int64# *)
@@ -171,10 +175,11 @@ let get_bad (x : #(string * float#) iarray) = get x #42L
 Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42L
                                                   ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* unsafe get indexed by int64# *)
@@ -204,10 +209,11 @@ let get_bad (x : #(string * float#) iarray) = get x #42L
 Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42L
                                                   ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* safe get indexed by int32# *)
@@ -237,10 +243,11 @@ let get_bad (x : #(string * float#) iarray) = get x #42l
 Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42l
                                                   ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* unsafe get indexed by int32# *)
@@ -270,10 +277,11 @@ let get_bad (x : #(string * float#) iarray) = get x #42l
 Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42l
                                                   ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* safe get indexed by nativeint# *)
@@ -304,10 +312,11 @@ let get_bad (x : #(string * float#) iarray) = get x #42n
 Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42n
                                                   ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* unsafe get indexed by nativeint# *)
@@ -338,10 +347,11 @@ let get_bad (x : #(string * float#) iarray) = get x #42n
 Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42n
                                                   ^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(string * float#), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(string * float#), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* expression literals *)
@@ -387,10 +397,11 @@ let f_illegal_literal (type a : value mod external_)
 Line 2, characters 47-63:
 2 |       (x : float#) (y : a) (z : bool option) = [: #(x, y, z) :]
                                                    ^^^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(float# * a * bool option), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(float# * a * bool option), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 let f_illegal_empty_literal (type a : value mod external_)
@@ -399,10 +410,11 @@ let f_illegal_empty_literal (type a : value mod external_)
 Lines 1-2, characters 28-46:
 1 | ............................(type a : value mod external_)
 2 |   : #(float# * a * bool option) iarray = [: :]
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(float# * 'a * bool option), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(float# * 'a * bool option), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 (* pattern literals *)
@@ -438,10 +450,11 @@ let f_illegal_literal : #(float# * bool option * int) iarray -> int =
 Line 3, characters 4-18:
 3 |   | [: #(a,b,c) :] -> 1
         ^^^^^^^^^^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(float# * bool option * int), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(float# * bool option * int), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]
 
 let f_illegal_empty_literal : #(float# * bool option * int) iarray -> int =
@@ -452,8 +465,9 @@ let f_illegal_empty_literal : #(float# * bool option * int) iarray -> int =
 Line 3, characters 4-9:
 3 |   | [: :] -> 0
         ^^^^^
-Error: Unboxed product array elements must be external or contain all gc
-       scannable types. But this array operation is peformed for an array
-       whose element type is #(float# * bool option * int), which is an unboxed
-       product that is not external and contains the non-scannable sort float64.
+Error: An unboxed product array element must be formed from all
+       gc-ignorable types or all gc-scannable types. But this array
+       operation is peformed for an array whose element type is
+       #(float# * bool option * int), which is an unboxed product that cannot be ignored
+       (as it is not [external]) but contains the non-scannable sort float64.
 |}]

--- a/testsuite/tests/typing-layouts-products/product_iarrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_iarrays.ml
@@ -40,8 +40,9 @@ Line 1, characters 40-54:
 1 | let make_bad (x : #(string * float#)) = make_vect 42 x
                                             ^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* array length *)
@@ -72,8 +73,9 @@ Line 1, characters 49-54:
 1 | let length_bad (x : #(string * float#) iarray) = len x
                                                      ^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* safe get *)
@@ -104,8 +106,9 @@ Line 1, characters 46-54:
 1 | let get_bad (x : #(string * float#) iarray) = get x 42
                                                   ^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* unsafe get *)
@@ -136,8 +139,9 @@ Line 1, characters 46-54:
 1 | let get_bad (x : #(string * float#) iarray) = get x 42
                                                   ^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* safe get indexed by int64# *)
@@ -168,8 +172,9 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42L
                                                   ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* unsafe get indexed by int64# *)
@@ -200,8 +205,9 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42L
                                                   ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* safe get indexed by int32# *)
@@ -232,8 +238,9 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42l
                                                   ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* unsafe get indexed by int32# *)
@@ -264,8 +271,9 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42l
                                                   ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* safe get indexed by nativeint# *)
@@ -297,8 +305,9 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42n
                                                   ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* unsafe get indexed by nativeint# *)
@@ -330,8 +339,9 @@ Line 1, characters 46-56:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42n
                                                   ^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(string * float#), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* expression literals *)
@@ -378,8 +388,9 @@ Line 2, characters 47-63:
 2 |       (x : float#) (y : a) (z : bool option) = [: #(x, y, z) :]
                                                    ^^^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(float# * a * bool option), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 let f_illegal_empty_literal (type a : value mod external_)
@@ -389,8 +400,9 @@ Lines 1-2, characters 28-46:
 1 | ............................(type a : value mod external_)
 2 |   : #(float# * a * bool option) iarray = [: :]
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(float# * 'a * bool option), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 (* pattern literals *)
@@ -427,8 +439,9 @@ Line 3, characters 4-18:
 3 |   | [: #(a,b,c) :] -> 1
         ^^^^^^^^^^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(float# * bool option * int), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]
 
 let f_illegal_empty_literal : #(float# * bool option * int) iarray -> int =
@@ -440,6 +453,7 @@ Line 3, characters 4-9:
 3 |   | [: :] -> 0
         ^^^^^
 Error: Unboxed product array elements must be external or contain all gc
-       scannable types. The product type this function is applied at is
-       not external but contains an element of sort float64.
+       scannable types. But this array operation is peformed for an array
+       whose element type is #(float# * bool option * int), which is an unboxed
+       product that is not external and contains the non-scannable sort float64.
 |}]

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -1134,10 +1134,11 @@ let report_error ppf = function
          products."
   | Mixed_product_array (const, elt_ty) ->
       fprintf ppf
-        "Unboxed product array elements must be external or contain all gc@ \
-         scannable types. But this array operation is peformed for an array@ \
-         whose element type is %a, which is an unboxed@ product \
-         that is not external and contains the non-scannable sort %a."
+        "An unboxed product array element must be formed from all@ \
+         gc-ignorable types or all gc-scannable types. But this array@ \
+         operation is peformed for an array whose element type is@ \
+         %a, which is an unboxed product that cannot be ignored@ \
+         (as it is not [external]) but contains the non-scannable sort %a."
         Printtyp.type_expr elt_ty
         Jkind.Sort.Const.format const
   | Product_iarrays_unsupported ->

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -1139,7 +1139,9 @@ let report_error ppf = function
          operation is peformed for an array whose element type is@ \
          %a, which is an unboxed product that cannot be ignored@ \
          (as it is not [external]) and contains a type with the non-scannable@ \
-         layout %a."
+         layout %a.@ \
+         @[Hint: if the array contents should not be scanned, annotating@ \
+         contained abstract types as [mod external] may resolve this error.@]"
         Printtyp.type_expr elt_ty
         Jkind.Sort.Const.format const
   | Product_iarrays_unsupported ->

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -32,7 +32,7 @@ type error =
   | Unsupported_sort of Jkind.Sort.Const.t
   | Unsupported_product_in_lazy of Jkind.Sort.Const.t
   | Unsupported_vector_in_product_array
-  | Mixed_product_array of Jkind.Sort.Const.t
+  | Mixed_product_array of Jkind.Sort.Const.t * type_expr
   | Product_iarrays_unsupported
 
 exception Error of Location.t * error
@@ -199,20 +199,22 @@ let classify ~classify_product env loc ty sort : _ classification =
     raise (Error (loc, Unsupported_sort c))
   | Product c -> Product (classify_product ty c)
 
-let rec scannable_product_array_kind loc sorts =
-  List.map (sort_to_scannable_product_element_kind loc) sorts
+let rec scannable_product_array_kind elt_ty_for_error loc sorts =
+  List.map (sort_to_scannable_product_element_kind elt_ty_for_error loc) sorts
 
-and sort_to_scannable_product_element_kind loc (s : Jkind.Sort.Const.t) =
+and sort_to_scannable_product_element_kind elt_ty_for_error loc
+      (s : Jkind.Sort.Const.t) =
   (* Unfortunate: this never returns `Pint_scannable`.  Doing so would require
      this to traverse the type, rather than just the kind, or to add product
      kinds. *)
   match s with
   | Base Value -> Paddr_scannable
   | Base (Float64 | Float32 | Bits32 | Bits64 | Word | Vec128) as c ->
-    raise (Error (loc, Mixed_product_array c))
+    raise (Error (loc, Mixed_product_array (c, elt_ty_for_error)))
   | Base Void as c ->
     raise (Error (loc, Unsupported_sort c))
-  | Product sorts -> Pproduct_scannable (scannable_product_array_kind loc sorts)
+  | Product sorts ->
+    Pproduct_scannable (scannable_product_array_kind elt_ty_for_error loc sorts)
 
 let rec ignorable_product_array_kind loc sorts =
   List.map (sort_to_ignorable_product_element_kind loc) sorts
@@ -237,11 +239,13 @@ let array_kind_of_elt ~elt_sort env loc ty =
       Jkind.Sort.default_for_transl_and_get
         (type_legacy_sort ~why:Array_element env loc ty)
   in
+  let elt_ty_for_error = ty in (* report the un-scraped ty in errors *)
   let classify_product ty sorts =
     if is_always_gc_ignorable env ty then
       Pgcignorableproductarray (ignorable_product_array_kind loc sorts)
     else
-      Pgcscannableproductarray (scannable_product_array_kind loc sorts)
+      Pgcscannableproductarray
+        (scannable_product_array_kind elt_ty_for_error loc sorts)
   in
   (* CR dkalinichenko: many checks in [classify] are redundant
      with separability. *)
@@ -1128,11 +1132,13 @@ let report_error ppf = function
       fprintf ppf
         "Unboxed vector types are not yet supported in arrays of unboxed@ \
          products."
-  | Mixed_product_array const ->
+  | Mixed_product_array (const, elt_ty) ->
       fprintf ppf
         "Unboxed product array elements must be external or contain all gc@ \
-         scannable types. The product type this function is applied at is@ \
-         not external but contains an element of sort %a."
+         scannable types. But this array operation is peformed for an array@ \
+         whose element type is %a, which is an unboxed@ product \
+         that is not external and contains the non-scannable sort %a."
+        Printtyp.type_expr elt_ty
         Jkind.Sort.Const.format const
   | Product_iarrays_unsupported ->
       fprintf ppf

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -1135,10 +1135,10 @@ let report_error ppf = function
   | Mixed_product_array (const, elt_ty) ->
       fprintf ppf
         "An unboxed product array element must be formed from all@ \
-         gc-ignorable types or all gc-scannable types. But this array@ \
-         operation is peformed for an array whose element type is@ \
-         %a, which is an unboxed product that cannot be ignored@ \
-         (as it is not [external]) and contains a type with the non-scannable@ \
+         external types (which are ignored by the gc) or all gc-scannable \
+         types.@ But this array operation is peformed for an array whose@ \
+         element type is %a, which is an unboxed product@ \
+         that is not external and contains a type with the non-scannable@ \
          layout %a.@ \
          @[Hint: if the array contents should not be scanned, annotating@ \
          contained abstract types as [mod external] may resolve this error.@]"

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -1138,7 +1138,8 @@ let report_error ppf = function
          gc-ignorable types or all gc-scannable types. But this array@ \
          operation is peformed for an array whose element type is@ \
          %a, which is an unboxed product that cannot be ignored@ \
-         (as it is not [external]) but contains the non-scannable sort %a."
+         (as it is not [external]) and contains a type with the non-scannable@ \
+         layout %a."
         Printtyp.type_expr elt_ty
         Jkind.Sort.Const.format const
   | Product_iarrays_unsupported ->


### PR DESCRIPTION
Give a more informative error message for product arrays whose elements are neither scannable nor external.

Old:
```
1 | let f_bad (x : #(string * float#)) = make_vect 42 x
                                         ^^^^^^^^^^^^^^
Error: Unboxed product array elements must be external or contain all gc
       scannable types. The product type this function is applied at is
       not external but contains an element of sort float64.
```
New:
```
1 | let f_bad (x : #(string * float#)) = make_vect 42 x
                                         ^^^^^^^^^^^^^^
Error: An unboxed product array element must be formed from all
       external types (which are ignored by the gc) or all gc-scannable types.
       But this array operation is peformed for an array whose
       element type is #(string * float#), which is an unboxed product
       that is not external and contains a type with the non-scannable
       layout float64.
       Hint: if the array contents should not be scanned, annotating
       contained abstract types as [mod external] may resolve this error.
```