### PR TITLE
runtime: add macros to handle `or_null` values alike those available for `option`

### DIFF
--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -69,8 +69,13 @@ typedef opcode_t * code_t;
 
 #include "domain_state.h"
 
-/* The null pointer value. */
+/* Or_null constructors. */
+
 #define Val_null ((value) 0)
+#define Val_this(v) (v)
+#define This_val(v) (v)
+#define Is_null(v) ((v) == Val_null)
+#define Is_this(v) ((v) != Val_null)
 
 /* Longs vs blocks. */
 

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -143,8 +143,8 @@ static intnat do_compare_val(struct compare_stack* stk,
       if (v1 == v2 && total) goto next_item;
       if (Is_long(v1)) {
         if (v1 == v2) goto next_item;
-        if (v1 == Val_null) return LESS; /* v1 null < v2 non-null */
-        if (v2 == Val_null) return GREATER; /* v1 non-null > v2 null */
+        if (Is_null(v1)) return LESS; /* v1 null < v2 non-null */
+        if (Is_null(v2)) return GREATER; /* v1 non-null > v2 null */
         if (Is_long(v2))
           return Long_val(v1) - Long_val(v2);
         /* Subtraction above cannot overflow and cannot result in UNORDERED */

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -813,7 +813,7 @@ static void extern_rec(struct caml_extern_state* s, value v)
   sp = s->extern_stack;
 
   while(1) {
-  if (v == Val_null) {
+  if (Is_null(v)) {
     extern_null(s);
   } else if (Is_long(v)) {
     extern_int(s, Long_val(v));

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -124,7 +124,7 @@ caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
            && (code_t) v >= prog
            && (code_t) v < (code_t) ((char *) prog + proglen))
     fprintf (f, "=code@%ld", (long) ((code_t) v - prog));
-  else if (v == Val_null)
+  else if (Is_null(v))
     fprintf (f, "=null");
   else if (Is_long (v))
     fprintf (f, "=long%" ARCH_INTNAT_PRINTF_FORMAT "d", Long_val (v));

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -36,7 +36,7 @@ static int obj_tag (value arg)
 {
   header_t hd;
 
-  if (arg == Val_null) {
+  if (Is_null(arg)) {
     return 1010;   /* null_tag */
   } else if (Is_long (arg)) {
     return 1000;   /* int_tag */
@@ -410,5 +410,5 @@ CAMLprim value caml_succ_scannable_prefix_len (value v) {
 
 CAMLprim value caml_is_null(value v)
 {
-  return v == Val_null ? Val_true : Val_false;
+  return Is_null(v) ? Val_true : Val_false;
 }

--- a/runtime4/caml/mlvalues.h
+++ b/runtime4/caml/mlvalues.h
@@ -71,8 +71,13 @@ typedef uintnat mark_t;
 
 #include "domain_state.h"
 
-/* The null pointer value. */
+/* Or_null constructors. */
+
 #define Val_null ((value) 0)
+#define Val_this(v) (v)
+#define This_val(v) (v)
+#define Is_null(v) ((v) == Val_null)
+#define Is_this(v) ((v) != Val_null)
 
 /* Longs vs blocks. */
 

--- a/runtime4/compare.c
+++ b/runtime4/compare.c
@@ -124,8 +124,8 @@ static intnat do_compare_val(struct compare_stack* stk,
     if (v1 == v2 && total) goto next_item;
     if (Is_long(v1)) {
       if (v1 == v2) goto next_item;
-      if (v1 == Val_null) return LESS; /* v1 null < v2 non-null */
-      if (v2 == Val_null) return GREATER; /* v1 non-null > v2 null */
+      if (Is_null(v1)) return LESS; /* v1 null < v2 non-null */
+      if (Is_null(v2)) return GREATER; /* v1 non-null > v2 null */
       if (Is_long(v2))
         return Long_val(v1) - Long_val(v2);
       /* Subtraction above cannot overflow and cannot result in UNORDERED */

--- a/runtime4/extern.c
+++ b/runtime4/extern.c
@@ -730,7 +730,7 @@ static void extern_rec(value v)
   sp = extern_stack;
 
   while(1) {
-  if (v == Val_null) {
+  if (Is_null(v)) {
     extern_null();
   } else if (Is_long(v)) {
     extern_int(Long_val(v));
@@ -1230,7 +1230,7 @@ intnat reachable_words_once(value root, intnat identifier, value sizes_by_root_i
   CAMLassert(identifier >= 0);
 
   while (1) {
-    if (Is_long(v) || v == Val_null) {
+    if (Is_long(v) || Is_null(v)) {
       /* Tagged integers or nulls contribute 0 to the size, nothing to do */
     } else if (! Is_in_heap_or_young(v)) {
       /* Out-of-heap blocks contribute 0 to the size, nothing to do */

--- a/runtime4/instrtrace.c
+++ b/runtime4/instrtrace.c
@@ -188,7 +188,7 @@ caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
            && (code_t) v >= prog
            && (code_t) v < (code_t) ((char *) prog + proglen))
     fprintf (f, "=code@%ld", (long) ((code_t) v - prog));
-  else if (v == Val_null)
+  else if (Is_null(v))
     fprintf (f, "=null");
   else if (Is_long (v))
     fprintf (f, "=long%" ARCH_INTNAT_PRINTF_FORMAT "d", Long_val (v));

--- a/runtime4/obj.c
+++ b/runtime4/obj.c
@@ -32,7 +32,7 @@
 
 static int obj_tag (value arg)
 {
-  if (arg == Val_null) {
+  if (Is_null(arg)) {
     return 1010;   /* null_tag */
   } else if (Is_long (arg)) {
     return 1000;   /* int_tag */
@@ -383,5 +383,5 @@ CAMLprim value caml_succ_scannable_prefix_len (value v) {
 
 CAMLprim value caml_is_null(value v)
 {
-  return v == Val_null ? Val_true : Val_false;
+  return Is_null(v) ? Val_true : Val_false;
 }


### PR DESCRIPTION
A first commit adds `Val_this`, `This_val`, `Is_null` and `Is_this` (next to the existing `Val_null`) to make the API to work with `or_null` values alike the API available to work with `option` values. Granted, `Val_this` and `This_val` are essentially "the identity macro", but I believe it to be useful to "document" the current (supposed) type of some `value` in C code.

A second commit uses these new macros in the runtime implementation. It uses `Is_null`, since that's the only applicable one, switching `== Val_null` comparisons with, well, `Is_null`. If this is deemed an unnecessary change, the commit can easily be dropped.

While doing so, I noticed there's some existing code calling

```
if (Is_long(v) || Is_null(v))
```

which, I believe, is a bit superfluous since `Is_long(v)` is true for `v == Val_null` already. I imagine a C compiler optimizing this away when the macro-version of `Is_long` is used, but maybe not when using the `inline __asm__` version (though I didn't check).